### PR TITLE
Add Robotics options to the newsletter sign-up form

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -31,6 +31,13 @@
 
         <li class="p-list__item u-no-margin--top u-clearfix">
           <label>
+            <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="Robotics" type="checkbox">
+            <label for="insightsrobotics">Robotics</label>
+          </label>
+        </li>
+
+        <li class="p-list__item u-no-margin--top u-clearfix">
+          <label>
             <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
             <label for="insightstutorials">Tutorials</label>
           </label>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -198,6 +198,12 @@ Thank you for your contribution
               </li>
               <li class="p-list__item u-no-margin--top u-clearfix">
                 <label>
+                  <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="Robotics" type="checkbox">
+                  <label for="insightsrobotics">Robotics</label>
+                </label>
+              </li>
+              <li class="p-list__item u-no-margin--top u-clearfix">
+                <label>
                   <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
                   <label for="insightstutorials">Tutorials</label>
                 </label>


### PR DESCRIPTION
## Done

- Add Robotics option to the newsletter sign-up form on /download/desktop/thank-you
- Add Robotics option to the newsletter sign-up form on all /blog pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:[/download/desktop/thank-you ](http://0.0.0.0:8001/download/desktop/thank-you)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to [/download/desktop/thank-you?country=&version=18.04.2&architecture=amd64](http://0.0.0.0:8001/download/desktop/thank-you?country=&version=18.04.2&architecture=amd64) and make sure the sign-up form contains Robotics as an option
- Go to any blog page (i.e. [/blog](http://0.0.0.0:8001/blog) or [/blog/new-release-vanilla-framework-2-0](http://0.0.0.0:8001/blog/new-release-vanilla-framework-2-0)) and make sure the sign-up form contains Robotics as an option


## Issue / Card

Fixes #5368 

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/60001395-4cbc1e80-965e-11e9-89bc-15c634fc82fd.png)

