### PR TITLE
K8s docs misc updates

### DIFF
--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -48,14 +48,14 @@ documentation for instructions.
 
 ## Deploying Charmed Kubernetes with Calico
 
-To deploy CDK with Calico, deploy the kubernetes-calico bundle:
+To deploy Charmed Kubernetes with Calico, deploy the kubernetes-calico bundle:
 
 ```bash
 juju deploy cs:~containers/kubernetes-calico
 ```
 
-The calico bundle is identical to the standard `charmed-kubernetes` bundle with the
-exception of replacing flannel with calico. You can apply any customisation overlays
+The Calico bundle is identical to the standard `charmed-kubernetes` bundle with the
+exception of replacing Flannel with Calico. You can apply any customisation overlays
 that would apply to `charmed-kubernetes` to this bundle also.
 
 ## Calico configuration options
@@ -116,6 +116,16 @@ juju config calico ipip=CrossSubnet
 The default configuration of Calico uses BGP mode, with all Calico nodes
 connected in a full node-to-node mesh, and with no external peerings. This
 comes with some limitations which will be explained in the following sections.
+
+<div class="p-notification--positive">
+<p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Note:</span>
+If you intend to use MetalLB with Calico in BGP mode,
+please also refer to this
+<a href="https://metallb.universe.tf/configuration/calico/">
+explanation of the required MetalLB configuration</a> from the
+<a href="https://metallb.universe.tf/"> MetalLB website</a>
+</p></div>
 
 ### BGP with multiple subnets
 

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -32,5 +32,3 @@ Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because 
     </div>
   </div>
 </div>
-
-{% include links.html %}

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -4,30 +4,28 @@ markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
   title: "Kubernetes documentation"
-  description: Documentation for the Charmed Distribution of Kubernetes.
+  description: Documentation for Charmed Kubernetes.
+toc: False
 ---
 
-The Charmed Distribution of Kubernetes<sup>&reg;</sup> (CDK), is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
+ Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
 
 Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 
-[Find out more in the CDK overview&nbsp;&rsaquo;](/kubernetes/docs/overview)
+[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](../overview)
 
-<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" width="608" alt="" style="margin-top: 1rem;">
+## Getting started
 
-<div class="p-strip is-shallow">
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3>Get started</h3>
-      <p><a href="/kubernetes/docs/quickstart">Install CDK&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3>What's new</h3>
-      <p><a href="/kubernetes/docs/release-notes">Version 1.15 released&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3>Tutorials</h3>
-      <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/get-started-kubeflow#0">Get started with Kubeflow</a></p>
-    </div>
-  </div>
-</div>
+[Getting started with Charmed Kubernetes<sup>&reg;</sup>&nbsp;&rsaquo;](../quickstart)
+
+## What's new
+
+- [Version 1.15 released&nbsp;&rsaquo;](../release-notes)
+
+## Tutorials
+
+- [Get started with Kubeflow](https://tutorials.ubuntu.com/tutorial/get-started-kubeflow#0)
+
+<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" style="float:right; margin-left: 2rem; border: 0" alt="">
+
+{% include links.html %}

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -12,20 +12,25 @@ toc: False
 
 Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 
-[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](../overview)
+[Find out more in the CDK overview&nbsp;&rsaquo;](/kubernetes/docs/overview)
 
-## Getting started
+<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" width="608" alt="" style="margin-top: 1rem;">
 
-[Getting started with Charmed Kubernetes<sup>&reg;</sup>&nbsp;&rsaquo;](../quickstart)
-
-## What's new
-
-- [Version 1.15 released&nbsp;&rsaquo;](../release-notes)
-
-## Tutorials
-
-- [Get started with Kubeflow](https://tutorials.ubuntu.com/tutorial/get-started-kubeflow#0)
-
-<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" style="float:right; margin-left: 2rem; border: 0" alt="">
+<div class="p-strip is-shallow">
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <h3>Get started</h3>
+      <p><a href="/kubernetes/docs/quickstart">Install CDK&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3>What's new</h3>
+      <p><a href="/kubernetes/docs/release-notes">Version 1.15 released&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3>Tutorials</h3>
+      <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/get-started-kubeflow#0">Get started with Kubeflow</a></p>
+    </div>
+  </div>
+</div>
 
 {% include links.html %}

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -8,7 +8,7 @@ context:
 toc: False
 ---
 
- Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
+ Charmed Kubernetes<sup>&reg;</sup> is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
 
 Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -56,5 +56,4 @@ Further configuration can be performed by using a [MetalLB configmap][configmap]
 [metallb]: https://metallb.universe.tf
 [arp]: https://tools.ietf.org/html/rfc826
 [bgp]: https://tools.ietf.org/html/rfc1105
-[helm]: /kubernetes/docs/helm
 [configmap]: https://metallb.universe.tf/configuration/

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -31,7 +31,18 @@ traffic, but they will each receive 50% of the traffic even if one of the nodes 
 three pods and the other only has one pod running on it. It is recommended to use node
 anti-affinity to prevent Kubernetes pods from stacking on a single node.
 
-Currently, the best way to install MetalLB on CDK is with a helm chart:
+<div class="p-notification--positive">
+<p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Note:</span>
+For more information on configuring MetalLB with Calico in BGP mode,
+please see this
+<a href="https://metallb.universe.tf/configuration/calico/">
+explanation of the required configuration</a> from the
+<a href="https://metallb.universe.tf/"> MetalLB website</a>
+
+</p></div>
+
+Currently, the best way to install MetalLB on Charmed Kubernetes is with a helm chart:
 
 ```bash
 helm install --name metallb stable/metallb
@@ -39,9 +50,11 @@ helm install --name metallb stable/metallb
 Further configuration can be performed by using a [MetalLB configmap][configmap].
 
 
+
 <!-- LINKS -->
 
 [metallb]: https://metallb.universe.tf
 [arp]: https://tools.ietf.org/html/rfc826
 [bgp]: https://tools.ietf.org/html/rfc1105
+[helm]: /kubernetes/docs/helm
 [configmap]: https://metallb.universe.tf/configuration/

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "base-docs.html"
 markdown_includes:
   nav: "shared/_side-navigation.md"
 context:
@@ -14,7 +14,7 @@ toc: False
 ---
 
 Deliver ‘Containers as a Service’ across the enterprise with
-**Charmed Kubernetes** , enabling each
+**Charmed Kubernetes<sup>&reg;</sup>** , enabling each
 project to spin up a standardised K8s of arbitrary scale, on demand, with centralised
 operational control. **Charmed Kubernetes** provides a well integrated, turn-key
 **Kubernetes<sup>&reg;</sup>** platform that is open, extensible, and secure.
@@ -53,7 +53,7 @@ aggregation and systems monitoring dashboards with every cloud, using
 ### Cloud integration
 
 Depending on your choice of cloud, **Charmed Kubernetes** will also install an integration application.
-This enables your cluster to seamlessly access cloud resources and components without
+This enables **Charmed Kubernetes** to seamlessly access cloud resources and components without
 additional configuration or hassle.
 
 <!-- LINKS -->

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "base-docs.html"
+wrapper_template: "base_docs.html"
 markdown_includes:
   nav: "shared/_side-navigation.md"
 context:

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -15,13 +15,14 @@ toc: False
 
 On-disk files in a container are ephemeral and can't be shared with other members of a pod. For some applications, this is not an issue, but for many persistent storage is required.
 
-The **Charmed Distribution of Kubernetes**<sup>&reg;</sup> makes it easy to add and configure different types of persistent storage for your **Kubernetes** cluster, as outlined below. For more detail on the concept of storage volumes in **Kubernetes**, please see the [Kubernetes documentation][kubernetes-storage-docs].
+**Charmed Kubernetes**<sup>&reg;</sup> makes it easy to add and configure different types of persistent storage for your **Kubernetes** cluster, as outlined below. For more detail on the concept of storage volumes in **Kubernetes**, please see the [Kubernetes documentation][kubernetes-storage-docs].
 
 ## Ceph storage
 
-**CDK** can make use of [Ceph][ceph-home] to provide persistent storage
-volumes. The following sections assume you have already deployed a **CDK**
-cluster and you have internet access to the **Juju** Charm Store.
+**Charmed Kubernetes** can make use of [Ceph][ceph-home] to provide persistent storage
+volumes. The following sections assume you have already deployed a
+**Charmed Kubernetes** cluster and you have internet access to the
+**Juju** Charm Store.
 
 ### Deploy Ceph
 
@@ -52,7 +53,7 @@ So, for example, to deploy three `ceph-osd` storage nodes, using the default sto
 For a more detailed explanation of Juju's storage pools and options, please see the relevant <a href="https://docs.jujucharms.com/stable/en/charms-storage">Juju documentation</a>.
 </p></div>
 
-Note that actually deploying these charms with storage may take some time, but you can continue
+Note that actually deploying these charms with storage may take some time, but you can continue to run other Juju commands in the meantime.
 
 The `ceph-osd` and `ceph-mon` deployments should then be connected:
 
@@ -60,9 +61,9 @@ The `ceph-osd` and `ceph-mon` deployments should then be connected:
 juju add-relation ceph-osd ceph-mon
 ```
 
-### Relate to CDK
+### Relate to Charmed Kubernetes
 
-Making **CDK** aware of your **Ceph** cluster requires 2 **Juju** relations.
+Making **Charmed Kubernetes** aware of your **Ceph** cluster requires 2 **Juju** relations.
 
 ```bash
 juju add-relation ceph-mon:admin kubernetes-master
@@ -123,7 +124,7 @@ unit-ceph-mon-0:
 
 ### Verification
 
-Now you can look at your **CDK** cluster to verify things are working. Running:
+Now you can look at your **Charmed Kubernetes** cluster to verify things are working. Running:
 
 ```bash
 kubectl get sc,po
@@ -175,7 +176,7 @@ juju add-storage ceph-osd/2 --storage osd-devices=32G,2
 
 ### Using a separate Juju model
 
-In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and CDK.
+In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kuberentes**.
 
 For more information on how to achieve this, please see the [Juju documentation][juju-cmr] on cross-model relations.
 
@@ -191,7 +192,7 @@ Make use of **Juju** constraints to allocate an instance with the required amoun
 juju deploy nfs --constraints root-disk=200G
 ```
 
-### Relate to CDK
+### Relate to Charmed Kubernetes
 
 The NFS units can be related directly to the **Kubernetes** workers:
 
@@ -201,7 +202,8 @@ The NFS units can be related directly to the **Kubernetes** workers:
 
 ### Verification
 
-Now you can look at your **CDK** cluster to verify things are working. Running:
+Now you can look at your **Charmed Kubernetes** cluster to verify things
+are working. Running:
 
 ```bash
 kubectl get sc,po

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -176,7 +176,7 @@ juju add-storage ceph-osd/2 --storage osd-devices=32G,2
 
 ### Using a separate Juju model
 
-In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kuberentes**.
+In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kubernetes**.
 
 For more information on how to achieve this, please see the [Juju documentation][juju-cmr] on cross-model relations.
 

--- a/templates/kubernetes/docs/using-vault.md
+++ b/templates/kubernetes/docs/using-vault.md
@@ -16,20 +16,20 @@ toc: True
 As mentioned in the [Certificates and trust reference][certs-doc] documentation,
 [HashiCorp's Vault][vault] can be used to provide either a root or intermediate CA. It can
 also be deployed HA, as well as provide a secure secrets store which can be used to enable
-[encryption-at-rest for **CDK**][encryption-doc].
+[encryption-at-rest for **Charmed Kubernetes**][encryption-doc].
 
 Vault does require an additional database to store its data and (depending on
 configuration) some manual steps will be required after deployment or any reboot so
 that secrets, such as certificates and signing keys, can be accessed.
 
-## Deploying CDK with Vault as a root CA
+## Deploying Charmed Kubernetes with Vault as a root CA
 
-When deploying **CDK** manually via the [published Juju bundle][cdk-bundle], it is
-possible to make use of an overlay file to change the composition and  configuration of
-**CDK**
+When deploying **Charmed Kubernetes** manually via the
+[published Juju bundle][cdk-bundle], it is possible to make use of an overlay
+file to change the composition and configuration of the cluster.
 
-The following overlay file ([download][k8s-vault-yaml]) alters **CDK** to use **Vault**
-instead of EasyRSA:
+The following overlay file ([download][k8s-vault-yaml]) alters
+**Charmed Kubernetes** to use **Vault** instead of EasyRSA:
 
 ```yaml
 applications:
@@ -62,6 +62,7 @@ Save this to a file named `k8s-vault.yaml` and deploy with:
 
 ```bash
 juju deploy charmed-kubernetes --overlay ./k8s-vault.yaml
+juju remove-application easyrsa
 ```
 
 Once the deployment settles, you will notice that several applications are in a
@@ -83,44 +84,67 @@ exit
 juju run-action vault/0 authorize-charm token={charm token}
 ```
 
-Note that it is _critical_ that you save all five unseal keys as well as the
-root token.  If the **Vault** unit is ever rebooted, you will have to repeat the
-unseal steps (but not the init step) before the CA can become functional again.
+<div class="p-notification--information">
+  <p markdown="1" class="p-notification__response">
+    It is <strong><em>critical </em></strong> that you save all five unseal keys as well as the root
+    token.  If the <strong>Vault</strong> unit is ever rebooted, you will have to repeat the
+    unseal steps (but not the init step) before the CA can become functional
+    again.
+  </p>
+</div>
 
-## Transitioning an existing CDK from EasyRSA to Vault
+## Transitioning an existing cluster from EasyRSA to Vault
 
-An existing **CDK** deployment which is using Vault can easily transition to
-**Vault** simply by following the same steps as above, redeploying the same
-base bundle that you initially deployed on top of the existing deployment
-with the addition of the overlay and then following the steps to unseal
-**Vault**. This will transition all of the components of the cluster to
-the new CA and certificates (this will include restarting all of the worker
-nodes and result in a brief bit of downtime). Once that is complete, you will
-need to re-download the `kubectl` config file, since it contains the certificate
-info for connecting to the cluster.  Once you are satisfied with the state of
-the cluster, you can remove the **EasyRSA** application with:
+An existing **Charmed Kubernetes** deployment which is using EasyRSA can
+be transitioned to use **Vault** as a CA.
 
-```bash
-juju remove-application easyrsa
-```
+Follow the same steps as outlined above, and redeploy the same
+base bundle which was initially deployed on top of the existing deployment,
+adding the Vault overlay ([download][k8s-vault-yaml]).
 
 <div class="p-notification--information">
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
     Using an unpinned bundle revision may result in the cluster charms being
     upgraded. To avoid this, specify the exact bundle revision you deployed
-    with originally, or use `juju export-bundle` to create a custom bundle
-    based on exactly what you currently have deployed.
+    originally, or use `juju export-bundle` to create a custom bundle
+    based on exactly what is currently deployed.
   </p>
 </div>
+
+For example, for a 1.15 release:
+
+```bash
+juju deploy charmed-kubernetes-139 --overlay ./k8s-vault.yaml
+```
+
+Then follow the steps to unseal **Vault**. This will transition all of the
+components of the cluster to the new CA and certificates. This will not cause
+any disruption to running workloads, but you will be unable to issue cluster
+commands with `kubectl` for a brief period.
+
+
+After the transition, you must remove **EasyRSA** to prevent it from
+conflicting with **Vault**:
+
+```bash
+juju remove-application easyrsa
+```
+
+You will need to re-download the `kubectl` config file,
+since it contains the certificate info for connecting to the cluster:
+
+```bash
+juju scp kubernetes-master/0:config ~/.kube/config
+```
 
 ## Using Vault as an intermediary CA
 
 If you don't wish **Vault** to act as a self-signed root CA, you can remove the
 `auto-generate-root-ca-cert: true` option from the overlay and follow [these
 instructions][vault-guide-csr] to generate a
-[Certificate Signing Request (CSR)][csr], have it signed by a trusted root CA, and upload it
-back to **Vault**.
+[Certificate Signing Request (CSR)][csr], have it signed by a trusted root CA,
+and upload it back to **Vault**.
 
 ## Using Vault in Auto-Unseal mode
 


### PR DESCRIPTION
## Done

- Added note about MetalLB on cni-calico page
- Added note about Calico BGP on MetalLB page
 - Added section on Vault docs describing how to transition to Vault from EasyRSA 
 - Fixed ambiguity in storage page
 - various updates of CDK to Charmed Kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)