### PR TITLE
Update copy on /engage/edge-month CTAs

### DIFF
--- a/templates/engage/edge-month.html
+++ b/templates/engage/edge-month.html
@@ -37,7 +37,7 @@
       <p>
         Join our upcoming webinar hosted by Galem Kayo, Ubuntu Product Manager, to understand what is driving businesses to process their data at the edge and how you can add an edge computing layer to your business's infrastructure.  
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362197">Watch the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362197">Register for the webinar</a>
     </div>
 
     <div class="col-4 prefix-1 u-vertically-center">
@@ -70,7 +70,7 @@
         <p>
           We’ll explore use cases, architecture, and tools that will help you at every stage of your development lifecycle - from development to production deployments at scale. MicroK8s and Charmed Kubernetes will be explored in sufficient detail to get you started with Kubernetes on Ubuntu.
         </p>
-        <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362200">Watch the webinar</a>
+        <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362200">Register for the webinar</a>
       </div>
     </div>
   </div>
@@ -101,7 +101,7 @@
       <p>
         In this webinar join Ubuntu MAAS Product Manager, Andres Rodriguez to discuss use cases and how MAAS could benefit your business. 
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362201">Watch the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362201">Register for the webinar</a>
     </div>
 
     <div class="col-4 prefix-1 u-vertically-center">
@@ -134,7 +134,7 @@
       <p>
         Join Canonical’s telco team to hear about the strategies and tactics you can adopt to build an edge that can match your requirements of today and tomorrow.
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362202">Watch the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362202">Register for the webinar</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Changed webinar CTA text from 'Watch the webinar' to 'Register for the webinar'

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/engage/edge-month](http://0.0.0.0:8001/engage/edge-month)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the green CTAs all read "Register for the webinar"
