### PR TITLE
Drop www from canonical URLs and og:url

### DIFF
--- a/templates/contact-us/form/thank-you.html
+++ b/templates/contact-us/form/thank-you.html
@@ -3,7 +3,7 @@
 {% block title %}Thank you{% endblock %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1uNruzpoTYxhrCJDxB0q_FH8z8YFs8w_m02fckevjFrU/edit{% endblock meta_copydoc %}
-{% block canonical_url %}https://www.ubuntu.com/contact-us/form{% endblock %}
+{% block canonical_url %}https://ubuntu.com/contact-us/form{% endblock %}
 
 {% block content %}
 

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -3,7 +3,7 @@
 {% block title %}Thank you | Containers{% endblock %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/17WtTD1VsXnMlsI7qp67hkJhItU6XUcSmIYzGv06we7k/edit{% endblock meta_copydoc %}
-{% block canonical_url %}https://www.ubuntu.com/containers/contact-us{% endblock %}
+{% block canonical_url %}https://ubuntu.com/containers/contact-us{% endblock %}
 
 {% block content %}
 {% if product == 'containers-kubernetes' %}

--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Thanks for downloading Ubuntu Server for IBM Z and LinuxONE{% endblock %}
-{% block canonical_url %}https://www.ubuntu.com/download/server/s390x{% endblock %}
+{% block canonical_url %}https://ubuntu.com/download/server/s390x{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1hDkrBqpJXWaENYZMSxd8P-XLFQ2LQqS1wNe4o2MGLho/edit{% endblock meta_copydoc %}
 
 {% block head_extra %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -2,7 +2,7 @@
 {% load versioned_static  %}
 
 {% block title %}Thanks for downloading Ubuntu Server{% endblock %}
-{% block canonical_url %}https://www.ubuntu.com/download/server{% endblock %}
+{% block canonical_url %}https://ubuntu.com/download/server{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit{% endblock meta_copydoc %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -2,7 +2,7 @@
 
 {% block title %}Thank you | Ubuntu for the Internet of Things{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1-WTp-Zf29CA5fiMV0A1rCyaNPF6xAYzZu6BThUXUSlk/edit{% endblock meta_copydoc %}
-{% block canonical_url %}https://www.ubuntu.com/internet-of-things/contact-us{% endblock %}
+{% block canonical_url %}https://ubuntu.com/internet-of-things/contact-us{% endblock %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}

--- a/templates/openstack/thank-you.html
+++ b/templates/openstack/thank-you.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Thank you{% endblock %}
-{% block canonical_url %}https://www.ubuntu.com/cloud/contact-us{% endblock %}
+{% block canonical_url %}https://ubuntu.com/cloud/contact-us{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1-dWhd0ydDWlYg16rEybPPmkQ6cdxsBmiFOuUz0ApCBM/edit{% endblock meta_copydoc %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 

--- a/templates/server/thank-you.html
+++ b/templates/server/thank-you.html
@@ -1,7 +1,7 @@
 {% extends "server/base_server.html" %}
 
 {% block title %}Thank you{% endblock %}
-{% block canonical_url %}https://www.ubuntu.com/server/contact-us{% endblock %}
+{% block canonical_url %}https://ubuntu.com/server/contact-us{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1XWmMQlhgqHeDrMepfxDzeDvXSwTMUbXW8s78bBOsfDw/edit{% endblock meta_copydoc %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 

--- a/templates/templates/_extra_metadata.html
+++ b/templates/templates/_extra_metadata.html
@@ -3,7 +3,7 @@
     <meta name="twitter:account_id" content="4503599627481511" />
     <meta name="twitter:site" content="@ubuntu">
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.ubuntu.com{{ request.get_full_path }}" />
+    <meta property="og:url" content="https://ubuntu.com{{ request.get_full_path }}" />
     <meta property="og:site_name" content="Ubuntu" />
 
     {% if title %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -34,7 +34,7 @@
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
-    <link rel="canonical" href="{% block canonical_url %}https://www.ubuntu.com{{ request.get_full_path }}{% endblock %}" />
+    <link rel="canonical" href="{% block canonical_url %}https://ubuntu.com{{ request.get_full_path }}{% endblock %}" />
 
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}cb22ba5d-favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="{{ ASSET_SERVER_URL }}49a1a858-favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
Drop "www" from explicit and implicit canonical URLs and from `og:url`.

## QA
* On any page, ensure the canonical URL starts with "https://ubuntu.com"
* On a recent engage page, such as `/engage/ubuntu-lime-telco`, ensure the `og:title` tag starts with "https://ubuntu.com"