### PR TITLE
Makes “Tutorials” a link in “Developer” mega-menu

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -190,8 +190,8 @@
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading">Tutorials</h4>
-          <p class="p-p--small">Fun <a href="http://tutorials.ubuntu.com/">guides and HOWTOs</a> covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
+          <h4 class="p-muted-heading"><a href="http://tutorials.ubuntu.com/">Tutorials</a></h4>
+          <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">
               <li class="p-list__item">

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -190,7 +190,7 @@
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading"><a href="http://tutorials.ubuntu.com/">Tutorials</a></h4>
+          <h4 class="p-muted-heading"><a href="http://tutorials.ubuntu.com/">Tutorials&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -190,7 +190,7 @@
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading"><a href="http://tutorials.ubuntu.com/">Tutorials&nbsp;&rsaquo;</a></h4>
+          <h4 class="p-muted-heading"><a href="https://tutorials.ubuntu.com/">Tutorials&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">


### PR DESCRIPTION
A drive-by fix of an oddity I noticed while designing the developer desktop survey results page…

In the “Developer” mega-menu, 6/8 of the headings — including 3/4 of the “muted” headings — are links.

This change makes the mega-menu slightly more consistent — 7/8 and 4/4 — by moving the tutorials link to the “Tutorials” heading. It also resolves the visual weirdness of this link being the only one in the mega-menu that starts part-way through a sentence.

An alternative solution would be to no longer make _any_ of the headings links, i.e. 0/8 and 0/4. That would be more work, but would also solve the problem that 3/7 of the heading links are duplicated by one of the links below it.