### PR TITLE
Add buy.u.c cta back to /pricing and /pricing/infra

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -51,24 +51,7 @@
   </div>
 </section>
 
-<section class="p-strip--accent is-dark is-bordered is-x-shallow" style="background-blend-mode: color;
-background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
-  <div class="row u-vertically-center">
-    <div class="col-1 u-vertically-center u-hide--small">
-      <img src="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Epath4185%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-131 -719)' fill='%23FFFFFF'%3E%3Cg transform='translate(-15 697)'%3E%3Cg transform='translate(157 34) scale(-1 1) translate(-17 -18)'%3E%3Cg transform='translate(.27856 .15983)'%3E%3Cg transform='translate(16.286 17.834) rotate(-90) translate(-17 -16)'%3E%3Cg transform='translate(17.282 16) scale(-1 1) translate(-16.5 -16)'%3E%3Cg transform='translate(16.641 16) scale(-1 1) translate(-16 -16)'%3E%3Cpath transform='translate(13.652 13.564) scale(1 -1) translate(-13.652 -13.564)' d='m27.303 5.8745c-0.574-2.5209-1.428-6.83-5.29-5.6848-4.907 1.4556-9.373 5.5584-12.791 8.9531v-1e-4c-0.0033 0.0034-0.0068 0.0067-0.0102 0.0101-0.0032 0.0034-0.0068 0.0067-0.0102 0.0101l1e-4 1e-4c-3.4165 3.396-7.5458 7.833-9.0107 12.709-1.1526 3.837 3.1842 4.686 5.7214 5.256l3.6037-8.142-1.7315-3.191c0.7581-1.18 2.6604-3.219 3.9284-4.48 1.269-1.26 3.321-3.1499 4.509-3.9032l2.886 2.0434 8.195-3.5807z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A" width="28" alt="" />
-    </div>
-    <div class="col-11 u-no-margin--left u-no-margin--bottom">
-      <h4 style="margin-bottom: 0.5rem;">Any questions?</h4>
-      <p class="u-no-margin--bottom u-no-max-width">
-        <span style="margin-right: 0.25rem;">
-          Call us <tel href="+17372040291">+1&nbsp;737&nbsp;204&nbsp;0291</tel>&nbsp;(Americas),
-          <tel href="+442036565291">+44&nbsp;203&nbsp;656&nbsp;5291</tel>&nbsp;(RoW) or
-        </span>
-        <br class="u-hide--large u-hide--medium" /><br class="u-hide--large u-hide--medium" />
-        <a href="/support/contact-us" class="p-button--neutral js-invoke-modal">contact us online</a></p>
-    </div>
-  </div>
-</section>
+{% include "shared/_call-sales.html" with colour="dark" %}
 
 <section class="p-strip is-deep is-bordered" id="enable-esm">
   <div class="row">

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -64,24 +64,7 @@
   </div>
 </section>
 
-<div class="p-strip--accent is-dark is-bordered is-x-shallow" style="background-blend-mode: color;
-background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
-  <div class="row u-vertically-center">
-    <div class="col-1 u-vertically-center u-hide--small">
-      <img src="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Epath4185%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-131 -719)' fill='%23FFFFFF'%3E%3Cg transform='translate(-15 697)'%3E%3Cg transform='translate(157 34) scale(-1 1) translate(-17 -18)'%3E%3Cg transform='translate(.27856 .15983)'%3E%3Cg transform='translate(16.286 17.834) rotate(-90) translate(-17 -16)'%3E%3Cg transform='translate(17.282 16) scale(-1 1) translate(-16.5 -16)'%3E%3Cg transform='translate(16.641 16) scale(-1 1) translate(-16 -16)'%3E%3Cpath transform='translate(13.652 13.564) scale(1 -1) translate(-13.652 -13.564)' d='m27.303 5.8745c-0.574-2.5209-1.428-6.83-5.29-5.6848-4.907 1.4556-9.373 5.5584-12.791 8.9531v-1e-4c-0.0033 0.0034-0.0068 0.0067-0.0102 0.0101-0.0032 0.0034-0.0068 0.0067-0.0102 0.0101l1e-4 1e-4c-3.4165 3.396-7.5458 7.833-9.0107 12.709-1.1526 3.837 3.1842 4.686 5.7214 5.256l3.6037-8.142-1.7315-3.191c0.7581-1.18 2.6604-3.219 3.9284-4.48 1.269-1.26 3.321-3.1499 4.509-3.9032l2.886 2.0434 8.195-3.5807z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A" width="28" alt="" />
-    </div>
-    <div class="col-11 u-no-margin--left u-no-margin--bottom">
-      <h4 style="margin-bottom: 0.5rem;">Any questions?</h4>
-      <p class="u-no-margin--bottom u-no-max-width">
-        <span style="margin-right: 0.25rem;">
-          Call us <tel href="+17372040291">+1&nbsp;737&nbsp;204&nbsp;0291</tel>&nbsp;(Americas),
-          <tel href="+442036565291">+44&nbsp;203&nbsp;656&nbsp;5291</tel>&nbsp;(RoW) or
-        </span>
-        <br class="u-hide--large u-hide--medium" /><br class="u-hide--large u-hide--medium" />
-        <a href="/support/contact-us" class="p-button--neutral js-invoke-modal">contact us online</a></p>
-    </div>
-  </div>
-</div>
+{% include "shared/_call-sales.html" with colour="dark" %}
 
 <section class="p-strip--light is bordered">
   <div class="row">
@@ -111,14 +94,14 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
       <ol class="p-list-step">
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            
+
             Generate your credentials
           </h3>
           <p>Via the <a class="p-link--external" href="https://auth.livepatch.canonical.com/">Canonical Livepatch portal</a>.</p>
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            
+
             Install the livepatch daemon
           </h3>
           <div class="p-code-snippet">
@@ -128,7 +111,7 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
         </li>
         <li class="p-list-step__item">
           <h3 class="p-list-step__title">
-            
+
             Enable it on your system
           </h3>
           <div class="p-code-snippet">

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -29,7 +29,8 @@
           <li class="p-list__item is-ticked">SDN</li>
           <li class="p-list__item is-ticked">Storage</li>
         </ul>
-        <p><a href="/pricing/infra/">See our services&nbsp;&rsaquo;</a>
+        <p><a class="p-button--neutral" href="/pricing/infra/">See our services</a></p>
+        <p><a class="p-link--external" href="https://buy.ubuntu.com/">Purchase from the store</a>
       </div>
       <div class="col-6 p-card">
         <div class="p-card__header">

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -30,7 +30,7 @@
           <li class="p-list__item is-ticked">Storage</li>
         </ul>
         <p><a class="p-button--neutral" href="/pricing/infra/">See our services</a></p>
-        <p><a class="p-link--external" href="https://buy.ubuntu.com/">Purchase from the store</a>
+        <p><a class="p-button--positive" href="https://buy.ubuntu.com/"><span class="p-link--external">Purchase from the store</span></a>
       </div>
       <div class="col-6 p-card">
         <div class="p-card__header">
@@ -43,7 +43,7 @@
           <li class="p-list__item is-ticked">Data center automation</li>
           <li class="p-list__item is-ticked">Logging, alerting, monitoring</li>
         </ul>
-        <p><a href="/pricing/infra#managed">Managed open infrastructure&nbsp;&rsaquo;</a></p>
+        <p><a class="p-button--neutral" href="/pricing/infra#managed">Managed open infrastructure</a></p>
       </div>
 
       <div class="col-6 p-card">
@@ -56,7 +56,7 @@
           <li class="p-list__item is-ticked">Kubernetes</li>
           <li class="p-list__item is-ticked">Kubeflow</li>
         </ul>
-        <p><a href="/pricing/consulting/">Dive in with Canonical&nbsp;&rsaquo;</a></p>
+        <p><a class="p-button--neutral" href="/pricing/consulting/">Dive in with Canonical</a></p>
       </div>
     </div>
   </section>

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -29,8 +29,8 @@
           <li class="p-list__item is-ticked">SDN</li>
           <li class="p-list__item is-ticked">Storage</li>
         </ul>
-        <p><a class="p-button--neutral" href="/pricing/infra/">See our services</a></p>
-        <p><a class="p-button--positive" href="https://buy.ubuntu.com/"><span class="p-link--external">Purchase from the store</span></a>
+        <p><a class="p-button--neutral is-wide" href="/pricing/infra/">See our services</a></p>
+        <p><a class="p-button--positive is-wide" href="https://buy.ubuntu.com/"><span class="p-link--external">Purchase from the store</span></a>
       </div>
       <div class="col-6 p-card">
         <div class="p-card__header">
@@ -43,7 +43,7 @@
           <li class="p-list__item is-ticked">Data center automation</li>
           <li class="p-list__item is-ticked">Logging, alerting, monitoring</li>
         </ul>
-        <p><a class="p-button--neutral" href="/pricing/infra#managed">Managed open infrastructure</a></p>
+        <p><a class="p-button--neutral is-wide" href="/pricing/infra#managed">Managed open infrastructure</a></p>
       </div>
 
       <div class="col-6 p-card">
@@ -56,7 +56,7 @@
           <li class="p-list__item is-ticked">Kubernetes</li>
           <li class="p-list__item is-ticked">Kubeflow</li>
         </ul>
-        <p><a class="p-button--neutral" href="/pricing/consulting/">Dive in with Canonical</a></p>
+        <p><a class="p-button--neutral is-wide" href="/pricing/consulting/">Dive in with Canonical</a></p>
       </div>
     </div>
   </section>

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -19,7 +19,7 @@
         <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
       </li>
       <li class="p-inline-list__item">
-        <span>or see our <a href="/legal/ubuntu-advantage-service-description#uasd-subscriptions">service description</a>.</span>
+        <a href="https://buy.ubuntu.com/" class="p-button--neutral"><span class="p-link--external">Visit our store</span></a>
       </li>
     </ul>
   </div>
@@ -84,6 +84,9 @@
     </div>
   </div>
 </section>
+
+{% include "shared/_call-sales.html" with colour="dark" %}
+
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_pricing-infra.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -14,7 +14,7 @@
       <h4>Open Source for the enterprise</h4>
       <p>Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry. With OpenStack and Kubernetes support included, Ubuntu Advantage for Infrastructure provides everything you need to future-proof your data centre.</p>
       <p>
-        <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Visit the store</span></a>
+        <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Buy online</span></a>
         <a href="{{ ASSET_SERVER_URL }}b0b42477-Ubuntu_Advantage_+Datasheet-2019.pdf" class="p-button--neutral">Read the datasheet</a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- added links to buy.u.c on pricing and /pricing/infra
- made use of the _call_sales include on three pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/pricing
    - http://0.0.0.0:8001/pricing/infra
    - http://0.0.0.0:8001/livepatch
    - http://0.0.0.0:8001/esm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the copy docs: [pricing](https://docs.google.com/document/d/1iOM6oBqsTkptsst3yG-U3sGaYLQqs27go_8yJQdhMBE/edit#) and [infra](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#)

## Issue / Card

Fixes #5410
