### PR TITLE
Remove AI whitepaper takeover and replace with webinar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,7 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {# include "takeovers/_active-directory_takeover.html" #}
-  {% include "takeovers/_starting-with-ai-takeover.html" %}
+  {% include "takeovers/_starting-with-ai-webinar_takeover.html" %}
   {% include "takeovers/_451-automotive_takeover.html" %}
   {% include "takeovers/_1904-webinar_takeover.html" %}
 {% endblock takeover_content %}


### PR DESCRIPTION
Make sure the whitepaper AI takeover is replaced by webinar AI takeover.