### PR TITLE
1179: add lime telco landing page and takeover

### DIFF
--- a/templates/engage/ubuntu-lime-telco.html
+++ b/templates/engage/ubuntu-lime-telco.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="The future of mobile connectivity " meta_image="{{ ASSET_SERVER_URL }}1d93a6b3-social.jpg" meta_description="Unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025." %}
+{% extends_with_args "engage/base_engage.html" with title="The future of mobile connectivity " meta_image="https://assets.ubuntu.com/v1/b739cc2c-social.jpg" meta_description="Unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/126V5e7cQ7ICiP0MAZlrTNsZ_xHknG5VTtcj_T-cUrwM{% endblock meta_copydoc %}
 
@@ -21,7 +21,7 @@
     </div>
 
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}2b86e4d3-Lime+Hi-Res_logo.svg" alt="Lime Microsystems logo" style="width: 320px;">
+      <img src="{{ ASSET_SERVER_URL }}4ba0e3a6-Joint+Lime-illustration-white.svg" alt="Lime Microsystems logo" style="width: 320px;">
     </div>
   </div>
 </section>
@@ -55,25 +55,20 @@
   
   <style>
     .p-takeover {
-      background-image: url("{{ ASSET_SERVER_URL }}4aca8ea6-suru.svg"), linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
-      background-position: right;
+      background-image: url("{{ ASSET_SERVER_URL }}e9f7cb35-left.svg"), url("{{ ASSET_SERVER_URL }}9e4ec700-right.svg"), linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      background-position: left, right, center;
       background-repeat: no-repeat;
-      background-size: auto 100%, cover;
-    }
-
-    .p-takeover__image {
-      width: 311px;
+      background-size: auto 100%, auto 100%, cover;
     }
 
     @media (max-width: 874px) {
       .p-takeover {
-        background-image: linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
+        background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
       }
 
       .p-takeover__image {
         margin-bottom: 2.2rem;
         max-width: 100%;
-        width: 270px;
       }
     }
   </style>

--- a/templates/engage/ubuntu-lime-telco.html
+++ b/templates/engage/ubuntu-lime-telco.html
@@ -1,0 +1,82 @@
+{% extends_with_args "engage/base_engage.html" with title="The future of mobile connectivity " meta_image="{{ ASSET_SERVER_URL }}1d93a6b3-social.jpg" meta_description="Unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025." %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/126V5e7cQ7ICiP0MAZlrTNsZ_xHknG5VTtcj_T-cUrwM{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip p-strip--dark p-takeover">
+  <div class="row u-equal-height">
+    <div class="col-7 u-vertically-center">
+      <div>
+        <h1>The future of mobile connectivity</h1>
+
+        <p class="p-heading--four u-sv2">Are mobile operators ready to adopt open source in favour of proprietary technology?</p>
+        
+        <br class="u-hide--medium u-hide--large">
+
+        <p class="u-hide--medium u-hide--large">
+          <a href="#register-section" class="p-button--positive">Download the whitepaper</a>
+        </p>
+      </div>
+    </div>
+
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}2b86e4d3-Lime+Hi-Res_logo.svg" alt="Lime Microsystems logo" style="width: 320px;">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <p>Mobile operators face a range of challenges today from saturation, competition and regulation - all of which are having a negative impact on revenues. The introduction of 5G offers new customer segments and services to offset this decline. However, unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025.</p>
+
+      <p>Rather than rely on costly proprietary hardware and operating models, the use of open source technologies offers the ability to commoditise and democratise the wireless network infrastructure. Major operators such as Vodafone, Telefonica and China Mobile have already adopted such practices.</p>
+
+      <blockquote class="p-pull-quote"><p>Enterprises will generate 60 percent of the world’s data by 2025</p></blockquote>
+
+      <p>Shifting to open source technology and taking a software defined approach enables mobile operators to differentiate based on the services they offer, rather than network coverage or subscription costs.</p>
+
+      <p>This whitepaper will explain how mobile operators can break the proprietary stranglehold and adopt an open approach including:</p>
+
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">The open source initiatives and technologies available today and being adopted by major operators.</li>
+
+        <li class="p-list__item is-ticked">How a combination of software defined radio, mobile base stations and 3rd party app development can provide a way for mobile operators to differentiate and drive down CAPEX</li>
+
+        <li class="p-list__item is-ticked">Use cases by Vodafone and EE on successful implementations by adopting an open source approach </li>
+      </ul>
+    </div>
+
+    <div class="col-5" id="register-section">
+      {% include "engage/shared/_en_engage_form.html" with id="3407" returnURL="https://pages.ubuntu.com/Whitepaper_LimeSDR_TY.html " %}
+    </div>
+  </div>
+  
+  <style>
+    .p-takeover {
+      background-image: url("{{ ASSET_SERVER_URL }}4aca8ea6-suru.svg"), linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
+      background-position: right;
+      background-repeat: no-repeat;
+      background-size: auto 100%, cover;
+    }
+
+    .p-takeover__image {
+      width: 311px;
+    }
+
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
+      }
+
+      .p-takeover__image {
+        margin-bottom: 2.2rem;
+        max-width: 100%;
+        width: 270px;
+      }
+    }
+  </style>
+</section>
+
+{% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
   {# ALL #}
   {# include "takeovers/_active-directory_takeover.html" #}
   {% include "takeovers/_starting-with-ai-webinar_takeover.html" %}
+  {% include "takeovers/_ubuntu-lime-telco_takeover.html" %}
   {% include "takeovers/_451-automotive_takeover.html" %}
   {% include "takeovers/_1904-webinar_takeover.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_ubuntu-lime-telco_takeover.html
+++ b/templates/takeovers/_ubuntu-lime-telco_takeover.html
@@ -10,7 +10,7 @@
 
     <div class="col-5">
       <p class="p-takeover__image u-align-text--center">
-        <img src="{{ ASSET_SERVER_URL }}2b86e4d3-Lime+Hi-Res_logo.svg" alt="Lime Microsystems logo" width="100%"
+        <img src="{{ ASSET_SERVER_URL }}4ba0e3a6-Joint+Lime-illustration-white.svg" alt="Lime Microsystems logo" width="100%"
         />
       </p>
 
@@ -23,25 +23,25 @@
 
   <style>
     .p-takeover {
-      background-image: url("{{ ASSET_SERVER_URL }}4aca8ea6-suru.svg"), linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
-      background-position: right;
+      background-image: url("{{ ASSET_SERVER_URL }}e9f7cb35-left.svg"), url("{{ ASSET_SERVER_URL }}9e4ec700-right.svg"), linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+      background-position: left, right, center;
       background-repeat: no-repeat;
-      background-size: auto 100%, cover;
+      background-size: auto 100%, auto 100%, cover;
     }
 
     .p-takeover__image {
-      width: 311px;
+      max-width: 100%;
+      width: 390px;
     }
 
     @media (max-width: 874px) {
       .p-takeover {
-        background-image: linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
+        background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
       }
 
       .p-takeover__image {
         margin-bottom: 2.2rem;
-        max-width: 100%;
-        width: 270px;
+        width: 250px;
       }
     }
   </style>

--- a/templates/takeovers/_ubuntu-lime-telco_takeover.html
+++ b/templates/takeovers/_ubuntu-lime-telco_takeover.html
@@ -1,0 +1,48 @@
+<section class="p-strip--dark p-takeover js-takeover">
+  <div class="row u-clearfix u-vertically-center">
+    <div class="col-7">
+      <h1>The future of mobile connectivity</h1>
+
+      <p class="p-heading--four u-sv2">Are mobile operators ready to adopt open source in favour of proprietary technology?</p>
+
+      <a href="/engage/ubuntu-lime-telco?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_IOT_UbuntuCore_Whitepaper_LimeSDR" class="u-hide--small p-button--positive">Download the whitepaper</a>
+    </div>
+
+    <div class="col-5">
+      <p class="p-takeover__image u-align-text--center">
+        <img src="{{ ASSET_SERVER_URL }}2b86e4d3-Lime+Hi-Res_logo.svg" alt="Lime Microsystems logo" width="100%"
+        />
+      </p>
+
+      <p class="u-hide--medium u-hide--large">
+        <a href="/engage/ubuntu-lime-telco?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_IOT_UbuntuCore_Whitepaper_LimeSDR" class="p-button--positive">Download the whitepaper
+        </a>
+      </p>
+    </div>
+  </div>
+
+  <style>
+    .p-takeover {
+      background-image: url("{{ ASSET_SERVER_URL }}4aca8ea6-suru.svg"), linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
+      background-position: right;
+      background-repeat: no-repeat;
+      background-size: auto 100%, cover;
+    }
+
+    .p-takeover__image {
+      width: 311px;
+    }
+
+    @media (max-width: 874px) {
+      .p-takeover {
+        background-image: linear-gradient(45deg, #333333 0%, #111111 60%, #111111 100%);
+      }
+
+      .p-takeover__image {
+        margin-bottom: 2.2rem;
+        max-width: 100%;
+        width: 270px;
+      }
+    }
+  </style>
+</section>


### PR DESCRIPTION
## Done

- added Lime telco takeover and landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001](http://0.0.0.0:8001)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see a takeover featuring the Lime Systems logo, see that it matches the [brief](https://docs.google.com/document/d/1Dzzfmkaq7_m2Y4ySjkqXcHVDjcYAEsNPbbwz6J64B5I/edit#)
- Click the CTA to visit the landing page, see that it matches the [designs](https://github.com/canonical-web-and-design/web-squad/issues/1174#issuecomment-501216906) and the [copy doc](https://docs.google.com/document/d/126V5e7cQ7ICiP0MAZlrTNsZ_xHknG5VTtcj_T-cUrwM/edit?ts=5cf63918)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1179