### PR TITLE
Replace 19.04 takeover with active directory

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,10 +32,9 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
-  {# include "takeovers/_active-directory_takeover.html" #}
+  {% include "takeovers/_active-directory_takeover.html" %}
   {% include "takeovers/_starting-with-ai-webinar_takeover.html" %}
   {% include "takeovers/_451-automotive_takeover.html" %}
-  {% include "takeovers/_1904-webinar_takeover.html" %}
 {% endblock takeover_content %}
 
 


### PR DESCRIPTION
- Make sure you can see the active directory takeover and not 19.04 takeover

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1262