### PR TITLE
Remove starting with AI webinar takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,6 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {# include "takeovers/_active-directory_takeover.html" #}
-  {% include "takeovers/_starting-with-ai-webinar_takeover.html" %}
   {% include "takeovers/_starting-with-ai-takeover.html" %}
   {% include "takeovers/_451-automotive_takeover.html" %}
   {% include "takeovers/_1904-webinar_takeover.html" %}


### PR DESCRIPTION
Remove starting with AI webinar takeover as it is not supposed to be live yet