### PR TITLE
Bump blog to v2.0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.0.12
+canonicalwebteam.blog==2.0.13
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4


### PR DESCRIPTION
# Summary

Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/2469/?query=is%3Aunresolved

Fixes 500 when requesting a unexisting tag: https://ubuntu.com/blog/tag/snapasdadsfasf

Should return 404 page

# QA

- `./run` 
- access:  `/blog/tag/asdfasdfasdf`
- Should get a 404