### PR TITLE
5323 update blog links on nav and homepage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: sleep 5
       - run:
           name: Run Linkchecker
-          command: linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --no-warnings http://127.0.0.1:8000
+          command: linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --ignore-url /blog --no-warnings http://127.0.0.1:8000
   lint-python:
     <<: *defaults
     steps:

--- a/templates/shared/_insights_news_strip.html
+++ b/templates/shared/_insights_news_strip.html
@@ -23,7 +23,7 @@
       {% if articles %}
         {% for article in articles %}
           <div class="col-3">
-            <h4><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h4>
+            <h4><a href="/blog/{{ article.slug }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : '{{ gtm_event_label }} news link', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h4>
             <p class="u-no-padding--top"><em><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></em></p>
           </div>
         {% endfor %}
@@ -37,7 +37,7 @@
     <h3>Spotlight</h3>
     {% for article in spotlight_articles %}
     <div>
-      <h4><a href="{{ article.link|replace_admin }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h4>
+      <h4><a href="/blog/{{ article.slug }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : '{{ gtm_event_label }} spotlight article', 'eventLabel' : '{{ article.title|escapejs }}', 'eventValue' : '{{ article.link }}' });">{{ article.title.rendered|safe }}</a></h4>
       <p class="u-no-padding--top"><em><time pubdate datetime="{{ article.date }}">{{ article.date|format_date }}</time></em></p>
     </div>
     {% endfor %}
@@ -47,7 +47,7 @@
 <div class="u-sv3"></div>
 <div class="row">
   <div class="col-12">
-    <a href="https://blog.ubuntu.com/" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
+    <a href="/blog" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : '{{ gtm_event_label }}', 'eventValue' : undefined });">
       View more from our blog
     </a>
   </div>

--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -72,7 +72,7 @@
           </div>
           <div class="col-10">
             <ul class="p-inline-list--middot is-x-dense">
-              <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/">Blog</a></li>
+              <li class="p-inline-list__item"><a href="/blog">Blog</a></li>
               <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/UbuntuWeeklyNewsletter">Weekly Newsletter</a></li>
               <li class="p-inline-list__item"><a href="http://community.ubuntu.com/">Discourse</a></li>
               <li class="p-inline-list__item"><a href="http://planet.ubuntu.com/">Planet</a></li>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -68,7 +68,7 @@
               <a href="/public-cloud">Ubuntu images on public clouds&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://blog.ubuntu.com/2018/07/09/minimal-ubuntu-released">Minimal Ubuntu for containers&nbsp;&rsaquo;</a>
+              <a href="/blog/minimal-ubuntu-released">Minimal Ubuntu for containers&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
               <a href="https://cloud-init.io/">Cloud-init - customise cloud instances&nbsp;&rsaquo;</a>
@@ -256,7 +256,7 @@
             <a href="/resources?content=whitepapers">Whitepapers</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://blog.ubuntu.com/">Blog</a>
+            <a href="/blog">Blog</a>
           </li>
         </ul>
       </div>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -142,7 +142,7 @@
         <h4 class="p-muted-heading"><a href="/ai">AI &amp; ML&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="/kubernetes/features">Kubernetes support for AI/ML</a></li>
-          <li class="p-list__item"><a href="https://blog.ubuntu.com/2018/10/02/ai-ml-model-ubuntu">Deploy your first model with Kubeflow</a></li>
+          <li class="p-list__item"><a href="/blog/ai-ml-model-ubuntu">Deploy your first model with Kubeflow</a></li>
           <li class="p-list__item"><a href="https://github.com/canonical-labs/kaggle-kubeflow-tutorial">Kaggle on Kubeflow coding example</a></li>
           <li class="p-list__item"><a href="/ai">Specialised AI/ML workshop</a></li>
           <li class="p-list__item"><a href="https://www.tensorflow.org/install/gpu">Tensorflow on Nvidia GPUs</a></li>
@@ -195,8 +195,8 @@
           <li class="p-inline-list__item"><a href="/resources?content=whitepapers">White papers</a></li>
           <li class="p-inline-list__item"><a href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
           <li class="p-inline-list__item"><a href="/cloud/training">Training</a></li>
-          <li class="p-inline-list__item"><a href="https://insights.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
-          <li class="p-inline-list__item"><a href="https://blog.ubuntu.com/press-centre" title="Visit the Press Centre - external site">Press centre</a></li>
+          <li class="p-inline-list__item"><a href="/blog" title="Visit the Blog">Blog</a></li>
+          <li class="p-inline-list__item"><a href="/blog/press-centre" title="Visit the Press Centre">Press centre</a></li>
         </ul>
       </div>
     </div>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -152,11 +152,11 @@
             <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
             <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
             <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
+            <li class="p-list__item"><a class="p-link" href="/blog/archives?category=case-studies" title="Visit the Case studies">Case studies</a></li>
+            <li class="p-list__item"><a class="p-link" href="/blog/archives?category=white-papers" title="Visit the White papers">White papers</a></li>
             <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
             <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
+            <li class="p-list__item"><a class="p-link" href="/blog" title="Visit the Blog">Blog</a></li>
             <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
             <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
             <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
@@ -167,7 +167,7 @@
           <ul class="p-list is-split second-level-nav">
             <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
             <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
+            <li class="p-list__item"><a class="p-link" href="/blog/press-centre">Press centre</a></li>
             <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
             <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
             <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>
@@ -288,11 +288,11 @@
               <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
               <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
               <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=case-studies" title="Visit the Case studies - external site">Case studies</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/archives?category=white-papers" title="Visit the White papers - external site">White papers</a></li>
+              <li class="p-list__item"><a class="p-link" href="/blog/archives?category=case-studies" title="Visit the Case studies">Case studies</a></li>
+              <li class="p-list__item"><a class="p-link" href="/blog/archives?category=white-papers" title="Visit the White papers">White papers</a></li>
               <li class="p-list__item"><a class="p-link" href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
               <li class="p-list__item"><a class="p-link" href="/cloud/training">Training</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com" title="Visit the Blog - external site">Blog</a></li>
+              <li class="p-list__item"><a class="p-link" href="/blog" title="Visit the Blog">Blog</a></li>
               <li class="p-list__item"><a class="p-link" href="https://developer.ubuntu.com">Developer</a></li>
               <li class="p-list__item"><a class="p-link" href="/download/cloud">Install</a></li>
               <li class="p-list__item"><a class="p-link" href="/download">Download</a></li>
@@ -301,7 +301,7 @@
             <ul class="p-list is-split u-no-margin--bottom">
               <li class="p-list__item"><a class="p-link" href="/">Ubuntu</a></li>
               <li class="p-list__item"><a class="p-link" href="https://www.canonical.com">Canonical</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://blog.ubuntu.com/press-centre">Press centre</a></li>
+              <li class="p-list__item"><a class="p-link" href="/blog/press-centre">Press centre</a></li>
               <li class="p-list__item"><a class="p-link" href="https://partners.ubuntu.com">Partners</a></li>
               <li class="p-list__item"><a class="p-link" href="https://shop.canonical.com/">Merchandise</a></li>
               <li class="p-list__item"><a class="p-link" href="/about/contact-us">Contact</a></li>


### PR DESCRIPTION
## Done
- Changed appropriate dropdown navigation links from blog.ubuntu.com to u.c/blog
  - Global nav links aren't updated yet, that will be resolved when [this PR](https://github.com/canonical-web-and-design/global-nav/pull/117) on the global-nav repo is merged
- Updated homepage links from blog.ubuntu.com

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/) 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click the following links and ensure they take you to the appropriate pages:
  - Homepage:
    - Any of the posts in the "Latest news from our blog" section
    - The post featured under "Spotlight"
    - "View more from our blog"
  - Community dropdown navigation:
    - "Blog"
  - Developer dropdown navigation:
    - "Minimal Ubuntu for containers"
    - "Blog"
  - Enterprise dropdown navigation:
    - "Deploy your first model with Kubeflow"
    - "Blog"
    - "Press centre"

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5323 and #5326 