### PR TITLE
Fix newsletter form on /download/desktop/thank-you

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -226,6 +226,7 @@ Thank you for your contribution
               <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
               <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
               <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+              <input value="1212" class="mktoField mktoFieldDescriptor" name="formVid" type="hidden">
               <input type="hidden" name="ret" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
               <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
               <input name="kw" value="" type="hidden">


### PR DESCRIPTION
* Re-added this line. Marketo rejects forms without a `formVid`, people who have subscribed in the last day or two (since the line was removed) on this page, won't receive their newsletters.