### PR TITLE
Point to snapcraft.io as canonical link

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,7 +1,9 @@
 {% extends_with_args "templates/one-column.html" with title=article.title.rendered meta_description=article.excerpt.raw  meta_image=article.image.source_url %}
 
-{% block content %}
+{# Change canonical URL for "snapcraft.io" articles (2996 is the ID of the "snapcraft.io" tag) #}
+{% block canonical_url %}{% if 2996 in article.tags %}https://snapcraft.io/blog/{{ article.slug }}{% else %}{{ block.super }}{% endif %}{% endblock canonical_url %}
 
+{% block content %}
 <article>
   <header class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">
     <div class="row">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -33,7 +33,7 @@
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
-    <link rel="canonical" href="{% block canonical_url %}https://www.ubuntu.com{{ request.get_full_path }}{% endblock %}" />
+    <link rel="canonical" href="{% block canonical_url %}https://ubuntu.com{{ request.get_full_path }}{% endblock %}" />
 
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
Include canonical link to snapcraft.io for blogs tagged `snapcraft.io`.

Also, fix canonical links for other pages for new domain `ubuntu.com` (rather than `www.ubuntu.com`)

## QA

- [x] See how https://ubuntu-com-canonical-web-and-design-pr-5329.run.demo.haus/blog/customisable-for-the-enterprise-the-next-generation-of-drones has `<link rel="canonical" href="https://snapcraft.io/blog/customisable-for-the-enterprise-the-next-generation-of-drones" />`
- [x] Check the canonical target is a real, working URL
- [x] Check a blog post without the `snapcraft.io` tag has a self-referential `rel="canonical"` URL - e..g https://ubuntu-com-canonical-web-and-design-pr-5329.run.demo.haus/blog/canonical-announces-support-for-ubuntu-on-windows-subsystem-for-linux-2
- [x] Check other pages (e.g. https://ubuntu-com-canonical-web-and-design-pr-5329.run.demo.haus/) also have valid `rel="canonical"` URLs.

