### PR TITLE
Bump blog to v2.0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.0.13
+canonicalwebteam.blog==2.0.14
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4


### PR DESCRIPTION
# Summary

Fix author not found that was returning a 500 instead of a 404.

# qa

- `./run`
- http://0.0.0.0:8001/blog/author/aaaaaaaaaaaaaaaaaaaaaaa
- should get a 404 page