### PR TITLE
Move Talisker to top of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
 canonicalwebteam.blog==2.0.8
 canonicalwebteam.custom_response_headers==0.2.0
@@ -7,7 +8,6 @@ canonicalwebteam.http==1.0.1
 canonicalwebteam.versioned_static==1.0.2
 canonicalwebteam.yaml-responses[django]==1.1.0
 whitenoise==4.1.2
-talisker[gunicorn,prometheus,raven,django]==0.14.3
 django-yaml-redirects==0.5.4
 django-asset-server-url==0.1
 django-static-root-finder==0.3.1


### PR DESCRIPTION
I'm trying to fix this error:
https://sentry.is.canonical.com/canonical/ubuntu-com/issues/2172/

As a first step, I think we should at least try to install the dependency versions that Talisker wants, crucially prometheus_client 0.4.2 rather than 0.7.0. So I'm just moving Talisker to the top of the dependency list. For a fuller explanation see 02a4a80f

QA
--

```
.,/run --env TALISKER_NETWORKS=172.17.0.1
```

Go to http://127.0.0.1, click around a bit. Go to http://127.0.0.1/_status/metrics, check you successfully see prometheus metrics.