### PR TITLE
QA u.c/blog

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -11,6 +11,7 @@
         <h1>{{ article.title.rendered|safe }}</h1>
       </div>
     </div>
+    
     <div class="row">
       <div class="col-8">
         <div class="p-media-object">
@@ -28,21 +29,25 @@
           </div>
         </div>
       </div>
+
       <div class="col-4">
         <ul class="p-inline-list u-vertically-center p-social-widget">
           <li class="p-inline-list__item">
             Share on:
           </li>
+
           <li class="p-inline-list__item">
             <a class="p-icon--facebook" title="Share on Facebook" href="http://www.facebook.com/sharer/sharer.php?u=https://www.ubuntu.com/blog/{{ article.slug }}">
               Facebook
             </a>
           </li>
+
           <li class="p-inline-list__item">
             <a class="p-icon--twitter" title="Share on Twitter" href="http://twitter.com/share?text={{ article.title.rendered|safe|urlencode }}&amp;url=https://www.ubuntu.com/blog/{{ article.slug }}&amp;hashtags=ubuntu">
               Twitter
             </a>
           </li>
+
           <li class="p-inline-list__item">
             <a class="p-icon--linkedin" title="Share on LinkedIn" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.ubuntu.com/blog/{{ article.slug }}&amp;title={{ article.title.rendered|safe|urlencode }}">
             LinkedIn
@@ -74,6 +79,7 @@
           {{ article.content.rendered|safe }}
         </div>
       </div>
+
       <div class="col-4">
         {% include 'blog/product-cards.html' %}
 
@@ -92,12 +98,14 @@
       <div class="row">
         <div class="col-8">
           <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>
+
           <p>
             <a href="https://www.ubuntu.com/internet-of-things/contact-us?product=robotics" class="p-button--positive">
               Contact Us
             </a>
           </p>
         </div>
+
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
           <img width="100" src="https://assets.ubuntu.com/v1/39ebd977-robot.svg" alt="" />
         </div>
@@ -113,6 +121,7 @@
       <h3>Related posts</h3>
     </div>
   </div>
+
   <div class="row p-divider">
     {% for related_article in related_articles %}
     <div class="col-4 p-divider__block">

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -100,7 +100,7 @@
           <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>
 
           <p>
-            <a href="https://www.ubuntu.com/internet-of-things/contact-us?product=robotics" class="p-button--positive">
+            <a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive">
               Contact Us
             </a>
           </p>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <article>
-  <header class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">
+  <header class="p-strip--image is-shallow" style="background-image: url({{ ASSET_SERVER_URL }}f8a323a7-image-background-paper.png);">
     <div class="row">
       <div class="col-8">
         <h1>{{ article.title.rendered|safe }}</h1>
@@ -16,7 +16,7 @@
       <div class="col-8">
         <div class="p-media-object">
           {% if article.author %}
-            <img src="{% if article.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ article.author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
+            <img src="{% if article.author.id == 217 %}{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg{% else %}{{ article.author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
           {% endif %}
 
           <div class="p-media-object__details">
@@ -107,7 +107,7 @@
         </div>
 
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
-          <img width="100" src="https://assets.ubuntu.com/v1/39ebd977-robot.svg" alt="" />
+          <img width="100" src="{{ ASSET_SERVER_URL }}39ebd977-robot.svg" alt="" />
         </div>
       </div>
     </section>

--- a/templates/blog/author.html
+++ b/templates/blog/author.html
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-8">
       <div class="p-media-object u-no-margin--bottom">
-        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
+        <img src="{% if author.id == 217 %}{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls.96 }}{% endif %}" class="p-media-object__image is-round">
 
         <div class="p-media-object__details">
           <h1 class="p-media-object__title">

--- a/templates/blog/blog-card-header.html
+++ b/templates/blog/blog-card-header.html
@@ -1,0 +1,23 @@
+{% if request.path == "/blog/cloud-and-server" %}
+  <header class="blog-p-card__header--cloud-and-server">
+    <h5 class="p-muted-heading u-no-margin--bottom">Cloud and Server</h5>
+  </header>
+{% elif request.path == "/blog/desktop" %}
+  <header class="blog-p-card__header--desktop">
+    <h5 class="p-muted-heading u-no-margin--bottom">Desktop</h5>
+  </header>
+{% elif request.path == "/blog/internet-of-things" %}
+  <header class="blog-p-card__header--internet-of-things">
+    <h5 class="p-muted-heading u-no-margin--bottom">Internet of Things</h5>
+  </header>
+{% else %}
+  <header class="blog-p-card__header{% if article.group %}--{{ article.group.slug }}{% endif %}">
+    <h5 class="p-muted-heading u-no-margin--bottom">
+      {% if article.group %}
+        {{ article.group.name }}
+      {% else %}
+        Ubuntu
+      {% endif %}
+    </h5>
+  </header>
+{% endif %}

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -1,13 +1,6 @@
 <div class="col-4 blog-p-card--post">
-  <header class="blog-p-card__header{% if article.group %}--{{ article.group.slug }}{% endif %}">
-    <h5 class="p-muted-heading u-no-margin--bottom">
-      {% if article.group %}
-        {{ article.group.name }}
-      {% else %}
-        Ubuntu
-      {% endif %}
-    </h5>
-  </header>
+  {% include 'blog/blog-card-header.html' %}
+  
   <div class="blog-p-card__content">
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -5,7 +5,7 @@
 
   <div class="blog-p-card__content">
     <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-      <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re interested in</h3>
+      <h3 class="p-card--title p-heading--four">Select topics you&rsquo;re <br />interested in</h3>
       
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top u-clearfix">

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,4 +1,4 @@
-{% if article.group and article.group.slug == "cloud" %}
+{% if article.group and article.group.slug == "cloud-and-server" %}
 <div class="p-card" id="rtp-cloud">
   <h3>
     <a href="http://www.ubuntu.com/cloud" class="p-link--external">

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,7 +1,7 @@
 {% if article.group and article.group.slug == "cloud-and-server" %}
 <div class="p-card" id="rtp-cloud">
   <h3>
-    <a href="http://www.ubuntu.com/cloud" class="p-link--external">
+    <a href="/cloud">
       Ubuntu cloud
     </a>
   </h3>
@@ -13,7 +13,7 @@
 {% elif article.group and article.group.slug == "internet-of-things" %}
 <div class="p-card" id="rtp-iot">
   <h3>
-    <a href="http://www.ubuntu.com/internet-of-things" class="p-link--external">
+    <a href="/internet-of-things">
       Internet of Things
     </a>
   </h3>
@@ -24,7 +24,7 @@
 {% elif article.group and article.group.slug == "support" %}
 <div class="p-card" id="rtp-support">
   <h3>
-    <a href="http://www.ubuntu.com/support" class="p-link--external">
+    <a href="/support">
       Ubuntu Advantage support
     </a>
   </h3>
@@ -35,7 +35,7 @@
 {% elif article.group and article.group.slug == "desktop" %}
 <div class="p-card" id="rtp-desktop">
   <h3>
-    <a href="http://www.ubuntu.com/desktop" class="p-link--external">
+    <a href="/desktop">
       Ubuntu desktop
     </a>
   </h3>
@@ -46,7 +46,7 @@
 {% elif article.group and article.group.slug == "server" %}
 <div class="p-card" id="rtp-server">
   <h3>
-    <a href="http://www.ubuntu.com/server" class="p-link--external">
+    <a href="/server">
       Ubuntu Server
     </a>
   </h3>
@@ -57,7 +57,7 @@
 {% else %}
 <div class="p-card" id="rtp-contact-us">
   <h3>
-    <a href="https://www.ubuntu.com/about/contact-us/form" class="p-link--external">
+    <a href="/about/contact-us/form">
       Talk to us today
     </a>
   </h3>


### PR DESCRIPTION
Pages on ubuntu.com/blog should match blog.ubuntu.com as much as possible, but there are a few intentional differences, listed below:

# Blog QA checklist
- [x] Index
  - [x] Cards to left of newsletter block should include an excerpt (desktop only)
  - [x] Ensure pagination behaves the same way
  - [x] Ensure nav is present ("Overview" is highlighted)
- [x] Topics
  - [x] Ensure nav is present ("Topics" is highlighted)
    - [x] Ensure that the dropdown works when hovering over "Topics"
  - [x] On mobile, ensure topic links are visible in the navigation, and that the current topic is highlighted
- [x] Internet of Things / Desktop / Cloud and Server
  - [x] Ensure nav is present, and respective link is highlighted
  - [x] Ensure displayed posts are from the correct group
- [x] Article
  - [x] Any article tagged with "snapcraft.io" should have a `rel="canonical"` link tag beginning with "snapcraft.io", and not "www.ubuntu.com"
  - [x] Product card above newsletter can differ, but should be consistent for each post on old blog and new
  - [x] meta tags: og description and title should be present, along with image if the article has a featured image
  - [x] Ensure nav is present (nothing is highlighted)
- [x] Tags
  - [x] Ensure nav is present (nothing highlighted)
/blog/tag/brand or /blog/tag/front-end
- [x] Author
  - [x] Google plus links should not be present
  - [x] Ensure nav is present (nothing highlighted)
  - [x] All posts by that author are displayed
- [x] Archives
  - [x] Ensure nav is present (nothing highlighted)
- [x] Upcoming
  - [x] Ensure nav is present (nothing highlighted)
  - [x] Should look completely different, more like a blog index than an archive page
- [x] Press centre
  - [x] Ensure nav is present ("Press Centre" highlighted)