### PR TITLE
Redirect /blog/search to /search

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -735,3 +735,4 @@ usn/rss\.xml: "https://usn.ubuntu.com/rss.xml"
 (?P<page>.+)/: "/{page}"
 telco/?: "/telecommunications"
 telcos/?: "/telecommunications"
+blog/search/?: /search


### PR DESCRIPTION
This is so we can trivially redirect blog.ubuntu.com -> ubuntu.com/blog,
and blog.ubuntu.com/search URLs will also redirect properly.

QA
--

`./run`, go to http://0.0.0.0:8001/blog/search?q=hello, check you end up at http://0.0.0.0:8001/search?q=hello (even though you'll see a 500 error)