### PR TITLE
“sha256sum” > “shasum -a 256” to work on macOS/BSD

### DIFF
--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -3,7 +3,7 @@
   <div class="p-card__content">
     <p><small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small></p>
     <div class="p-code-snippet">
-      <textarea class="p-code-snippet__input" style="background-position: 0 0.25rem; color: rebeccapurple; padding-right: 1.5rem" readonly="readonly">echo "{{ releases.checksums | keyvalue:system | keyvalue:version }}" | sha256sum --check</textarea>
+      <textarea class="p-code-snippet__input" style="background-position: 0 0.25rem; color: rebeccapurple; padding-right: 1.5rem" readonly="readonly">echo "{{ releases.checksums | keyvalue:system | keyvalue:version }}" | shasum -a 256 --check</textarea>
       <button class="p-code-snippet__action">Copy to clipboard</button>
     </div>
     <p><small>You should get the following output:</small></p>


### PR DESCRIPTION
“sha256sum” is usually available on Linux systems, but usually not on macOS/BSD.

“shasum -a 256” does the same thing and is usually available on all three.

# QA

1. Click “Download” in the top-level navigation
2. Click any of the four desktop/server download buttons
3. Wait for the download to complete
4. Copy the verification command and verify that it now works (macOS) or still works (Ubuntu)

Fixes #5307.