### PR TITLE
Remove stateCountry.js

### DIFF
--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -41,6 +41,7 @@
               <input required  id="phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired mktoInvalid">
             </li>
             {% include "shared/forms/_country.html" %}
+            {% include "shared/forms/_state.html" %}
             <li class="mktFormReq mktField p-list__item">
               <label for="mktoPersonNotes" class="mktoLabel">Are you working on a commercial IoT deployment?</label>
               <select required id="mktoPersonNotes" name="MktoPersonNotes" class="mktoField mktoRequired mktoInvalid"><option value="">Select...</option>
@@ -72,8 +73,3 @@
     </div>
   </div>
 </section>
-
-{% block footer_extra %}
-  <!-- marketo form dependencies -->
-  <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js" defer async></script>
-{% endblock footer_extra %}

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -110,7 +110,6 @@
         <input type="hidden" name="retURL" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" aria-label="retURL">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="https://pages.ubuntu.com/openstack-made-easy-fr-TY.html" />
       </form>
-      <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
 
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -61,5 +61,4 @@
     </ul>
   </fieldset>
 </form>
-<script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
 <!-- /MARKETO FORM -->

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -69,5 +69,4 @@
     </ul>
   </fieldset>
 </form>
-<script src="//assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
 <!-- /MARKETO FORM -->

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -56,4 +56,3 @@
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{ returnURL }}" />
   </fieldset>
 </form>
-<script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -111,8 +111,6 @@
         <input type="hidden" name="_mkt_disp" value="return"/>
         <input type="hidden" name="_mkt_trk" value=""/>
       </form>
-    <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
-    <script  src="//assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
     
     <!-- /MARKETO FORM -->
 

--- a/templates/whitepapers/beta/shared/form.html
+++ b/templates/whitepapers/beta/shared/form.html
@@ -85,7 +85,6 @@
   });
 
 </script>
-<script  src="//assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
 
 <!-- /MARKETO FORM -->
 

--- a/templates/whitepapers/shared/form.html
+++ b/templates/whitepapers/shared/form.html
@@ -85,7 +85,6 @@
   });
 
 </script>
-<script  src="//assets.ubuntu.com/v1/f97fa297-stateCountry.js"></script>
 
 <!-- /MARKETO FORM -->
 


### PR DESCRIPTION
## Done

- removed unused stateCountry.js from many forms where country/state fields weren't included
  - fixes `$ is not defined` errors on those pages
- added state field to /download contact form, ala https://github.com/canonical-web-and-design/ubuntu.com/pull/5298

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/iot/intel-joule-desktop/](http://0.0.0.0:8001/download/iot/intel-joule-desktop)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the state field is present in the contact form and displays the appropriate options when selecting either "United States of America" or "Canada"
- Visit the following pages, open dev tools in your browser and see that `$ is not defined` and `jQuery is not defined` errors do not appear in the console:
  - /rfp
  - /engage/fr/esm
  - /engage/fr/openstack-made-easy
  - /engage/de/openstack-made-easy
  - /engage/apparmor-intro
  - /whitepapers/robotics
  - /whitepapers/beta/robotics



## Issue / Card

Fixes #5268 