### PR TITLE
Add link to the english page on the UASD japanese page

### DIFF
--- a/templates/legal/shared/_uasd-toc-ja.html
+++ b/templates/legal/shared/_uasd-toc-ja.html
@@ -18,3 +18,9 @@
     <li class="p-nested-counter-list__item"><a href="#uasd-definitions">用語の定義</a></li>
   </ol>
 </nav>
+<nav class="p-card">
+  <h3>English translation</h3>
+  <ul class="p-list">
+    <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description">UA service description&nbsp;›</a></li>
+  </ul>
+</nav>

--- a/templates/legal/shared/_uasd-toc-ja.html
+++ b/templates/legal/shared/_uasd-toc-ja.html
@@ -19,7 +19,7 @@
   </ol>
 </nav>
 <nav class="p-card">
-  <h3>English translation</h3>
+  <h3>English version</h3>
   <ul class="p-list">
     <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description">UA service description&nbsp;›</a></li>
   </ul>


### PR DESCRIPTION

## Done

Add link to the english page on the UASD japanese page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/legal/ubuntu-advantage-service-description/ja](http://0.0.0.0:8001/legal/ubuntu-advantage-service-description/ja)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure there is link to the english version


## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/59906997-f05cc300-9401-11e9-847f-0df86c6a5df2.png)
