### PR TITLE
Move copydoc meta block out of partial

### DIFF
--- a/templates/templates/_extra_metadata.html
+++ b/templates/templates/_extra_metadata.html
@@ -1,4 +1,4 @@
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
+
     <meta name="theme-color" content="#E95420" />
     <meta name="twitter:account_id" content="4503599627481511" />
     <meta name="twitter:site" content="@ubuntu">
@@ -19,4 +19,3 @@
         <meta name="twitter:image" content="{{ meta_image }}">
         <meta property="og:image" content="{{ meta_image }}" />
     {% endif %}
-    

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -22,6 +22,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     {% include "templates/_extra_metadata.html" %}
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
 
     <title>{% block title %}{{ title }}{% endblock %} | Ubuntu</title>
 

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -14,6 +14,7 @@
     <meta property="twitter:account_id" content="4503599627481511" />
     <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
     <meta name="theme-color" content="#E95420" />
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 


### PR DESCRIPTION
Fixes #5317

Seems like template `{% block %}` doesn't work when it's in partial, not in main template.
So moving out copydoc meta block back to template to make it work again.

### QA
- ./run or https://ubuntu-com-canonical-web-and-design-pr-5335.run.demo.haus/
- visit couple of pages with [Ubuntu Copy Docs](https://github.com/canonical-web-and-design/ubuntu-copy-docs) plugin
- make sure plugin correctly links to copydocs again