### PR TITLE
Load #get-in-touch form on button click

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -1,142 +1,36 @@
 (function () {
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('DOMContentLoaded', function () {
+    var formContainer = document.getElementById('contact-form-container');
     var triggeringHash = '#get-in-touch';
-    var contactIndex = 1;
-    var contactModal = document.getElementById("contact-modal");
     var contactButtons = document.querySelectorAll('.js-invoke-modal');
-    var closeModal = document.querySelector('.p-modal__close');
-    var closeModalButton = document.querySelector('.js-close');
-    var modalPaginationButtons = contactModal.querySelectorAll('.pagination a');
-    var paginationContent = contactModal.querySelectorAll('.js-pagination');
-    var submitButton = contactModal.querySelector('.mktoButton');
-    var inputs = contactModal.querySelectorAll('input, textarea');
-    var comment = contactModal.querySelector('#Comments_from_lead__c');
-    var otherContainers = document.querySelectorAll('.js-other-container');
 
-
-    contactButtons.forEach(function(contactButton) {
-      contactButton.addEventListener('click', function(e) {
+    contactButtons.forEach(function (contactButton) {
+      contactButton.addEventListener('click', function (e) {
         e.preventDefault();
-        setProductContext(contactButton);
+        fetchForm('/shared/forms/interactive/_support-openstack.html');
         open();
       });
     });
 
-    document.onkeydown = function(evt) {
-      evt = evt || window.event;
-      if (evt.keyCode == 27) {
-        close();
-      }
-    };
-
-    if (submitButton) {
-      closeModal.addEventListener('click', function(e) {
-        ga('send', 'event', 'interactive-forms', 'submitted', window.location.pathname);
-      });
-    }
-
-    if (closeModal) {
-      closeModal.addEventListener('click', function(e) {
-        e.preventDefault();
-        close();
-      });
-    }
-
-    if (closeModalButton) {
-      closeModalButton.addEventListener('click', function(e) {
-        e.preventDefault();
-        close();
-      });
-    }
-
-    if (contactModal) {
-      contactModal.addEventListener('click', function(e) {
-        if (e.target.id == 'contact-modal') {
-          e.preventDefault();
-          close();
-        }
-      });
-    }
-
-    modalPaginationButtons.forEach(function(modalPaginationButton) {
-      modalPaginationButton.addEventListener('click', function(e) {
-        e.preventDefault();
-        var button = e.target.closest('a');
-        var index = contactIndex;
-        if (button.classList.contains('pagination__link--previous')) {
-          index = index - 1;
-          setState(index);
-          ga('send', 'event', 'interactive-forms', 'goto:'+index, window.location.pathname);
-        } else {
-          index = index + 1;
-          setState(index);
-          ga('send', 'event', 'interactive-forms', 'goto:'+index, window.location.pathname);
-        }
-      });
-    });
-
-    otherContainers.forEach(function(otherContainer) {
-      var checkbox = otherContainer.querySelector('.js-other-container__checkbox');
-      var input = otherContainer.querySelector('.js-other-container__input');
-      checkbox.addEventListener('change', function(e) {
-        if (e.target.checked) {
-          input.style.opacity = 1;
-          input.focus();
-        } else {
-          input.style.opacity = 0;
-          input.value = '';
-        }
-      });
-    });
-
-    function setProductContext(contactButton) {
-      // Capture current path and stringify
-      // eg. /kubernetes/install -> kubernetes-install
-      // fallbacks to "global"
-      var product = window.location.pathname.split("/").slice(1).join("-") || "global";
-      // If present, override with product parameter from button URL
-      if (contactButton) {
-        contactButton.search.split("&").forEach(function(param) {
-          if (param.startsWith("product") || param.startsWith("?product")) {
-            product = param.split("=")[1];
-          }
-        });
-      }
-
-      // Set product in form field
-      var productContext = document.getElementById("product-context");
-      if (productContext) {
-        productContext.value = product;
-      }
-    }
-
-
-    // Hack for now but updates the styling based on the thank you panel
-    function checkThankYou() {
-      if (contactIndex == 4) {
-        contactModal.classList.add('thank-you');
-      } else {
-        contactModal.classList.remove('thank-you');
-      }
-    }
-
-    // Updates the index and renders the changes
-    function setState(index) {
-      contactIndex = index;
-      render();
-    }
-
-    // Close the modal and set the index back to the first stage
-    function close() {
-      setState(1);
-      contactModal.classList.add('u-hide');
-      updateHash('');
-      ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
+    // Fetch, load and initialise form
+    function fetchForm(url) {
+      fetch(url)
+        .then(function (response) {
+          return response.text();
+        })
+        .then(function (text) {
+          formContainer.classList.remove('u-hide');
+          formContainer.innerHTML = text;
+          initialiseForm();
+        })
+        .catch(function (error) {
+          console.log('Request failed', error)
+        })
     }
 
     // Open the contact us modal
     function open() {
-      contactModal.classList.remove('u-hide');
+      // contactModal.classList.remove('u-hide');
       updateHash(triggeringHash);
       ga('send', 'event', 'interactive-forms', 'open', window.location.pathname);
     }
@@ -153,75 +47,180 @@
       }
     }
 
-    // Update the content of the modal based on the current index
-    function render() {
-      checkThankYou();
+    function initialiseForm() {
+      var contactIndex = 1;
+      var contactModal = document.getElementById("contact-modal");
+      var closeModal = document.querySelector('.p-modal__close');
+      var closeModalButton = document.querySelector('.js-close');
+      var modalPaginationButtons = contactModal.querySelectorAll('.pagination a');
+      var paginationContent = contactModal.querySelectorAll('.js-pagination');
+      var submitButton = contactModal.querySelector('.mktoButton');
+      var inputs = contactModal.querySelectorAll('input, textarea');
+      var comment = contactModal.querySelector('#Comments_from_lead__c');
+      var otherContainers = document.querySelectorAll('.js-other-container');
 
-      comment.value = createMessage();
+      document.onkeydown = function (evt) {
+        evt = evt || window.event;
+        if (evt.keyCode == 27) {
+          close();
+        }
+      };
 
-      var currentContent = contactModal.querySelector('.js-pagination--'+contactIndex);
-      paginationContent.forEach(function(content) {
-        content.classList.add('u-hide');
-      });
-      currentContent.classList.remove('u-hide');
-    }
+      if (submitButton) {
+        closeModal.addEventListener('click', function (e) {
+          ga('send', 'event', 'interactive-forms', 'submitted', window.location.pathname);
+        });
+      }
 
-    // Concatinate the options selected into a string
-    function createMessage() {
-      var message = '';
+      if (closeModal) {
+        closeModal.addEventListener('click', function (e) {
+          e.preventDefault();
+          close();
+        });
+      }
 
-      var formFields = contactModal.querySelectorAll('.js-formfield');
-      formFields.forEach(function(formField) {
-        var comma = '';
-        var fieldTitle = formField.querySelector('.p-heading--five');
-        var inputs = formField.querySelectorAll('input, textarea');
-        message += fieldTitle.innerText + '\r\n';
+      if (closeModalButton) {
+        closeModalButton.addEventListener('click', function (e) {
+          e.preventDefault();
+          close();
+        });
+      }
 
-        inputs.forEach(function(input) {
-          switch (input.type) {
-            case 'radio':
-            if (input.checked) {
-              message += comma + input.value;
-              comma = ', ';
-            }
-            break;
-            case 'checkbox':
-            if (input.checked) {
-              var subSectionText = '';
-              var subSection = input.closest('[class*="col-"]').querySelector('.js-sub-section');
-              if (subSection) {
-                subSectionText = subSection.innerText + ': ';
-              }
-
-              var label = formField.querySelector('label[for='+input.id+']');
-              if (label) {
-                label = subSectionText + label.innerText;
-              } else {
-                label = input.id;
-              }
-              message += comma + label;
-              comma = ', ';
-            }
-            break;
-            case 'text':
-            if (!input.classList.contains('mktoField') && input.value !== '') {
-              message += comma + input.value;
-              comma = ', ';
-            }
-            break;
-            case 'textarea':
-            if (!input.classList.contains('mktoField') && input.value !== '') {
-              message += comma + input.value;
-              comma = ', ';
-            }
-            break;
+      if (contactModal) {
+        contactModal.addEventListener('click', function (e) {
+          if (e.target.id == 'contact-modal') {
+            e.preventDefault();
+            close();
           }
         });
-        message += '\r\n\r\n';
+      }
+
+      modalPaginationButtons.forEach(function (modalPaginationButton) {
+        modalPaginationButton.addEventListener('click', function (e) {
+          e.preventDefault();
+          var button = e.target.closest('a');
+          var index = contactIndex;
+          if (button.classList.contains('pagination__link--previous')) {
+            index = index - 1;
+            setState(index);
+            ga('send', 'event', 'interactive-forms', 'goto:' + index, window.location.pathname);
+          } else {
+            index = index + 1;
+            setState(index);
+            ga('send', 'event', 'interactive-forms', 'goto:' + index, window.location.pathname);
+          }
+        });
       });
 
-      return message;
-    }
+      otherContainers.forEach(function (otherContainer) {
+        var checkbox = otherContainer.querySelector('.js-other-container__checkbox');
+        var input = otherContainer.querySelector('.js-other-container__input');
+        checkbox.addEventListener('change', function (e) {
+          if (e.target.checked) {
+            input.style.opacity = 1;
+            input.focus();
+          } else {
+            input.style.opacity = 0;
+            input.value = '';
+          }
+        });
+      });
+
+      // Hack for now but updates the styling based on the thank you panel
+      function checkThankYou() {
+        if (contactIndex == 4) {
+          contactModal.classList.add('thank-you');
+        } else {
+          contactModal.classList.remove('thank-you');
+        }
+      }
+
+      // Updates the index and renders the changes
+      function setState(index) {
+        contactIndex = index;
+        render();
+      }
+
+      // Close the modal and set the index back to the first stage
+      function close() {
+        setState(1);
+        formContainer.classList.add('u-hide');
+        formContainer.removeChild(contactModal);
+        updateHash('');
+        ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
+      }
+
+      // Update the content of the modal based on the current index
+      function render() {
+        checkThankYou();
+
+        comment.value = createMessage();
+
+        var currentContent = contactModal.querySelector('.js-pagination--' + contactIndex);
+        paginationContent.forEach(function (content) {
+          content.classList.add('u-hide');
+        });
+        currentContent.classList.remove('u-hide');
+      }
+
+      // Concatinate the options selected into a string
+      function createMessage() {
+        var message = '';
+
+        var formFields = contactModal.querySelectorAll('.js-formfield');
+        formFields.forEach(function (formField) {
+          var comma = '';
+          var fieldTitle = formField.querySelector('.p-heading--five');
+          var inputs = formField.querySelectorAll('input, textarea');
+          message += fieldTitle.innerText + '\r\n';
+
+          inputs.forEach(function (input) {
+            switch (input.type) {
+              case 'radio':
+                if (input.checked) {
+                  message += comma + input.value;
+                  comma = ', ';
+                }
+                break;
+              case 'checkbox':
+                if (input.checked) {
+                  var subSectionText = '';
+                  var subSection = input.closest('[class*="col-"]').querySelector('.js-sub-section');
+                  if (subSection) {
+                    subSectionText = subSection.innerText + ': ';
+                  }
+
+                  var label = formField.querySelector('label[for=' + input.id + ']');
+                  if (label) {
+                    label = subSectionText + label.innerText;
+                  } else {
+                    label = input.id;
+                  }
+                  message += comma + label;
+                  comma = ', ';
+                }
+                break;
+              case 'text':
+                if (!input.classList.contains('mktoField') && input.value !== '') {
+                  message += comma + input.value;
+                  comma = ', ';
+                }
+                break;
+              case 'textarea':
+                if (!input.classList.contains('mktoField') && input.value !== '') {
+                  message += comma + input.value;
+                  comma = ', ';
+                }
+                break;
+            }
+          });
+          message += '\r\n\r\n';
+        });
+
+        return message;
+      }
+
+    };
 
     // Opens the form when the initial hash matches the trigger
     if (window.location.hash === triggeringHash) {

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -1,27 +1,31 @@
 (function () {
   document.addEventListener('DOMContentLoaded', function () {
-    var formContainer = document.getElementById('contact-form-container');
     var triggeringHash = '#get-in-touch';
+    var formContainer = document.getElementById('contact-form-container');
     var contactButtons = document.querySelectorAll('.js-invoke-modal');
 
     contactButtons.forEach(function (contactButton) {
       contactButton.addEventListener('click', function (e) {
         e.preventDefault();
-        fetchForm('/shared/forms/interactive/_support-openstack.html');
+        if (contactButton.dataset.formLocation) {
+          fetchForm(contactButton.dataset);
+        } else {
+          fetchForm(formContainer.dataset);
+        }
+        setProductContext(contactButton);
         open();
       });
     });
 
     // Fetch, load and initialise form
-    function fetchForm(url) {
-      fetch(url)
+    function fetchForm(formData) {
+      fetch(formData.formLocation)
         .then(function (response) {
           return response.text();
         })
         .then(function (text) {
           formContainer.classList.remove('u-hide');
-          text.replace('%% formid %%','1240');
-          formContainer.innerHTML = text;
+          formContainer.innerHTML = text.replace(/%% formid %%/g, formData.formId).replace(/%% lpId %%/g, formData.lpId).replace(/%% returnURL %%/g, formData.returnUrl).replace(/%% lpurl %%/g, formData.lpUrl);
           initialiseForm();
         })
         .catch(function (error) {
@@ -31,7 +35,6 @@
 
     // Open the contact us modal
     function open() {
-      // contactModal.classList.remove('u-hide');
       updateHash(triggeringHash);
       ga('send', 'event', 'interactive-forms', 'open', window.location.pathname);
     }
@@ -45,6 +48,27 @@
         } else {
           location.hash = hash;
         }
+      }
+    }
+
+    function setProductContext(contactButton) {
+      // Capture current path and stringify
+      // eg. /kubernetes/install -> kubernetes-install
+      // fallbacks to "global"
+      var product = window.location.pathname.split("/").slice(1).join("-") || "global";
+      // If present, override with product parameter from button URL
+      if (contactButton) {
+        contactButton.search.split("&").forEach(function (param) {
+          if (param.startsWith("product") || param.startsWith("?product")) {
+            product = param.split("=")[1];
+          }
+        });
+      }
+
+      // Set product in form field
+      var productContext = document.getElementById("product-context");
+      if (productContext) {
+        productContext.value = product;
       }
     }
 
@@ -145,11 +169,12 @@
       // Close the modal and set the index back to the first stage
       function close() {
         setState(1);
-        formContainer.classList.add('u-hide');
-        formContainer.removeChild(contactModal);
+        contactModal.classList.add('u-hide');
         updateHash('');
         ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
       }
+
+
 
       // Update the content of the modal based on the current index
       function render() {
@@ -220,15 +245,14 @@
 
         return message;
       }
+    }
 
-    };
 
     // Opens the form when the initial hash matches the trigger
     if (window.location.hash === triggeringHash) {
       setProductContext();
       open();
     }
-
 
     // Listens for hash changes and opens the form if it matches the trigger
     function locationHashChanged() {
@@ -240,3 +264,255 @@
     window.onhashchange = locationHashChanged;
   });
 })()
+
+
+
+// ###########################################################################################################################################################################################################################################
+
+
+
+// (function () {
+//   document.addEventListener('DOMContentLoaded', function () {
+//     var formContainer = document.getElementById('contact-form-container');
+//     var triggeringHash = '#get-in-touch';
+//     var contactButtons = document.querySelectorAll('.js-invoke-modal');
+
+//     contactButtons.forEach(function (contactButton) {
+//       contactButton.addEventListener('click', function (e) {
+//         e.preventDefault();
+//         if (contactButton.dataset.formLocation) {
+//           fetchForm(contactButton.dataset);
+//         } else {
+//           fetchForm(formContainer.dataset);
+//           console.log("Use default");
+//         }
+//         open();
+//       });
+//     });
+
+//     // Fetch, load and initialise form
+//     function fetchForm(formData) {
+//       fetch(formData.formLocation)
+//         .then(function (response) {
+//           return response.text();
+//         })
+//         .then(function (text) {
+//           formContainer.classList.remove('u-hide');
+//           formContainer.innerHTML = text.replace(/%% formid %%/g, formData.formId).replace(/%% lpId %%/g, formData.lpId).replace(/%% returnURL %%/g, formData.returnUrl).replace(/%% lpurl %%/g, formData.lpUrl);
+//           initialiseForm();
+//         })
+//         .catch(function (error) {
+//           console.log('Request failed', error)
+//         })
+//     }
+
+//     // Open the contact us modal
+//     function open() {
+//       updateHash(triggeringHash);
+//       ga('send', 'event', 'interactive-forms', 'open', window.location.pathname);
+//     }
+
+//     // Removes the triggering hash
+//     function updateHash(hash) {
+//       var location = window.location;
+//       if (location.hash !== hash || hash === '') {
+//         if ("pushState" in history) {
+//           history.pushState('', document.title, location.pathname + location.search + hash);
+//         } else {
+//           location.hash = hash;
+//         }
+//       }
+//     }
+
+//     function initialiseForm() {
+//       var contactIndex = 1;
+//       var contactModal = document.getElementById("contact-modal");
+//       var closeModal = document.querySelector('.p-modal__close');
+//       var closeModalButton = document.querySelector('.js-close');
+//       var modalPaginationButtons = contactModal.querySelectorAll('.pagination a');
+//       var paginationContent = contactModal.querySelectorAll('.js-pagination');
+//       var submitButton = contactModal.querySelector('.mktoButton');
+//       var inputs = contactModal.querySelectorAll('input, textarea');
+//       var comment = contactModal.querySelector('#Comments_from_lead__c');
+//       var otherContainers = document.querySelectorAll('.js-other-container');
+
+//       document.onkeydown = function (evt) {
+//         evt = evt || window.event;
+//         if (evt.keyCode == 27) {
+//           close();
+//         }
+//       };
+
+//       if (submitButton) {
+//         closeModal.addEventListener('click', function (e) {
+//           ga('send', 'event', 'interactive-forms', 'submitted', window.location.pathname);
+//         });
+//       }
+
+//       if (closeModal) {
+//         closeModal.addEventListener('click', function (e) {
+//           e.preventDefault();
+//           close();
+//         });
+//       }
+
+//       if (closeModalButton) {
+//         closeModalButton.addEventListener('click', function (e) {
+//           e.preventDefault();
+//           close();
+//         });
+//       }
+
+//       if (contactModal) {
+//         contactModal.addEventListener('click', function (e) {
+//           if (e.target.id == 'contact-modal') {
+//             e.preventDefault();
+//             close();
+//           }
+//         });
+//       }
+
+//       modalPaginationButtons.forEach(function (modalPaginationButton) {
+//         modalPaginationButton.addEventListener('click', function (e) {
+//           e.preventDefault();
+//           var button = e.target.closest('a');
+//           var index = contactIndex;
+//           if (button.classList.contains('pagination__link--previous')) {
+//             index = index - 1;
+//             setState(index);
+//             ga('send', 'event', 'interactive-forms', 'goto:' + index, window.location.pathname);
+//           } else {
+//             index = index + 1;
+//             setState(index);
+//             ga('send', 'event', 'interactive-forms', 'goto:' + index, window.location.pathname);
+//           }
+//         });
+//       });
+
+//       otherContainers.forEach(function (otherContainer) {
+//         var checkbox = otherContainer.querySelector('.js-other-container__checkbox');
+//         var input = otherContainer.querySelector('.js-other-container__input');
+//         checkbox.addEventListener('change', function (e) {
+//           if (e.target.checked) {
+//             input.style.opacity = 1;
+//             input.focus();
+//           } else {
+//             input.style.opacity = 0;
+//             input.value = '';
+//           }
+//         });
+//       });
+
+//       // Hack for now but updates the styling based on the thank you panel
+//       function checkThankYou() {
+//         if (contactIndex == 4) {
+//           contactModal.classList.add('thank-you');
+//         } else {
+//           contactModal.classList.remove('thank-you');
+//         }
+//       }
+
+//       // Updates the index and renders the changes
+//       function setState(index) {
+//         contactIndex = index;
+//         render();
+//       }
+
+//       // Close the modal and set the index back to the first stage
+//       function close() {
+//         setState(1);
+//         formContainer.classList.add('u-hide');
+//         formContainer.removeChild(contactModal);
+//         updateHash('');
+//         ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
+//       }
+
+//       // Update the content of the modal based on the current index
+//       function render() {
+//         checkThankYou();
+
+//         comment.value = createMessage();
+
+//         var currentContent = contactModal.querySelector('.js-pagination--' + contactIndex);
+//         paginationContent.forEach(function (content) {
+//           content.classList.add('u-hide');
+//         });
+//         currentContent.classList.remove('u-hide');
+//       }
+
+//       // Concatinate the options selected into a string
+//       function createMessage() {
+//         var message = '';
+
+//         var formFields = contactModal.querySelectorAll('.js-formfield');
+//         formFields.forEach(function (formField) {
+//           var comma = '';
+//           var fieldTitle = formField.querySelector('.p-heading--five');
+//           var inputs = formField.querySelectorAll('input, textarea');
+//           message += fieldTitle.innerText + '\r\n';
+
+//           inputs.forEach(function (input) {
+//             switch (input.type) {
+//               case 'radio':
+//                 if (input.checked) {
+//                   message += comma + input.value;
+//                   comma = ', ';
+//                 }
+//                 break;
+//               case 'checkbox':
+//                 if (input.checked) {
+//                   var subSectionText = '';
+//                   var subSection = input.closest('[class*="col-"]').querySelector('.js-sub-section');
+//                   if (subSection) {
+//                     subSectionText = subSection.innerText + ': ';
+//                   }
+
+//                   var label = formField.querySelector('label[for=' + input.id + ']');
+//                   if (label) {
+//                     label = subSectionText + label.innerText;
+//                   } else {
+//                     label = input.id;
+//                   }
+//                   message += comma + label;
+//                   comma = ', ';
+//                 }
+//                 break;
+//               case 'text':
+//                 if (!input.classList.contains('mktoField') && input.value !== '') {
+//                   message += comma + input.value;
+//                   comma = ', ';
+//                 }
+//                 break;
+//               case 'textarea':
+//                 if (!input.classList.contains('mktoField') && input.value !== '') {
+//                   message += comma + input.value;
+//                   comma = ', ';
+//                 }
+//                 break;
+//             }
+//           });
+//           message += '\r\n\r\n';
+//         });
+
+//         return message;
+//       }
+
+//     };
+
+//     // Opens the form when the initial hash matches the trigger
+//     if (window.location.hash === triggeringHash) {
+//       setProductContext();
+//       open();
+//     }
+
+
+//     // Listens for hash changes and opens the form if it matches the trigger
+//     function locationHashChanged() {
+//       if (window.location.hash === triggeringHash) {
+//         setProductContext();
+//         open();
+//       }
+//     }
+//     window.onhashchange = locationHashChanged;
+//   });
+// })()

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -20,6 +20,7 @@
         })
         .then(function (text) {
           formContainer.classList.remove('u-hide');
+          text.replace('%% formid %%','1240');
           formContainer.innerHTML = text;
           initialiseForm();
         })

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -8,17 +8,16 @@
       contactButton.addEventListener('click', function (e) {
         e.preventDefault();
         if (contactButton.dataset.formLocation) {
-          fetchForm(contactButton.dataset);
+          fetchForm(contactButton.dataset, contactButton);
         } else {
           fetchForm(formContainer.dataset);
         }
-        setProductContext(contactButton);
         open();
       });
     });
 
     // Fetch, load and initialise form
-    function fetchForm(formData) {
+    function fetchForm(formData, contactButton) {
       fetch(formData.formLocation)
         .then(function (response) {
           return response.text();
@@ -26,6 +25,7 @@
         .then(function (text) {
           formContainer.classList.remove('u-hide');
           formContainer.innerHTML = text.replace(/%% formid %%/g, formData.formId).replace(/%% lpId %%/g, formData.lpId).replace(/%% returnURL %%/g, formData.returnUrl).replace(/%% lpurl %%/g, formData.lpUrl);
+          setProductContext(contactButton);
           initialiseForm();
         })
         .catch(function (error) {
@@ -169,12 +169,11 @@
       // Close the modal and set the index back to the first stage
       function close() {
         setState(1);
-        contactModal.classList.add('u-hide');
+        formContainer.classList.add('u-hide');
+        formContainer.removeChild(contactModal);
         updateHash('');
         ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
       }
-
-
 
       // Update the content of the modal based on the current index
       function render() {
@@ -250,269 +249,17 @@
 
     // Opens the form when the initial hash matches the trigger
     if (window.location.hash === triggeringHash) {
-      setProductContext();
+      fetchForm(formContainer.dataset);
       open();
     }
 
     // Listens for hash changes and opens the form if it matches the trigger
     function locationHashChanged() {
       if (window.location.hash === triggeringHash) {
-        setProductContext();
+        fetchForm(formContainer.dataset);
         open();
       }
     }
     window.onhashchange = locationHashChanged;
   });
 })()
-
-
-
-// ###########################################################################################################################################################################################################################################
-
-
-
-// (function () {
-//   document.addEventListener('DOMContentLoaded', function () {
-//     var formContainer = document.getElementById('contact-form-container');
-//     var triggeringHash = '#get-in-touch';
-//     var contactButtons = document.querySelectorAll('.js-invoke-modal');
-
-//     contactButtons.forEach(function (contactButton) {
-//       contactButton.addEventListener('click', function (e) {
-//         e.preventDefault();
-//         if (contactButton.dataset.formLocation) {
-//           fetchForm(contactButton.dataset);
-//         } else {
-//           fetchForm(formContainer.dataset);
-//           console.log("Use default");
-//         }
-//         open();
-//       });
-//     });
-
-//     // Fetch, load and initialise form
-//     function fetchForm(formData) {
-//       fetch(formData.formLocation)
-//         .then(function (response) {
-//           return response.text();
-//         })
-//         .then(function (text) {
-//           formContainer.classList.remove('u-hide');
-//           formContainer.innerHTML = text.replace(/%% formid %%/g, formData.formId).replace(/%% lpId %%/g, formData.lpId).replace(/%% returnURL %%/g, formData.returnUrl).replace(/%% lpurl %%/g, formData.lpUrl);
-//           initialiseForm();
-//         })
-//         .catch(function (error) {
-//           console.log('Request failed', error)
-//         })
-//     }
-
-//     // Open the contact us modal
-//     function open() {
-//       updateHash(triggeringHash);
-//       ga('send', 'event', 'interactive-forms', 'open', window.location.pathname);
-//     }
-
-//     // Removes the triggering hash
-//     function updateHash(hash) {
-//       var location = window.location;
-//       if (location.hash !== hash || hash === '') {
-//         if ("pushState" in history) {
-//           history.pushState('', document.title, location.pathname + location.search + hash);
-//         } else {
-//           location.hash = hash;
-//         }
-//       }
-//     }
-
-//     function initialiseForm() {
-//       var contactIndex = 1;
-//       var contactModal = document.getElementById("contact-modal");
-//       var closeModal = document.querySelector('.p-modal__close');
-//       var closeModalButton = document.querySelector('.js-close');
-//       var modalPaginationButtons = contactModal.querySelectorAll('.pagination a');
-//       var paginationContent = contactModal.querySelectorAll('.js-pagination');
-//       var submitButton = contactModal.querySelector('.mktoButton');
-//       var inputs = contactModal.querySelectorAll('input, textarea');
-//       var comment = contactModal.querySelector('#Comments_from_lead__c');
-//       var otherContainers = document.querySelectorAll('.js-other-container');
-
-//       document.onkeydown = function (evt) {
-//         evt = evt || window.event;
-//         if (evt.keyCode == 27) {
-//           close();
-//         }
-//       };
-
-//       if (submitButton) {
-//         closeModal.addEventListener('click', function (e) {
-//           ga('send', 'event', 'interactive-forms', 'submitted', window.location.pathname);
-//         });
-//       }
-
-//       if (closeModal) {
-//         closeModal.addEventListener('click', function (e) {
-//           e.preventDefault();
-//           close();
-//         });
-//       }
-
-//       if (closeModalButton) {
-//         closeModalButton.addEventListener('click', function (e) {
-//           e.preventDefault();
-//           close();
-//         });
-//       }
-
-//       if (contactModal) {
-//         contactModal.addEventListener('click', function (e) {
-//           if (e.target.id == 'contact-modal') {
-//             e.preventDefault();
-//             close();
-//           }
-//         });
-//       }
-
-//       modalPaginationButtons.forEach(function (modalPaginationButton) {
-//         modalPaginationButton.addEventListener('click', function (e) {
-//           e.preventDefault();
-//           var button = e.target.closest('a');
-//           var index = contactIndex;
-//           if (button.classList.contains('pagination__link--previous')) {
-//             index = index - 1;
-//             setState(index);
-//             ga('send', 'event', 'interactive-forms', 'goto:' + index, window.location.pathname);
-//           } else {
-//             index = index + 1;
-//             setState(index);
-//             ga('send', 'event', 'interactive-forms', 'goto:' + index, window.location.pathname);
-//           }
-//         });
-//       });
-
-//       otherContainers.forEach(function (otherContainer) {
-//         var checkbox = otherContainer.querySelector('.js-other-container__checkbox');
-//         var input = otherContainer.querySelector('.js-other-container__input');
-//         checkbox.addEventListener('change', function (e) {
-//           if (e.target.checked) {
-//             input.style.opacity = 1;
-//             input.focus();
-//           } else {
-//             input.style.opacity = 0;
-//             input.value = '';
-//           }
-//         });
-//       });
-
-//       // Hack for now but updates the styling based on the thank you panel
-//       function checkThankYou() {
-//         if (contactIndex == 4) {
-//           contactModal.classList.add('thank-you');
-//         } else {
-//           contactModal.classList.remove('thank-you');
-//         }
-//       }
-
-//       // Updates the index and renders the changes
-//       function setState(index) {
-//         contactIndex = index;
-//         render();
-//       }
-
-//       // Close the modal and set the index back to the first stage
-//       function close() {
-//         setState(1);
-//         formContainer.classList.add('u-hide');
-//         formContainer.removeChild(contactModal);
-//         updateHash('');
-//         ga('send', 'event', 'interactive-forms', 'close', window.location.pathname);
-//       }
-
-//       // Update the content of the modal based on the current index
-//       function render() {
-//         checkThankYou();
-
-//         comment.value = createMessage();
-
-//         var currentContent = contactModal.querySelector('.js-pagination--' + contactIndex);
-//         paginationContent.forEach(function (content) {
-//           content.classList.add('u-hide');
-//         });
-//         currentContent.classList.remove('u-hide');
-//       }
-
-//       // Concatinate the options selected into a string
-//       function createMessage() {
-//         var message = '';
-
-//         var formFields = contactModal.querySelectorAll('.js-formfield');
-//         formFields.forEach(function (formField) {
-//           var comma = '';
-//           var fieldTitle = formField.querySelector('.p-heading--five');
-//           var inputs = formField.querySelectorAll('input, textarea');
-//           message += fieldTitle.innerText + '\r\n';
-
-//           inputs.forEach(function (input) {
-//             switch (input.type) {
-//               case 'radio':
-//                 if (input.checked) {
-//                   message += comma + input.value;
-//                   comma = ', ';
-//                 }
-//                 break;
-//               case 'checkbox':
-//                 if (input.checked) {
-//                   var subSectionText = '';
-//                   var subSection = input.closest('[class*="col-"]').querySelector('.js-sub-section');
-//                   if (subSection) {
-//                     subSectionText = subSection.innerText + ': ';
-//                   }
-
-//                   var label = formField.querySelector('label[for=' + input.id + ']');
-//                   if (label) {
-//                     label = subSectionText + label.innerText;
-//                   } else {
-//                     label = input.id;
-//                   }
-//                   message += comma + label;
-//                   comma = ', ';
-//                 }
-//                 break;
-//               case 'text':
-//                 if (!input.classList.contains('mktoField') && input.value !== '') {
-//                   message += comma + input.value;
-//                   comma = ', ';
-//                 }
-//                 break;
-//               case 'textarea':
-//                 if (!input.classList.contains('mktoField') && input.value !== '') {
-//                   message += comma + input.value;
-//                   comma = ', ';
-//                 }
-//                 break;
-//             }
-//           });
-//           message += '\r\n\r\n';
-//         });
-
-//         return message;
-//       }
-
-//     };
-
-//     // Opens the form when the initial hash matches the trigger
-//     if (window.location.hash === triggeringHash) {
-//       setProductContext();
-//       open();
-//     }
-
-
-//     // Listens for hash changes and opens the form if it matches the trigger
-//     function locationHashChanged() {
-//       if (window.location.hash === triggeringHash) {
-//         setProductContext();
-//         open();
-//       }
-//     }
-//     window.onhashchange = locationHashChanged;
-//   });
-// })()

--- a/templates/about/base_about.html
+++ b/templates/about/base_about.html
@@ -1,9 +1,16 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6c3hFbTVzdHB5SGs{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_generic_download" third_item="_further_reading" %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="2154" data-lp-id="1257" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -1,5 +1,7 @@
 {% extends "ai/base_ai.html" %} 
 
+{% load versioned_static  %}
+
 {% block title %}AI Consulting and Delivery{% endblock %} 
 {% block meta_description %}Consulting on artificial intelligence and machine learning for enterprise data analytics. Infrastructure for multi-cloud operations with Kubeflow, Tensorflow on Kubernetes.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#{% endblock meta_copydoc %}
@@ -295,6 +297,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubeflow.html" with  formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/ai/features.html
+++ b/templates/ai/features.html
@@ -1,5 +1,7 @@
 {% extends "ai/base_ai.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Canonical&rsquo;s AI and ML features{% endblock %}
 {% block meta_description %}Canonical Kubeflow on Ubuntu includes software-defined networking and storage options, architectural flexibility, and shared community-driven ops code independent of architecture.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1DT5nCRSJH-OkvDmlyKh6vVhofeHPHZJHTTBDNu44wCY/edit{% endblock meta_copydoc %}
@@ -183,6 +185,11 @@
   </div>
 </section>
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubeflow.html" with formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-features' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/ai/thank-you?product=ai-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -1,5 +1,7 @@
 {% extends "ai/base_ai.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}AI and Machine Learning on Ubuntu{% endblock %}
 {% block meta_description %}The default platform for Tensorflow and other AI/ML frameworks, with automatic hardware GPGPU acceleration on Ubuntu. Canonical provides training and K8s-based ML expertise.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1mJq8PxH8FVRVF9i1Xzh0f6M73eyjqZE4NaKYHRcRAKM/edit{% endblock meta_copydoc %}
@@ -205,6 +207,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubeflow.html" with formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -1,5 +1,7 @@
 {% extends "ai/base_ai.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Install Kubeflow yourself{% endblock %}
 {% block meta_description %}A step-by-step installation guide to Ubuntu OpenStack with Kubernetes and Kubeflow on bare metal servers.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1KVyyvZsDyrfoi5tK2m5SLWs9YuHg9hgqVz0c8cWHsf8/edit{% endblock meta_copydoc %}
@@ -108,6 +110,11 @@
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubeflow.html" with  formid='3231'  lpId='6279' returnURL='https://www.ubuntu.com/ai/thank-you?product=ai-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}The leading operating system for PCs, IoT devices, servers and the cloud{% endblock %}
 {% block extra_body_class %}homepage {% block takeover_body_class %}{% endblock takeover_body_class %}{% endblock extra_body_class %}
 
@@ -214,6 +216,10 @@
       }
     </script>
 
-    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="2154" data-lp-id="1257" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    </div>
+
+    <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
   {% endblock content %}
 {% endblock outer_content %}

--- a/templates/community/_base_community.html
+++ b/templates/community/_base_community.html
@@ -1,9 +1,16 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/10pxxjYNoTsQK8BbXPMEHRZuQQR8Kxv3O{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_generic_download" third_item="_further_reading" %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="2154" data-lp-id="1257" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/containers/base_containers.html
+++ b/templates/containers/base_containers.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/0B7On4yuSCsiPbnJ2bWpQbzhSVWc{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1964" data-lp-id="3828" data-return-url="https://www.ubuntu.com/containers/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -573,8 +573,12 @@ store for access to all the standard apps, or curate your own collection.</p>
 </style>
 <script src="{% versioned_static 'js/build/stickyNav.min.js' %}"></script>
 
-{% include "shared/forms/interactive/_embedded.html" with formid="1266" lpId="2166"  returnURL="https://www.ubuntu.com/core/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/desktop/base_desktop.html
+++ b/templates/desktop/base_desktop.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3UThna3NsNzNZSEU{% endblock meta_copydoc %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_general.html" with formid="1253" lpId="1409"  returnURL="https://www.ubuntu.com/desktop/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1253" data-lp-id="1409" data-return-url="https://www.ubuntu.com/desktop/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    </div>
+
+    <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/download/_base_download.html
+++ b/templates/download/_base_download.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3VE11eUc5LXNURS0yYjFyeU5FZDZHUQ{% endblock meta_copydoc %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    </div>
+
+    <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -672,9 +672,13 @@
 
 <script src="{% versioned_static 'js/build/stickyNav.min.js' %}"></script>
 
-{% include "shared/forms/interactive/_embedded.html" with formid="1266" lpId="2166"  returnURL="https://www.ubuntu.com/core/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}
 

--- a/templates/esm/base_esm.html
+++ b/templates/esm/base_esm.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/0B73pr1ianygAZDBnTEZnZURwcUE{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -1,5 +1,7 @@
 {% extends "templates/one-column.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Financial services{% endblock %}
 {% block meta_description %}With evolving regulations, growing security threats and increasing costs – plus the emergence of game-changing new technologies like AI and Blockchain – the finance world needs practical solutions, now more than ever.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1o9s_MFaiZZIS26tusRi0ALNrcqUihhTSZgxS55oHZj4/edit{% endblock meta_copydoc %}
@@ -236,6 +238,11 @@
   </div>
 </section>
 
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
+
 {% endblock content %}
 
-{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -1,5 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}White label app store for IOT | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}For cloud based and enterprise IoT app stores, control, manage and monetise software deployments on your connected Linux devices.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit{% endblock meta_copydoc %}
@@ -248,8 +250,12 @@
   </div>
 </section>
 
-{% include "shared/forms/interactive/_embedded.html" with formid="2639" lpId="5811" returnURL="https://ubuntu.com/internet-of-things/thank-you?product=appstore" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="2639" data-lp-id="5811" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=appstore" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -1,5 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Digital signage | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}With hundreds of thousands of devices deployed the world over, Ubuntu Core is the perfect robust, reliable and secure OS for the digital signage sector.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit{% endblock meta_copydoc %}
@@ -210,8 +212,12 @@
   </div>
 </div>
 
-{% include "shared/forms/interactive/_embedded.html" with formid="1422" lpId="2166" returnURL="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1422" data-lp-id="2166" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -1,5 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Gateways | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}Ubuntu Core is the perfect robust, reliable and secure OS host for the edge gateways and it&rsquo;s deployment.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1hQon1vuYPDg_GojABIwbp2gFBkE2WApZTZJGT3yUdLU/edit{% endblock meta_copydoc %}
@@ -181,6 +183,12 @@
   </div>
 </section>
 
-{% include "shared/forms/interactive/_embedded.html" with formid="1663" lpId="3143" returnURL="https://ubuntu.com/internet-of-things/thank-you?product=gateways" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %} 
 
-{% include "shared/contextual_footers/_contextual_footer.html" with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %} {% endblock content %}
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=gateways" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
+
+{% endblock content %}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -1,5 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Ubuntu for the Internet of Things{% endblock %}
 {% block meta_description %}From home control to drones, robots and industrial systems, Ubuntu Core provides robust security, app stores and reliable updates for all your IoT devices.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit{% endblock meta_copydoc %}
@@ -211,8 +213,12 @@
   </div>
 </div>
 
-{% include "shared/forms/interactive/_embedded.html" with formid="1266" lpId="2551" returnURL="https://ubuntu.com/internet-of-things/thank-you?product=iot" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -1,5 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Robotics | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}With hundreds of thousands of drones and robots deployed the world over, Ubuntu Core is the perfect robust, reliable and secure OS for the robotics sector. {% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1g8XpVzDkAdFETrfZvOf5Q6WlYwHCBYQ8Y6TgTlyTEYc/edit{% endblock meta_copydoc %}
@@ -145,8 +147,12 @@
   </div>
 </div>
 
-{% include "shared/forms/interactive/_robotics.html" with formid="1650" lpId="2838" returnURL="http://ubuntu.com/internet-of-things/thank-you?product=robotics" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
-
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_robotics.html" data-form-id="1650" data-lp-id="2838" data-return-url="http://ubuntu.com/internet-of-things/thank-you?product=robotics" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -1,5 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Charmed Kubernetes features{% endblock %}
 {% block meta_description %}Ubuntu K8s gives you the flexibility to place your services exactly where you want them while sharing operational code with a large community.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit{% endblock meta_copydoc %}
@@ -174,6 +176,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,5 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Multi-cloud Kubernetes on Ubuntu{% endblock %}
 
 {% block meta_description %}Ubuntu and Canonical deliver a pure upstream K8s experience, tested across a wide range of multi-cloud architectures for optimum Kubernetes performance and integrated with modern metrics and monitoring.{% endblock meta_description %}
@@ -321,6 +323,11 @@
   </section>
 
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
-  {% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
   {% endblock content %}

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -1,5 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Install Charmed Kubernetes{% endblock %}
 {% block meta_description %}A step-by-step installation guide to Kubernetes on your software defined infrastructure.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1oiD6UUomf2daZitS3UOosujYBXPbiOMzPtXVZBq-ph0/edit{% endblock meta_copydoc %}
@@ -163,6 +165,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_ubuntu_advantage" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -1,5 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Managed Kubernetes | Kubernetes{% endblock %}
 {% block meta_description %}Canonical is the leading managed private cloud provider. We will build, support and manage your Kubernetes private cloud for only $5-15 per server per day.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/15jzhasokjH5Ql9Za56ZxRknXNNhEXYdIFXXtLODGxns/edit#heading=h.q9m33avd7enn{% endblock meta_copydoc %}
@@ -402,7 +404,12 @@
     </div>
   </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
+  {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -1,5 +1,7 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Charmed Kubernetes Partners{% endblock %}
 {% block meta_description %}Canonical’s Kubernetes partners provide regional consulting and operations, hosting, and third-party technology for storage, networking, monitoring and chargeback to the Charmed Kubernetes and OpenStack ecosystem.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit{% endblock meta_copydoc %}
@@ -66,6 +68,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_containers_juju" second_item="_cloud_lxd" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_kubernetes.html" with formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html"  %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/livepatch/base_livepatch.html
+++ b/templates/livepatch/base_livepatch.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/1jDMjzaftyp7CJbYMSNqKMWzQISffvKGu{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Consulting | OpenStack{% endblock %}
 {% block meta_description %}Private Cloud Build is a service that builds, supports and manages your cloud for you.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit{% endblock meta_copydoc %}
@@ -232,6 +234,11 @@
   </section>
 
   {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
-  {% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Features | OpenStack{% endblock %}
 {% block meta_description %}Canonical OpenStack on Ubuntu includes software-defined networking and storage options, architectural flexibility and shared community-driven ops code independent of architecture.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit{% endblock meta_copydoc %}
@@ -347,6 +349,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}OpenStack on Ubuntu is your scalable private cloud, by Canonical{% endblock %}
 {% block meta_description %}Ubuntu OpenStack is the most trusted and economical way to build your private OpenStack cloud. Supported or fully managed by Canonical.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit{% endblock meta_copydoc %}
@@ -306,6 +308,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_ubuntu_advantage" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Install | OpenStack | Ubuntu{% endblock %}
 {% block meta_description %}A step-by-step installation guide to Ubuntu OpenStack on bare metal servers.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit{% endblock meta_copydoc %}
@@ -397,7 +399,12 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_cloud_bootstack" second_item="_download_cloud_buy_landscape" third_item="_download_documentation" %}
-{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 
 {% endblock content %}

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -542,6 +542,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_bootstack.html" with formid="1128" lpId="1646" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_bootstack.html" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/openstack/partners.html
+++ b/templates/openstack/partners.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Partners | OpenStack{% endblock %}
 {% block meta_description %}Canonical partners with a wide range of cloud vendors, offering engineering assistance, support and ongoing quality assurance to the ecosystem that is fast developing around Ubuntu and OpenStack.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1J2AxzOkFgkXyV7C7VO7ZJ0urzbEtrqRYCRt1SL64f3I/edit{% endblock meta_copydoc %}
@@ -70,6 +72,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Ubuntu Advantage Storage | OpenStack{% endblock %}
 {% block meta_description %}Canonical includes proven software-defined storage - Ceph, NexentaEdge, Swift and SwiftStack, in a 24x7 supported OpenStack with pay-for-what-you-use metered pricing options.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1iw2SWNmoj4GZ2pUh0yB8gbtVXK0oXfyEaXT44bQbPlI/edit{% endblock meta_copydoc %}
@@ -102,6 +104,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_openstack.html" with formid="1233" lpId="2001" returnURL="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1233" data-lp-id="2001" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/openstack/training.html
+++ b/templates/openstack/training.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Training | OpenStack{% endblock %}
 {% block meta_description %}Canonical run OpenStack, Kubernetes and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
@@ -231,9 +233,12 @@
     </div>
   </div>
 </section>
-{% include "shared/forms/interactive/_openstack.html" with formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
-{% include "shared/forms/interactive/_openstack.html" with lpId="2086" formid="1251" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}
 {% endblock outer_content %}

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -1,5 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}What is Openstack | OpenStack{% endblock %}
 {% block meta_description %}OpenStack is an open source cloud computing platform that allows businesses to control large pools of compute, storage and networking in a data centre.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit{% endblock meta_copydoc %}
@@ -116,6 +118,11 @@
 </section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_ubuntu_advantage" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_openstack.html" with formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you' lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -1,5 +1,7 @@
 {% extends "pricing/base_pricing.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Consulting{% endblock %}
 {% block meta_description %}Open Infrastructure training and consulting on openstack, kubernetes and kubeflow. Learn how to design, deploy and operate open infrastructure at scale.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY{% endblock meta_copydoc %}
@@ -21,7 +23,7 @@
       {% include "shared/pricing/_openstack-packages.html" with columns='2' %}
     </div>
     <div class="row">
-      <a href="/support/contact-us?product=openstack" class="js-invoke-modal p-button--positive">Get in touch</a>
+      <a href="/support/contact-us?product=openstack" data-formid="1240" data-lpId="2065" data-returnURL="https://www.ubuntu.com/support/thank-you" data-lpurl="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">Get in touch</a>
     </div>
   </section>
 
@@ -40,6 +42,12 @@
   </section>
 
   {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
+
+  <div class="u-hide" id="contact-form-container">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
+
   {% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
 
 {% endblock content %}

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -49,6 +49,4 @@
 
   <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
-  {# include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" #}
-
 {% endblock content %}

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -23,7 +23,7 @@
       {% include "shared/pricing/_openstack-packages.html" with columns='2' %}
     </div>
     <div class="row">
-      <a href="/support/contact-us?product=openstack" data-formid="1240" data-lpId="2065" data-returnURL="https://www.ubuntu.com/support/thank-you" data-lpurl="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">Get in touch</a>
+      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">Get in touch</a>
     </div>
   </section>
 
@@ -42,12 +42,13 @@
   </section>
 
   {% include "shared/contextual_footers/_contextual_footer.html" with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
-
-  <div class="u-hide" id="contact-form-container">
+  
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
-  {% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+  {# include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" #}
 
 {% endblock content %}

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -1,5 +1,7 @@
 {% extends "pricing/base_pricing.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Pricing{% endblock %}
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1iOM6oBqsTkptsst3yG-U3sGaYLQqs27go_8yJQdhMBE{% endblock meta_copydoc %}
@@ -58,6 +60,10 @@
     </div>
   </section>
 
-  {% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+  <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -1,5 +1,7 @@
 {% extends "pricing/base_pricing.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Ubuntu Advantage Infrastructure | plans and pricing{% endblock %}
 
 {% block meta_description %}Canonical provides infrastructure solutions - OpenStack and Kubernetes training, consulting and managed services, and enterprise-grade support with a single subscription for open source software and security.{% endblock %}
@@ -83,7 +85,11 @@
   </div>
 </section>
 
-{% include "shared/forms/interactive/_pricing-infra.html" with formid="1240" lpId="2065"  returnURL="https://www.ubuntu.com/pricing/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_pricing-infra.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}
 {% block footer_extra %}{% endblock footer_extra %}

--- a/templates/public-cloud/_base_public-cloud.html
+++ b/templates/public-cloud/_base_public-cloud.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/1Clp1XT2Mp6HNIX8Rklu0UXQpMpUoaym5{% endblock meta_copydoc %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    </div>
+
+    <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/rfp/_base_rfp.html
+++ b/templates/rfp/_base_rfp.html
@@ -1,8 +1,14 @@
 {% extends "templates/base.html" %}
 
+{% load versioned_static  %}
+
 {% block meta_copydoc %}https://drive.google.com/drive/folders/1jDMjzaftyp7CJbYMSNqKMWzQISffvKGu{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  {% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    </div>
+
+    <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 {% endblock %}

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -1,5 +1,7 @@
 {% extends "templates/one-column.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Canonical security certifications{% endblock %}
 {% block meta_description %}Technical details on all of the security certifications for Ubuntu Advantage subscribers.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1CiF-dPqG1Y--h4FWfgKB1ft4G3nC2Boa8NT_JG7D6dQ/edit#{% endblock meta_copydoc %}
@@ -114,7 +116,12 @@
   </div>
 </section>
 
-{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_security_discussion" second_item="_security_esm" third_item="_security_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -1,5 +1,7 @@
 {% extends "templates/one-column.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Security{% endblock %}
 {% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit{% endblock meta_copydoc %}
@@ -295,7 +297,12 @@
   </div>
 </section>
 
-{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_security_discussion" second_item="_security_esm" third_item="_security_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -1,5 +1,7 @@
 {% extends "server/base_server.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Ubuntu Server and hyperscale | Server{% endblock %}
 {% block meta_description %}Unlock the promise of new extreme low-energy server technology{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1f56CCzH519lIVa4KvxDt0QpxYFMK-bMdVlKo4TvPSIk/edit{% endblock meta_copydoc %}
@@ -205,6 +207,11 @@
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
-{% include "shared/forms/interactive/_support.html" with formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -1,5 +1,7 @@
 {% extends "server/base_server.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Ubuntu Server - for scale out workloads{% endblock %}
 {% block meta_description %}Secure, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit{% endblock meta_copydoc %}
@@ -306,6 +308,10 @@
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
 
-{% include "shared/forms/interactive/_support.html" with formid="1254"   lpId="2152"  returnURL="https://www.ubuntu.com/server/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -297,7 +295,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -330,17 +328,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -370,5 +368,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -149,7 +147,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -182,17 +180,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -222,5 +220,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -182,7 +180,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -215,17 +213,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -256,4 +254,3 @@
   </div>
 </div>
 
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -132,7 +130,7 @@
       <h3 class="p-heading--five">How should we stay in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -165,17 +163,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -205,5 +203,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -213,7 +211,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -246,17 +244,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -286,5 +284,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_openstack.html
+++ b/templates/shared/forms/interactive/_openstack.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -299,7 +297,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -332,17 +330,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -372,5 +370,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -154,7 +152,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -186,17 +184,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -226,5 +224,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_robotics.html
+++ b/templates/shared/forms/interactive/_robotics.html
@@ -1,6 +1,4 @@
-{% load versioned_static  %}
-
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
@@ -166,7 +164,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -199,17 +197,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
@@ -239,5 +237,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -1,0 +1,739 @@
+<div class="p-modal" id="contact-modal">
+  <div
+    class="p-modal__dialog"
+    role="dialog"
+    aria-labelledby="modal-title"
+    aria-describedby="modal-description"
+  >
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button
+        class="p-modal__close"
+        aria-label="Close active modal"
+        style="margin-left: -1rem"
+      >
+        Close
+      </button>
+      <hr />
+      <h2 class="p-modal__title" id="modal-title">
+        Accelerate your OpenStack project
+      </h2>
+      <p>
+        Tell us about your project so we bring the right team to the
+        conversation.
+      </p>
+    </header>
+
+    <div class="js-pagination js-pagination--1">
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Where do you want your OpenStack?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input
+              type="radio"
+              id="where-Own-data-center"
+              name="openstack-where"
+              value="Our own data center"
+            />
+            <label for="where-Own-data-center">Our own data center</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input
+              type="radio"
+              id="where-My-hosting-company"
+              name="openstack-where"
+              value="My hosting company"
+            />
+            <label for="where-My-hosting-company">My hosting company</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input
+              type="radio"
+              id="where-Any-hosting-company"
+              name="openstack-where"
+              value="Any hosting company"
+            />
+            <label for="where-Any-hosting-company">Any hosting company</label>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">
+          What are priority workloads and use cases?
+        </h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="priority-workloads-High-availability" />
+            <label for="priority-workloads-High-availability"
+              >High availability</label
+            >
+            <input type="checkbox" id="priority-workloads-High-performance" />
+            <label for="priority-workloads-High-performance"
+              >High performance</label
+            >
+            <input type="checkbox" id="priority-workloads-Multi-region" />
+            <label for="priority-workloads-Multi-region">Multi-region</label>
+            <input type="checkbox" id="priority-workloads-Multi-cloud" />
+            <label for="priority-workloads-Multi-cloud">Multi-cloud</label>
+            <input type="checkbox" id="priority-workloads-Disaster-recovery" />
+            <label for="priority-workloads-Disaster-recovery"
+              >Disaster recovery</label
+            >
+            <input type="checkbox" id="priority-workloads-Encryption-at-rest" />
+            <label for="priority-workloads-Encryption-at-rest"
+              >Encryption at rest</label
+            >
+            <input type="checkbox" id="priority-workloads-FedRAMP" />
+            <label for="priority-workloads-FedRAMP">FedRAMP</label>
+            <input type="checkbox" id="priority-workloads-PCI-DSS" />
+            <label for="priority-workloads-PCI-DSS">PCI-DSS</label>
+            <input type="checkbox" id="priority-workloads-FIPS" />
+            <label for="priority-workloads-FIPS">FIPS</label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="priority-workloads-Kubernetes" />
+            <label for="priority-workloads-Kubernetes">Kubernetes</label>
+            <input type="checkbox" id="priority-workloads-Enterprise-Apps" />
+            <label for="priority-workloads-Enterprise-Apps"
+              >Enterprise Apps</label
+            >
+            <input type="checkbox" id="priority-workloads-Telco-NFV" />
+            <label for="priority-workloads-Telco-NFV">Telco NFV</label>
+            <input type="checkbox" id="priority-workloads-Databases" />
+            <label for="priority-workloads-Databases">Databases</label>
+            <input type="checkbox" id="priority-workloads-HPC" />
+            <label for="priority-workloads-HPC">HPC</label>
+            <input type="checkbox" id="priority-workloads-Messaging" />
+            <label for="priority-workloads-Messaging">Messaging</label>
+            <input type="checkbox" id="priority-workloads-Web-apps" />
+            <label for="priority-workloads-Web-apps">Web apps</label>
+            <input type="checkbox" id="priority-workloads-Service-catalog" />
+            <label for="priority-workloads-Service-catalog"
+              >Service catalog</label
+            >
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="priority-workloads-Dev-and-test" />
+            <label for="priority-workloads-Dev-and-test">Dev and test</label>
+            <input type="checkbox" id="priority-workloads-CI-CD" />
+            <label for="priority-workloads-CI-CD">CI/CD</label>
+            <input type="checkbox" id="priority-workloads-Build-farm" />
+            <label for="priority-workloads-Build-farm">Build farm</label>
+            <input type="checkbox" id="priority-workloads-Containers" />
+            <label for="priority-workloads-Containers">Containers</label>
+            <input type="checkbox" id="priority-workloads-VDI" />
+            <label for="priority-workloads-VDI">VDI</label>
+            <input type="checkbox" id="priority-workloads-LDAP" />
+            <label for="priority-workloads-LDAP">LDAP</label>
+            <input type="checkbox" id="priority-workloads-AD" />
+            <label for="priority-workloads-AD">AD</label>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <input type="checkbox" id="priority-workloads-Data-lake" />
+            <label for="priority-workloads-Data-lake">Data lake</label>
+            <input type="checkbox" id="priority-workloads-Hadoop" />
+            <label for="priority-workloads-Hadoop">Hadoop</label>
+            <input type="checkbox" id="priority-workloads-Spark" />
+            <label for="priority-workloads-Spark">Spark</label>
+            <input type="checkbox" id="priority-workloads-Analytics" />
+            <label for="priority-workloads-Analytics">Analytics</label>
+            <input type="checkbox" id="priority-workloads-ETL" />
+            <label for="priority-workloads-ETL">ETL</label>
+            <div class="js-other-container u-align--bottom">
+              <input
+                type="checkbox"
+                class="js-other-container__checkbox"
+                id="priority-workloads-other"
+              />
+              <label for="priority-workloads-other">Other</label>
+              <input
+                type="text"
+                id="priority-workloads-other-specified"
+                class="js-other-container__input"
+                placeholder="Please specify"
+                style="opacity: 0; margin-top: .25rem;"
+                aria-label="Other Board"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">What are your platform preferences?</h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-3 u-sv3 u-align">
+            <p class="js-sub-section">Architecture</p>
+            <input
+              type="checkbox"
+              id="platform-preferences-Architecture-Intel"
+            />
+            <label for="platform-preferences-Architecture-Intel">Intel</label>
+            <input type="checkbox" id="platform-preferences-Architecture-ARM" />
+            <label for="platform-preferences-Architecture-ARM">ARM</label>
+            <input
+              type="checkbox"
+              id="platform-preferences-Architecture-POWER"
+            />
+            <label for="platform-preferences-Architecture-POWER">POWER</label>
+            <input type="checkbox" id="platform-preferences-Architecture-Z" />
+            <label for="platform-preferences-Architecture-Z">Z</label>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <p class="js-sub-section">Servers</p>
+            <input
+              type="checkbox"
+              id="platform-preferences-Servers-Undecided"
+            />
+            <label for="platform-preferences-Servers-Undecided"
+              >Undecided</label
+            >
+            <input type="checkbox" id="platform-preferences-Servers-Dell" />
+            <label for="platform-preferences-Servers-Dell">Dell</label>
+            <input type="checkbox" id="platform-preferences-Servers-HP" />
+            <label for="platform-preferences-Servers-HP">HP</label>
+            <input type="checkbox" id="platform-preferences-Servers-Lenovo" />
+            <label for="platform-preferences-Servers-Lenovo">Lenovo</label>
+            <input
+              type="checkbox"
+              id="platform-preferences-Servers-Supermicro"
+            />
+            <label for="platform-preferences-Servers-Supermicro"
+              >Supermicro</label
+            >
+            <input
+              type="checkbox"
+              id="platform-preferences-Servers-Intel-Select"
+            />
+            <label for="platform-preferences-Servers-Intel-Select"
+              >Intel Select</label
+            >
+            <input type="checkbox" id="platform-preferences-Servers-Cisco" />
+            <label for="platform-preferences-Servers-Cisco">Cisco</label>
+            <div class="js-other-container u-align--bottom">
+              <input
+                type="checkbox"
+                class="js-other-container__checkbox"
+                id="platform-preferences-Servers-other"
+              />
+              <label for="platform-preferences-Servers-other">Other</label>
+              <input
+                type="text"
+                id="platform-preferences-Servers-other-specified"
+                class="js-other-container__input"
+                placeholder="Please specify"
+                style="opacity: 0; margin-top: .25rem;"
+                aria-label="Other Board"
+              />
+            </div>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <p class="js-sub-section">Networking</p>
+            <input type="checkbox" id="platform-preferences-Networking-Cisco" />
+            <label for="platform-preferences-Networking-Cisco">Cisco</label>
+            <input
+              type="checkbox"
+              id="platform-preferences-Networking-Juniper"
+            />
+            <label for="platform-preferences-Networking-Juniper">Juniper</label>
+            <input
+              type="checkbox"
+              id="platform-preferences-Networking-Arista"
+            />
+            <label for="platform-preferences-Networking-Arista">Arista</label>
+            <input type="checkbox" id="platform-preferences-Networking-Dell" />
+            <label for="platform-preferences-Networking-Dell">Dell</label>
+            <input
+              type="checkbox"
+              id="platform-preferences-Networking-Mellanox"
+            />
+            <label for="platform-preferences-Networking-Mellanox"
+              >Mellanox</label
+            >
+            <input
+              type="checkbox"
+              id="platform-preferences-Networking-Whitebox"
+            />
+            <label for="platform-preferences-Networking-Whitebox"
+              >Whitebox</label
+            >
+            <div class="js-other-container u-align--bottom">
+              <input
+                type="checkbox"
+                class="js-other-container__checkbox"
+                id="platform-preferences-Networking-other"
+              />
+              <label for="platform-preferences-Networking-other">Other</label>
+              <input
+                type="text"
+                id="platform-preferences-Networking-other-specified"
+                class="js-other-container__input"
+                placeholder="Please specify"
+                style="opacity: 0; margin-top: .25rem;"
+                aria-label="Other Board"
+              />
+            </div>
+          </div>
+          <div class="col-3 u-sv3 u-align">
+            <p class="js-sub-section">Storage</p>
+            <input
+              type="checkbox"
+              id="platform-preferences-Storage-Commodity"
+            />
+            <label for="platform-preferences-Storage-Commodity"
+              >Commodity</label
+            >
+            <input type="checkbox" id="platform-preferences-Storage-NetApp" />
+            <label for="platform-preferences-Storage-NetApp">NetApp</label>
+            <input type="checkbox" id="platform-preferences-Storage-EMC" />
+            <label for="platform-preferences-Storage-EMC">EMC</label>
+            <input
+              type="checkbox"
+              id="platform-preferences-Storage-PureStorage"
+            />
+            <label for="platform-preferences-Storage-PureStorage"
+              >PureStorage</label
+            >
+            <div class="js-other-container u-align--bottom">
+              <input
+                type="checkbox"
+                class="js-other-container__checkbox"
+                id="platform-preferences-Storage-other"
+              />
+              <label for="platform-preferences-Storage-other">Other</label>
+              <input
+                type="text"
+                id="platform-preferences-Storage-other-specified"
+                class="js-other-container__input"
+                placeholder="Please specify"
+                style="opacity: 0; margin-top: .25rem;"
+                aria-label="Other Board"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <div class="js-formfield">
+        <h3 class="p-heading--five">
+          Which OpenStack capabilities matter to you?
+        </h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="openstack-capabilities-KVM" />
+            <label for="openstack-capabilities-KVM">KVM</label>
+            <input type="checkbox" id="openstack-capabilities-LXD" />
+            <label for="openstack-capabilities-LXD">LXD</label>
+            <input type="checkbox" id="openstack-capabilities-Ceph" />
+            <label for="openstack-capabilities-Ceph">Ceph</label>
+            <input type="checkbox" id="openstack-capabilities-Swift" />
+            <label for="openstack-capabilities-Swift">Swift</label>
+            <input type="checkbox" id="openstack-capabilities-Manila" />
+            <label for="openstack-capabilities-Manila">Manila</label>
+            <input
+              type="checkbox"
+              id="openstack-capabilities-SAN-integration"
+            />
+            <label for="openstack-capabilities-SAN-integration"
+              >iSCSI/SAN integration</label
+            >
+            <input type="checkbox" id="openstack-capabilities-OVS" />
+            <label for="openstack-capabilities-OVS">OVS</label>
+            <input type="checkbox" id="openstack-capabilities-OVN" />
+            <label for="openstack-capabilities-OVN">OVN</label>
+            <input type="checkbox" id="openstack-capabilities-Contrail" />
+            <label for="openstack-capabilities-Contrail">Contrail</label>
+            <input type="checkbox" id="openstack-capabilities-ACI" />
+            <label for="openstack-capabilities-ACI">ACI</label>
+            <input type="checkbox" id="openstack-capabilities-Nuage" />
+            <label for="openstack-capabilities-Nuage">Nuage</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="openstack-capabilities-Keystone" />
+            <label for="openstack-capabilities-Keystone">Keystone</label>
+            <input type="checkbox" id="openstack-capabilities-Designate" />
+            <label for="openstack-capabilities-Designate">Designate</label>
+            <input type="checkbox" id="openstack-capabilities-Barbican" />
+            <label for="openstack-capabilities-Barbican">Barbican</label>
+            <input type="checkbox" id="openstack-capabilities-Octavia" />
+            <label for="openstack-capabilities-Octavia">Octavia</label>
+            <input type="checkbox" id="openstack-capabilities-Monitoring" />
+            <label for="openstack-capabilities-Monitoring">Monitoring</label>
+            <input
+              type="checkbox"
+              id="openstack-capabilities-Air-gapped-enviroment"
+            />
+            <label for="openstack-capabilities-Air-gapped-enviroment"
+              >Air-gapped enviroment</label
+            >
+            <input
+              type="checkbox"
+              id="openstack-capabilities-LDAP-AD-integration"
+            />
+            <label for="openstack-capabilities-LDAP-AD-integration"
+              >LDAP/AD integration</label
+            >
+            <input type="checkbox" id="openstack-capabilities-Vault" />
+            <label for="openstack-capabilities-Vault">Vault</label>
+            <input
+              type="checkbox"
+              id="openstack-capabilities-High-Availability"
+            />
+            <label for="openstack-capabilities-High-Availability"
+              >High Availability</label
+            >
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="openstack-capabilities-SR-IOV" />
+            <label for="openstack-capabilities-SR-IOV">SR-IOV</label>
+            <input type="checkbox" id="openstack-capabilities-DPDK" />
+            <label for="openstack-capabilities-DPDK">DPDK</label>
+            <input type="checkbox" id="openstack-capabilities-CPU-pinning" />
+            <label for="openstack-capabilities-CPU-pinning">CPU pinning</label>
+            <input type="checkbox" id="openstack-capabilities-NUMA" />
+            <label for="openstack-capabilities-NUMA">NUMA</label>
+            <input type="checkbox" id="openstack-capabilities-VNF-Workloads" />
+            <label for="openstack-capabilities-VNF-Workloads"
+              >VNF Workloads</label
+            >
+            <input type="checkbox" id="openstack-capabilities-SmartNICs" />
+            <label for="openstack-capabilities-SmartNICs">SmartNICs</label>
+            <input type="checkbox" id="openstack-capabilities-GPGPU" />
+            <label for="openstack-capabilities-GPGPU">GPGPU</label>
+            <input type="checkbox" id="openstack-capabilities-Encryption" />
+            <label for="openstack-capabilities-Encryption">Encryption</label>
+          </div>
+        </div>
+      </div>
+      <div class="row u-no-padding js-formfield">
+        <h3 class="p-heading--five">What would be most helpful?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="most-helpful-Fully-managed-cloud" />
+            <label for="most-helpful-Fully-managed-cloud"
+              >Fully managed cloud</label
+            >
+            <input type="checkbox" id="most-helpful-One-time-deployment" />
+            <label for="most-helpful-One-time-deployment"
+              >One-time deployment</label
+            >
+            <input type="checkbox" id="most-helpful-Architecture-design" />
+            <label for="most-helpful-Architecture-design"
+              >Architecture design</label
+            >
+            <input type="checkbox" id="most-helpful-Performance-tuning" />
+            <label for="most-helpful-Performance-tuning"
+              >Performance tuning</label
+            >
+            <input type="checkbox" id="most-helpful-Conformance-Production" />
+            <label for="most-helpful-Conformance-Production">Production</label>
+            <input type="checkbox" id="most-helpful-Workload-migration" />
+            <label for="most-helpful-Workload-migration"
+              >Workload migration</label
+            >
+            <input type="checkbox" id="most-helpful-Integration" />
+            <label for="most-helpful-Integration">Integration</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="most-helpful-Version-upgrades" />
+            <label for="most-helpful-Version-upgrades"
+              >Upgrade to new version</label
+            >
+            <input type="checkbox" id="most-helpful-Upstream-enhancement" />
+            <label for="most-helpful-Upstream-enhancement"
+              >Upstream enhancement</label
+            >
+            <input type="checkbox" id="most-helpful-Security-updates" />
+            <label for="most-helpful-Security-updates">Security updates</label>
+            <input type="checkbox" id="most-helpful-POC" />
+            <label for="most-helpful-POC"> POC</label>
+            <input type="checkbox" id="most-helpful-Single-sign-on" />
+            <label for="most-helpful-Single-sign-on">Single sign-on</label>
+            <input type="checkbox" id="most-helpful-Training" />
+            <label for="most-helpful-Training">Training</label>
+            <input type="checkbox" id="most-helpful-Documentation" />
+            <label for="most-helpful-Documentation">Documentation</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="most-helpful-Automation" />
+            <label for="most-helpful-Automation">Automation</label>
+            <input type="checkbox" id="most-helpful-Hardware-selection" />
+            <label for="most-helpful-Hardware-selection"
+              >Hardware selection</label
+            >
+            <input type="checkbox" id="most-helpful-Enterprise-support" />
+            <label for="most-helpful-Enterprise-support"
+              >Enterprise support</label
+            >
+            <input type="checkbox" id="most-helpful-Data-replication" />
+            <label for="most-helpful-Data-replication">Data replication</label>
+            <input type="checkbox" id="most-helpful-Backup-and-recovery" />
+            <label for="most-helpful-Backup-and-recovery"
+              >Backup and recovery</label
+            >
+            <input type="checkbox" id="most-helpful-Logging-and-monitoring" />
+            <label for="most-helpful-Logging-and-monitoring"
+              >Logging and monitoring</label
+            >
+          </div>
+        </div>
+        <div class="pagination">
+          <a class="pagination__link--previous p-button--neutral" href=""
+            >Previous</a
+          >
+          <a class="pagination__link--next p-button--positive" href="">Next</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <div class="u-sv3 js-formfield">
+        <h3 class="p-heading--five">Have we missed something?</h3>
+        <textarea
+          id="particular-sectors"
+          aria-label="Have we missed something?"
+          rows="3"
+          placeholder="Are there particular sectors which are important to you such as industrial, automotive, display, retail, home, office, data center, networking, robotics?"
+        ></textarea>
+      </div>
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form
+            action="https://pages.ubuntu.com/index.php/leadCapture/save"
+            method="post"
+            id="mktoForm_{{ formid }}"
+            class="modal-form marketo-form"
+          >
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input
+                  required
+                  id="FirstName"
+                  name="FirstName"
+                  maxlength="255"
+                  type="text"
+                  class="mktoField mktoRequired"
+                  required="required"
+                />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input
+                  required
+                  id="LastName"
+                  name="LastName"
+                  maxlength="255"
+                  type="text"
+                  class="mktoField mktoRequired"
+                  required="required"
+                />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Email address:</label>
+                <input
+                  required
+                  id="Email"
+                  name="Email"
+                  maxlength="255"
+                  type="email"
+                  class="mktoField mktoEmailField mktoRequired"
+                  required="required"
+                />
+              </li>
+              <li class="mktField p-list__item">
+                <input
+                  class="mktoField"
+                  value="yes"
+                  id="canonicalUpdatesOptIn"
+                  name="canonicalUpdatesOptIn"
+                  type="checkbox"
+                />
+                <label
+                  class="mktoLabel mktoHasWidth"
+                  for="canonicalUpdatesOptIn"
+                  >I agree to receive information about Canonical’s products and
+                  services.</label
+                >
+              </li>
+              <li class="p-list__item">
+                In submitting this form, I confirm that I have read and agree to
+                <a href="/legal/data-privacy/contact"
+                  >Canonical&rsquo;s Privacy Notice</a
+                >
+                and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
+              <li class="p-list__item">
+                <div
+                  class="g-recaptcha"
+                  data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
+                  style="margin: 2rem 0;"
+                ></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel"
+                    >What would you like to talk to us about?</label
+                  >
+                  <textarea
+                    id="Comments_from_lead__c"
+                    name="Comments_from_lead__c"
+                    rows="5"
+                    class="mktoField"
+                    maxlength="2000"
+                  ></textarea>
+                </li>
+              </ul>
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="formValidation"
+                value=""
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="formid"
+                class="mktoField"
+                value="{{ formid }}"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="formVid"
+                class="mktoField"
+                value="{{ formid }}"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="lpId"
+                class="mktoField"
+                value="{{ lpId }}"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="subId"
+                class="mktoField"
+                value="30"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="munchkinId"
+                class="mktoField"
+                value="066-EOV-335"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="lpurl"
+                class="mktoField"
+                value="{{ lpurl }}?cr={creative}&amp;kw={keyword}"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="cr"
+                class="mktoField"
+                value=""
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="kw"
+                class="mktoField"
+                value=""
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="q"
+                class="mktoField"
+                value=""
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="returnURL"
+                value="{{ returnURL }}"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="retURL"
+                value="{{ returnURL }}"
+              />
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="Consent_to_Processing__c"
+                value="yes"
+              />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href=""
+                >Previous</a
+              >
+              <button
+                type="submit"
+                class="pagination__link--next p-button--positive mktoButton"
+                aria-label="Submit"
+              >
+                Let's discuss
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+    <!-- There is no info in the copy doc for this page -->
+    <div class="js-pagination js-pagination--4 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">
+              Thank you for enquiring about Ubuntu Advantage
+            </h3>
+            <p class="p-heading--four">
+              A member of our team will be in touch within one working day.
+            </p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            <img
+              src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg"
+              alt="smile"
+              width="200"
+              height="200"
+            />
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>
+  

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -621,7 +621,7 @@
                 aria-label="hidden field"
                 name="lpId"
                 class="mktoField"
-                value="{{ lpId }}"
+                value="%% lpId %%"
               />
               <input
                 type="hidden"
@@ -645,7 +645,7 @@
                 aria-label="hidden field"
                 name="lpurl"
                 class="mktoField"
-                value="{{ lpurl }}?cr={creative}&amp;kw={keyword}"
+                value="%% lpurl %%?cr={creative}&amp;kw={keyword}"
               />
               <input
                 type="hidden"
@@ -676,14 +676,14 @@
                 aria-hidden="true"
                 aria-label="hidden field"
                 name="returnURL"
-                value="{{ returnURL }}"
+                value="%% returnURL %%"
               />
               <input
                 type="hidden"
                 aria-hidden="true"
                 aria-label="hidden field"
                 name="retURL"
-                value="{{ returnURL }}"
+                value="%% returnURL %%"
               />
               <input
                 type="hidden"
@@ -692,6 +692,13 @@
                 name="Consent_to_Processing__c"
                 value="yes"
               />
+              <input 
+                type="hidden" 
+                aria-hidden="true" 
+                aria-label="hidden field" 
+                name="productContext" 
+                id="product-context" 
+                value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -505,7 +505,7 @@
           <form
             action="https://pages.ubuntu.com/index.php/leadCapture/save"
             method="post"
-            id="mktoForm_{{ formid }}"
+            id="mktoForm_%% formid %%"
             class="modal-form marketo-form"
           >
             <ul class="p-list">
@@ -605,7 +605,7 @@
                 aria-label="hidden field"
                 name="formid"
                 class="mktoField"
-                value="{{ formid }}"
+                value="%% formid %%"
               />
               <input
                 type="hidden"
@@ -613,7 +613,7 @@
                 aria-label="hidden field"
                 name="formVid"
                 class="mktoField"
-                value="{{ formid }}"
+                value="%% formid %%"
               />
               <input
                 type="hidden"

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -1,4 +1,4 @@
-<div class="p-modal u-hide" id="contact-modal">
+<div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -1,5 +1,3 @@
-{% load versioned_static  %}
-
 <div class="p-modal u-hide" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
@@ -225,5 +223,3 @@
     </div>
   </div>
 </div>
-
-<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -150,7 +150,7 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ formid }}" class="modal-form marketo-form">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
@@ -183,17 +183,17 @@
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ formid }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{ lpId }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="{{ lpurl }}?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -1,5 +1,7 @@
 {% extends "support/base_support.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Community support{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit{% endblock meta_copydoc %}
 
@@ -44,7 +46,12 @@
 </div>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
-{% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1,5 +1,7 @@
 {% extends "support/base_support.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Support and management{% endblock %}
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit{% endblock meta_copydoc %}
@@ -220,6 +222,11 @@
     </section>
 
     {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_support_landscape" second_item="_support_contact_us" third_item="_further_reading" %}
-    {% include "shared/forms/interactive/_support.html" with formid="1240"   lpId="2065"  returnURL="https://www.ubuntu.com/support/thank-you" lpurl="https://pages.ubuntu.com/things-contact-us.html" %}
+
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    </div>
+
+    <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
 
     {% endblock content %}

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -1,5 +1,7 @@
 {% extends "templates/one-column.html" %}
 
+{% load versioned_static  %}
+
 {% block title %}Ubuntu solutions for telecommunications{% endblock %}
 {% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit{% endblock meta_copydoc %}
@@ -231,6 +233,12 @@
   </div>
 </section>
 
-{% include "shared/forms/interactive/_general.html" with lpId="2154" formid="1257" lpurl="https://pages.ubuntu.com/things-contact-us.html" returnURL="https://www.ubuntu.com/contact-us/form/thank-you" %}
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_newsletter" third_item="_telco_further_reading" %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>
+
 {% endblock content %}


### PR DESCRIPTION
## Done

- Load #get-in-touch form on button click
- Create new #get-in-touch for openstack on pricing/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [pricing/consulting](http://0.0.0.0:8001/pricing/consulting)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to [pricing/consulting](http://0.0.0.0:8001/pricing/consulting) and click the "Get in touch" button in the OpenStack section. Compare with [copy doc](https://docs.google.com/document/d/1PG64GkPBA-Y7LR0OWYEIKWE-mD6BDgbgiTgTNisB-20/edit#heading=h.8j6e6xp4ehkf). If you press any other "Get in touch" button on this page, the form should be different.
- Go to any page that has a "Get in touch" and make sure the form is displayed on button click.


## Issue / Card

Fixes #5013 
