### PR TITLE
5250 improve blog post template

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -226,6 +226,7 @@ ai:
 blog:
   title: Blog
   path: /blog
+  persist: True
 
   children:
     - title: Overview

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==2.2
 django-prometheus==1.0.15
-canonicalwebteam.blog==1.5.15
+canonicalwebteam.blog==2.0.1
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==2.2
 django-prometheus==1.0.15
-canonicalwebteam.blog==2.0.1
+canonicalwebteam.blog==2.0.2
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,8 +1,4 @@
-{% extends "templates/one-column.html" %}
-
-{% block title %}{{ article.title.rendered|safe }}{% endblock %}
-
-{% block meta_description %}{{ article.excerpt.raw }}{% endblock %}
+{% extends_with_args "templates/one-column.html" with title=article.title.rendered meta_description=article.excerpt.raw  meta_image=article.image.source_url %}
 
 {% block content %}
 
@@ -36,7 +32,7 @@
             Share on:
           </li>
           <li class="p-inline-list__item">
-            <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com{{ article.link }}&#9;&#9;&#9;&amp;p[title]={{ article.title.rendered | safe | urlencode }}&amp;p[summary]={{ article.excerpt.raw|cut:'[…]'|truncatewords:36|urlencode }}{% if article.image and article.image.source_url %}&amp;p[images][0]=https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}{% endif %}">
+            <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://www.ubuntu.com/blog/{{ article.slug }}&#9;&#9;&#9;&amp;p[title]={{ article.title.rendered | safe | urlencode }}&amp;p[summary]={{ article.excerpt.raw|cut:'[…]'|truncatewords:36|urlencode }}{% if article.image and article.image.source_url %}&amp;p[images][0]=https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}{% endif %}">
               Facebook
             </a>
           </li>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,23 +1,118 @@
 {% extends "templates/one-column.html" %}
-{% block title %}{{article.title.rendered|safe}}{% endblock %}
+
+{% block title %}{{ article.title.rendered|safe }}{% endblock %}
+
+{% block meta_description %}{{ article.excerpt.raw }}{% endblock %}
+
 {% block content %}
-<section id="main-content" class="p-strip">
-  <div class="row">
-    <div class="col-8 p-blog-post">
-      <h1 class="p-heading--two">{{ article.title.rendered|safe }}</h1>
-      <p>by {{ article.author.name }} on {{ article.date }}</p>
-      {{ article.content.rendered|safe }}
+
+<article>
+  <header class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">
+    <div class="row">
+      <div class="col-8">
+        <h1>{{ article.title.rendered|safe }}</h1>
+      </div>
     </div>
-  </div>
-</section>
+    <div class="row">
+      <div class="col-8">
+        <div class="p-media-object">
+          {% if article.author %}
+            <img src="{% if article.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ article.author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
+          {% endif %}
+
+          <div class="p-media-object__details">
+            {% if article.author %}
+              <h3 class="p-media-object__title">
+                <a href="/blog/author/{{ article.author.slug }}" title="More about {{ article.author.name }}">{{ article.author.name }}</a>
+              </h3>
+            {% endif %}
+            <p class="p-media-object__content">on {{ article.date }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-4">
+        <ul class="p-inline-list u-vertically-center p-social-widget">
+          <li class="p-inline-list__item">
+            Share on:
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://blog.ubuntu.com{{ article.link }}&#9;&#9;&#9;&amp;p[title]={{ article.title.rendered | safe | urlencode }}&amp;p[summary]={{ article.excerpt.raw|cut:'[…]'|truncatewords:36|urlencode }}{% if article.image and article.image.source_url %}&amp;p[images][0]=https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}{% endif %}">
+              Facebook
+            </a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ article.title.rendered|safe|urlencode }}&amp;url=https://www.ubuntu.com/blog/{{ article.slug }}&amp;hashtags=ubuntu">
+              Twitter
+            </a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.ubuntu.com/blog/{{ article.slug }}&amp;title={{ article.title.rendered|safe|urlencode }}">
+            LinkedIn
+          </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    {% if tags %}
+      <div class="row">
+        <div class="col-10">
+          <p>
+            <strong>Tags:</strong>
+            {% for tag in tags %}
+              <a href="/blog/tag/{{ tag.slug }}">
+                {{ tag.name }}
+              </a>{% if not forloop.last %}, {% endif %}
+            {% endfor %}
+          </p>
+        </div>
+      </div>
+    {% endif %}
+  </header>
+
+  <section class="p-strip is-shallow" style="overflow-x: initial;">
+    <div class="row u-equal-height">
+      <div class="col-8">
+        <div class="p-post__content">
+          {{ article.content.rendered|safe }}
+        </div>
+      </div>
+      <div class="col-4">
+        {% include 'blog/product-cards.html' %}
+
+        <div style="position: sticky; top: 2rem;">
+          {% include 'blog/newsletter-form.html' %}
+        </div>
+      </div>
+    </div>
+  </section>
+</article>
+
+{% for tag in tags %}
+  {% if tag.name == 'robotics' %}
+    <section class="p-strip--image is-dark"
+      style="background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);">
+      <div class="row">
+        <div class="col-8">
+          <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>
+          <p>
+            <a href="https://www.ubuntu.com/internet-of-things/contact-us?product=robotics" class="p-button--positive">
+              Contact Us
+            </a>
+          </p>
+        </div>
+        <div class="col-4 u-align--center u-vertically-center u-hide--small">
+          <img width="100" src="https://assets.ubuntu.com/v1/39ebd977-robot.svg" alt="" />
+        </div>
+      </div>
+    </section>
+  {% endif %}
+{% endfor %}
 
 {% if related_articles %}
-<section class="p-strip is-shallow">
+<section class="p-strip--light is-shallow">
   <div class="row">
-    <div class="col-12">
-      <h3>
-        Related posts
-      </h3>
+    <div class="col-8">
+      <h3>Related posts</h3>
     </div>
   </div>
   <div class="row p-divider">
@@ -28,7 +123,7 @@
           {{ related_article.title.rendered|safe }}
         </a>
       </h4>
-      <p>{{ related_article.excerpt.raw }}</p>
+      <p>{{ related_article.excerpt.raw|cut:"[…]"|truncatewords:36 }}</p>
     </div>
     {% endfor %}
   </div>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -32,7 +32,7 @@
             Share on:
           </li>
           <li class="p-inline-list__item">
-            <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer.php?s=100&amp;p[url]=https://www.ubuntu.com/blog/{{ article.slug }}&#9;&#9;&#9;&amp;p[title]={{ article.title.rendered | safe | urlencode }}&amp;p[summary]={{ article.excerpt.raw|cut:'[…]'|truncatewords:36|urlencode }}{% if article.image and article.image.source_url %}&amp;p[images][0]=https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}{% endif %}">
+            <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer/sharer.php?u=https://www.ubuntu.com/blog/{{ article.slug }}">
               Facebook
             </a>
           </li>

--- a/templates/blog/author.html
+++ b/templates/blog/author.html
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-8">
       <div class="p-media-object">
-        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% elif author.user_photo %}{{ author.user_photo }}{% else %}{{ author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
+        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
 
         <div class="p-media-object__details">
           <h1 class="p-media-object__title">

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -15,7 +15,9 @@
         <div class="row u-equal-height u-clearfix">
       {% endif %}
       {% if forloop.counter == 3 %}
-        {% include 'blog/newsletter-form.html' %}
+        <div class="col-4">
+          {% include 'blog/newsletter-form.html' %}
+        </div>
       {% elif forloop.counter <= 2 %}
         {% include 'blog/blog-card.html' with summary_visible=True %}
       {% else %}

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -1,90 +1,88 @@
-<div class="col-4" style="position: sticky; top: 2rem;">
-  <div class="blog-p-card--muted">
-    <header class="blog-p-card__header">
-      <h5 class="p-muted-heading u-no-margin--bottom">Newsletter signup</h5>
-    </header>
+<div class="blog-p-card--muted">
+  <header class="blog-p-card__header">
+    <h5 class="p-muted-heading u-no-margin--bottom">Newsletter signup</h5>
+  </header>
 
-    <div class="blog-p-card__content">
-      <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-        <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
-        
-        <ul class="p-list">
-          <li class="p-list__item u-no-margin--top u-clearfix">
-            <label>
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
-              <label for="insightscloudserver">Cloud and Server</label>
-            </label>
-          </li>
-
-          <li class="p-list__item u-no-margin--top u-clearfix">
-            <label>
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
-              <label for="insightsdesktop">Desktop</label>
-            </label>
-          </li>
-
-          <li class="p-list__item u-no-margin--top u-clearfix">
-            <label>
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
-              <label for="insightsiot">Internet of Things</label>
-            </label>
-          </li>
-
-          <li class="p-list__item u-no-margin--top u-clearfix">
-            <label>
-              <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
-              <label for="insightstutorials">Tutorials</label>
-            </label>
-          </li>
-        </ul>
-
-        <div class="mktFormReq mktField u-margin-medium--top">
+  <div class="blog-p-card__content">
+    <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+      <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
+      
+      <ul class="p-list">
+        <li class="p-list__item u-no-margin--top u-clearfix">
           <label>
-            <span class="u-no-margin--top">Work email: <span>*</span></span>
-            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+            <label for="insightscloudserver">Cloud and Server</label>
           </label>
-        </div>
+        </li>
 
-        <div class="mktField mktLblRight u-margin-medium--top">
-          <span class="mktInput mktLblRight">
-            <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
-            <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
-              <small>I agree to receive information about Canonical’s products and services.</small>
-            </label>
-            <span class="mktFormMsg"></span>
-          </span>
-        </div>
+        <li class="p-list__item u-no-margin--top u-clearfix">
+          <label>
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+            <label for="insightsdesktop">Desktop</label>
+          </label>
+        </li>
 
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+        <li class="p-list__item u-no-margin--top u-clearfix">
+          <label>
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+            <label for="insightsiot">Internet of Things</label>
+          </label>
+        </li>
 
-        <p class="u-margin-medium--top">
-          <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
-        </p>
+        <li class="p-list__item u-no-margin--top u-clearfix">
+          <label>
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+            <label for="insightstutorials">Tutorials</label>
+          </label>
+        </li>
+      </ul>
 
-        <div class="u-margin-medium--top">
-          <span class="mktoButtonWrap p-card--content">
-            <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
-          </span>
+      <div class="mktFormReq mktField u-margin-medium--top">
+        <label>
+          <span class="u-no-margin--top">Work email: <span>*</span></span>
+          <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+        </label>
+      </div>
 
-          <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-          
-          <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-          
-          <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-          
-          <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
-          <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-          <input type="hidden" name="ret" value="{{request.build_absolute_uri}}?newsletter=true" />
-          <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-          <input name="kw" value="" type="hidden">
-          <input name="cr" value="" type="hidden">
-          <input name="searchstr" value="" type="hidden">
-          <input name="_mkt_disp" value="return" type="hidden">
-          <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
-          <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
-        </div>
-      </form>
-    </div>
+      <div class="mktField mktLblRight u-margin-medium--top">
+        <span class="mktInput mktLblRight">
+          <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+          <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
+            <small>I agree to receive information about Canonical’s products and services.</small>
+          </label>
+          <span class="mktFormMsg"></span>
+        </span>
+      </div>
+
+      <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+
+      <p class="u-margin-medium--top">
+        <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
+      </p>
+
+      <div class="u-margin-medium--top">
+        <span class="mktoButtonWrap p-card--content">
+          <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
+        </span>
+
+        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+        
+        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
+        
+        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
+        
+        <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
+        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+        <input type="hidden" name="ret" value="{{request.build_absolute_uri}}?newsletter=true" />
+        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
+        <input name="kw" value="" type="hidden">
+        <input name="cr" value="" type="hidden">
+        <input name="searchstr" value="" type="hidden">
+        <input name="_mkt_disp" value="return" type="hidden">
+        <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+        <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
+      </div>
+    </form>
   </div>
 </div>
 

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,0 +1,68 @@
+{% if article.group and article.group.slug == "cloud" %}
+<div class="p-card" id="rtp-cloud">
+  <h3>
+    <a href="http://www.ubuntu.com/cloud" class="p-link--external">
+      Ubuntu cloud
+    </a>
+  </h3>
+  <p>
+    Ubuntu offers all the training, software infrastructure, tools,
+    services and support you need for your public and private clouds.
+  </p>
+</div>
+{% elif article.group and article.group.slug == "internet-of-things" %}
+<div class="p-card" id="rtp-iot">
+  <h3>
+    <a href="http://www.ubuntu.com/internet-of-things" class="p-link--external">
+      Internet of Things
+    </a>
+  </h3>
+  <p>
+    From home control to drones, robots and industrial systems, Ubuntu Core and Snaps provide robust security, app stores and reliable updates for all your IoT devices.
+  </p>
+</div>
+{% elif article.group and article.group.slug == "support" %}
+<div class="p-card" id="rtp-support">
+  <h3>
+    <a href="http://www.ubuntu.com/support" class="p-link--external">
+      Ubuntu Advantage support
+    </a>
+  </h3>
+  <p>
+    If you are running Ubuntu in your organisation, you should talk to us about getting Ubuntu Advantage support with Landscape management tools.
+  </p>
+</div>
+{% elif article.group and article.group.slug == "desktop" %}
+<div class="p-card" id="rtp-desktop">
+  <h3>
+    <a href="http://www.ubuntu.com/desktop" class="p-link--external">
+      Ubuntu desktop
+    </a>
+  </h3>
+  <p>
+    Learn how the Ubuntu desktop operating system powers millions of PCs and laptops around the world.
+  </p>
+</div>
+{% elif article.group and article.group.slug == "server" %}
+<div class="p-card" id="rtp-server">
+  <h3>
+    <a href="http://www.ubuntu.com/server" class="p-link--external">
+      Ubuntu Server
+    </a>
+  </h3>
+  <p>
+    The leading platform for scale-out computing, Ubuntu Server delivers the best value scale-out performance available.
+  </p>
+</div>
+{% else %}
+<div class="p-card" id="rtp-contact-us">
+  <h3>
+    <a href="https://www.ubuntu.com/about/contact-us/form" class="p-link--external">
+      Talk to us today
+    </a>
+  </h3>
+  <p>
+    Interested in running Ubuntu Desktop in your organisation?
+  </p>
+</div>
+{% endif %}

--- a/templates/blog/tag.html
+++ b/templates/blog/tag.html
@@ -1,0 +1,18 @@
+{% extends "templates/one-column.html" %}
+
+{% block content %}
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-8">
+        <h1 class="u-no-margin--bottom">{{ tag.name }}</h1>
+        <div id="rtp-banner" class="rtp-banner"></div>
+      </div>
+    </div>
+  </div>
+
+  <section class="p-strip is-shallow" id="posts-list">
+    {% include "blog/posts.html" %}
+  </section>
+
+  {% include "blog/pagination.html" %}
+{% endblock %}

--- a/webapp/context_processors.py
+++ b/webapp/context_processors.py
@@ -23,14 +23,18 @@ def navigation(request):
     path = request.path
     breadcrumbs = {}
     nav_sections = deepcopy(settings.NAV_SECTIONS)
-    is_topic_page = path.startswith("/blog/topics")
+    is_topic_page = path.startswith("/blog/topics/")
 
     for nav_section_name, nav_section in nav_sections.items():
+        # Persist parent navigation on child pages in certain cases
+        if nav_section.get("persist") and path.startswith(nav_section["path"]):
+            breadcrumbs["section"] = nav_section
+            breadcrumbs["children"] = nav_section.get("children", [])
+
         for child in nav_section["children"]:
-            if is_topic_page and child["path"] == ("/blog/topics"):
+            if is_topic_page and child["path"] == "/blog/topics":
+                # always show "Topics" as active on child topic pages
                 child["active"] = True
-                breadcrumbs["section"] = nav_section
-                breadcrumbs["children"] = nav_section.get("children", [])
                 break
             elif child["path"] == path:
                 child["active"] = True


### PR DESCRIPTION
## Done

- updated blog post template to match current blog e.g. https://blog.ubuntu.com/2019/04/09/speed-up-your-ros-snap-builds
- added tag template to match current blog e.g https://blog.ubuntu.com/tag/robotics

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog/speed-up-your-ros-snap-builds](http://0.0.0.0:8001/blog/speed-up-your-ros-snap-builds)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks and behaves similarly to https://blog.ubuntu.com/2019/04/09/speed-up-your-ros-snap-builds
- Click any of the tag links in the top of the page, and see that the page you then see looks and behaves similarly to https://blog.ubuntu.com/tag/robotics


## Issue / Card

Fixes #5250 

## Notes
The related posts section at the bottom of the page currently shows posts from multiple languages, this issue is being addressed [here](https://github.com/canonical-web-and-design/canonicalwebteam.blog/issues/71).
