### PR TITLE
K8s backups documentation updates

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -138,6 +138,9 @@ kubernetes:
         - title: Monitoring
           path: /kubernetes/docs/monitoring
           hidden: True
+        - title: Backups
+          path: /kubernetes/docs/backups
+          hidden: True
         - title: Upgrading
           path: /kubernetes/docs/upgrading
           hidden: True

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -78,15 +78,18 @@ Restoring a snapshot should not be performed when there is more than one unit of
 As restoring only works when there is a single unit of **etcd**, it is usual to deploy a new instance of the application first.
 
 ```bash
-juju deploy etcd new-etcd --series=bionic
+juju deploy etcd new-etcd --series=bionic --config channel=3.2/stable
+juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
+juju add-relation new-etcd:certificates new-easyrsa:client
 ```
 
 The `--series` option is included here to illustrate how to specify which series the new unit should be running on.
+The `--config` option is required to specify the same channel of etcd as the original unit.
 
 Next we upload and identify the snapshot file to this new unit:
 
 ```bash
-juju attach newer-etcd snapshot=./etcd-snapshot-2018-09-26-18.04.02.tar.gz
+juju attach new-etcd snapshot=./etcd-snapshot-2018-09-26-18.04.02.tar.gz
 ```
 
 Then run the restore action:

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -19,7 +19,7 @@
   - [Basic operations](/kubernetes/docs/operations)
   - [Logging](/kubernetes/docs/logging)
   - [Monitoring](/kubernetes/docs/monitoring)
-  - [backups](/kubernetes/docs/backups)
+  - [Backups](/kubernetes/docs/backups)
   - [Upgrading](/kubernetes/docs/upgrading)
   - [Storage](/kubernetes/docs/storage)
   - [Scaling](/kubernetes/docs/scaling)

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -19,6 +19,7 @@
   - [Basic operations](/kubernetes/docs/operations)
   - [Logging](/kubernetes/docs/logging)
   - [Monitoring](/kubernetes/docs/monitoring)
+  - [backups](/kubernetes/docs/backups)
   - [Upgrading](/kubernetes/docs/upgrading)
   - [Storage](/kubernetes/docs/storage)
   - [Scaling](/kubernetes/docs/scaling)


### PR DESCRIPTION

## Done

Adds some updates to the K8s Backups page
Adds the backup page to main navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
