### PR TITLE
ensure blog card excerpt is visible if there is no image

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -42,7 +42,7 @@
       >
     </p>
 
-    {% if summary_visible or not article.image %}
+    {% if summary_visible or not article.image.source_url %}
     <p class="u-no-padding--bottom{% if summary_visible %} u-hide--small{% endif %}">{{ article.excerpt.raw|cut:"[…]"|truncatewords:36 }}</p>
     {% endif %}
   </div>


### PR DESCRIPTION
## Done

- Ensured that excerpt text is visible on blog cards if it doesn't have a featured image to display

## QA

- Check out this feature branch
- Run `./run`
- Visit [/blog/tag/brand](http://0.0.0.0:8001/blog/tag/brand)
- See that "Ubuntu Brand Guidelines get their own site" and "Ubuntu Orange is #dd4814" posts have an excerpt and don't have an image.
- Visit [/blog/tag/front-end](http://0.0.0.0:8001/blog/tag/front-end)
- See that "A seachange in front-end best practice (but not for a while)" post has an excerpt and doesn't have an image.

Fixes #5327