### PR TITLE
5290: refactor state form js

### DIFF
--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -4,53 +4,25 @@ if (typeof forms !== 'undefined') {
 
 var forms = {}
 
-// Marketo form state/province select/optgroup js
 forms.stateFormField = function() {
-	var formStateLabel = document.querySelector('[for="State"]');
-  var formStateSelect = document.getElementById('State');
+  var countrySelect = document.getElementById('Country');
   var formStateContainer = document.querySelector('.mktoPlaceholderState');
-  var formUSAOpt = document.querySelector('[value="SelectState"]');
-  var formCanadaOpt = document.querySelector('[value="SelectProvince"]');
 
   // Only if things exist...
-  if (formStateContainer === null) {
+  if (countrySelect === null || formStateContainer === null) {
     return;
   }
 
-	// starting state, no field
-	state('default');
+  countrySelect.addEventListener('change', function(e) {
+    var val = e.target.value;
+    var optionGroup = document.querySelector('.mktoPlaceholderState__group--' + val);
+    
+    formStateContainer.setAttribute('data-country', val);
 
-	function state(stateChange) {
-    switch(stateChange) {
-      case 'US':
-        formStateContainer.style.display = 'inline';
-        formStateLabel.innerHTML = 'State:';
-        formUSAOpt.style.display = 'inline';
-        formStateSelect.selectedIndex = '-1';
-        formCanadaOpt.style.display = 'none';
-        break;
-      case 'CA':
-        formStateContainer.style.display = 'inline';
-        formStateLabel.innerHTML = 'Province:';
-        formCanadaOpt.style.display = 'inline';
-        formStateSelect.selectedIndex = '-1';
-        formUSAOpt.style.display = 'none';
-        break;
-      default:
-        // default is to hide the field
-        formStateContainer.style.display = 'none';
-        formUSAOpt.style.display = 'none';
-        formCanadaOpt.style.display = 'none';
-        break;
-     };
-	};
-
-	var countrySelect = document.getElementById('Country');
-	  countrySelect.addEventListener('change', function(e) {
-  	  var val = e.target.value;
-      state(val);
-    });
+    if (optionGroup) {
+      optionGroup.querySelectorAll('option')[0].selected = 'selected';
+    }
+  });
 };
 
 forms.stateFormField();
-// end Marketo form state/province select/optgroup js

--- a/templates/shared/forms/_state.html
+++ b/templates/shared/forms/_state.html
@@ -1,13 +1,35 @@
-<li class="mktoPlaceholder mktoPlaceholderState p-list__item">
-    <label for="State" class="mktoLabel mktoHasWidth">State:</label>
-    <select id="State" name="State" class="mktoField  mktoRequired mktFReq">
-        <optgroup label="Select Province" value="SelectProvince">
+<li class="mktoPlaceholder mktoPlaceholderState mktoPlaceholderState--CA p-list__item">
+    <label for="State" class="mktoPlaceholderState__label mktoLabel mktoHasWidth">
+        <span class="mktoPlaceholderState__label--CA">Province:</span>
+        <span class="mktoPlaceholderState__label--US">State:</span>
+    </label>
+
+    <select id="State" name="State" class="mktoField mktoRequired mktFReq mktoPlaceholderState__group">
+        <optgroup class="mktoPlaceholderState__group--CA" label="Select Province" value="SelectProvince">
             <option value="AB">Alberta</option><option value="BC">British Columbia</option><option value="MB">Manitoba</option><option value="NB">New Brunswick</option><option value="NF">Newfoundland</option><option value="NT">Northwest Territories</option><option value="NS">Nova Scotia</option><option value="NU">Nunavut</option><option value="ON">Ontario</option><option value="PE">Prince Edward Island</option><option value="QC">Quebec</option><option value="SK">Saskatchewan</option><option value="YT">Yukon Territory</option>
-        </optgroup>
-        <optgroup label="Select State" value="SelectState">
+        </optgroup> 
+        
+        <optgroup class="mktoPlaceholderState__group--US" label="Select State" value="SelectState">
             <option value="AK">Alaska</option><option value="AL">Alabama</option><option value="AR">Arkansas</option><option value="AZ">Arizona</option><option value="CA">California</option><option value="CO">Colorado</option><option value="CT">Connecticut</option><option value="DC">District of Columbia</option><option value="DE">Delaware</option><option value="FL">Florida</option><option value="GA">Georgia</option><option value="HI">Hawaii</option><option value="IA">Iowa</option><option value="ID">Idaho</option><option value="IL">Illinois</option><option value="IN">Indiana</option><option value="KS">Kansas</option><option value="KY">Kentucky</option><option value="LA">Louisiana</option><option value="MA">Massachusetts</option><option value="MD">Maryland</option><option value="ME">Maine</option><option value="MI">Michigan</option><option value="MN">Minnesota</option><option value="MO">Missouri</option><option value="MS">Mississippi</option><option value="MT">Montana</option><option value="NC">North Carolina</option><option value="ND">North Dakota</option><option value="NE">Nebraska</option><option value="NH">New Hampshire</option><option value="NJ">New Jersey</option><option value="NM">New Mexico</option><option value="NV">Nevada</option><option value="NY">New York</option><option value="OH">Ohio</option><option value="OK">Oklahoma</option><option value="OR">Oregon</option><option value="PA">Pennsylvania</option><option value="PR">Puerto Rico</option><option value="RI">Rhode Island</option><option value="SC">South Carolina</option><option value="SD">South Dakota</option><option value="TN">Tennessee</option><option value="TX">Texas</option><option value="UT">Utah</option><option value="VA">Virginia</option><option value="VT">Vermont</option><option value="WA">Washington</option><option value="WI">Wisconsin</option><option value="WV">West Virginia</option><option value="WY">Wyoming</option>
         </optgroup>
     </select>
 </li>
+
+<style>
+    .mktoPlaceholderState,
+    [class*="mktoPlaceholderState__label--"],
+    [class*="mktoPlaceholderState__group--"] {
+        display: none;
+    }
+
+    [data-country="US"],
+    [data-country="US"] .mktoPlaceholderState__label--US,
+    [data-country="US"] .mktoPlaceholderState__group--US,
+    [data-country="CA"],
+    [data-country="CA"] .mktoPlaceholderState__label--CA,
+    [data-country="CA"] .mktoPlaceholderState__group--CA {
+        display: inline;
+    }
+</style>
 
 <script src="/static/js/build/forms.min.js"></script>


### PR DESCRIPTION
## Done

- Reduced the amount of JS controlling the state/province field on contact forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/contact-us/form](http://0.0.0.0:8001//contact-us/form)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select Canada from the country dropdown, see that a dropdown labelled "Provinces" appears below, and contains Canadian provinces
- Select United States of America from the country dropdown, see that a dropdown labelled "States" appears below, and contains American states


## Issue / Card

Fixes #5290 
