### PR TITLE
Fix typo and some tables in k8s docs

### DIFF
--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -61,7 +61,7 @@ that would apply to `charmed-kubernetes` to this bundle also.
 ## Calico configuration options
 
 | Name                |  Type  |  Default value                           | Description                                                    |
-|=====================|========|==========================================|================================================================|
+|---------------------|--------|------------------------------------------|----------------------------------------------------------------|
 | calico-node-image   | string | docker.io/calico/node:v3.6.1             | The image id to use for calico/node                            |
 | calico-policy-image | string | docker.io/calico/kube-controllers:v3.6.1 | The image id to use for calico/kube-controllers                |
 | ipip                | string | Never                                    | IPIP mode. Must be one of "Always", "CrossSubnet", or "Never". |

--- a/templates/kubernetes/docs/cni-canal.md
+++ b/templates/kubernetes/docs/cni-canal.md
@@ -36,7 +36,7 @@ that would apply to `charmed-kubernetes` to this bundle also.
 ## Canal configuration options
 
 |Name                  | Type    | Default   | Description                      |
-|======================|=========|===========|==================================|
+|----------------------|---------|-----------|----------------------------------|
 | calico-node-image    | string  | docker.io/calico/node:v3.6.1|The image id to use for calico/node. |
 | calico-policy-image  | string  | docker.io/calico/kube-controllers:v3.6.1|The image id to use for calico/kube-controllers. |
 | cidr                 | string  | 10.1.0.0/16|Network CIDR to assign to Flannel |

--- a/templates/kubernetes/docs/cni-flannel.md
+++ b/templates/kubernetes/docs/cni-flannel.md
@@ -31,7 +31,7 @@ flannel will be used for CNI.
 
 
 | Name                  |  Type     |  Default value | Description  |
-|=============|=======|============|====================================|
+|-----------------------|-----------|----------------|--------------|
 | cidr                       | string     | 10.1.0.0/16      | Network CIDR to assign to Flannel  |
 | iface                      | string     | see description>  |  The interface to bind flannel overlay networking. The default value is the interface bound to the CNI endpoint. |
 |  nagios_context |  string |  juju  |  A string that will be prepended to instance name to set the host name in nagios. If you're running multiple environments with the same services in them this allows you to differentiate between them. Used by the nrpe subordinate charm. |

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -16,23 +16,23 @@ toc: False
 
 # 1.15
 
-### June 26, 2019 -  [charmed-kubernetes-139](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-139/archive/bundle.yaml))
+### June 26, 2019 -  [charmed-kubernetes-139](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-139/archive/bundle.yaml)
 
 ## What's new
 
 - Containerd support
 
-Although Docker is still supported, [containerd](https://containerd.io/) is now
+Although Docker is still supported, [containerd](https://containerd.io/) is now 
 the default container runtime in Charmed Kubernetes. Containerd brings significant
 [peformance improvements](https://kubernetes.io/blog/2018/05/24/kubernetes-containerd-integration-goes-ga/)
 and prepares the way for Charmed Kubernetes integration with
 [Kata](https://katacontainers.io/) in the future.
 
 Container runtime code has been moved out of the kubernetes-worker charm, and
-into subordinate charms (one for Docker and one for containerd). This allows
+into subordinate charms (one for Docker and one for containerd). This allows 
 the operator to swap the container runtime as desired, and even mix
 container runtimes within a cluster. It also allows for additional container
-runtimes to be supported in the future. Because this is a significant change, you
+runtimes to be supported in the future. Because this is a significant change, you 
 are advised to read the [upgrade notes](/kubernetes/docs/upgrade-notes) before
 upgrading from a previous version.
 


### PR DESCRIPTION

## Done

The tables on cni-flannel, cni-canal and cni-calico weren't rendering properly due to differences in the markdown engine
this also fixes a minor typo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


