### PR TITLE
Bump blog to v2.0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.0.10
+canonicalwebteam.blog==2.0.11
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4


### PR DESCRIPTION
Fixes:

- Bad category name: https://ubuntu.com/blog?category=asdfasdfasdf
- Page with string: https://ubuntu.com/blog?page=asdf
- Exceptions where failing: https://sentry.is.canonical.com/canonical/ubuntu-com/issues/2443/?query=is%3Aunresolved