### PR TITLE
K8s Services datasheet + page changes

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -67,7 +67,7 @@
 
       <p><a href="/kubernetes/install">Install instructions&nbsp;&rsaquo;</a></p>
       <p><a href="/kubernetes/managed">Fully managed Kubernetes options&nbsp;&rsaquo;</a>
-        <p><a href="{{ ASSET_SERVER_URL }}62e71815-Kubernetes-for-the-Enterprise.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">Charmed Kubernetes datasheet&nbsp;&rsaquo;</a></p>
+        <p><a href="{{ ASSET_SERVER_URL }}8db65a1e-Kubernetes-for-the-Enterprise.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">Charmed Kubernetes datasheet&nbsp;&rsaquo;</a></p>
       </div>
 
       <div class="col-6 p-card">
@@ -275,7 +275,7 @@
     <div class="row">
       <div class="col-12">
         <p>
-          <a href="{{ ASSET_SERVER_URL }}62e71815-Kubernetes-for-the-Enterprise.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">
+          <a href="{{ ASSET_SERVER_URL }}8db65a1e-Kubernetes-for-the-Enterprise.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">
             Download the Enterprise Kubernetes datasheet&nbsp;&rsaquo;
           </a>
         </p>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -23,7 +23,7 @@
           <li>Monitoring and log management integration</li>
         </ul>
         <div>
-          <a href="{{ ASSET_SERVER_URL }}62e71815-Kubernetes-for-the-Enterprise.pdf" class="p-button--positive">Read the datasheet</a>
+          <a href="{{ ASSET_SERVER_URL }}8db65a1e-Kubernetes-for-the-Enterprise.pdf" class="p-button--positive">Read the datasheet</a>
 
           <a href="/kubernetes/contact-us?product=kubernetes-managed" class="p-button--neutral js-invoke-modal">Talk to us</a>
         </div>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -65,7 +65,7 @@
               <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" width="32" alt="" />
               <h4 class="p-heading-icon__title">Datasheet</h4>
             </div>
-            <h3 class="p-heading--four"><a class="p-link--external" href="{{ ASSET_SERVER_URL }}62e71815-Kubernetes-for-the-Enterprise.pdf">Kubernetes for the enterprise</a></h3>
+            <h3 class="p-heading--four"><a class="p-link--external" href="{{ ASSET_SERVER_URL }}8db65a1e-Kubernetes-for-the-Enterprise.pdf">Kubernetes for the enterprise</a></h3>
           </div>
         </div>
         <div class="col-4 p-divider__block">

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -36,7 +36,7 @@
 
   <section class="p-strip--light">
     <div class="row">
-      <h2 id="kubeflow">Kubeflow</h2>
+      <h2 id="kubeflow">Kubeflow Machine Learning Starter</h2>
     </div>
     {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
   </section>


### PR DESCRIPTION
## Done

- /kubernetes page (update links to new pdf 'Upstream K8s options...' + 'AI/ML add-on...' sections)
- /kubernetes/managed (update link to new pdf in hero + resources sections)
- /pricing/consulting 'Kubeflow' name changed to 'Kubeflow Machine Learning Starter'

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/kubernetes](http://0.0.0.0:8001/kubernetes)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- go to [/kubernetes](http://0.0.0.0:8001/kubernetes) and make sure the links to the datasheet in the  'Upstream K8s options...' + 'AI/ML add-on...' sections give you [this pdf](https://github.com/canonical-web-and-design/web-squad/files/3320837/DS_Kubernetes-for-the-Enterprise_screen-AW_24.06.19.pdf)
 - go to [/kubernetes/managed](http://0.0.0.0:8001/kubernetes/managed) and make sure the links to datasheet in hero + resources sections give you [this pdf](https://github.com/canonical-web-and-design/web-squad/files/3320837/DS_Kubernetes-for-the-Enterprise_screen-AW_24.06.19.pdf)
- go to [/pricing/consulting](http://0.0.0.0:8001/pricing/consulting) and make sure 'Kubeflow' name is changed to 'Kubeflow Machine Learning Starter' to match [copy doc](https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY/edit)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1327
