### PR TITLE
Add Getting Started with AI takeover and landing page

### DIFF
--- a/templates/engage/451-automotive.html
+++ b/templates/engage/451-automotive.html
@@ -19,6 +19,12 @@
         <h4>
           Addressing risk and complexity with software
         </h4>
+        <br class="u-hide--medium u-hide--large">
+        <p class="u-hide--medium u-hide--large">
+          <a href="#register-section" class="p-button--neutral">
+            Watch the webinar
+          </a>
+        </p>
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">

--- a/templates/engage/ai-gettingstarted.html
+++ b/templates/engage/ai-gettingstarted.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="How to get started and progress with an AI program" meta_image="" meta_description="Whether you are just exploring the opportunities that AI can hold for your business or are preparing to deploy in production at scale join us to learn what you need to achieve your goals." %}
+{% extends_with_args "engage/base_engage.html" with title="How to get started and progress with an AI program" meta_image="https://assets.ubuntu.com/v1/dd0f6313-social+embedded.jpg" meta_description="Whether you are just exploring the opportunities that AI can hold for your business or are preparing to deploy in production at scale join us to learn what you need to achieve your goals." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1TOfGfuNOGfAjNQEPyOJ0G6JRznwsb-FUe4xL378CG0Q{% endblock meta_copydoc %}
 

--- a/templates/engage/ai-gettingstarted.html
+++ b/templates/engage/ai-gettingstarted.html
@@ -1,0 +1,61 @@
+{% extends_with_args "engage/base_engage.html" with title="How to get started and progress with an AI program" meta_image="" meta_description="Whether you are just exploring the opportunities that AI can hold for your business or are preparing to deploy in production at scale join us to learn what you need to achieve your goals." %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1TOfGfuNOGfAjNQEPyOJ0G6JRznwsb-FUe4xL378CG0Q{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip p-strip--dark p-takeover--ai">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center">
+      <div>
+      <h1 class="u-no-margin--bottom">
+        How to get started and progress with an AI program
+      </h1>
+      <br class="u-hide--medium u-hide--large">
+      <p class="u-hide--medium u-hide--large">
+        <a href="#register-section" class="p-button--neutral">
+          Watch the webinar
+        </a>
+      </p>
+      </div>
+    </div>
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}5fc06110-AI+illustration.svg" alt="image for getting started with ai" style="height: 160px;">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <p>
+        Whether you’re exploring what AI can do for your business and how to get started; have developed machine learning models you’re looking to deploy in production at scale; want to optimise your models for performance, audit your neural network for adversarial attacks or orchestrate your data pipelines, this webinar will provide an overview of what you need to achieve your goals.
+      </p>
+      <p>
+        With data often described as the new electricity powering the 4th industrial revolution, and many leading companies falling behind innovative newcomers, we will discuss how you can maximise the value of your data, and where to use transfer learning or find more data when needed to train models for accurate predictions.
+      </p>
+      <p>
+        In this webinar, you will learn which AI solutions are ready for production and for which applications. You will also learn about open-source state-of-the-art frameworks and pretrained models ready to be fine-tuned and deployed with minimal effort to realise your intelligent automation objectives. And you will learn about current advancements and limitations in a technology moving at an unprecedented pace, powered by big data, advanced algorithms and infinite cloud resources.
+      </p>
+      <p>
+        Next, we will cover MLOps, or how you can abstract your data scientists from the underlying infrastructure, and how to bridge the gap between researchers and DevOps engineers and offer orchestrated, scale-out resources to your users for training and inference.
+      </p>
+      <p>
+        Finally we’ll discuss how you can manage change and prepare for the impact to your people, and wrap up by listing available resources to bring your team up to speed, build your centre of competence and find help when you need it.
+      </p>
+    </div>
+  </div>
+  <style>
+    .p-takeover--ai {
+      background-image: linear-gradient(0deg, #48929B 0%, #2B585D 100%);
+    }
+  </style>
+</section>
+
+<section class="p-strip is-shallow" id="register-section">
+  <div class="row">
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 358706, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {# include "takeovers/_active-directory_takeover.html" #}
+  {% include "takeovers/_starting-with-ai-webinar_takeover.html" %}
   {% include "takeovers/_starting-with-ai-takeover.html" %}
   {% include "takeovers/_451-automotive_takeover.html" %}
   {% include "takeovers/_1904-webinar_takeover.html" %}

--- a/templates/takeovers/_starting-with-ai-webinar_takeover.html
+++ b/templates/takeovers/_starting-with-ai-webinar_takeover.html
@@ -1,0 +1,53 @@
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row u-clearfix u-vertically-center">
+    <div class="col-7">
+      <h1>
+        Getting started with AI
+      </h1>
+      <p class="p-heading--four u-sv2">
+        Get data-ready, plan your infrastructure and mobilise your teams.
+      </p>
+      <a
+        href="/engage/ai-gettingstarted?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_AI_WBN_GettingStartedWithAI"
+        class="u-hide--small p-button--neutral"
+        >Watch the webinar
+      </a>
+    </div>
+    <div class="col-5">
+      <p class="p-takeover__image u-align-text--center">
+        <img
+          src="{{ ASSET_SERVER_URL }}5fc06110-AI+illustration.svg"
+          alt=""
+        />
+      </p>
+      <p class="u-hide--medium u-hide--large">
+        <a
+          href="/engage/ai-gettingstarted?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_AI_WBN_GettingStartedWithAI"
+          class="p-button--neutral"
+          >Watch the webinar
+        </a>
+      </p>
+    </div>
+  </div>
+  <style>
+    .p-takeover {
+      background-image: url("{{ ASSET_SERVER_URL }}42b254a6-suru-fold.svg"),
+        linear-gradient(0deg, #48929B 0%, #2B585D 100%);
+      background-position: right;
+      background-repeat: no-repeat;
+      background-size: auto 100%, cover;
+    }
+    .p-takeover__image {
+      width: 300px;
+    }
+
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(0deg, #48929B 0%, #2B585D 100%);
+      }
+      .p-takeover__image {
+        width: 200px;
+      }
+    }
+  </style>
+</section>


### PR DESCRIPTION
## Done

- Add Getting Started with AI takeover and landing page
- Add mobile CTA to [/engage/451-automotive](http://0.0.0.0:8001/engage/451-automotive) landing page as it was missing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/), [/engage/451-automotive](http://0.0.0.0:8001/engage/451-automotive) and [/engage/ai-gettingstarted](http://0.0.0.0:8001/engage/ai-gettingstarted)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [brief](https://docs.google.com/document/d/1TOfGfuNOGfAjNQEPyOJ0G6JRznwsb-FUe4xL378CG0Q/edit#)
- Check design


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1220

