### PR TITLE
Add logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0
 whitenoise==4.1.2
 statsd==3.3.0
-prometheus_client==0.6.0
 talisker[gunicorn]==0.14.3
 django-yaml-redirects==0.5.4
 django-asset-server-url==0.1
@@ -19,3 +18,4 @@ requests==2.21.0
 requests-cache==0.4.13
 python-dateutil==2.8.0
 pyyaml==5.1
+raven==6.10.0

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -37,8 +37,11 @@ CUSTOM_SEARCH_ID = "009048213575199080868:i3zoqdwqk8o"
 INSTALLED_APPS = [
     "canonicalwebteam",
     "whitenoise.runserver_nostatic",
+    "raven.contrib.django.raven_compat",
     "django.contrib.staticfiles",  # Needed for STATICFILES_DIRS to work
 ]
+
+SENTRY_CLIENT = "talisker.django.SentryClient"
 
 WHITENOISE_MAX_AGE = 31557600
 WHITENOISE_ALLOW_ALL_ORIGINS = False

--- a/webapp/wsgi.py
+++ b/webapp/wsgi.py
@@ -11,7 +11,10 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 import os
 
 # Modules
+import talisker.logs
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "webapp.settings")
+
+talisker.logs.set_global_extra({"service": "ubuntu.com"})
 application = get_wsgi_application()


### PR DESCRIPTION
## Done

- Add sentry
- Add service name to logs

## QA

- Check out this feature branch
- In .env file add those 2 lines:

```
SENTRY_DSN=<ASK_TOTO>
TALISKER_NETWORKS=172.17.0.1
```

- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- http://0.0.0.0:8001/_status
- http://0.0.0.0:8001/_status/test/sentry
- Should get an issue on sentry
- Check the logs and make is at the end of every line: `service=ubuntu.com`
