### PR TITLE
add link to AI whitepaper in footer of /ai/consulting template

### DIFF
--- a/templates/ai/consulting.html
+++ b/templates/ai/consulting.html
@@ -234,30 +234,24 @@
   <div class="row">
     <div class="col-12">
       <div class="row p-divider">
-        <div class="col-6 p-divider__block">
-            <div class="p-heading-icon--muted">
-              <div class="p-heading-icon__header">
-                <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
-                <h4 class="p-heading-icon__title">Webinars</h4>
-              </div>
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
+              <h4 class="p-heading-icon__title">Webinars</h4>
             </div>
+          </div>
           <p>
             A detailed look into the artificial intelligence and machine learning world. Learn about the AI landscape, how to deploy your first model, and more.
           </p>
           <p>
-            <a
-              class="p-link--external"
-              href="https://blog.ubuntu.com/2018/07/26/ai-ml-ubuntu-everything-you-need-to-know"
-              >AI, ML, & Ubuntu: Everything you need to know.</a
-            >
+            <a href="/blog/ai-ml-ubuntu-everything-you-need-to-know">AI, ML, & Ubuntu: Everything you need to know</a>
           </p>
           <p>
-            <a class="p-link--external" href="https://blog.ubuntu.com/2018/10/02/ai-ml-model-ubuntu"
-              >How to build and deploy your first AI/ML model on Ubuntu</a
-            >
+            <a href="/blog/ai-ml-model-ubuntu">How to build and deploy your first AI/ML model on Ubuntu</a>
           </p>
         </div>
-        <div class="col-6 p-divider__block">
+        <div class="col-4 p-divider__block">
           <div class="p-heading-icon--muted">
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" width="32" alt="">
@@ -288,6 +282,23 @@
               class="p-link--external"
               href="https://www.comparethecloud.net/articles/automating-the-future-workplace/"
               >Automating the Future of the Workplace</a
+            >
+          </p>
+        </div>
+        <div class="col-4 p-divider__block">
+          <div class="p-heading-icon--muted">
+            <div class="p-heading-icon__header">
+              <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+              <h4 class="p-heading-icon__title">Whitepaper</h4>
+            </div>
+          </div>
+          <p>
+            Getting started with AI - a structured program to help organizations  achieve their AI ambitions quickly, reliably, and cost-effectively. Examine the fundamentals of a successful AI project.
+          </p>
+          <p>
+            <a
+              href="/engage/starting-with-ai"
+              >Get started with AI</a
             >
           </p>
         </div>


### PR DESCRIPTION
## Done

- Added whitepaper section to footer on /ai/consulting, per the copy doc
- Updated blog links to point to u.c/blog

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/ai/consulting](http://0.0.0.0:8001/ai/consulting)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the [copy doc](https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk)
- Check that "AI, ML, & Ubuntu: Everything you need to know." and "How to build and deploy your first AI/ML model on Ubuntu" links take you the relevant posts on u.c/blog


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5365
