### PR TITLE
1307: update openstack overview per the copy doc

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -7,26 +7,78 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--light is-deep is-bordered">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-8">
       <h1>OpenStack, Delivered</h1>
       <p>Canonical designs, builds, operates and supports OpenStack private clouds on Ubuntu. We understand the importance of certainty, stability, performance and economic efficiency for private cloud infrastructure.</p>
+      
+      <p>Ready to move from proprietary virtualisation to OpenStack?</p>
+      
       <p>
-        <a href="/openstack/contact-us" class="p-button--positive js-invoke-modal">
-          Get in touch
+        <a href="/engage/vmware-to-openstack" class="p-button--positive">
+          Watch the VMware to Openstack webinar
+        </a>
+      </p>
+
+      <p>
+        <a href="/openstack/contact-us?product=openstack">
+          Move to OpenStack today&nbsp;&rsaquo;
         </a>
       </p>
     </div>
     <div class="col-4">
       <img src="{{ ASSET_SERVER_URL }}35515576-openstack-cloud.svg" width="323" alt="Canonical Openstack" class="u-hide--small" />
     </div>
-    <p>Choose your OpenStack package:</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2>Fully managed OpenStack &ndash; maintain your business focus</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-7">
+      <p>Canonical operates many private OpenStack clouds on behalf of customers, enabling them to get the benefits of OpenStack while focusing their team on business workloads rather than infrastructure.</p>
+      <p>This is the fast way to validate the economic case for OpenStack; you don&rsquo;t need new staff or skills, just allocate the hardware and engage with Canonical to manage your OpenStack. Once you have established devops engagement with your cloud, and once you have proven the economics of private cloud, you can invest in the skills and time to operate it yourself.</p>
+      <p>BootStack is a &rsquo;build, operate, transfer, support&lsquo; service that allows you to take control of your own cloud at any time. All Openstack and operational components deployed are open source.</p>
+    </div>
+    <div class="col-5 u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}450d7c2f-openstack-hero.svg" width="413" alt="" />
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered u-no-padding--top">
+  <div class="row">
+    <div class="col-12">
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Jointly shape the OpenStack architecture</li>
+        <li class="p-list__item is-ticked">We help you plan your cloud hardware requirements</li>
+        <li class="p-list__item is-ticked">We build OpenStack in your data center</li>
+        <li class="p-list__item is-ticked">We operate the cloud to an SLA</li>
+        <li class="p-list__item is-ticked">Transparent audit, logging, monitoring and management</li>
+        <li class="p-list__item is-ticked">When your team is ready, we hand over the keys</li>
+      </ul>
+      <p>
+        <a class="p-button--positive" href="/openstack/managed">
+          Learn about managed OpenStack
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
+    <h2>Choose your OpenStack package</h2>
   </div>
   {% include "shared/pricing/_openstack-packages.html" with columns='3' %}
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Migrate from VMware to OpenStack with Canonical</h2>
@@ -38,11 +90,12 @@
       </p>
     </div>
     <div class="col-4 u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}86914194-halfcostgraph.svg" alt="VMware cost savings" width="250px" />
+      <img src="{{ ASSET_SERVER_URL }}b8c1c0e2-halfcostgraph-white.svg" alt="VMware cost savings" width="250px" />
     </div>
   </div>
 </section>
-<section class="p-strip u-no-padding--top is-bordered">
+
+<section class="p-strip--light u-no-padding--top is-bordered">
   <div class="row">
     <div class="col-12">
       <ul class="p-list is-split">
@@ -84,45 +137,7 @@
   </div>
 </section>
 
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2>Fully managed OpenStack &ndash; maintain your business focus</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-7">
-      <p>Canonical operates many private OpenStack clouds on behalf of customers, enabling them to get the benefits of OpenStack while focusing their team on business workloads rather than infrastructure.</p>
-      <p>This is the fast way to validate the economic case for OpenStack; you don&rsquo;t need new staff or skills, just allocate the hardware and engage with Canonical to manage your OpenStack. Once you have established devops engagement with your cloud, and once you have proven the economics of private cloud, you can invest in the skills and time to operate it yourself.</p>
-      <p>BootStack is a &rsquo;build, operate, transfer, support&lsquo; service that allows you to take control of your own cloud at any time. All Openstack and operational components deployed are open source.</p>
-    </div>
-    <div class="col-5 u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}450d7c2f-openstack-hero.svg" width="413" alt="" />
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered u-no-padding--top">
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Jointly shape the OpenStack architecture</li>
-        <li class="p-list__item is-ticked">We help you plan your cloud hardware requirements</li>
-        <li class="p-list__item is-ticked">We build OpenStack in your data center</li>
-        <li class="p-list__item is-ticked">We operate the cloud to an SLA</li>
-        <li class="p-list__item is-ticked">Transparent audit, logging, monitoring and management</li>
-        <li class="p-list__item is-ticked">When your team is ready, we hand over the keys</li>
-      </ul>
-      <p>
-        <a class="p-button--positive" href="/openstack/managed">
-          Learn about managed OpenStack
-        </a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   {% include "openstack/shared/_openstack_clients.html" with heading="A SELECTION OF OUR OPENSTACK CLIENTS" %}
 </section>
 
@@ -137,6 +152,7 @@
     </div>
   </div>
 </section>
+
 <section class="p-strip is-bordered u-no-padding--top">
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
## Done

- Updated /openstack in to match the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/openstack](http://0.0.0.0:8001/openstack)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1307
