### PR TITLE
Remove link to blog post & remove blog post

### DIFF
--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -35,18 +35,6 @@
       <p>The data center is following, and software-defined storage based on commodity servers and disks with Ubuntu has become the new norm for high-growth low-cost block storage, object stores and data lakes. Open source Ceph, Swift and HDFS enable massive enterprise operations with total costs in line with the underlying bulk commodity disk prices.</p>
       <p>Ubuntu Advantage Storage is the proven enterprise software-defined storage offering at the lowest per gigabyte price.</p>
     </div>
-
-    <div class="col-4">
-      <div class="p-card--highlighted">
-        <div class="p-card__header">
-          <p class="p-muted-heading">FAQ</p>
-        </div>
-        <div class="p-card__content u-no-margin--top">
-          <h3 class="p-card__title p-heading--four"><a href="https://blog.ubuntu.com/2015/05/18/ubuntu-advantage-storage-factsheet" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Ubuntu Storage FAQ', 'eventLabel' : 'from ubuntu.com/openstack/storage', 'eventValue' : undefined });">Ubuntu Advantage Storage FAQs&nbsp;&rsaquo;</a></h3>
-          <p>Answers to your most frequently asked questions about Ubuntu Advantage Storage.</p>
-        </div>
-      </div>
-    </div>
   </div>
   <div class="row">
     <div class="col-8">


### PR DESCRIPTION
## Done

- Remove `FAQ` section from /openstack/storage
- Delete https://blog.ubuntu.com/2015/05/18/ubuntu-advantage-storage-factsheet post 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [x] Make sure the `FAQ` section is removed from [/openstack/storage](https://ubuntu-com-canonical-web-and-design-pr-5374.run.demo.haus/openstack/storage)
- [x] Make sure you get a 404 for this page https://blog.ubuntu.com/2015/05/18/ubuntu-advantage-storage-factsheet


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1293

