### PR TITLE
Fix /blog/archives 500 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.0.9
+canonicalwebteam.blog==2.0.10
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4


### PR DESCRIPTION
## Done

- Updated version of blog module used to 2.0.10
  - /blog/archives was returning a 500 error unless a 'year' query parameter was present, version 2.0.10 of the blog module resolves this

## QA

- Check out this feature branch
- Run the site using the command `./run clean && ./run serve`
- View the site locally in your web browser at: [/blog/archives](http://0.0.0.0:8001/blog/archives)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that you see the archives page, and not a 500 error
