### PR TITLE
Add menu for the uasd Japanese translation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -232,11 +232,11 @@ blog:
     - title: Overview
       path: /blog
     - title: Internet of Things
-      path: /blog/internet-of-things          
+      path: /blog/internet-of-things
     - title: Desktop
-      path: /blog/desktop          
+      path: /blog/desktop
     - title: Cloud and Server
-      path: /blog/cloud-and-server         
+      path: /blog/cloud-and-server
     - title: Topics
       path: /blog/topics
 
@@ -257,7 +257,7 @@ blog:
     - title: Archives
       path: /blog/archives
     - title: Upcoming
-      path: /blog/upcoming   
+      path: /blog/upcoming
 
 desktop:
   title: Desktop
@@ -549,6 +549,9 @@ legal:
       children:
         - title: Service description
           path: /legal/ubuntu-advantage-service-description
+        - title: サービス範囲
+          path: /legal/ubuntu-advantage-service-description/ja
+          hidden: True
         - title: Ubuntu Assurance
           path: /legal/ubuntu-advantage-assurance
 

--- a/templates/legal/shared/_uasd_toc.html
+++ b/templates/legal/shared/_uasd_toc.html
@@ -21,6 +21,6 @@
 <nav class="p-card">
   <h3>Japanese translation</h3>
   <ul class="p-list">
-    <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA 略式サービス契約&nbsp;›</a></li>
+    <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA サービス範囲&nbsp;›</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
## Done

- Added the Japanese uasd page as a hidden navigation element, so it gets a secondary nav if you get to the page
- Update the p-card on the english page to use a better translation

## QA

- download this branch
- go to http://0.0.0.0:8001/legal/ubuntu-advantage-service-description
- click on the link to the Japanese translation (http://0.0.0.0:8001/legal/ubuntu-advantage-service-description/ja)
- see there is a secondary nav

Fixes #5354