### PR TITLE
Updated /uasd with new Ceph storage details

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -89,7 +89,7 @@ As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infra
     6. [Charms](#term-charms):
         1. Each Charm version is supported for one year from the release date.
         2. Canonical will not provide support for any Charms that have been modified from the supported version found in the page at [https://wiki.ubuntu.com/OpenStack/OpenStackCharms](https://wiki.ubuntu.com/OpenStack/OpenStackCharms)
-    7. Canonical will provide support for 12 TB of usable storage per Node with Ceph or Swift storage exposed to the OpenStack cluster. This allowance can be used for Ceph, Swift, or a combination of these. If the number of these Nodes exceeds the number of compute Nodes in the covered OpenStack cluster, the supported Ceph and Swift storage will be limited to 12 TB per compute Node in the cluster.
+    7. Canonical will provide support for 48TB of raw storage per Node with Ceph or Swift storage exposed to the OpenStack cluster. This allowance can be used for Ceph, Swift, or a combination of these. If the number of these Nodes exceeds the number of compute Nodes in the covered OpenStack cluster, the supported Ceph and Swift storage will be limited to 12 TB per compute Node in the cluster.
     8. Ubuntu Advantage OpenStack includes a licence to use available Canonical provided Microsoft-certified drivers in Windows Guest instances.
     9. OpenStack support excludes:
         1. Support for workloads other than those required to run an OpenStack deployment.

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -131,10 +131,10 @@
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
         </tr>
         <tr>
-          <td>Ceph/Swift usable storage support included</td>
+          <td>Ceph/Swift raw storage support included</td>
           <td class="u-align--center">-</td>
-          <td class="u-align--center">12TB</td>
-          <td class="u-align--center">12TB</td>
+          <td class="u-align--center">48TB</td>
+          <td class="u-align--center">48TB</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Updated the /uasd page

## QA

- Download this branch
- Go to http://0.0.0.0:8001/legal/ubuntu-advantage-service-description
- See that the page is good
- Compare the page to the [copy doc](https://docs.google.com/document/d/1vQNdVmpsB3iQP7SnJHxT3A8rbD5jSAzTEoYUOepR-SM/edit)

Fixes #5344 