### PR TITLE
Change press centre link in the footer nav

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -78,7 +78,7 @@
               <a class="p-link--soft" href="http://www.canonical.com/careers"><small>Careers</small></a>
             </li>
             <li class="p-inline-list__item">
-              <a class="p-link--soft" href="https://blog.ubuntu.com/press-centre"><small>Press centre</small></a>
+              <a class="p-link--soft" href="/blog/press-centre"><small>Press centre</small></a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
## Done

Change press centre link in the footer nav  to point to /blog/press-centre

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click Press centre link at the bottom of the page and make sure it takes you to [/blog/press-centre](http://0.0.0.0:8001/blog/press-centre)


## Issue / Card

Fixes #5324 