### PR TITLE
lowercase pull request name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -13,7 +13,7 @@ assignees: ''
 
 - Check out this feature branch
 - Run the site using the command `./run serve`
-- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
+- View the site locally in your web browser at: http://0.0.0.0:8001/
 - Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
 - [List additional steps to QA the new features or prove the bug has been resolved]
 


### PR DESCRIPTION
Based on a support request to get the default one working


> Stacey Burns (GitHub Developer Support)Jun 20, 6:49 AM UTCHey 
> Peter,
> Thanks for contacting GitHub Support!I believe the template named pull_request_template.md should display as the default template. Let us know if you have any trouble setting it up. We'd be more than happy to further assist.
> Cheers
> Stacey
