### PR TITLE
Remove django_prometheus to use talisker default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==2.2
-django-prometheus==1.0.15
 canonicalwebteam.blog==1.5.15
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
@@ -8,8 +7,7 @@ canonicalwebteam.http==1.0.1
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0
 whitenoise==4.1.2
-statsd==3.3.0
-talisker[gunicorn]==0.14.3
+talisker[gunicorn,prometheus,raven,django]==0.14.3
 django-yaml-redirects==0.5.4
 django-asset-server-url==0.1
 django-static-root-finder==0.3.1
@@ -18,4 +16,3 @@ requests==2.21.0
 requests-cache==0.4.13
 python-dateutil==2.8.0
 pyyaml==5.1
-raven==6.10.0

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -83,17 +83,6 @@ MIDDLEWARE = [
     "canonicalwebteam.custom_response_headers.Middleware",
 ]
 
-# Prometheus
-if not DEBUG:
-    INSTALLED_APPS.append("django_prometheus")
-    MIDDLEWARE.insert(
-        0, "django_prometheus.middleware.PrometheusBeforeMiddleware"
-    )
-    MIDDLEWARE.append("django_prometheus.middleware.PrometheusAfterMiddleware")
-    # Run the prometheus exporters on a range of ports
-    PROMETHEUS_METRICS_EXPORT_PORT_RANGE = range(9990, 9999)
-
-
 STATICFILES_FINDERS = ["django_static_root_finder.finders.StaticRootFinder"]
 
 # Read navigation.yaml

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -8,6 +8,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
+import logging.config
 import os
 import socket
 import yaml
@@ -81,6 +82,7 @@ SEARCH_TIMEOUT = 10
 MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "canonicalwebteam.custom_response_headers.Middleware",
+    "talisker.django.middleware",
 ]
 
 STATICFILES_FINDERS = ["django_static_root_finder.finders.StaticRootFinder"]
@@ -111,6 +113,8 @@ TEMPLATES = [
 
 ASSET_SERVER_URL = "https://assets.ubuntu.com/v1/"
 
+LOGGING_CONFIG = None
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -131,5 +135,7 @@ LOGGING = {
         }
     },
 }
+
+logging.config.dictConfig(LOGGING)
 
 TESTRUNNER = "app.testrunner.NoDbTestRunner"

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -78,7 +78,6 @@ urlpatterns += [
         name="topic",
     ),
     path("blog", include("canonicalwebteam.blog.django.urls")),
-    url("", include("django_prometheus.urls")),
     url(
         r"^(?P<template>download/(desktop|server|cloud)/thank-you)$",
         DownloadView.as_view(),


### PR DESCRIPTION
# summary

remove `django_prometheus` dependency to use talisker prometheus instead

# qa

- `./run --env TALIKSER_NETWORKS=172.17.0.1`
- navigate on the site
- access `/_status/metrics`
- make sure some metrics are logged