### PR TITLE
5309: increase space above list section, using suggested solution

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -48,6 +48,7 @@
   </div>
   <div class="row">
     <div class="col-12">
+      <p></p>
       <h3>Here&rsquo;s why Ubuntu is the best answer to the scale-out challenge:</h3>
       <ul class="p-list--divided is-split">
         <li class="p-list__item is-ticked"><strong>Scale-out at the core</strong>: Ubuntu Server supports the scale-out compute model and provides tools which make it simple to manage the entire cluster.</li>


### PR DESCRIPTION
## Done

- add empty `p` tag above list to trigger additional margin on the list's `h3` tag, per [suggested solution](https://github.com/canonical-web-and-design/ubuntu.com/issues/5309#issuecomment-502029058).

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/server/hyperscale](http://0.0.0.0:8001/server/hyperscale)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is more space between "Here’s why Ubuntu is the best answer to the scale-out challenge:" and the paragraphs above it, compared to https://ubuntu.com/server/hyperscale


## Issue / Card

Fixes #5309
