### PR TITLE
Add blog navigation in the footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -78,6 +78,9 @@
               <a class="p-link--soft" href="http://www.canonical.com/careers"><small>Careers</small></a>
             </li>
             <li class="p-inline-list__item">
+              <a class="p-link--soft" href="/blog"><small>Blog</small></a>
+            </li>
+            <li class="p-inline-list__item">
               <a class="p-link--soft" href="/blog/press-centre"><small>Press centre</small></a>
             </li>
           </ul>


### PR DESCRIPTION
## Done

Add blog navigation in the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:  [http://0.0.0.0:8001/](http://0.0.0.0:8001/) 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the Blog navigation is present in the footer and it looks like [this](https://github.com/canonical-web-and-design/ubuntu.com/issues/5322)


## Issue / Card

Fixes #5322 