### PR TITLE
ESM blog post engage page in French

### DIFF
--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -22,7 +22,7 @@
 
 <section class="p-strip">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <p>Aujourd’hui, Ubuntu est le point de départ pour la majorité des applications cloud. Avec plus de 450 million d’instances clouds publiques déployées depuis la sortie d’Ubuntu 16.04 LTS, on constate que la plupart des déploiements les plus larges - à l’échelle du web - utilisent Ubuntu.</p>
 
       <p>Ce sont notamment des applications financières, de big data et de distribution de contenu, qui dépendent de la stabilité et de la continuité du système d’exploitation sous-jacent pour fournir les services essentiels dont leurs clients dépendent.</p>
@@ -54,7 +54,7 @@
       <p>Contactez ci-dessous les équipes de vente de Canonical pour commencer à planifier la fin de vie d’Ubuntu 14.04 ou pour parler de vos systèmes sous Ubuntu 12.04: l’ESM facilitera votre processus de migration, tout en assurant votre conformité aux normes et votre sécurité.</p>
     </div>
   
-    <div class="col-4">
+    <div class="col-5">
       {% include "engage/shared/_fr_engage_form.html" with id="1240" returnURL="https://www.ubuntu.com/support/thank-you" cta="Planifiez votre passage à l'ESM" %}
     </div>
   </div>

--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -8,7 +8,7 @@
 {% block content %}
 
 <section class="p-strip--dark is-deep p-takeover--esm" lang="fr">
-  <div class="row">
+  <div class="row u-vertically-center">
     <div class="col-8">
       <h1 class="p-takeover__title">Extension Sécurité et Maintenance pour Ubuntu 14.04</h1>
       <h2 class="p-heading--four">Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.</h2>

--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -7,13 +7,23 @@
 
 {% block content %}
 
-<section class="p-strip is-deep p-takeover--private-cloud-economics" lang="fr">
-  <div class="row u-equal-height">
+<section class="p-strip--dark is-deep p-takeover--esm" lang="fr">
+  <div class="row">
     <div class="col-8">
       <h1 class="p-takeover__title">Extension Sécurité et Maintenance pour Ubuntu 14.04</h1>
-      <h3>Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.</h3>
-      <p class="p-takeover__text">
-      Aujourd’hui, Ubuntu est le point de départ pour la majorité des applications cloud. Avec plus de 450 million d’instances clouds publiques déployées depuis la sortie d’Ubuntu 16.04 LTS, on constate que la plupart des déploiements les plus larges - à l’échelle du web - utilisent Ubuntu.</p>
+      <h2 class="p-heading--four">Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.</h2>
+    </div>
+
+    <div class="col-4 u-hide--small u-align--center">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <p>Aujourd’hui, Ubuntu est le point de départ pour la majorité des applications cloud. Avec plus de 450 million d’instances clouds publiques déployées depuis la sortie d’Ubuntu 16.04 LTS, on constate que la plupart des déploiements les plus larges - à l’échelle du web - utilisent Ubuntu.</p>
 
       <p>Ce sont notamment des applications financières, de big data et de distribution de contenu, qui dépendent de la stabilité et de la continuité du système d’exploitation sous-jacent pour fournir les services essentiels dont leurs clients dépendent.</p>
 
@@ -42,17 +52,22 @@
       <p>Elle est en option dans le pack de support technique commercial de Canonical, <a href="/esm">Ubuntu Advantage</a>.</p>
 
       <p>Contactez ci-dessous les équipes de vente de Canonical pour commencer à planifier la fin de vie d’Ubuntu 14.04 ou pour parler de vos systèmes sous Ubuntu 12.04: l’ESM facilitera votre processus de migration, tout en assurant votre conformité aux normes et votre sécurité.</p>
-
     </div>
-    <div class="col-4 u-hide--small u-align--center">
-      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
+  
+    <div class="col-4">
       {% include "engage/shared/_fr_engage_form.html" with id="1240" returnURL="https://www.ubuntu.com/support/thank-you" cta="Planifiez votre passage à l'ESM" %}
     </div>
   </div>
 </section>
+
+<style>
+  .p-takeover--esm {
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+  }
+
+  .p-takeover__image {
+    width: 160px;
+  }
+</style>
 
 {% endblock content %}

--- a/templates/engage/fr/esm_1404.html
+++ b/templates/engage/fr/esm_1404.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--dark p-takeover--esm">
-  <div class="row">
+  <div class="row u-vertically-center">
     <div class="col-8">
       <h1 class="p-takeover__title">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support)</h1>
     </div>

--- a/templates/engage/fr/esm_1404.html
+++ b/templates/engage/fr/esm_1404.html
@@ -1,0 +1,102 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support){% endblock %}
+{% block meta_description %}Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1T4Ar7n4Jwypecr96Wv5SQjdNdsISNkRHBU4DTxseHo0/edit{% endblock meta_copydoc %}
+
+
+{% block content %}
+
+<section class="p-strip is-deep p-takeover--private-cloud-economics" lang="fr">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h1 class="p-takeover__title">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support)</h1>
+      <p>Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.</p>
+      <p class="p-takeover__text">
+      Les releases Ubuntu long term support (LTS) fournissent une platform stable et supportée pour le développement et la production, avec cinq ans de maintenance de sécurité garantie (Standard Security Maintenance). Une fois la “Standard Security Maintenance” finit, Ubuntu LTS ont accès à ESM pour une période de 3 à 5 ans (cela dépend des releases).</p>
+
+      <p>L'accès à ESM étend la vie de la release LTS, permettant de continuer les mises à jour de sécurité pour les vulnérabilité haute et critique (CVEs) pour la plupart des packages Ubuntu de la librairie main. Cet accès permet aux entreprises avec des machines sur Ubuntu LTS de conserver leur conformité informatique en attendant de pour monter en version leur version de LTS.</p>
+
+      <p>Pour les utilisateurs qui ont besoin d'accès à ESM, ou qui ont des questions à propos de ce service, vous trouverez ci-dessous les questions fréquentes.  N'hésitez pas à nous contacter si vous avez d’autres questions sur ESM pour Ubuntu 14.04 LTS.</p>
+
+      <h3>Comment accéder à ESM?</h3>
+
+      <p>Si vous etes deja un client UA Infrastructure (ou UA Server) and avez besoin à ESM, votre accès peut être trouver en cliquant sur ‘My Account’ dans la section profile du <a href="https://support.canonical.com" target="_blank">portail de Canonical.</a></p>
+
+      <p>Ce <a href="https://support.canonical.com" target="_blank">Knowledge Base article</a> (en Anglais) donne tous les détails pour activer ESM. Si votre login/password pour ESM credentials n'a pas été fourni pour votre compte, merci de le demander par l'intermédiaire du support en <a href="https://support.canonical.com" target="_blank">ouvrant un ticket.</a></p>
+
+      <p>Si n'êtes pas un client UA Infrastructure and avez besoin à ESM, merci de nous  contacter pour en savoir plus.</p>
+
+      <h3>Pourquoi est que mon entreprise à besoin d’ESM?</h3>
+
+      <p>Si vous êtes dans une industrie très réglementée ou la certification de la sécurité ou la compliance des systèmes d’infrastructure doit être respecté, il est alors recommandé d'utiliser ESM pour maintenir l'intégrité de ces systèmes.</p>
+
+      <p>PCI DSS, SOC 2 et GDPR sont trois exemples de certifications qui nécessite des update de sécurité réguliers.</p>
+
+      <p class="p-heading--four">
+        D’autres demandes d’ESM inclus:
+      </p>
+
+      <ul>
+        <li>
+          Les logiciels anciens qui doivent être maintenu - si votre entreprise utilise ces logiciels qui nécessitent d’anciennes libraries qui ne peuvent pas être re-développé.
+        </li>
+        <li>
+          Due au hardware - si votre entreprise à des logiciels qui tourne sur des systèmes embarqués comme HDI ou SCADA qui ne peuvent pas être upgradé sans un testing (souvent vu dans l’industrie médicale).
+        </li>
+        <li>
+          Déploiement à longue durée - souvent vu des les télécommunications.
+        </li>
+      </ul>
+
+      <p>Dans les 5 année après la première release de 14.10, plus de 1,300 notices de sécurité (USNs) ont ete publies, avec une seule USN qui peut couvrir plusieurs CVEs.  Avec ESM, les USNs continue d’etre adresse.</p>
+
+    <h3>Est-il temps de faire une montée de version?</h3>
+
+    <p>Il est recommandé pour tous les utilisateurs de passer à la dernière LTS, Ubuntu 18.04. 18.04 est notamment plus rapide à booter, est basée sur le noyau 4.15, a été développé pour CI/CD avec Kubernetes, elle a les mitigations pour Spectre and Meltdown. Finalement, elle est aussi alignée avec le machine learning.</p>
+
+    <p>Il y a trois façon de faire une monté de verison -</p>
+
+    <ol>
+      <li>Utiliser l’interface graphique (Desktop seulement)</li>
+      <li>Entrer la commande suivante:</li> <br>
+
+      <pre class="wp-block-code">
+          <code>$ sudo do-release-upgrade</code>
+        </pre>
+
+      <li>Utilise la commande en utilisant Landscape, le cloud-management platform pour les machine Ubuntu.</li> <br>
+
+      <pre class="wp-block-code">
+          <code>$ sudo apt-get dist-upgrade</code>
+        </pre>
+
+    </ol>
+    
+    <p>Pour ceux qui sont sur 14.04 et qui ne peuvent pas monté en version, (ou si vous aller le faire plus tard), il est recommandé de s'abonner à ESM à travers le UA Infrastructure.</p>
+
+    <h3>Quels sont les risks sans ESM?</h3>
+
+    <p>Les vulnérabilités de sécurités qui restent sans update laissent vos systèmes d’infrastructures ouvert aux hackers et bien ouvert à une attaque majeure.</p>
+
+    <p>De plus , les updates sont souvent nécessaires pour respecter les réglementations comme GDPR.</p>
+
+    <h3>Combien de temps est ce que Ubuntu 14.04 LTS peut être supporté avec ESM?</h3>
+
+    <p>Ubuntu 14.04 LTS ‘Trusty Tahr’ sera supporté jusqu’a avril 2022 a avec la souscription UA Infrastructure’s ESM service.</p>
+
+    <p>Extended Security Maintenance (ESM) pour Ubuntu 14.04 Trusty Tahr inclut les patchs de sécurité pour les vulnérabilités haute et critical pour 3 ans et est disponible à travers Ubuntu Advantage pour Infrastructure. Pour plus d’information, merci de visiter ubuntu.com/esm and contactez nous si vous avez des questions.</p>
+        
+    </div>
+    <div class="col-4 u-hide--small u-align--center">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      {% include "engage/shared/_fr_engage_form.html" with id="1240" returnURL="https://www.ubuntu.com/support/thank-you" cta="Planifiez votre passage à l'ESM" %}
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/fr/esm_1404.html
+++ b/templates/engage/fr/esm_1404.html
@@ -1,25 +1,34 @@
-{% extends "engage/base_engage.html" %}
+{% extends_with_args "engage/base_engage.html" title="Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support)" meta_description="Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure." %}
 
-{% block title %}Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support){% endblock %}
-{% block meta_description %}Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1T4Ar7n4Jwypecr96Wv5SQjdNdsISNkRHBU4DTxseHo0/edit{% endblock meta_copydoc %}
 
 
 {% block content %}
-
-<section class="p-strip is-deep p-takeover--private-cloud-economics" lang="fr">
-  <div class="row u-equal-height">
+<section class="p-strip--dark p-takeover--esm">
+  <div class="row">
     <div class="col-8">
       <h1 class="p-takeover__title">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support)</h1>
+    </div>
+
+    <div class="col-4 u-hide--small u-align--center">
+      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip" lang="fr">
+  <div class="row">
+    <div class="col-8">
       <p>Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.</p>
-      <p class="p-takeover__text">
+
+      <p>
       Les releases Ubuntu long term support (LTS) fournissent une platform stable et supportée pour le développement et la production, avec cinq ans de maintenance de sécurité garantie (Standard Security Maintenance). Une fois la “Standard Security Maintenance” finit, Ubuntu LTS ont accès à ESM pour une période de 3 à 5 ans (cela dépend des releases).</p>
 
       <p>L'accès à ESM étend la vie de la release LTS, permettant de continuer les mises à jour de sécurité pour les vulnérabilité haute et critique (CVEs) pour la plupart des packages Ubuntu de la librairie main. Cet accès permet aux entreprises avec des machines sur Ubuntu LTS de conserver leur conformité informatique en attendant de pour monter en version leur version de LTS.</p>
 
       <p>Pour les utilisateurs qui ont besoin d'accès à ESM, ou qui ont des questions à propos de ce service, vous trouverez ci-dessous les questions fréquentes.  N'hésitez pas à nous contacter si vous avez d’autres questions sur ESM pour Ubuntu 14.04 LTS.</p>
 
-      <h3>Comment accéder à ESM?</h3>
+      <h2>Comment accéder à ESM?</h2>
 
       <p>Si vous etes deja un client UA Infrastructure (ou UA Server) and avez besoin à ESM, votre accès peut être trouver en cliquant sur ‘My Account’ dans la section profile du <a href="https://support.canonical.com" target="_blank">portail de Canonical.</a></p>
 
@@ -27,15 +36,15 @@
 
       <p>Si n'êtes pas un client UA Infrastructure and avez besoin à ESM, merci de nous  contacter pour en savoir plus.</p>
 
-      <h3>Pourquoi est que mon entreprise à besoin d’ESM?</h3>
+      <h2>Pourquoi est que mon entreprise à besoin d’ESM?</h2>
 
       <p>Si vous êtes dans une industrie très réglementée ou la certification de la sécurité ou la compliance des systèmes d’infrastructure doit être respecté, il est alors recommandé d'utiliser ESM pour maintenir l'intégrité de ces systèmes.</p>
 
       <p>PCI DSS, SOC 2 et GDPR sont trois exemples de certifications qui nécessite des update de sécurité réguliers.</p>
 
-      <p class="p-heading--four">
+      <h3>
         D’autres demandes d’ESM inclus:
-      </p>
+      </h3>
 
       <ul>
         <li>
@@ -51,52 +60,52 @@
 
       <p>Dans les 5 année après la première release de 14.10, plus de 1,300 notices de sécurité (USNs) ont ete publies, avec une seule USN qui peut couvrir plusieurs CVEs.  Avec ESM, les USNs continue d’etre adresse.</p>
 
-    <h3>Est-il temps de faire une montée de version?</h3>
+      <h2>Est-il temps de faire une montée de version?</h2>
 
-    <p>Il est recommandé pour tous les utilisateurs de passer à la dernière LTS, Ubuntu 18.04. 18.04 est notamment plus rapide à booter, est basée sur le noyau 4.15, a été développé pour CI/CD avec Kubernetes, elle a les mitigations pour Spectre and Meltdown. Finalement, elle est aussi alignée avec le machine learning.</p>
+      <p>Il est recommandé pour tous les utilisateurs de passer à la dernière LTS, Ubuntu 18.04. 18.04 est notamment plus rapide à booter, est basée sur le noyau 4.15, a été développé pour CI/CD avec Kubernetes, elle a les mitigations pour Spectre and Meltdown. Finalement, elle est aussi alignée avec le machine learning.</p>
 
-    <p>Il y a trois façon de faire une monté de verison -</p>
+      <p>Il y a trois façon de faire une monté de verison -</p>
 
-    <ol>
-      <li>Utiliser l’interface graphique (Desktop seulement)</li>
-      <li>Entrer la commande suivante:</li> <br>
+      <ol>
+        <li>Utiliser l’interface graphique (Desktop seulement)</li>
+        <li>Entrer la commande suivante:<br>
+          <pre><code>$ sudo do-release-upgrade</code></pre>
+        </li>
 
-      <pre class="wp-block-code">
-          <code>$ sudo do-release-upgrade</code>
-        </pre>
-
-      <li>Utilise la commande en utilisant Landscape, le cloud-management platform pour les machine Ubuntu.</li> <br>
-
-      <pre class="wp-block-code">
-          <code>$ sudo apt-get dist-upgrade</code>
-        </pre>
-
-    </ol>
+        <li>Utilise la commande en utilisant Landscape, le cloud-management platform pour les machine Ubuntu.<br>
+          <pre><code>$ sudo apt-get dist-upgrade</code></pre>
+        </li>
+      </ol>
     
-    <p>Pour ceux qui sont sur 14.04 et qui ne peuvent pas monté en version, (ou si vous aller le faire plus tard), il est recommandé de s'abonner à ESM à travers le UA Infrastructure.</p>
+      <p>Pour ceux qui sont sur 14.04 et qui ne peuvent pas monté en version, (ou si vous aller le faire plus tard), il est recommandé de s'abonner à ESM à travers le UA Infrastructure.</p>
 
-    <h3>Quels sont les risks sans ESM?</h3>
+      <h2>Quels sont les risks sans ESM?</h2>
 
-    <p>Les vulnérabilités de sécurités qui restent sans update laissent vos systèmes d’infrastructures ouvert aux hackers et bien ouvert à une attaque majeure.</p>
+      <p>Les vulnérabilités de sécurités qui restent sans update laissent vos systèmes d’infrastructures ouvert aux hackers et bien ouvert à une attaque majeure.</p>
 
-    <p>De plus , les updates sont souvent nécessaires pour respecter les réglementations comme GDPR.</p>
+      <p>De plus , les updates sont souvent nécessaires pour respecter les réglementations comme GDPR.</p>
 
-    <h3>Combien de temps est ce que Ubuntu 14.04 LTS peut être supporté avec ESM?</h3>
+      <h2>Combien de temps est ce que Ubuntu 14.04 LTS peut être supporté avec ESM?</h2>
 
-    <p>Ubuntu 14.04 LTS ‘Trusty Tahr’ sera supporté jusqu’a avril 2022 a avec la souscription UA Infrastructure’s ESM service.</p>
+      <p>Ubuntu 14.04 LTS ‘Trusty Tahr’ sera supporté jusqu’a avril 2022 a avec la souscription UA Infrastructure’s ESM service.</p>
 
-    <p>Extended Security Maintenance (ESM) pour Ubuntu 14.04 Trusty Tahr inclut les patchs de sécurité pour les vulnérabilités haute et critical pour 3 ans et est disponible à travers Ubuntu Advantage pour Infrastructure. Pour plus d’information, merci de visiter ubuntu.com/esm and contactez nous si vous avez des questions.</p>
-        
+      <p>Extended Security Maintenance (ESM) pour Ubuntu 14.04 Trusty Tahr inclut les patchs de sécurité pour les vulnérabilités haute et critical pour 3 ans et est disponible à travers Ubuntu Advantage pour Infrastructure. Pour plus d’information, merci de visiter ubuntu.com/esm and contactez nous si vous avez des questions.</p>
     </div>
-    <div class="col-4 u-hide--small u-align--center">
-      <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}9e59756d-shield-ESM.svg" alt="" class="u-hide--small">
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
+    
+    <div class="col-4">
       {% include "engage/shared/_fr_engage_form.html" with id="1240" returnURL="https://www.ubuntu.com/support/thank-you" cta="Planifiez votre passage à l'ESM" %}
     </div>
   </div>
 </section>
+
+<style>
+  .p-takeover--esm {
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+  }
+
+  .p-takeover__image {
+    width: 160px;
+  }
+</style>
 
 {% endblock content %}

--- a/templates/engage/fr/esm_1404.html
+++ b/templates/engage/fr/esm_1404.html
@@ -7,7 +7,7 @@
 <section class="p-strip--dark p-takeover--esm">
   <div class="row u-vertically-center">
     <div class="col-8">
-      <h1 class="p-takeover__title">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM</h1>
+      <h1 class="p-takeover__title u-no-margin--bottom">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM</h1>
     </div>
 
     <div class="col-4 u-hide--small u-align--center">
@@ -18,7 +18,7 @@
 
 <section class="p-strip" lang="fr">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <p>Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM  (Extended Maintenance Support) fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.</p>
 
       <p>
@@ -96,7 +96,7 @@
       <a class="p-button--positive" href="https://www.ubuntu.com/esm?utm_source=blog&utm_campaign=CY19_DC_UA_GenConForm_ESM14-04#get-in-touch">Nous contacter</a>
     </div>
     
-    <div class="col-4">
+    <div class="col-5">
       {% include "engage/shared/_fr_engage_form.html" with id="1240" returnURL="https://www.ubuntu.com/support/thank-you" cta="Planifiez votre passage à l'ESM" %}
     </div>
   </div>

--- a/templates/engage/fr/esm_1404.html
+++ b/templates/engage/fr/esm_1404.html
@@ -7,7 +7,7 @@
 <section class="p-strip--dark p-takeover--esm">
   <div class="row u-vertically-center">
     <div class="col-8">
-      <h1 class="p-takeover__title">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM (Extended Maintenance Support)</h1>
+      <h1 class="p-takeover__title">Le support d’Ubuntu 14.04 LTS est maintenant passé à ESM</h1>
     </div>
 
     <div class="col-4 u-hide--small u-align--center">
@@ -19,7 +19,7 @@
 <section class="p-strip" lang="fr">
   <div class="row">
     <div class="col-8">
-      <p>Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.</p>
+      <p>Le support d’Ubuntu 14.04 LTS ‘Trusty Tahr’ est maintenant passé à ESM  (Extended Maintenance Support) fin avril 2019, et ne sera plus supporté pour les utilisateurs sans ESM. ESM peut être contracté avec Ubuntu Advantage for Infrastructure.</p>
 
       <p>
       Les releases Ubuntu long term support (LTS) fournissent une platform stable et supportée pour le développement et la production, avec cinq ans de maintenance de sécurité garantie (Standard Security Maintenance). Une fois la “Standard Security Maintenance” finit, Ubuntu LTS ont accès à ESM pour une période de 3 à 5 ans (cela dépend des releases).</p>

--- a/templates/engage/fr/esm_1404.html
+++ b/templates/engage/fr/esm_1404.html
@@ -28,6 +28,8 @@
 
       <p>Pour les utilisateurs qui ont besoin d'accès à ESM, ou qui ont des questions à propos de ce service, vous trouverez ci-dessous les questions fréquentes.  N'hésitez pas à nous contacter si vous avez d’autres questions sur ESM pour Ubuntu 14.04 LTS.</p>
 
+      <a class="p-button--positive" href="https://www.ubuntu.com/esm?utm_source=blog&utm_campaign=CY19_DC_UA_GenConForm_ESM14-04#get-in-touch">Nous contacter</a>
+
       <h2>Comment accéder à ESM?</h2>
 
       <p>Si vous etes deja un client UA Infrastructure (ou UA Server) and avez besoin à ESM, votre accès peut être trouver en cliquant sur ‘My Account’ dans la section profile du <a href="https://support.canonical.com" target="_blank">portail de Canonical.</a></p>
@@ -90,6 +92,8 @@
       <p>Ubuntu 14.04 LTS ‘Trusty Tahr’ sera supporté jusqu’a avril 2022 a avec la souscription UA Infrastructure’s ESM service.</p>
 
       <p>Extended Security Maintenance (ESM) pour Ubuntu 14.04 Trusty Tahr inclut les patchs de sécurité pour les vulnérabilités haute et critical pour 3 ans et est disponible à travers Ubuntu Advantage pour Infrastructure. Pour plus d’information, merci de visiter ubuntu.com/esm and contactez nous si vous avez des questions.</p>
+
+      <a class="p-button--positive" href="https://www.ubuntu.com/esm?utm_source=blog&utm_campaign=CY19_DC_UA_GenConForm_ESM14-04#get-in-touch">Nous contacter</a>
     </div>
     
     <div class="col-4">

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -8,11 +8,12 @@
 <section class="p-strip--dark is-deep p-takeover--openstack" lang="fr">
   <div class="row u-vertically-center">
     <div class="col-8">
-      <h1 class="p-takeover__title">Installez et mettez OpenStack à l'échelle en toute simplicité</h1>
+      <h1 class="p-takeover__title u-no-margin--bottom">Installez et mettez OpenStack à l'échelle en toute simplicité</h1>
       <p class="u-hide--medium u-hide--large u-align--center">
         <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="">
       </p>
     </div>
+
     <div class="col-4 u-hide--small u-align--center">
       <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="" class="u-hide--small">
     </div>
@@ -21,7 +22,7 @@
 
 <section class="p-strip">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <h2>Avec les bons outils, OpenStack est un jeu d'enfant.</h3>
       
       <p>L'utilisation de plus en plus fréquente de gros logiciels basés sur des microservices multi-hôtes au lieu de logiciels  monolithiques traditionnels exige des perspectives et des approches fondamentalement nouvelles en matière d'installation, d'intégration et d'exploitation.</p>
@@ -49,7 +50,7 @@
       </ul>
     </div>
 
-    <div class="col-4">
+    <div class="col-5">
             <!-- MARKETO FORM -->
       <script src="{{ ASSET_SERVER_URL }}37b1db88-jquery.min.js"></script>
       <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -6,14 +6,14 @@
 {% block content %}
 
 <section class="p-strip--dark is-deep p-takeover--openstack" lang="fr">
-  <div class="row">
+  <div class="row u-vertically-center">
     <div class="col-8">
       <h1 class="p-takeover__title">Installez et mettez OpenStack à l'échelle en toute simplicité</h1>
       <p class="u-hide--medium u-hide--large u-align--center">
         <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="">
       </p>
     </div>
-    <div class="col-4 u-hide--small u-align--left">
+    <div class="col-4 u-hide--small u-align--center">
       <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="" class="u-hide--small">
     </div>
   </div>

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -5,40 +5,51 @@
 
 {% block content %}
 
-<section class="p-strip is-deep p-takeover--private-cloud-economics" lang="fr">
-  <div class="row u-equal-height">
+<section class="p-strip--dark is-deep p-takeover--openstack" lang="fr">
+  <div class="row">
     <div class="col-8">
       <h1 class="p-takeover__title">Installez et mettez OpenStack à l'échelle en toute simplicité</h1>
       <p class="u-hide--medium u-hide--large u-align--center">
         <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="">
       </p>
     </div>
-    <div class="col-3 u-hide--small u-align--left">
+    <div class="col-4 u-hide--small u-align--left">
       <img class="p-takeover__image" src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" alt="" class="u-hide--small">
     </div>
   </div>
+</section>
+
+<section class="p-strip">
   <div class="row">
-    <div class="col-7 p-takeover__text">
-      <h3>Avec les bons outils, OpenStack est un jeu d'enfant.</h3>
-      <p style="font-size:16px;">L'utilisation de plus en plus fréquente de gros logiciels basés sur des microservices multi-hôtes au lieu de logiciels  monolithiques traditionnels exige des perspectives et des approches fondamentalement nouvelles en matière d'installation, d'intégration et d'exploitation.</p>
-      <p style="font-size:16px;">Cet eBook vous permettra de mieux comprendre pourquoi l'installation et l'exécution d'OpenStack peut sembler complexe, et comment Canonical OpenStack simplifie les choses et peut vous aider à construire une infrastructure cloud privée moderne, évolutive, répliquable et abordable.</p>
+    <div class="col-8">
+      <h2>Avec les bons outils, OpenStack est un jeu d'enfant.</h3>
+      
+      <p>L'utilisation de plus en plus fréquente de gros logiciels basés sur des microservices multi-hôtes au lieu de logiciels  monolithiques traditionnels exige des perspectives et des approches fondamentalement nouvelles en matière d'installation, d'intégration et d'exploitation.</p>
+      
+      <p>Cet eBook vous permettra de mieux comprendre pourquoi l'installation et l'exécution d'OpenStack peut sembler complexe, et comment Canonical OpenStack simplifie les choses et peut vous aider à construire une infrastructure cloud privée moderne, évolutive, répliquable et abordable.</p>
+
       <h3 class="p-muted-heading u-align--center">Nous fournissons des clouds privés aux plus grandes entreprises</h3>
+      
       <ul class="p-inline-images">
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}4ef05fb7-bestbuy.jpg" alt="BestBuy" style="max-width:90px;"/>
         </li>
+
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b1fecbf0-logo-att-horizontal.png" width="242" alt="ATT" style="max-width:130px;"/>
         </li>
+
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" alt="Bloomberg" style="max-width:100px;"/>
         </li>
+
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}1ccb6d93-logo-deutschetelekom.svg" alt="Deutsche Telekom" />
         </li>
       </ul>
     </div>
-    <div class="col-5">
+
+    <div class="col-4">
             <!-- MARKETO FORM -->
       <script src="{{ ASSET_SERVER_URL }}37b1db88-jquery.min.js"></script>
       <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
@@ -115,5 +126,15 @@
     </div>
   </div>
 </section>
+
+<style>
+  .p-takeover--openstack {
+    background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+  }
+
+  .p-takeover__image {
+    width: 160px;
+  }
+</style>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

Updated the following /engage/fr/ pages to make them more consistent with other engage pages:
- /engage/fr/esm_1404
- /engage/fr/esm
- /engage/fr/openstack-made-easy

## QA

- Check out this feature branch
- Run `./run`
- Visit [/engage/fr/esm_1404](http://0.0.0.0:8001/engage/fr/esm_1404)
- See that the page matches the [copy doc](https://docs.google.com/document/d/1T4Ar7n4Jwypecr96Wv5SQjdNdsISNkRHBU4DTxseHo0/edit#)
- Visit [/engage/fr/esm](http://0.0.0.0:8001/engage/fr/esm)
- See that the page matches the [copy doc](https://docs.google.com/document/d/14owLexmd5yn9g9Opq2oYAw-oxG2k2YKLgEi9bGqzzMg/edit)
- Visit [/engage/fr/openstack-made-easy](http://0.0.0.0:8001/engage/fr/openstack-made-easy)
- See that the page matches the [copy doc](https://docs.google.com/document/d/16u6gbZGqzIyJgjlOOks3DyW0fhIBgogV5yNAIzXOiDc/edit#heading=h.jzec7xymbc16)