### PR TITLE
Remove p-list-step__bullet

### DIFF
--- a/templates/ai/install.html
+++ b/templates/ai/install.html
@@ -29,7 +29,7 @@
       <ol class="p-stepped-list--detailed">
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Install Kubernetes</h3>
+          <h3 class="p-list-step__title">Install Kubernetes</h3>
           <div class="p-list-step__content">
             <p>Kubeflow runs on top of Kubernetes, and Charmed Kubernetes is the best foundation for Kubeflow.</p>
             <p>Visit our <a href="/kubernetes/install">Kubernetes install</a> page and follow the instructions to install the Kubernetes as you want.</p>
@@ -38,7 +38,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Install microk8s</h3>
+          <h3 class="p-list-step__title">Install microk8s</h3>
           <div class="p-list-step__content">
             <p>Clone the kubernetes-tools project</p>
             <div class="p-code-snippet">
@@ -59,7 +59,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Install Kubeflow</h3>
+          <h3 class="p-list-step__title">Install Kubeflow</h3>
           <div class="p-list-step__content">
             <p>Clone the kubeflow-tools project</p>
             <div class="p-code-snippet">
@@ -75,7 +75,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Access Kubeflow</h3>
+          <h3 class="p-list-step__title">Access Kubeflow</h3>
           <div class="p-list-step__content">
             <p>If you installed Microk8s on your local host, then you can use localhost as the IP address in your browser. Otherwise, if you used Multipass as per the instructions above, you can get the IP address of the VM with either <code>multipass list</code> or <code>multipass info kubeflow</code>.</p>
             <p>Point browser to either:</p>

--- a/templates/download/iot/_flash-image.html
+++ b/templates/download/iot/_flash-image.html
@@ -1,6 +1,5 @@
 <li class="p-list-step__item">
   <h3 class="p-list-step__title">
-    <span class="p-list-step__bullet">{{ number|default:1 }}</span>
     Flash the {{ card|default:"card" }}
   </h3>
   <div class="p-list-step__content">

--- a/templates/download/iot/_setup-ubuntu-sso.html
+++ b/templates/download/iot/_setup-ubuntu-sso.html
@@ -1,6 +1,5 @@
 <li class="p-list-step__item ">
   <h3 class="p-list-step__title">
-    <span class="p-list-step__bullet">{{number|default:1}}</span>
     Setup an Ubuntu SSO account
   </h3>
   <div class="p-list-step__content">

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -28,57 +28,57 @@
       <ol class="p-list-step">
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+            
             Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Insert your SD card or USB flash drive
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
           </p>
           <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Else, run:
           </p>
           <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Then, run the <code>sync</code> command to finalize the process
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
           </p>
         </li>
@@ -94,31 +94,31 @@
       <ol class="p-list-step">
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+            
             Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Insert your SD card or USB flash drive
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
           </p>
           <p>
@@ -127,7 +127,7 @@
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
           </p>
           <ol>
@@ -138,13 +138,13 @@
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             When ready click on <strong>Write</strong> and wait for the process to complete.
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            <span class="p-list-step__bullet">*</span>
+            
             You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
           </p>
         </li>
@@ -158,26 +158,26 @@
           <ol class="p-list-step">
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                <span class="p-list-step__bullet">1</span>
+                
                 Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
               </p>
             </li>
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
+                
                 Insert your SD card or USB flash drive
               </p>
             </li>
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
+                
                 Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run the following command:
               </p>
               <p><pre><code>diskutil list</code></pre></p>
             </li>
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                <span class="p-list-step__bullet">*</span>
+                
                 In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
               </p>
               <pre>
@@ -199,21 +199,21 @@
               </li>
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  <span class="p-list-step__bullet">*</span>
+                  
                   Unmount your SD card with the following command
                 </p>
                 <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
               </li>
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  <span class="p-list-step__bullet">*</span>
+                  
                   When successful, you should see a message similar to this one:
                 </p>
                 <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
               </li>
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  <span class="p-list-step__bullet">*</span>
+                  
                   You can now copy the image to the SD card, using the following command:
                 </p>
                 <pre><code>sudo sh -c 'xzcat ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32M'</code></pre>
@@ -226,7 +226,7 @@
                 </li>
                 <li class="p-list-step__item col-8">
                   <p class="p-list-step__title">
-                    <span class="p-list-step__bullet">*</span>
+                    
                     You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
                   </p>
                 </li>

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -39,10 +39,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -52,7 +52,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+
             Prepare the two USB flash drives
           </h3>
           <div class="p-list-step__content">
@@ -64,7 +64,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Boot the live Ubuntu Desktop image
           </h3>
           <div class="p-list-step__content">
@@ -79,7 +79,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">5</span>
+
             Flash Ubuntu Core to the internal memory
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/intel-joule-desktop.html
+++ b/templates/download/iot/intel-joule-desktop.html
@@ -44,7 +44,7 @@
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Download Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">
@@ -57,7 +57,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+            
             Flash the USB drive with Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">
@@ -66,7 +66,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+            
             Install Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">
@@ -84,7 +84,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">5</span>
+            
             Change the default audio output
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/intel-joule.html
+++ b/templates/download/iot/intel-joule.html
@@ -45,10 +45,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -61,7 +61,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+
             Flash the USB drives
           </h3>
           <div class="p-list-step__content">
@@ -73,7 +73,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Install Ubuntu Core
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -43,7 +43,7 @@
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+            
             Download Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">
@@ -56,7 +56,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Flash the USB drive
           </h3>
           <div class="p-list-step__content">
@@ -65,7 +65,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+            
             Install Ubuntu Desktop
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -46,10 +46,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -60,7 +60,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+
             Flash the USB drives
           </h3>
           <div class="p-list-step__content">
@@ -72,7 +72,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Install Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -86,7 +86,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Boot from the Live USB flash drive
           </h3>
           <div class="p-list-step__content">
@@ -99,7 +99,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Flash Ubuntu Core
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/kvm.html
+++ b/templates/download/iot/kvm.html
@@ -36,10 +36,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -55,7 +55,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+
             Install KVM
           </h3>
           <div class="p-list-step__content">
@@ -79,7 +79,7 @@ KVM acceleration can be used</code></pre>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Launch KVM
           </h3>
           <div class="p-list-step__content">
@@ -104,7 +104,7 @@ KVM acceleration can be used</code></pre>
         {% include "./_first-boot-setup.html" with number=5 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">6</span>
+
             Login
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/orange-pi-zero.html
+++ b/templates/download/iot/orange-pi-zero.html
@@ -41,10 +41,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -54,10 +54,10 @@
             </ul>
           </div>
         </li>
-        {% include "./_flash-image.html" with card="microSD card" number=3 %}
+        {% include "./_flash-image.html" with card="microSD card" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Install Ubuntu Core
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/qualcomm-dragonboard-410c.html
+++ b/templates/download/iot/qualcomm-dragonboard-410c.html
@@ -42,10 +42,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -56,10 +56,10 @@
             </ul>
           </div>
         </li>
-        {% include "./_flash-image.html" with card="microSD card" number=3 %}
+        {% include "./_flash-image.html" with card="microSD card" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Install Ubuntu Core
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/raspberry-pi-2-3-core.html
+++ b/templates/download/iot/raspberry-pi-2-3-core.html
@@ -40,10 +40,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -57,10 +57,10 @@
             </ul>
           </div>
         </li>
-        {% include "./_flash-image.html" with card="microSD card" number=3 %}
+        {% include "./_flash-image.html" with card="microSD card" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Install Ubuntu Core
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -45,7 +45,7 @@
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+
             Download Ubuntu Server
           </h3>
           <div class="p-list-step__content">
@@ -59,10 +59,10 @@
             </ul>
           </div>
         </li>
-        {% include "./_flash-image.html" with card="microSD card" number=2 %}
+        {% include "./_flash-image.html" with card="microSD card" %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+
             Install Ubuntu Server
           </h3>
           <div class="p-list-step__content">
@@ -74,7 +74,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Login
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/raspberry-pi-compute-module-3.html
+++ b/templates/download/iot/raspberry-pi-compute-module-3.html
@@ -44,10 +44,10 @@
     <div class="col-12">
       <h2>Installation instructions</h2>
       <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
+        {% include "./_setup-ubuntu-sso.html" %}
         <li class="p-list-step__item" id="step2">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -60,7 +60,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+
             Setup USBboot on your host system
           </h3>
           <div class="p-list-step__content">
@@ -83,7 +83,7 @@ sudo ./rpiboot</code></pre>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+
             Setup the Compute Module IO board
           </h3>
           <div class="p-list-step__content">
@@ -105,7 +105,7 @@ sudo ./rpiboot</code></pre>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">5</span>
+
             Flash the board from your host system
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/samsung-artik-5-10-server.html
+++ b/templates/download/iot/samsung-artik-5-10-server.html
@@ -42,7 +42,7 @@
         {% include "./_setup-ubuntu-sso.html" with number=1 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -56,7 +56,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+            
             Set your board to boot from the SD card
           </h3>
           <div class="p-list-step__content">
@@ -65,7 +65,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+            
             Install Ubuntu Server
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/samsung-artik-5-10.html
+++ b/templates/download/iot/samsung-artik-5-10.html
@@ -42,7 +42,7 @@
         {% include "./_setup-ubuntu-sso.html" with number=1 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
@@ -57,7 +57,7 @@
         {% include "./_flash-image.html" with card="SD card" number=3 %}
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+            
             Install Ubuntu Core
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/iot/up-squared-iot-grove-server.html
+++ b/templates/download/iot/up-squared-iot-grove-server.html
@@ -39,7 +39,7 @@
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+            
             Download Ubuntu Server
           </h3>
           <div class="p-list-step__content">
@@ -52,7 +52,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Install Ubuntu Server
           </h3>
           <div class="p-list-step__content">

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -40,21 +40,21 @@
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item ">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+            
             Setup your hardware
           </h3>
           <p class="p-list-step__content">You need one small server for MAAS and at least one server which can be managed with a <abbr title="Baseboard Management Controller">BMC</abbr>. It is recommended to have the MAAS server provide <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> and <abbr title="Domain Name Service">DNS</abbr> on a network the managed machines are connected to.</p>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Install Ubuntu Server
           </h3>
           <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server {{ releases.lts.short_version }} LTS" href="/download/server">Download Ubuntu Server {{ releases.lts.short_version }} LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+            
             Install MAAS
           </h3>
           <div class="p-list-step__content">
@@ -70,7 +70,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">4</span>
+            
             Create admin user
           </h3>
           <div class="p-list-step__content">
@@ -84,7 +84,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">5</span>
+            
             Complete the first user configuration journey
           </h3>
           <div class="p-list-step__content">
@@ -101,7 +101,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">6</span>
+            
             Turn on DHCP
           </h3>
           <div class="p-list-step__content">
@@ -118,7 +118,7 @@
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">7</span>
+            
             Enlist and commission servers
           </h3>
           <div class="p-list-step__content">

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -87,7 +87,7 @@
     <div class="col-12">
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Install latest MicroK8s</h3>
+          <h3 class="p-list-step__title">Install latest MicroK8s</h3>
           <div class="p-list-step__content">
             <p>MicroK8s is packaged as a snap which requires snapd to be installed. The latest Ubuntu release comes with this already built in. For other Linux systems install snapd first. Use this command to get the latest version of MicroK8s:</p>
             <div class="p-code-snippet">
@@ -98,7 +98,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Install specific versions of MicroK8s</h3>
+          <h3 class="p-list-step__title">Install specific versions of MicroK8s</h3>
           <div class="p-list-step__content">
             <p><strong>List specific Kubernetes versions</strong></p>
             <p>The following command will list all versions of MicroK8s that can be installed:</p>
@@ -116,7 +116,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Useful tips</h3>
+          <h3 class="p-list-step__title">Useful tips</h3>
           <div class="p-list-step__content">
             <p>This command will install a the stable 1.14 version of MicroK8s:</p>
             <p>After installing MicroK8s, you should verify it is ready. Use this command:</p>
@@ -177,7 +177,7 @@
       <ol class="p-stepped-list--detailed">
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Install Juju</h3>
+          <h3 class="p-list-step__title">Install Juju</h3>
           <div class="p-list-step__content">
             <p>Juju simplifies how you configure, scale and operate today’s complex software. Juju deploys everywhere: to public or private clouds. It is packaged as a snap which requires snapd to be installed. The latest Ubuntu release comes with this already built in. For other Linux systems install snapd first:</p>
             <div class="p-code-snippet">
@@ -188,7 +188,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Add your cloud - optional</h3>
+          <h3 class="p-list-step__title">Add your cloud - optional</h3>
           <div class="p-list-step__content">
             <p>This interactive step allows you to register a cloud that isn’t known to Juju by default. In the summary instructions above, since AWS is used, this step isn’t necessary - AWS and other public clouds have well-known IP addresses. For private clouds you need to give some details to juju. An example is a MAAS cloud, which operates your bare metal infrastructure.</p>
             <div class="p-code-snippet">
@@ -215,7 +215,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Add Credentials</h3>
+          <h3 class="p-list-step__title">Add Credentials</h3>
           <div class="p-list-step__content">
             <p>Most clouds require credentials so that the cloud knows which operations are authorised and on which account. If you choose to use AWS, for example, you would run <code>juju add-credential aws</code></p>
             <div class="p-code-snippet">
@@ -226,7 +226,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Add Controller</h3>
+          <h3 class="p-list-step__title">Add Controller</h3>
           <div class="p-list-step__content">
             <p>The Juju controller is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations.</p>
             <div class="p-code-snippet">
@@ -237,7 +237,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Add Model</h3>
+          <h3 class="p-list-step__title">Add Model</h3>
           <div class="p-list-step__content">
             <p>The model holds a specific deployment, like Kubernetes, which includes all necessary applications and the number of instances of each one. This is where the number of Kubernetes worker nodes are scaled up or down.</p>
             <div class="p-code-snippet">
@@ -248,7 +248,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Deploy Kubernetes</h3>
+          <h3 class="p-list-step__title">Deploy Kubernetes</h3>
           <div class="p-list-step__content">
             <p>Add the Kubernetes bundle to the model and deploy the components, including the default number of components, like worker nodes.</p>
             <div class="p-code-snippet">

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -104,7 +104,7 @@
             <div class="row u-equal-height">
               <div class="col-6">
                 <h3 class="p-list-step__title">
-                  <span class="p-list-step__bullet">1</span>
+                  
                   Design and <strong>build</strong>
                 </h3>
                 <p>Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. This happens on your site and in your preferred data centre. We’ll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we’ll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
@@ -118,7 +118,7 @@
             <div class="row u-equal-height">
               <div class="col-6">
                 <h3 class="p-list-step__title">
-                  <span class="p-list-step__bullet">2</span>
+                  
                   We <strong>operate</strong> your Kubernetes
                 </h3>
                 <p>We take responsibility for the remote management and 24/7 availability of your Kubernetes clusters. Your SLA covers uptime and performance. Your hardware and software are proactively monitored. Scale on demand with additional racks.</p>
@@ -133,7 +133,7 @@
             <div class="row u-equal-height">
               <div class="col-6">
                 <h3 class="p-list-step__title">
-                  <span class="p-list-step__bullet">3</span>
+                  
                   We <strong>transfer</strong> control
                 </h3>
                 <p>On request, we’ll give you the keys. We provide training and a handover process with on-site  reliability engineers to ensure a smooth handover.</p>
@@ -148,7 +148,7 @@
             <div class="row">
               <div class="col-6">
                 <h3 class="p-list-step__title">
-                  <span class="p-list-step__bullet">4</span>
+                  
                   We <strong>support</strong> your operations
                 </h3>
                 <p>Once you have control of the cloud, Canonical provides 24/7 enterprise telephone support. Since we know the architecture of your Kubernetes clusters, problems are faster to debug and easier to resolve.</p>

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -111,14 +111,14 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
       <ol class="p-list-step">
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">1</span>
+            
             Generate your credentials
           </h3>
           <p>Via the <a class="p-link--external" href="https://auth.livepatch.canonical.com/">Canonical Livepatch portal</a>.</p>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">2</span>
+            
             Install the livepatch daemon
           </h3>
           <div class="p-code-snippet">
@@ -128,7 +128,7 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            <span class="p-list-step__bullet">3</span>
+            
             Enable it on your system
           </h3>
           <div class="p-code-snippet">

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -76,7 +76,7 @@
     <div class="col-12">
       <ol class="p-stepped-list--detailed">
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Minimum requirements</h3>
+          <h3 class="p-list-step__title">Minimum requirements</h3>
           <div class="p-list-step__content">
             <p>4 x Intel, POWER or ARM servers each with:</p>
             <ul class="p-list">
@@ -90,7 +90,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Set up your MAAS hardware</h3>
+          <h3 class="p-list-step__title">Set up your MAAS hardware</h3>
           <div class="p-list-step__content">
             <p>Connect the both NICs of the servers to the same network switch.</p>
             <p>Identify the smallest server, if they are not identical. You will use this for <a href="https://maas.io/" class="p-link--external">MAAS</a>, the &lsquo;Metal as a Service&rsquo; provisioning system which will drive automated installation of the OS on the rest of the cluster.</p>
@@ -99,7 +99,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Install MAAS</h3>
+          <h3 class="p-list-step__title">Install MAAS</h3>
           <div class="p-list-step__content">
             <p>On your Ubuntu Server 16.04 LTS machine:</p>
             <div class="p-code-snippet">
@@ -122,7 +122,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Configure the subnet and&nbsp;DHCP</h3>
+          <h3 class="p-list-step__title">Configure the subnet and&nbsp;DHCP</h3>
           <div class="p-list-step__content">
             <p>Go to the &ldquo;Subnets&rdquo; tab and verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are correct for your subnet.</p>
             <p>MAAS will provide DHCP and DNS for the /24 network on your isolated LAN switch.</p>
@@ -132,14 +132,14 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Verify image syncing</h3>
+          <h3 class="p-list-step__title">Verify image syncing</h3>
           <div class="p-list-step__content">
             <p>Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. Depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced.</p>
           </div>
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Register your hardware with<br /> MAAS</h3>
+          <h3 class="p-list-step__title">Register your hardware with<br /> MAAS</h3>
           <div class="p-list-step__content">
             <p>For the rest of the machines in the cluster:</p>
             <ul>
@@ -158,7 +158,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">7</span>Install and launch conjure-up</h3>
+          <h3 class="p-list-step__title">Install and launch conjure-up</h3>
           <div class="p-list-step__content">
             <p>Install conjure-up on the MAAS server:</p>
             <div class="p-code-snippet">
@@ -179,7 +179,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">8</span>Select OpenStack hypervisor</h3>
+          <h3 class="p-list-step__title">Select OpenStack hypervisor</h3>
           <div class="p-list-step__content">
             <p>conjure-up offers two options with OpenStack:</p>
             <p>1. OpenStack with NovaLXD</p>
@@ -195,7 +195,7 @@
         </li>
 
         <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">9</span>Configure a new cloud</h3>
+          <h3 class="p-list-step__title">Configure a new cloud</h3>
           <div class="p-list-step__content">
             <p>Once you have selected &lsquo;OpenStack with &lsquo;NovaKVM&rsquo;, you will be prompted to create a new cloud with MAAS.</p>
             <p>
@@ -266,7 +266,7 @@
     <h2>Installation instructions</h2>
     <ol class="p-stepped-list--detailed">
       <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">1</span>Minimum requirements</h3>
+        <h3 class="p-list-step__title">Minimum requirements</h3>
         <div class="p-list-step__content">
           <ul class="p-list">
             <li class="p-list__item">Single machine with 16GB RAM running Ubuntu 16.04 LTS or later and at least 40GB of free disk space</li>
@@ -276,7 +276,7 @@
       </li>
 
       <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Install conjure-up</h3>
+        <h3 class="p-list-step__title">Install conjure-up</h3>
         <div class="p-list-step__content">
           <p><code>conjure-up</code> provides a text-based wizard to walk you through the process of setting up OpenStack. It can be used with full bare metal clusters, or on your workstation with LXD. We&rsquo;ll be using LXD to create a set of container machines for the OpenStack services.</p>
           <p>Follow these step-by-step instructions.</p>
@@ -320,7 +320,7 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
         </div>
       </li>
       <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Deploy OpenStack</h3>
+        <h3 class="p-list-step__title">Deploy OpenStack</h3>
         <div class="p-list-step__content">
           <p>Now you are ready to start the OpenStack deployment process on your workstation.</p>
           <div class="p-code-snippet">
@@ -332,7 +332,7 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
         </div>
       </li>
       <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Follow the on-screen instructions</h3>
+        <h3 class="p-list-step__title">Follow the on-screen instructions</h3>
         <div class="p-list-step__content">
           <p>The conjure-up wizard will now prompt you for:</p>
           <ol>
@@ -349,7 +349,7 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
         </div>
       </li>
       <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Launch an instance</h3>
+        <h3 class="p-list-step__title">Launch an instance</h3>
         <div class="p-list-step__content">
           <p>Conjure-up will have created the basic building blocks for launching an instance . To launch an instance on the new cloud using the Openstack Dashboard, Horizon:</p>
           <ol>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -421,7 +421,7 @@
           <div class="row u-equal-height">
             <div class="col-6">
               <h3 class="p-list-step__title">
-                <span class="p-list-step__bullet">1</span>
+                
                 Design and build
               </h3>
               <p>Together, we <a href="/openstack/consulting">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system.</p>
@@ -437,7 +437,7 @@
           <div class="row u-equal-height">
             <div class="col-6">
               <h3 class="p-list-step__title">
-                <span class="p-list-step__bullet">2</span>
+                
                 Operations
               </h3>
               <p>We take responsibility for the remote management and 24/7 availability of your OpenStack.</p>
@@ -454,7 +454,7 @@
           <div class="row u-equal-height">
             <div class="col-6">
               <h3 class="p-list-step__title">
-                <span class="p-list-step__bullet">3</span>
+                
                 We transfer control
               </h3>
               <p>On request, we’ll give you the keys. We provide training and a handover process with on-site cloud reliability engineers to ensure a smooth handover.</p>
@@ -471,7 +471,7 @@
           <div class="row">
             <div class="col-6">
               <h3 class="p-list-step__title">
-                <span class="p-list-step__bullet">4</span>
+                
                 We support your operations
               </h3>
               <p>Once you have control of the cloud, Canonical provides 24/7 enterprise telephone support. Since we know the architecture of your cloud, problems are faster to debug and easier to resolve.</p>


### PR DESCRIPTION
## Done

- Removeed the p-list-step__bullet as it does not appear to be required and it seems to add an extra number on mobile.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/ai/install
    - http://0.0.0.0:8001/download/iot/installation-media
    - http://0.0.0.0:8001/download/iot/intel-iei-tank-870
    - http://0.0.0.0:8001/download/iot/intel-joule-desktop
    - http://0.0.0.0:8001/download/iot/intel-joule
    - http://0.0.0.0:8001/download/iot/intel-nuc-desktop
    - http://0.0.0.0:8001/download/iot/intel-nuc
    - http://0.0.0.0:8001/download/iot/kvm
    - http://0.0.0.0:8001/download/iot/orange-pi-zero
    - http://0.0.0.0:8001/download/iot/qualcomm-dragonboard-410c
    - http://0.0.0.0:8001/download/iot/raspberry-pi-2-3-core
    - http://0.0.0.0:8001/download/iot/raspberry-pi-2-3
    - http://0.0.0.0:8001/download/iot/raspberry-pi-compute-module-3
    - http://0.0.0.0:8001/download/iot/samsung-artik-5-10-server
    - http://0.0.0.0:8001/download/iot/samsung-artik-5-10
    - http://0.0.0.0:8001/download/iot/up-squared-iot-grove-server
    - http://0.0.0.0:8001/download/server/provisioning
    - http://0.0.0.0:8001/kubernetes/install
    - http://0.0.0.0:8001/kubernetes/managed
    - http://0.0.0.0:8001/livepatch/index
    - http://0.0.0.0:8001/openstack/install
    - http://0.0.0.0:8001/openstack/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there are no changes visually

## Issue / Card

Fixes #5387
