### PR TITLE
New pages and updates to docs for 1.15 release

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -111,6 +111,24 @@ kubernetes:
         - title: GCP integration
           path: /kubernetes/docs/gcp-integration
           hidden: True
+        - title: OpenStack integration
+          path: /kubernetes/docs/openstack-integration
+          hidden: True
+        - title: CNI overview
+          path: /kubernetes/docs/cni-overview
+          hidden: True
+        - title: Flannel
+          path: /kubernetes/docs/cni-flannel
+          hidden: True
+        - title: Calico
+          path: /kubernetes/docs/cni-calico
+          hidden: True
+        - title: Canal
+          path: /kubernetes/docs/cni-canal
+          hidden: True
+        - title: Using Tigera Secure EE
+          path: /kubernetes/docs/tigera-secure-ee
+          hidden: True
         - title: Basic Operations
           path: /kubernetes/docs/operations
           hidden: True
@@ -156,11 +174,11 @@ kubernetes:
         - title: Audit Logging
           path: /kubernetes/docs/audit-logging
           hidden: True
-        - title: Using Tigera Secure EE
-          path: /kubernetes/docs/tigera-secure-ee
-          hidden: True
         - title: Troubleshooting
           path: /kubernetes/docs/troubleshooting
+          hidden: True
+        - title: Containerd and Docker
+          path: /kubernetes/docs/container-runtime
           hidden: True
         - title: Overview
           path: /kubernetes/docs/high-availability
@@ -173,6 +191,9 @@ kubernetes:
           hidden: True
         - title: MetalLB
           path: /kubernetes/docs/metallb
+          hidden: True
+        - title: Custom loadbalancer
+          path: /kubernetes/docs/custom-loadbalancer
           hidden: True
         - title: Release notes
           path: /kubernetes/docs/release-notes

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -244,8 +244,6 @@ If you create ELBs and subsequently tear down the cluster, check with the AWS co
 to make sure all the associated resources have also been released.
   </p>
 </div>
-Note that if you subsequently decommission this service, it is useful to check through
-the AWS console that the ELB resources are also released.
 
 ### Upgrading the integrator-charm
 
@@ -275,7 +273,7 @@ juju debug-log --replay --include aws-integrator/0
 
 <!-- LINKS -->
 
-[asset-aws-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/aws-overlay.yaml
+[asset-aws-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/kubernetes-docs/master/assets/aws-overlay.yaml
 [quickstart]: /kubernetes/docs/quickstart
 [storage]: /kubernetes/docs/storage
 [ebs-info]: https://aws.amazon.com/ebs/features/

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -5,6 +5,12 @@ markdown_includes:
 context:
   title: "Backups"
   description: How to backup and restore the state of your Kubernetes cluster in the etcd datastore.
+keywords: juju, backup, etcd
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: backups.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
 The state of your **Kubernetes** cluster is kept in the **etcd** datastore. This page shows how to backup and restore the etcd included in the **Charmed Distribution of Kubernetes <sup>&reg;</sup>**.

--- a/templates/kubernetes/docs/ceph.md
+++ b/templates/kubernetes/docs/ceph.md
@@ -5,6 +5,12 @@ markdown_includes:
 context:
   title: "Ceph storage"
   description: How to get Ceph deployed and related to Kubernetes in order to have a default storage class. This allows for easy storage allocation.
+keywords: quickstart
+tags: [getting_started]
+sidebar: k8smain-sidebar
+permalink: ceph.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
 ## How to add **Ceph** storage

--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -1,0 +1,368 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CNI with Calico"
+  description: How to manage and deploy Kubernetes with Calico
+keywords: CNI, networking
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: cni-calico.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+[Calico][] is a software-defined network solution that can be used with Kubernetes.
+Support for Calico in **Charmed Kubernetes** is provided in the form of a `calico`
+subordinate charm.
+
+Unlike Flannel, Calico provides out-of-the-box support for the
+[NetworkPolicy][] feature of Kubernetes, along with different modes of
+network encapsulation that advanced users may find useful for optimising
+the throughput of their clusters.
+
+## Cloud configuration
+
+Calico's network traffic is filtered on many clouds, and may require
+special configuration at the cloud level to support it.
+
+If Calico is configured to use [BGP mode][bgp] (the default), then all of the
+Kubernetes instances must be located in the same subnet for Calico to work out
+of the box. Alternatively, the Calico charm may be configured with external
+BGP peers to allow cross-subnet traffic to work.
+
+If Calico is configured to use IPIP mode, then the cloud must be configured to
+allow IPIP (protocol 4) network traffic.
+
+### AWS
+
+On AWS, it is recommended to run Calico in BGP mode. This usually requires the
+creation of a VPC that has only a single subnet associated with it. See Juju's
+[Creating an AWS VPC][] documentation for instructions on how to create a VPC
+that's compatible with Juju.
+
+After deployment, each AWS instance must be manually configured to disable
+source/destination checks. See AWS's [Disabling Source/Destination Checks][]
+documentation for instructions.
+
+## Deploying Charmed Kubernetes with Calico
+
+To deploy CDK with Calico, deploy the kubernetes-calico bundle:
+
+```bash
+juju deploy cs:~containers/kubernetes-calico
+```
+
+The calico bundle is identical to the standard `charmed-kubernetes` bundle with the
+exception of replacing flannel with calico. You can apply any customisation overlays
+that would apply to `charmed-kubernetes` to this bundle also.
+
+## Calico configuration options
+
+| Name                |  Type  |  Default value                           | Description                                                    |
+|=====================|========|==========================================|================================================================|
+| calico-node-image   | string | docker.io/calico/node:v3.6.1             | The image id to use for calico/node                            |
+| calico-policy-image | string | docker.io/calico/kube-controllers:v3.6.1 | The image id to use for calico/kube-controllers                |
+| ipip                | string | Never                                    | IPIP mode. Must be one of "Always", "CrossSubnet", or "Never". |
+| nat-outgoing        | bool   | True                                     | Enable NAT on outgoing traffic                                 |
+| cidr                | string | 192.168.0.0/16                           | Network CIDR assigned to Calico. This is applied to the default Calico pool, and is also communicated to the Kubernetes charms for use in kube-proxy configuration. |
+| manage-pools        | bool   | True                                     | If true, a default pool is created using the cidr and ipip charm configuration values. Warning: When manage-pools is enabled, the charm will delete any pools that are unrecognized. |
+| global-as-number    | int    | 64512                                    | Global AS number.
+| subnet-as-numbers   | string | {}                                       | Mapping of subnets to AS numbers, specified as YAML. Each Calico node will be assigned an AS number based on the entries in this mapping. |
+| unit-as-numbers     | string | {}                                       | Mapping of unit IDs to AS numbers, specified as YAML. Each Calico node will be assigned an AS number based on the entries in this mapping. |
+| node-to-node-mesh   | bool   | True                                     | When enabled, each Calico node will peer with every other Calico node in the cluster. |
+| global-bgp-peers    | string | []                                       | List of global BGP peers. Each BGP peer is specified with an address and an as-number. |
+| subnet-bgp-peers    | string | {}                                       | Mapping of subnets to lists of BGP peers. Each BGP peer is specified with an address and an as-number. |
+| unit-bgp-peers      | string | {}                                       | Mapping of unit IDs to lists of BGP peers. Each BGP peer is specified with an address and an as-number. |
+| route-reflector-cluster-ids | string | {}                               | Mapping of unit IDs to route reflector cluster IDs. Assigning a route reflector cluster ID allows the node to function as a route reflector. |
+
+### Checking the current configuration
+
+To check the current configuration settings for Calico, run the command:
+
+```bash
+juju config calico
+```
+
+### Setting a config option
+
+To set an option, simply run the config command with and additional `<key>=<value>` argument. For example, to disable NAT on outgoing traffic:
+
+```bash
+juju config calico nat-outgoing=False
+```
+
+Config settings which require additional explanation are described below.
+
+## Calico IPIP configuration
+
+By default, IPIP encapsulation is disabled. To enable IPIP encapsulation, set
+the `ipip` charm config to `Always`:
+
+```
+juju config calico ipip=Always
+```
+
+Alternatively, if you would like IPIP encapsulation to be used for cross-subnet
+traffic only, set the `ipip` charm config to `CrossSubnet`:
+
+```
+juju config calico ipip=CrossSubnet
+```
+
+## Calico BGP configuration
+
+The default configuration of Calico uses BGP mode, with all Calico nodes
+connected in a full node-to-node mesh, and with no external peerings. This
+comes with some limitations which will be explained in the following sections.
+
+### BGP with multiple subnets
+
+If BGP mode is in use, and Calico units are deployed to separate subnets, then
+Calico must be configured to peer with external routers in order to accommodate
+cross-subnet traffic.
+
+For example, if you have units across two subnets (10.0.0.0/24 and
+10.0.1.0/24), and a single router that connects them (with IPs 10.0.0.1,
+10.0.1.1, and AS number 64512), then the simplest configuration would be to
+configure Calico to peer with that router and to use the same AS number.
+
+Configure the AS number:
+```bash
+juju config calico global-as-number=64512
+```
+
+And configure the external peering:
+
+```bash
+juju config calico subnet-bgp-peers="
+10.0.0.0/24:
+- address: 10.0.0.1
+  as-number: 64512
+10.0.1.0/24:
+- address: 10.0.1.1
+  as-number: 64512
+"
+```
+
+You will also need to configure the router to peer with each Calico node. This
+step varies based on the router's BGP implementation. Here's an
+[example configuration for BIRD][bgp-multiple-subnets-bird-example].
+
+### BGP route reflection
+
+By default, all Calico nodes are connected in a full BGP mesh. This works well
+for small deployments, but does not scale well to larger deployments. For
+large deployments, it is recommended that you configure Calico to use
+[route reflection].
+
+For example, in a deployment with more than 10 Calico units, you might
+configure it such that units calico/0 (with IP 10.0.0.2) and calico/1 (with IP
+10.0.0.3) are route reflectors, and all other Calico units only peer with them.
+To do this, you would first configure route reflector cluster IDs:
+
+```bash
+juju config calico route-reflector-cluster-ids="
+0: 0.0.0.0
+1: 0.0.0.0
+"
+```
+
+Then configure every node to peer with the route reflectors:
+```bash
+juju config calico global-bgp-peers="
+- address: 10.0.0.2
+  as-number: 64512
+- address: 10.0.0.3
+  as-number: 64512
+"
+```
+
+And disable the node-to-node-mesh:
+```bash
+juju config calico node-to-node-mesh=false
+```
+
+### BGP with the AS Per Rack model
+
+One commonly used model for Calico deployments on bare metal is the
+[AS Per Rack model]. The configuration in this scenario can be tricky, so let's
+walk through an example.
+
+Given:
+- Two racks:
+  - Rack 0
+    - Subnets 10.0.0.0/24, 10.0.1.0/24
+    - ToR router with IPs 10.0.0.1, 10.0.1.1
+    - Desired route reflectors:
+      - calico/0 at 10.0.0.2
+      - calico/1 at 10.0.1.2
+  - Rack 1
+    - Subnets 10.0.2.0/24, 10.0.3.0/24
+    - ToR router with IPs 10.0.2.1, 10.0.3.1
+    - Desired route reflectors:
+      - calico/2 at 10.0.2.2
+      - calico/3 at 10.0.3.2
+
+Assign a different AS number to each rack:
+
+```bash
+juju config calico subnet-as-numbers="
+10.0.0.0/24: 64512
+10.0.1.0/24: 64512
+10.0.2.0/24: 64513
+10.0.3.0/24: 64513
+"
+```
+
+Next, configure the route reflectors. Each route reflector needs to be assigned
+a cluster ID. The exact cluster ID used isn't important, as long as both route
+reflectors on a given rack share the same cluster ID. For this example, we'll
+choose 0.0.0.0 for rack 0 and 0.0.0.1 for rack 1.
+
+Configure the route reflectors:
+
+```bash
+juju config calico route-reflector-cluster-ids="
+0: 0.0.0.0
+1: 0.0.0.0
+2: 0.0.0.1
+3: 0.0.0.1
+"
+```
+
+Configure route reflectors to peer with the top of rack switches:
+
+```bash
+juju config calico unit-bgp-peers="
+0:
+- address: 10.0.0.1
+  as-number: 64512
+1:
+- address: 10.0.1.1
+  as-number: 64512
+2:
+- address: 10.0.2.1
+  as-number: 64513
+3:
+- address: 10.0.3.1
+  as-number: 64513
+"
+```
+
+Configure Calico nodes to peer with the route reflectors:
+
+```bash
+juju config calico subnet-bgp-peers="
+10.0.0.0/24:
+- address: 10.0.0.2
+  as-number: 64512
+- address: 10.0.1.2
+  as-number: 64512
+10.0.1.0/24:
+- address: 10.0.0.2
+  as-number: 64512
+- address: 10.0.1.2
+  as-number: 64512
+10.0.2.0/24:
+- address: 10.0.2.2
+  as-number: 64513
+- address: 10.0.3.2
+  as-number: 64513
+10.0.3.0/24:
+- address: 10.0.2.2
+  as-number: 64513
+- address: 10.0.3.2
+  as-number: 64513
+"
+```
+
+And disable the node-to-node mesh:
+
+```bash
+juju config calico node-to-node-mesh=false
+```
+
+You will also need to configure the top of rack switches to peer with the
+Calico route reflectors. Instructions for doing this should be provided in the
+documentation for the specific model of switch you are using.
+
+## Configuring multiple Calico pools
+
+The Calico charm creates a single IPPool. If multiple IPPools pools are desired,
+then you must first disable the charm's built-in pool management:
+
+```bash
+juju config calico manage-pools=false
+```
+
+Then use calicoctl to create your own pools. For example:
+
+```bash
+juju ssh calico/0 calicoctl apply -f - << EOF
+apiVersion: projectcalico.org/v3
+kind: IPPool
+metadata:
+  name: my-pool
+spec:
+  cidr: 192.168.0.0/24
+  ipipMode: Never
+  natOutgoing: true
+EOF
+```
+
+## Using a private Docker registry
+
+For a general introduction to using a private Docker registry with
+**Charmed Kubernetes**, please refer to the [Private Docker Registry][] page.
+
+In addition to the steps documented there, you will need to upload the
+following images to the registry:
+
+```no-highlight
+docker.io/calico/node:v3.6.1
+docker.io/calico/kube-controllers:v3.6.1
+```
+
+And configure Calico to use the registry:
+
+```bash
+export IP=`juju run --unit docker-registry/0 'network-get website --ingress-address'`
+export PORT=`juju config docker-registry registry-port`
+export REGISTRY=$IP:$PORT
+juju config calico \
+  calico-node-image=$registry/calico/node:v3.6.1 \
+  calico-policy-image=$registry/calico/kube-controllers:v3.6.1
+```
+
+## Troubleshooting
+
+If there is an issue with connectivity, it can be useful to inspect the Juju logs.
+To see a complete set of logs for Calico
+
+```bash
+juju debug-log --replay --include=calico
+```
+
+For additional troubleshooting pointers, please see the [dedicated troubleshooting page][troubleshooting].
+
+## Useful links
+
+- The [Calico website][calico-learn] has a thorough explanation of its network management strategy.
+
+<!-- LINKS -->
+
+[calico-learn]: https://www.projectcalico.org/learn/
+[NetworkPolicy]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+[Creating an AWS VPC]: https://docs.jujucharms.com/2.5/en/charms-fan-aws-vpc
+[Disabling Source/Destination Checks]: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html#EIP_Disable_SrcDestCheck
+[private docker registry]: /kubernetes/docs/docker-registry
+[bgp]: https://docs.projectcalico.org/v3.7/networking/service-advertisement#about-advertising-kubernetes-services-over-bgp
+[Calico]: https://www.projectcalico.org/
+[troubleshooting]: /kubernetes/docs/troubleshooting
+[quickstart]:  /kubernetes/docs/quickstart
+[install-manual]:  /kubernetes/docs/install-manual
+[bgp-multiple-subnets-bird-example]: https://gist.github.com/Cynerva/46712dd1e9b75d42cb38fb966abfa932
+[route reflection]: https://tools.ietf.org/html/rfc4456
+[AS Per Rack model]: https://docs.projectcalico.org/v3.6/networking/design/l3-interconnect-fabric#the-as-per-rack-model

--- a/templates/kubernetes/docs/cni-canal.md
+++ b/templates/kubernetes/docs/cni-canal.md
@@ -1,0 +1,79 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CNI with canal"
+  description: How to manage and deploy Kubernetes with Canal
+keywords: CNI, networking
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: cni-canal.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+"Canal" is a shorthand for saying "Calico and Flannel", a common practise which sets
+up Calico to handle policy management and Flannel to manage the network itself. This
+combination brings in Calico's support for the NetworkPolicy feature of Kubernetes,
+while utilizing Flannel's UDP-based network traffic to provide for an easier setup
+experience that works in a wider variety of host network environments without
+special configuration.
+
+
+## Deploying Charmed Kubernetes with Canal
+
+To deploy a cluster with Canal, deploy the kubernetes-canal bundle:
+
+```bash
+juju deploy cs:bundle/canonical-kubernetes-canal
+```
+
+The canal bundle is identical to the standard `charmed-kubernetes` bundle with the
+exception of replacing flannel with canal. You can apply any customisation overlays
+that would apply to `charmed-kubernetes` to this bundle also.
+
+## Canal configuration options
+
+|Name                  | Type    | Default   | Description                      |
+|======================|=========|===========|==================================|
+| calico-node-image    | string  | docker.io/calico/node:v3.6.1|The image id to use for calico/node. |
+| calico-policy-image  | string  | docker.io/calico/kube-controllers:v3.6.1|The image id to use for calico/kube-controllers. |
+| cidr                 | string  | 10.1.0.0/16|Network CIDR to assign to Flannel |
+| iface                | string  |           |The interface to bind flannel overlay networking. The default value is the interface bound to the cni endpoint. |
+| nagios_context       | string  | juju      |Used by the nrpe subordinate charms. A string that will be prepended to instance name to set the host name in nagios. So for instance the hostname would be something like:     juju-myservice-0 If you're running multiple environments with the same services in them this allows you to differentiate between them. |
+| nagios_servicegroups | string  |           |A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup |
+                                |
+
+### Checking the current configuration
+
+To check the current configuration settings for Canal, run the command:
+
+```bash
+juju config canal
+```
+
+### Setting a config option
+
+To set an option, simply run the config command with and additional `<key>=<value>` argument. For example, to set a specific network CIDR:
+
+```bash
+juju config canal cidr="10.5.0.0/16"
+```
+
+## Troubleshooting
+
+If there is an issue with connectivity, it can be useful to inspect the Juju logs. To
+see a complete set of logs for canal:
+
+```bash
+juju debug-log --replay --include=canal
+```
+
+For additional troubleshooting pointers, please see the
+[dedicated troubleshooting page][troubleshooting].
+
+<!-- LINKS -->
+
+[canal]: https://docs.projectcalico.org/v3.7/getting-started/kubernetes/installation/flannel
+[troubleshooting]: /kubernetes/docs/troubleshooting

--- a/templates/kubernetes/docs/cni-flannel.md
+++ b/templates/kubernetes/docs/cni-flannel.md
@@ -1,0 +1,76 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CNI with flannel"
+  description: How to manage and deploy Kubernetes with flannel
+keywords: CNI, networking, flannel
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: cni-flannel.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+
+[Flannel][] is a simple, lightweight layer 3 fabric for Kubernetes. Flannel manages an
+IPv4 network between multiple nodes in a cluster. It does not control how containers
+are networked to the host, only how the traffic is transported between hosts. For
+more complicated scenarios, see also [Calico][] and [Canal][]
+
+
+## Deploying **Charmed Kubernetes** with flannel
+
+Flannel is the default choice for networking with **Charmed Kubernetes**. If you
+[install using `conjure-up`][quickstart], or by
+[manually deploying the bundle][install-manual] without changing the default settings,
+flannel will be used for CNI.
+
+## Flannel options
+
+
+| Name                  |  Type     |  Default value | Description  |
+|=============|=======|============|====================================|
+| cidr                       | string     | 10.1.0.0/16      | Network CIDR to assign to Flannel  |
+| iface                      | string     | see description>  |  The interface to bind flannel overlay networking. The default value is the interface bound to the CNI endpoint. |
+|  nagios_context |  string |  juju  |  A string that will be prepended to instance name to set the host name in nagios. If you're running multiple environments with the same services in them this allows you to differentiate between them. Used by the nrpe subordinate charm. |
+| nagios_servicegroups | string  | (empty)  | A comma-separated list of nagios servicegroups. If left empty, the `nagios_context` will be used as the servicegroup  |
+
+### Checking the current configuration
+
+To check the current configuration settings for Flannel, run the command:
+
+```bash
+juju config flannel
+```
+
+### Setting a config option
+
+To set an option, simply run the config command with and additional `<key>=<value>` argument. For example, to set a specific network CIDR:
+
+```bash
+juju config flannel cidr="10.5.0.0/16"
+```
+
+## Troubleshooting
+
+If there is an issue with connectivity, it can be useful to inspect the Juju logs. To
+see a complete set of logs for flannel:
+
+```bash
+juju debug-log --replay --include=flannel
+```
+
+For additional troubleshooting pointers, please see the [dedicated troubleshooting page][troubleshooting].
+
+
+
+<!-- LINKS -->
+
+[Flannel]: https://github.com/coreos/flannel
+[troubleshooting]: /kubernetes/docs/troubleshooting
+[quickstart]:  /kubernetes/docs/quickstart
+[install-manual]:  /kubernetes/docs/install-manual
+[Calico]: /kubernetes/docs/cni-calico
+[Canal]: /kubernetes/docs/cni-canal

--- a/templates/kubernetes/docs/cni-overview.md
+++ b/templates/kubernetes/docs/cni-overview.md
@@ -1,0 +1,53 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CNI overview"
+  description: How to manage and deploy Kubernetes with flannel, calico, canal or Tigera Secure EE
+keywords: CNI, networking
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: cni-overview.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+Managing a network where containers can interoperate efficiently is very
+important. Kubernetes has adopted the Container Network Interface(CNI)
+specification for managing network resources on a cluster. This relatively
+simple specification makes it easy for Kubernetes to interact with a wide range
+of CNI-based software solutions.
+
+With **Charmed Kubernetes**, these networking 'plug-ins' are deployed as
+subordinate charms with each  node running as a `kubernetes-master` or
+`kubernetes-worker`, and ensure the smooth running of the cluster. It is
+possible to choose one of several different CNI providers for **Charmed
+Kubernetes**, which are listed below:
+
+## Supported CNI options
+
+The currently supported CNI solutions for **Charmed Kubernetes** are:
+
+ -   [Flannel][flannel]
+ -   [Calico][calico]
+ -   [Canal][canal]
+ -   [Tigera Secure EE][tigera]
+
+By default, **Charmed Kubernetes** will deploy the cluster using flannel. To chose a different CNI provider, see the individual links above.
+
+## Migrating to a different CNI solution
+
+As networking is a fundamental part of the cluster, changing the network on a live cluster
+is not straightforward. Currently it is recommended to create a new cluster with **Charmed Kubernetes**
+using the desired option. When [federation][] becomes part of a future release of
+Kubernetes, such a migration should be manageable with no downtime.
+
+<!-- LINKS -->
+
+[flannel]: /kubernetes/docs/cni-flannel
+[calico]: /kubernetes/docs/cni-calico
+[canal]: /kubernetes/docs/cni-canal
+[tigera]: /kubernetes/docs/tigera-secure-ee
+[install]: /kubernetes/docs/install-manual
+[federation]: https://github.com/kubernetes-sigs/kubefed

--- a/templates/kubernetes/docs/container-runtime.md
+++ b/templates/kubernetes/docs/container-runtime.md
@@ -1,0 +1,80 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "Container runtimes"
+  description: Configure and use containerd or docker as the container runtime
+keywords: containerd, docker, runtime, image
+tags: [architecture]
+sidebar: k8smain-sidebar
+permalink: container-runtime.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+From 1.15 onwards, **Charmed Kubernetes** uses **containerd** as part of a pluggable architecture for
+container runtimes, instead of directly using Docker only. This change has been
+demonstrated to increase performance, and also provides scope for using different
+runtimes on a case-by case basis.
+
+However, it is also possible to use Docker for running containers as in previous versions
+of **Charmed Kubernetes**.
+
+
+## Configuring containerd
+
+Settings which require additional explanation are described below.
+
+|Name             |   Type         |  Default Value                              |  Description                           |
+|==========|=========|========================|=====================|
+| custom_registries:   |  json |  '[]' |  Setting this config allows images to be pulled from registries requiring auth. [See below](#custom-registries).  |
+|enable-cgroups   | bool   | False   |   WARNING changing this option will reboot the host - [see notes](#enable-cgroups).|
+|extra-packages | string  | ""  | Space separated list of extra deb packages to install.  |
+|gpu-driver  |  string |   'auto' |  Override GPU driver installation.  Options are "auto", "nvidia", "none". |
+|http_proxy   |  string | ""  | URL to use for HTTP_PROXY: useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images.  |
+|https_proxy   | string | "" | URL to use for HTTP_PROXY: useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
+|install_keys   |  string | ""  | List of signing keys for install_sources package sources - [see notes](#install-keys)  |
+|install_sources   | string  | ""  |  List of extra apt sources - [See notes](#install-sources.) |
+|no_proxy | string | "" | Comma-separated list of destinations (either domain names or IP addresses) which should be accessed directly, rather than through the proxy defined in http_proxy or https_proxy. Must be less than 2023 characters long.|
+|package_status  |  string | 'install'  |  The status of service-affecting packages will be set to this value in the dpkg database. Valid values are "install" and "hold". |
+| runtime   |  string | 'auto'   | Set a custom containerd runtime.  Set "auto" to select based on hardware.|
+| shim | string | 'containerd-shim' |   Set a custom containerd shim. |
+
+### Checking the current configuration
+
+To check the current configuration settings for containerd, run the command:
+
+```bash
+juju config containerd
+```
+
+### Setting a config option
+
+To set an option, simply run the config command with and additional `<key>=<value>` argument. For example, to explicitly turn off the nvidia driver:
+
+```bash
+juju config containerd gpu_driver=none
+```
+
+## Migrating to containerd
+
+If you have upgraded to  **Charmed Kubernetes** version 1.15, you can transition to using containerd by following the steps outlined in
+[this section of the upgrade notes][docker2containerd].
+
+## Using Docker
+
+Although the default set up for **Charmed Kubernetes** from version 1.15 is to use containerd to provide the container runtime, it is also possible to
+run workers specifically using Docker. This is done by adding the Docker
+charm to your cluster and deploying Docker-based workers:
+
+```bash
+juju deploy cs:~containers/kubernetes-worker kubernetes-worker-docker
+juju deploy cs:~containers/docker
+juju relate docker kubernetes-worker-docker
+```
+
+
+<!-- LINKS -->
+
+[docker2containerd]: /kubernetes/docs/upgrade-notes#1.15

--- a/templates/kubernetes/docs/custom-loadbalancer.md
+++ b/templates/kubernetes/docs/custom-loadbalancer.md
@@ -1,0 +1,61 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "Custom load balancers"
+  description: How to configure your Kubernetes cluster to use a custom load balancer.
+keywords: high availability, vip, load balancer, f5
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: custom-loadbalancer.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** supports setting a
+custom IP address for the control plane.  There are two ways of achieving this, depending
+on which type of load balancing solution you wish to configure:
+
+ -  If you have a virtual IP to place in front of machines, configure the settings on the
+    `kubeapi-load-balancer` charm.
+
+ -  If a full load balancing solution is in place such as an F5 appliance, remove the
+     `kubeapi-load-balancer` and use the settings on the `kubernetes-master` charm to
+      configure the load balancer.
+
+Both solutions are described in the sections below.
+
+# Virtual IP in front of kubeapi-load-balancer
+
+If you have a virtual IP in front of the kubeapi-load-balancer
+units which isn't charm based, you should use the loadbalancer-ips configuration to
+specify them:
+
+```bash
+juju config kubeapi-load-balancer loadbalancer-ips="10.0.0.1 10.0.0.2"
+```
+
+Multiple IP addresses should be given as a space-separated list.
+
+
+# Custom load balancer in front of kubernetes-master charm
+
+If you have a full load balancer such as an F5 appliance or OpenStack's Neutron,
+use the configuration options on the `kubernetes-master` charm and forgo
+`kubeapi-load-balancer`  entirely.
+
+Remove the `kubeapi-load-balancer` application if it exists:
+
+```bash
+juju remove-application kubeapi-load-balancer
+```
+
+Then configure the IP addresses provided by the load balancing solution with the
+`kubernetes-master` charm.
+
+```bash
+juju config kubernetes-master loadbalancer-ips="192.168.1.1 192.168.2.1"
+```
+
+Multiple IP addresses should be given as a space-separated list.

--- a/templates/kubernetes/docs/gcp-integration.md
+++ b/templates/kubernetes/docs/gcp-integration.md
@@ -309,7 +309,7 @@ juju debug-log --replay --include gcp-integrator/0
 [quickstart]: /kubernetes/docs/quickstart
 [owner]: https://console.cloud.google.com/iam-admin/iam
 [iam-roles]: https://cloud.google.com/compute/docs/access/iam
-[asset-gcp-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/gcp-overlay.yaml
+[asset-gcp-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/kubernetes-docs/master/assets/gcp-overlay.yaml
 [operations]: https://console.cloud.google.com/compute/operations
 [storage]: /kubernetes/docs/storage
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes

--- a/templates/kubernetes/docs/high-availability.md
+++ b/templates/kubernetes/docs/high-availability.md
@@ -15,21 +15,21 @@ toc: False
 
 It is desirable to have a **CDK** cluster that is resilient to failure and highly available. For
 clusters operating in public cloud environments the options and the methodology are
-usually straightforward - cloud providers have HA solutions which will work well in these 
+usually straightforward - cloud providers have HA solutions which will work well in these
 environments, and these should be used for **CDK**.
 
 For 'on-premises' or private cloud deployments, there are a number of options. This
 documentation will present the strategies and methodology for software solutions only -
 if you have a hardware load-balancer, that would obviously be a better option.
 
- We start with the two basic components of a **CDK** cluster: 
- 
+ We start with the two basic components of a **CDK** cluster:
+
  - your control plane, the `kubernetes-master` charm
  - the worker units, the `kubernetes-worker` charm
 
 ## Control Plane
 
-An initial plan to make the control plane more resilient might be to simply add more 
+An initial plan to make the control plane more resilient might be to simply add more
 master nodes with  `juju add-unit kubernetes-master`:
 
 ![multi-master worker image][img-multi-master]
@@ -82,7 +82,7 @@ Multiple virtual IPs would be a good choice in front of the workers. This allows
 bit of load balancing with round-robin DNS and also allows individual workers to fail.
 A more robust option would be to add load balancers in front of the workers and
 float virtual IPs on those. Note a downside here is the increase in internal traffic as it may
-need to be routed due to load or just to find a worker with the correct destination pod. 
+need to be routed due to load or just to find a worker with the correct destination pod.
 This problem is under active development with projects that are Kubernetes-aware such
 as MetalLB.
 
@@ -94,6 +94,7 @@ software to enable HA
   - [Keepalived][keepalived]
   - [HAcluster][hacluster]
   - [MetalLB][metallb]
+  - [Custom Load Balancer/Virtual IP][customlb]
 
 <!-- IMAGES -->
 
@@ -106,3 +107,4 @@ software to enable HA
 [keepalived]: /kubernetes/docs/keepalived
 [hacluster]: /kubernetes/docs/hacluster
 [metallb]: /kubernetes/docs/metallb
+[customlb]: /kubernetes/docs/custom-loadbalancer

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -135,7 +135,7 @@ versions of the **CDK** bundle are shown in the table below:
 
 | Kubernetes version | CDK bundle |
 | --- | --- |
-| 1.14.x         | [charmed-kubernetes-96](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-96/archive/bundle.yaml) |
+| 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
 | 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -135,6 +135,7 @@ versions of the **CDK** bundle are shown in the table below:
 
 | Kubernetes version | CDK bundle |
 | --- | --- |
+| 1.15.x         | [charmed-kubernetes-139](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-139/archive/bundle.yaml) |   
 | 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
 | 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
 | 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -15,21 +15,21 @@ toc: False
 # About
 
 [MetalLB][metallb] is a Kubernetes-aware solution that will monitor for services with
-the type `LoadBalancer` and assign them an IP address from a virtual pool. 
+the type `LoadBalancer` and assign them an IP address from a virtual pool.
 
 It uses BGP([Border Gateway Protocol][bgp]) or ARP([Address Resolution Protocol][arp])
-to expose services. 
+to expose services.
 
 MetalLB has support for local traffic, meaning that the machine that receives the
 data will be the machine that services the request. It is not suggested to use a
 virtual IP with high traffic workloads because only one machine will receive the
-traffic for a service - the other machines are solely used for failover. 
+traffic for a service - the other machines are solely used for failover.
 
 BGP does not have this limitation but does see nodes as the atomic unit. This means
 if the service is running on two of five nodes then only those two nodes will receive
 traffic, but they will each receive 50% of the traffic even if one of the nodes has
 three pods and the other only has one pod running on it. It is recommended to use node
-anti-affinity to prevent Kubernetes pods from stacking on a single node. 
+anti-affinity to prevent Kubernetes pods from stacking on a single node.
 
 Currently, the best way to install MetalLB on CDK is with a helm chart:
 
@@ -38,12 +38,10 @@ helm install --name metallb stable/metallb
 ```
 Further configuration can be performed by using a [MetalLB configmap][configmap].
 
-See also the [Helm with CDK documentation][helm] for using Helm with CDK
 
 <!-- LINKS -->
 
 [metallb]: https://metallb.universe.tf
 [arp]: https://tools.ietf.org/html/rfc826
 [bgp]: https://tools.ietf.org/html/rfc1105
-[helm]: /kubernetes/docs/helm
 [configmap]: https://metallb.universe.tf/configuration/

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -38,6 +38,8 @@ helm install --name metallb stable/metallb
 ```
 Further configuration can be performed by using a [MetalLB configmap][configmap].
 
+See also the [Helm with CDK documentation][helm] for using Helm with CDK
+
 <!-- LINKS -->
 
 [metallb]: https://metallb.universe.tf

--- a/templates/kubernetes/docs/openstack-integration.md
+++ b/templates/kubernetes/docs/openstack-integration.md
@@ -1,0 +1,230 @@
+---
+wrapper_template: "base_docs.html"
+markdown_includes:
+  nav: "shared/_side-navigation.md"
+context:
+  title: "CDK on OpenStack"
+  description: Running CDK on OpenStack using the openstack-integrator.
+keywords: openstack, integrator, cinder, lbaas
+tags: [install]
+sidebar: k8smain-sidebar
+permalink: openstack-integration.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** will run seamlessly
+on OpenStack. With the addition of the `openstack-integrator`, your cluster
+will also be able to directly use OpenStack native features.
+
+
+## OpenStack integrator
+
+The `openstack-integrator` charm simplifies working with **CDK** on OpenStack. Using the
+credentials provided to Juju, it acts as a proxy between CDK and the underlying cloud,
+granting permissions to dynamically create, for example, Cinder volumes.
+
+### Installing
+
+When installing **CDK** using the Juju bundle, you can add the openstack-integrator at
+the same time by using the following overlay file
+([download it here][asset-openstack-overlay]):
+
+```yaml
+applications:
+  openstack-integrator:
+    charm: cs:~containers/openstack-integrator
+    num_units: 1
+relations:
+  - ['openstack-integrator', 'kubernetes-master']
+  - ['openstack-integrator', 'kubernetes-worker']
+  ```
+
+To use this overlay with the **CDK** bundle, it is specified during deploy like this:
+
+```bash
+juju deploy charmed-kubernetes --overlay ~/path/openstack-overlay.yaml
+```
+
+Then run the command to share credentials with this charm:
+
+```bash
+juju trust openstack-integrator
+```
+
+... and remember to fetch the configuration file!
+
+```bash
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+For more configuration options and details of the permissions which the integrator uses,
+please see the [charm readme][openstack-integrator-readme].
+
+### Using Cinder volumes
+
+Many  pods you may wish to deploy will require storage. Although you can use any type
+of storage supported by Kubernetes (see the [storage documentation][storage]), you
+also have the option to use Cinder storage volumes, if supported by your OpenStack.
+
+A `cinder` storage class will be automatically created for you when the integrator is
+used.  This storage class can then be used when creating a Persistent Volume Claim:
+
+```bash
+kubectl create -f - <<EOY
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: cinder
+EOY
+```
+
+This should finish with a confirmation. You can check the current PVCs with:
+
+```bash
+kubectl get pvc
+```
+
+...which should return something similar to:
+
+```bash
+NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+testclaim   Bound    pvc-54a94dfa-3128-11e9-9c54-028fdae42a8c   1Gi        RWO            cinder         9s
+```
+
+This PVC can then be used by pods operating in the cluster. As an example, the following
+deploys a `busybox` pod:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+      volumeMounts:
+        - mountPath: "/pv"
+          name: testvolume
+  restartPolicy: Always
+  volumes:
+    - name: testvolume
+      persistentVolumeClaim:
+        claimName: testclaim
+EOY
+```
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+If you create Cinder volumes and subsequently tear down the cluster, check with
+the OpenStack administration tools to make sure all the associated resources
+have also been released.
+  </p>
+</div>
+
+### Using LBaaS load balancers
+
+With the openstack-integrator charm in place, actions which invoke a
+loadbalancer in Kubernetes will automatically request a load balancer from
+OpenStack using Octavia, if available, or Neutron. This can be demonstrated
+with a simple application. Here we will create a simple application running in
+five pods:
+
+```bash
+kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+```
+
+You can verify that the application and replicas have been created with:
+
+```bash
+ kubectl get deployments hello-world
+ ```
+
+ Which should return output similar to:
+
+ ```bash
+ NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+ hello-world      5/5               5                            5             2m38s
+```
+
+To create a LoadBalancer, the application should now be exposed as a service:
+
+```bash
+ kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+ ```
+
+To check that the service is running correctly:
+
+```bash
+kubectl get service hello
+```
+
+...which should return output similar to:
+
+```yaml
+NAME    TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
+hello   LoadBalancer   10.152.183.136   202.49.242.3  8080:32662/TCP   2m
+```
+
+You can see that the External IP is now in front of the five endpoints of the
+example deployment. You can test the ingress address:
+
+```bash
+curl  http://202.49.242.3:8080
+```
+```
+Hello Kubernetes!
+```
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+If you create load balancers and subsequently tear down the cluster, check with
+the OpenStack administration tools to make sure all the associated resources
+have also been released.
+  </p>
+</div>
+
+### Upgrading the integrator charm
+
+The openstack-integrator is not specifically tied to the version of CDK installed and may
+generally be upgraded at any time with the following command:
+
+```bash
+juju upgrade-charm openstack-integrator
+```
+
+### Troubleshooting
+
+If you have any specific problems with the openstack-integrator, you can report bugs on
+[Launchpad][bugs].
+
+For logs of what the charm itself believes the world to look like, you can use Juju to replay
+the log history for that specific unit:
+
+```bash
+juju debug-log --replay --include openstack-integrator/0
+```
+
+
+<!-- LINKS -->
+
+[asset-openstack-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/kubernetes-docs/master/assets/openstack-overlay.yaml
+[storage]: /kubernetes/docs/storage
+[bugs]: https://bugs.launchpad.net/charmed-kubernetes
+[openstack-integrator-readme]: https://jujucharms.com/u/containers/openstack-integrator/

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "base-docs.html"
+wrapper_template: "base_docs.html"
 markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
@@ -13,24 +13,24 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-Deliver ‘Containers as a Service’ across the enterprise with the
-**Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)** , enabling each
+Deliver ‘Containers as a Service’ across the enterprise with
+**Charmed Kubernetes** , enabling each
 project to spin up a standardised K8s of arbitrary scale, on demand, with centralised
-operational control. **CDK** provides a well integrated, turn-key
+operational control. **Charmed Kubernetes** provides a well integrated, turn-key
 **Kubernetes<sup>&reg;</sup>** platform that is open, extensible, and secure.
 
-For more information on the features and benefits of **CDK**, including details on the
+For more information on the features and benefits of **Charmed Kubernetes**, including details on the
 [Managed Kubernetes][managedk8s] service, please see the [Kubernetes section][cdk].
 
 ## Components
 
-**CDK** is built around a number of applications, bundled together and deployed using
+**Charmed Kubernetes** is built around a number of applications, bundled together and deployed using
 [**Juju**][juju], the open source modelling tool for deploying and operating software in
 the cloud.
 
 ### Storage
 
-**CDK** comes with a powerful volume plugin system that enables many different types
+**Charmed Kubernetes** comes with a powerful volume plugin system that enables many different types
 of storage systems to:
 
 - Automatically create storage when required.
@@ -40,7 +40,7 @@ of storage systems to:
 ### Networking
 
 **Kubernetes** uses Container Network Interface (CNI) as an interface between
-network providers and **Kubernetes** networking. **CDK** comes pre-packaged with
+network providers and **Kubernetes** networking. **Charmed Kubernetes** comes pre-packaged with
 several tested CNI plugins like Calico and Flannel.
 
 ### Logging and monitoring
@@ -52,8 +52,8 @@ aggregation and systems monitoring dashboards with every cloud, using
 
 ### Cloud integration
 
-Depending on your choice of cloud, **CDK** will also install an integration application.
-This enables **CDK** to seamlessly access cloud resources and components without
+Depending on your choice of cloud, **Charmed Kubernetes** will also install an integration application.
+This enables your cluster to seamlessly access cloud resources and components without
 additional configuration or hassle.
 
 <!-- LINKS -->

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -1,23 +1,37 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "base-docs.html"
 markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "Overview"
-  description: Understand how the Charmed Distribution of Kubernetes workloads.
+  description: Understand how the Charmed Distribution of Kubernetes works.
+keywords: juju, kubernetes, cdk
+tags: [intro]
+sidebar: k8smain-sidebar
+permalink: overview.html
+layout: [base, ubuntu-com]
+toc: False
 ---
 
-Deliver ‘Containers as a Service’ across the enterprise with the **Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)** , enabling each project to spin up a standardised K8s of arbitrary scale, on demand, with centralised operational control. **CDK** provides a well integrated, turn-key **Kubernetes<sup>&reg;</sup>** platform that is open, extensible, and secure.
+Deliver ‘Containers as a Service’ across the enterprise with the
+**Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK)** , enabling each
+project to spin up a standardised K8s of arbitrary scale, on demand, with centralised
+operational control. **CDK** provides a well integrated, turn-key
+**Kubernetes<sup>&reg;</sup>** platform that is open, extensible, and secure.
 
-For more information on the features and benefits of **CDK**, including details on the [Managed Kubernetes][managedk8s] service, please see the [Kubernetes section][k8s-u-c].
+For more information on the features and benefits of **CDK**, including details on the
+[Managed Kubernetes][managedk8s] service, please see the [Kubernetes section][cdk].
 
 ## Components
 
-**CDK** is built around a number of applications, bundled together and deployed using [**Juju**][juju], the open source modelling tool for deploying and operating software in the cloud.
+**CDK** is built around a number of applications, bundled together and deployed using
+[**Juju**][juju], the open source modelling tool for deploying and operating software in
+the cloud.
 
 ### Storage
 
-**CDK** comes with a powerful volume plugin system that enables many different types of storage systems to:
+**CDK** comes with a powerful volume plugin system that enables many different types
+of storage systems to:
 
 - Automatically create storage when required.
 - Make storage available to containers wherever they’re scheduled.
@@ -25,21 +39,26 @@ For more information on the features and benefits of **CDK**, including details 
 
 ### Networking
 
-**Kubernetes** uses Container Network Interface (CNI) as an interface between network providers and **Kubernetes** networking. **CDK** comes pre-packaged with several tested CNI plugins like Calico and Flannel.
+**Kubernetes** uses Container Network Interface (CNI) as an interface between
+network providers and **Kubernetes** networking. **CDK** comes pre-packaged with
+several tested CNI plugins like Calico and Flannel.
 
 ### Logging and monitoring
 
-Operations in large-scale distributed clusters require a new level of operational monitoring and observability. Canonical delivers a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using **Prometheus**, the **Elasticsearch** and **Kibana** stack (ELK), and **Nagios**.
+Operations in large-scale distributed clusters require a new level of operational
+monitoring and observability. Canonical delivers a standardised set of open source log
+aggregation and systems monitoring dashboards with every cloud, using
+**Prometheus**, the **Elasticsearch** and **Kibana** stack (ELK), and **Nagios**.
 
 ### Cloud integration
 
-Depending on your choice of cloud, **CDK** will also install an integration application. This enables **CDK** to seamlessly access cloud resources and components without additional configuration or hassle.
+Depending on your choice of cloud, **CDK** will also install an integration application.
+This enables **CDK** to seamlessly access cloud resources and components without
+additional configuration or hassle.
 
 <!-- LINKS -->
 
 [managedk8s]: /kubernetes/managed
-[k8s-u-c]: /kubernetes
 [maas]: https://maas.io
 [cdk]: /kubernetes
-[managed-cdk]: /kubernetes/managed
 [juju]: https://jujucharms.com

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -14,6 +14,103 @@ toc: False
 ---
 
 
+# 1.15
+
+### DATE - TBC, REVISION TBC
+
+## What's new
+
+- Containerd support
+
+Although Docker is still supported, [containerd](https://containerd.io/) is now 
+the default container runtime in Charmed Kubernetes. Containerd brings significant
+[peformance improvements](https://kubernetes.io/blog/2018/05/24/kubernetes-containerd-integration-goes-ga/)
+and prepares the way for Charmed Kubernetes integration with
+[Kata](https://katacontainers.io/) in the future.
+
+Container runtime code has been moved out of the kubernetes-worker charm, and
+into subordinate charms (one for Docker and one for containerd). This allows 
+the operator to swap the container runtime as desired, and even mix
+container runtimes within a cluster. It also allows for additional container
+runtimes to be supported in the future. Because this is a significant change, you 
+are advised to read the [upgrade notes](/kubernetes/docs/upgrade-notes) before
+upgrading from a previous version.
+
+- Calico 3.x support
+
+The Calico and Canal charms have been updated to install Calico 3.6.1 by
+default. For users currently running Calico 2.x, the next time you upgrade your
+Calico or Canal charm, the charm will automatically upgrade to Calico 3.6.1
+with no user intervention required.
+
+The Calico charm's `ipip` config option has been changed from a boolean to a
+string to allow for the addition of a new mode. This change is illustrated in
+the table below:
+
+| New value     | Old value         | Description                                           |
+|---------------|-------------------|-------------------------------------------------------|
+| "Never"       | false             | Never use IPIP encapsulation. (The default)           |
+| "Always"      | true              | Always use IPIP encapsulation.                        |
+| "CrossSubnet" | \<Not supported\> | Only use IPIP encapsulation for cross-subnet traffic. |
+
+- Calico BGP support
+
+Several new config options have been added to the Calico charm to support BGP
+functionality within Calico. These additions make it possible to configure
+external BGP peers, route reflectors, and multiple IP pools. For instructions
+on how to use the new config options, see the
+[CNI with Calico documentation][cni-calico].
+
+- Custom load balancer addresses
+
+Support has been added to specify the IP address of an external load balancer.
+This support is in the kubeapi-load-balancer and the kubernetes-master charms.
+This allows a virtual IP address on the kubeapi-load-balancer charm or the
+IP address of an external load balancer. See the
+[custom load balancer page](https://www.ubuntu.com/kubernetes/docs/custom-loadbalancer)
+for more information.
+
+- Container image registry
+
+By default, all container images required by the deployment come from the
+[Canonical image registry](https://image-registry.canonical.com:5000). This includes
+images used by the cdk-addons snap, ingress, dns, storage providers, etc. The registry
+can be configured with the new `image-registry` config option on the `kubernetes-master`
+charm.
+
+The `addons-registry` config option is now deprecated. If set, this will take precedence
+over the new `image-registry` option when deploying images from the cdk-addons snap.
+However, the `addons-registry` option will be removed in 1.17. Users are encouraged
+to migrate to the new `image-registry` option as soon as possible.
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.15](https://launchpad.net/charmed-kubernetes/+milestone/1.15).
+
+## Known Issues
+
+- Docker-registry interface does not support containerd ([bug 1833579](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1833579))
+
+When a `docker-registry` charm is related, `kubernetes-worker` units will attempt to configure
+the Docker `daemon.json` configuration file and may also attempt to use `docker login` to
+authenticate with the connected registry. This will not work in a containerd environment,
+as there is no `daemon.json` file nor `docker` command available to invoke.
+
+Users relying on `docker-registry` to serve container images to Kubernetes deployments should
+continue to use the Docker subordinate runtime as outlined in the [upgrade notes](/kubernetes/docs/upgrade-notes#1.15),
+under the heading "To keep Docker as the container runtime".
+
+
+# 1.14 Bugfix release
+
+### June 19th, 2019 - [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml)
+
+## Fixes
+
+ - Fixed leader_set being called by kubernetes-master followers ([Issue](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1833089))
+
+
 # 1.14 Bugfix release
 
 ### June 6th, 2019 - [charmed-kubernetes-96](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-96/archive/bundle.yaml)
@@ -173,3 +270,5 @@ Please see [this page][historic] for release notes of earlier versions.
 [haoverview]: /kubernetes/docs/high-availability
 [metallb-docs]: /kubernetes/docs/metallb
 [hacluster-docs]: /kubernetes/docs/hacluster
+[cni-calico]: /kubernetes/docs/cni-calico
+[containerd]: /kubernetes/docs/containerd

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -16,23 +16,23 @@ toc: False
 
 # 1.15
 
-### DATE - TBC, REVISION TBC
+### June 26, 2019 -  [charmed-kubernetes-139](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-139/archive/bundle.yaml))
 
 ## What's new
 
 - Containerd support
 
-Although Docker is still supported, [containerd](https://containerd.io/) is now 
+Although Docker is still supported, [containerd](https://containerd.io/) is now
 the default container runtime in Charmed Kubernetes. Containerd brings significant
 [peformance improvements](https://kubernetes.io/blog/2018/05/24/kubernetes-containerd-integration-goes-ga/)
 and prepares the way for Charmed Kubernetes integration with
 [Kata](https://katacontainers.io/) in the future.
 
 Container runtime code has been moved out of the kubernetes-worker charm, and
-into subordinate charms (one for Docker and one for containerd). This allows 
+into subordinate charms (one for Docker and one for containerd). This allows
 the operator to swap the container runtime as desired, and even mix
 container runtimes within a cluster. It also allows for additional container
-runtimes to be supported in the future. Because this is a significant change, you 
+runtimes to be supported in the future. Because this is a significant change, you
 are advised to read the [upgrade notes](/kubernetes/docs/upgrade-notes) before
 upgrading from a previous version.
 

--- a/templates/kubernetes/docs/scaling.md
+++ b/templates/kubernetes/docs/scaling.md
@@ -17,6 +17,13 @@ The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** has been designed to
 be flexible enough to efficiently run your workloads. Various components of **CDK**
 can be horizontally scaled to meet demand or to increase reliability, as detailed below.
 
+<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Note:</span>
+The information here is for scaling the installed Kubernetes<sup>&reg;</sup> itself. For
+information about pod autoscaling,  please see the
+<a href="https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/">
+Kubernetes  autoscaling</a> documentation for details. </p></div>
+
 ## kubernetes-master
 
 The kubernetes-master nodes act as the control plane for the cluster. **CDK** was

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -8,6 +8,13 @@
 - **Cloud Integration**
   - [AWS integration](/kubernetes/docs/aws-integration)
   - [GCP integration](/kubernetes/docs/gcp-integration)
+  - [OpenStack integration](/kubernetes/docs/openstack-integration)
+- **Networking**
+  - [CNI overview](/kubernetes/docs/cni-overview)  
+  - [Flannel](/kubernetes/docs/cni-flannel)
+  - [Calico](/kubernetes/docs/cni-calico)
+  - [Canal](/kubernetes/docs/cni-canal)
+  - [Tigera Secure EE](/kubernetes/docs/tigera-secure-ee)  
 - **Operations**
   - [Basic operations](/kubernetes/docs/operations)
   - [Logging](/kubernetes/docs/logging)
@@ -26,11 +33,13 @@
   - [Audit Logging](/kubernetes/docs/audit-logging)
   - [Using Tigera Secure EE](/kubernetes/docs/tigera-secure-ee)
   - [Troubleshooting](/kubernetes/docs/troubleshooting)
+  - [Containerd and Docker](/kubernetes/docs/container-runtime)
 - **High Availability**
   - [Overview](/kubernetes/docs/high-availability)
   - [keepalived](/kubernetes/docs/keepalived)
   - [HAcluster](/kubernetes/docs/hacluster)
   - [MetalLB](/kubernetes/docs/metallb)
+  - [Custom load balancer](/kubernetes/docs/custom-loadbalancer)
 - **Reference**
   - [Release notes](/kubernetes/docs/release-notes)
   - [Upgrade notes](/kubernetes/docs/upgrade-notes)

--- a/templates/kubernetes/docs/troubleshooting.md
+++ b/templates/kubernetes/docs/troubleshooting.md
@@ -103,9 +103,9 @@ This will automatically ssh you to the easyrsa unit.
 
 ## Collecting debug information
 
-Sometimes it is useful to collect all the information from a cluster to share with a developer to identify problems. This is best accomplished with [CDK Field Agent](https://github.com/juju-solutions/cdk-field-agent).
+Sometimes it is useful to collect all the information from a cluster to share with a developer to identify problems. This is best accomplished with [CDK Field Agent](https://github.com/charmed-kubernetes/cdk-field-agent).
 
-Download and execute the collect.py script from [CDK Field Agent](https://github.com/juju-solutions/cdk-field-agent) on a box that has a Juju client configured with the current controller and model pointing at the CDK deployment of interest.
+Download and execute the collect.py script from [CDK Field Agent](https://github.com/charmed-kubernetes/cdk-field-agent) on a box that has a Juju client configured with the current controller and model pointing at the CDK deployment of interest.
 
 Running the script will generate a tarball of system information and includes basic information such as systemctl status, Juju logs, charm unit data, etc. Additional application-specific information may be included as well.
 
@@ -334,7 +334,6 @@ monitoring-influxdb         10.1.31.2:8086,10.1.31.2:8083   136m
 ### Attempt to authenticate directly to the service
 
 Use a token to auth with the Keystone service directly:
-
 
 ```bash
 cat <<EOF | curl -ks -XPOST -d @- https://10.152.183.200:8443/webhook | python -mjson.tool

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -14,18 +14,167 @@ toc: False
 ---
 
 This page is intended to deal with specific, special circumstances you may
-encounter when upgrading between versions of the
-**Charmed Distribution of Kubernetes<sup>&reg;</sup>.** The notes are
-organised according to the upgrade path below, but also be aware that any
+encounter when upgrading between versions of **Charmed Kubernetes**.
+The notes are organised according to the upgrade path below, but also be aware that any
 upgrade that spans more than one minor version may need to beware of notes in
 any of the intervening steps.
+
+<a  id="1.15"> </a>
+
+## Upgrading to 1.15
+
+This upgrade switches the container runtime to make use of containerd, rather
+than Docker. You have the option of keeping Docker as the container runtime,
+but even in that case you ***must*** perform the upgrade steps. To facilitate
+different container runtimes, the architecture of **Charmed Kubernetes** has
+changed slightly, and the container runtime is now part of a separate,
+subordinate charm rather than being included in the `kubernetes-master` and
+`kubernetes-worker` charms.
+
+### To keep Docker as the container runtime
+
+Docker is currently installed on your kubernetes-worker units. The Docker subordinate
+charm includes clean-up code to manage the transition to the new pluggable architecture.
+To upgrade whilst retaining Docker as the runtime, you need to additionally deploy the new charm
+and add relations to the master and worker components:
+
+```bash
+juju deploy cs:~containers/docker
+juju add-relation docker kubernetes-master
+juju add-relation docker kubernetes-worker
+```
+
+The upgrade is complete, and your worker nodes will continue to use the Docker runtime.
+For information on configuring the Docker charm, see the [Docker configuration page][docker-page].
+
+### To migrate to containerd
+
+If you intend to switch to containerd, it’s recommended that you first add some
+temporary extra worker units. While not strictly necessary, skipping this step will result
+in some cluster down time. Adding temporary additional workers provides a place for keeping pods running while new workers are brought online. The temporary workers can then be removed as the pods are migrated to the new workers. The rest of these instructions assume that you have deployed temporary workers.
+
+#### Deploy temporary workers
+```bash
+CURRENT_WORKER_REV=$(juju status | grep '^kubernetes-worker\s' | awk '{print $7}')
+CURRENT_WORKER_COUNT=$(juju status | grep '^kubernetes-worker/' | wc -l | sed -e 's/^[ \t]*//')
+
+juju deploy cs:~containers/kubernetes-worker-$CURRENT_WORKER_REV  kubernetes-worker-temp -n $CURRENT_WORKER_COUNT
+```
+
+#### Add necessary relations
+```bash
+juju status --relations | grep worker: | awk '{print $1,$2}' | sed 's/worker:/worker-temp:/g' | xargs -n2 juju relate
+```
+Wait for the temporary workers to become active before continuing.
+Upgrade the master and worker charms:
+```bash
+juju upgrade-charm kubernetes-master
+juju upgrade-charm kubernetes-worker
+```
+
+The kubernetes-worker units will enter a blocked state, with status message
+“Connect a container runtime.”
+
+#### Deploy and relate the new Docker charm
+
+This step is needed even if you do not intend to use Docker following the
+upgrade. Docker is already installed on your `kubernetes-worker` units, and
+the Docker subordinate includes clean-up code to uninstall Docker when the
+Docker charm is replaced with the containerd charm.
+
+```bash
+juju deploy cs:~containers/docker
+juju add-relation docker kubernetes-master
+juju add-relation docker kubernetes-worker
+```
+
+### Switching to Containerd
+
+Now, pause the existing workers, which will move pods to the temporary workers.
+
+```bash
+juju run-action [unit] pause --wait
+```
+
+For example:
+```bash
+juju run-action kubernetes-worker/0 pause --wait
+juju run-action kubernetes-worker/1 pause --wait
+juju run-action kubernetes-worker/2 pause --wait
+```
+
+One-liner:
+```bash
+juju status | grep ^kubernetes-worker/ | awk '{print $1}' | tr -d '*' | xargs -n1 -I '{}' juju run-action {} pause --wait
+```
+
+#### Remove Docker
+
+This will uninstall Docker from the workers.
+
+```bash
+juju remove-relation docker kubernetes-master
+juju remove-relation docker kubernetes-worker
+juju remove-application docker
+```
+
+#### Deploy Containerd
+
+```bash
+juju deploy cs:~containers/containerd
+juju add-relation containerd kubernetes-master
+juju add-relation containerd kubernetes-worker
+```
+
+#### Resume workers
+Now we can allow pods to be rescheduled to our original workers.
+
+```bash
+juju run-action [unit] resume --wait
+```
+
+E.g.
+```bash
+juju run-action kubernetes-worker/0 resume --wait
+juju run-action kubernetes-worker/1 resume --wait
+juju run-action kubernetes-worker/2 resume --wait
+```
+
+One-liner:
+```bash
+juju status | grep ^kubernetes-worker/ | awk '{print $1}' | tr -d '*' | xargs -n1 -I '{}' juju run-action {} resume --wait
+```
+
+#### Cleanup
+
+You can now pause the temporary workers to force all pods to migrate back
+to your “real” workers, then remove the temporary workers.
+
+```bash
+juju status | grep ^kubernetes-worker-temp/ | awk '{print $1}' | tr -d '*' | xargs -n1 -I '{}' juju run-action {} pause --wait
+
+juju remove-application kubernetes-worker-temp
+```
+
+
+#### Mixing Containerd and Docker
+
+
+Once you have a Containerd backed CDK running, you can add Docker backed
+workers like so:
+
+```bash
+juju deploy cs:~containers/kubernetes-worker kubernetes-worker-docker
+juju deploy cs:~containers/docker
+juju relate docker kubernetes-worker-docker
+```
 
 <a  id="1.14"> </a>
 
 ## Upgrading to 1.14
 
 This upgrade includes support for **CoreDNS 1.4.0**. All new deployments of
-**CDK 1.14** will install **CoreDNS** by default instead of **KubeDNS**.
+**Charmed Kubernetes** will install **CoreDNS** by default instead of **KubeDNS**.
 
 Existing deployments which are upgraded to **CDK 1.14** will continue to use
 **KubeDNS** until the operator chooses to upgrade to **CoreDNS**. To upgrade,

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -13,9 +13,9 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-It is recommended that you keep your **Kubernetes** deployment updated to the latest available stable version. You should also update the other applications which make up the **Charmed Distribution of Kubernetes<sup>&reg;</sup>.** Keeping up to date ensures you have the latest bug-fixes and security patches for smooth operation of your cluster.
+It is recommended that you keep your **Kubernetes** deployment updated to the latest available stable version. You should also update the other applications which make up the **Charmed Kubernetes**. Keeping up to date ensures you have the latest bug-fixes and security patches for smooth operation of your cluster.
 
-New minor versions of **Kubernetes** are set to release once per quarter. You can check the latest release version on the [Kubernetes release page on GitHub][k8s-release]. The **CDK** is kept in close sync with upstream Kubernetes: updated versions will be released within a week of a new upstream version of **Kubernetes**.
+New minor versions of **Kubernetes** are set to release once per quarter. You can check the latest release version on the [Kubernetes release page on GitHub][k8s-release]. **Charmed Kubernetes** is kept in close sync with upstream Kubernetes: updated versions will be released within a week of a new upstream version of **Kubernetes**.
 
 <div class="p-notification--information">
   <p markdown="1" class="p-notification__response">
@@ -62,16 +62,31 @@ Note that this may include other applications which you may have installed, such
 
 ### Upgrading Docker
 
-**CDK** will use the latest stable version of Docker when it is deployed. Since upgrading Docker
+**Charmed Kubernetes** will use the latest stable version of Docker when it is deployed. Since upgrading Docker
 can cause service disruption, there will be no automatic upgrades and instead this process must
 be triggered by the operator.
 
+Note that this upgrade step only applies to deployments which actually use the Docker
+container runtime. Versions 1.15 and later use containerd by default, and you should
+instead follow the [instructions below](#upgrading-containerd).
+
+#### Version 1.15 and later
+
+The `kubernetes-master` and `kubernetes-worker` are related to the docker subordinate
+charm where present. Whether you are running Docker on its own, or mixed with Containerd,
+the upgrade process is the same:
+
+```bash
+juju upgrade-charm docker
+```
+
+#### Versions prior to 1.15
 Only the `kubernetes-master` and `kubernetes-worker` units require Docker. The charms for each
 include an action to trigger the upgrade.
 
 Before the upgrade, it is useful to list all the units effected:
 
-```bash 
+```bash
 juju status kubernetes-* --format=short
 ```
 
@@ -93,36 +108,56 @@ juju run-action kubernetes-master/1 upgrade-docker --wait
 Once all the `kubernetes-master` units have been upgraded and the pods have respawned, the
 same procedure can then be applied to the `kubernetes-worker` units.
 
-```bash 
+```bash
 juju run-action kubernetes-worker/0 upgrade-docker --wait
 ```
 
 As previously, wait between running the action on sucessive units to allow pods to migrate.
 
 
+<a id='upgrading-containerd'> </a>
+
+### Upgrading containerd
+
+By default, Versions 1.15 and later use Containerd as the container
+runtime. This subordinate charm can be upgraded with the command:
+
+```bash
+juju upgrade-charm containerd
+```
+
 ### Upgrading etcd
 
-As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of this data before running an upgrade. This is covered in more detail in the [documentation on backups][backups], but the basic steps are:
+As **etcd** manages critical data for the cluster, it is advisable to create a snapshot of
+this data before running an upgrade. This is covered in more detail in the
+[documentation on backups][backups], but the basic steps are:
 
 #### 1. Run the snapshot action on the charm
 
 ```bash
 juju run-action etcd/0 snapshot --wait
 ```
-You should see confirmation of the snapshot being created, and the location of the file _on the **etcd** unit_
+You should see confirmation of the snapshot being created, and the location of the file
+_on the **etcd** unit_
 
 #### 2. Fetch a local copy of the snapshot
 
-Knowing the path to the snapshot file from the output of the above command, you can download a local copy:
+Knowing the path to the snapshot file from the output of the above command, you can
+download a local copy:
 `bash juju scp etcd/0:/home/ubuntu/etcd-snapshots/<filename>.tar.gz .`
+
+#### 3. Upgrade
+
 You can now upgrade **etcd**:
+
 ```bash
 juju upgrade-charm etcd
 ```
 
 ### Upgrading additional components
 
-The other infrastructure applications can be upgraded by running the `upgrade-charm` command:
+The other infrastructure applications can be upgraded by running the `upgrade-charm`
+command:
 
 ```bash
 juju upgrade-charm flannel
@@ -134,15 +169,23 @@ Any other infrastructure charms can be upgraded in a similar way.
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
-Some services may be briefly interrupted during the upgrade process. Upgrading <strong>flannel</strong> will cause a small amount of network downtime. Upgrading <strong>easyrsa</strong> will not cause any downtime. The behaviour of other components you have added to your cluster may vary - check individual documentation for these charms for more information on upgrades.
+Some services may be briefly interrupted during the upgrade process. Upgrading
+<strong>flannel</strong> will cause a small amount of network downtime. Upgrading
+<strong>easyrsa</strong> will not cause any downtime. The behaviour of other
+components you have added to your cluster may vary - check individual documentation
+for these charms for more information on upgrades.
   </p>
 </div>
 
 ## Upgrading Kubernetes
 
-Before you upgrade the **Kubernetes** components, you should be aware of the exact release you wish to upgrade to.
+Before you upgrade the **Kubernetes** components, you should be aware of the exact
+release you wish to upgrade to.
 
-The **Kubernetes** charms use **snap** _channels_ to manage the version of **Kubernetes** to use. Channels are explained in more detail in the [official snap documentation][snap-channels], but in terms of **Kubernetes** all you need to know are the major and minor version numbers and the 'risk-level':
+The **Kubernetes** charms use **snap** _channels_ to manage the version of
+**Kubernetes** to use. Channels are explained in more detail in the
+[official snap documentation][snap-channels], but in terms of **Kubernetes** all you
+need to know are the major and minor version numbers and the 'risk-level':
 
 | Risk level | Description                                               |
 | ---------- | --------------------------------------------------------- |
@@ -155,13 +198,17 @@ For most use cases, it is strongly recommended to use the 'stable' version of ch
 
 ### Upgrading the **kube-api-loadbalancer**
 
-A core part of **CDK** is the kubeapi-load-balancer component. To ensure API service continuity this upgrade should precede any upgrades to the **Kubernetes** master and worker units.
+A core part of **CDK** is the kubeapi-load-balancer component. To ensure API service
+continuity this upgrade should precede any upgrades to the **Kubernetes** master and
+worker units.
 
 ```bash
 juju upgrade-charm kubeapi-load-balancer
 ```
 
-The load balancer itself is based on NGINX, and the version reported by `juju status` is that of NGINX rather than Kubernetes. Unlike the other Kubernetes components, there is no need to set a specific channel or version for this charm. 
+The load balancer itself is based on NGINX, and the version reported by `juju status` is
+that of NGINX rather than Kubernetes. Unlike the other Kubernetes components, there
+is no need to set a specific channel or version for this charm.
 
 ### Upgrading the **kubernetes-master** units
 


### PR DESCRIPTION
## Done

Includes all the updates to docs for the 1.15 release of Kubernetes
This includes new pages:
- cni-overview
- cni-flannel
- cni-calico
- cni-canal
- container-runtime
- custom-loadbalancer
- openstack-integration

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)



