### PR TITLE
Add training strips to /kubernetes and /openstack

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -283,6 +283,8 @@
     </div>
   </section>
 
+{% include "shared/_training.html" with type="Kubernetes" %}
+
   <section class="p-strip--light is-deep is-bordered">
     <div class="row">
       <div class="col-12">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -12,9 +12,9 @@
     <div class="col-8">
       <h1>OpenStack, Delivered</h1>
       <p>Canonical designs, builds, operates and supports OpenStack private clouds on Ubuntu. We understand the importance of certainty, stability, performance and economic efficiency for private cloud infrastructure.</p>
-      
+
       <p>Ready to move from proprietary virtualisation to OpenStack?</p>
-      
+
       <p>
         <a href="/engage/vmware-to-openstack" class="p-button--positive">
           Watch the VMware to Openstack webinar
@@ -305,6 +305,8 @@
     </div>
   </div>
 </section>
+
+{% include "shared/_training.html" with type="OpenStack" %}
 
 <section class="p-strip--light">
   <div class="row">

--- a/templates/shared/_training.html
+++ b/templates/shared/_training.html
@@ -1,0 +1,15 @@
+<section class="p-strip is-bordered">
+ <div class="row">
+   <div class="col-8">
+     <h2>
+       {% if type %}{{ type }} training{% else %}Train with Ubuntu{% endif %}
+     </h2>
+     <p>
+       Train your sysadmins and devops engineers to become Ubuntu OpenStack, Ubuntu Server or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Get the most out of your investment.
+     </p>
+     <p>
+       <a href="/training">Learn more about training&nbsp;&rsaquo;</a>
+     </p>
+   </div>
+ </div>
+</section>


### PR DESCRIPTION
12## Done

- Add training strips to /kubernetes and /openstack

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes and http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is an include for training on both pages and compare to the [openstack copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#) and [kubernetes copy doc](https://docs.google.com/document/d/1G-h1eWiBSKqG9oWB15Pup8VDe1axBUwQGvtkwJ9g8T0/edit#)

NOTE: I have asked @anasereijo to provide an illustration, but this is ok for now.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1295

## Screenshots

![image](https://user-images.githubusercontent.com/441217/60652139-83a0ea00-9e3f-11e9-94db-6b4701982297.png)

