### PR TITLE
5378: extends_with_args: if variable doesn't exist, return empty string

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -16,7 +16,7 @@
           {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
           <p>
             Try reloading the page.
-            If the error persists, please it may be a <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues">known issue</a>.
+            If the error persists, please note that it may be a <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues">known issue</a>.
             If not, please <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new">file a new issue</a>.
           </p>
         </div>

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -109,7 +109,11 @@ class ExtendsWithArgsNode(template.Node):
                 extra_context[key] = value[1:-1]
             else:
                 # It's a variable
-                extra_context[key] = template.Variable(value).resolve(context)
+                try:
+                    variable = template.Variable(value)
+                    extra_context[key] = variable.resolve(context)
+                except template.VariableDoesNotExist:
+                    extra_context[key] = ""
 
         context.update(extra_context)
         self.node.origin = self.origin


### PR DESCRIPTION
## Done

- `extends_with_args` tag can take template variables, added a check to make sure the variable exists, and if it doesn't, return an empty string instead of an error
- fixed grammar mistake on 500 page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/blog/minimal-ubuntu-released](http://0.0.0.0:8001/blog/minimal-ubuntu-released)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that you see the post "Minimal Ubuntu, on public clouds and Docker Hub", and not a 500 error page


## Issue / Card

Fixes #5378 and #5379
