### PR TITLE
Add anchor to on /download/iot for /core links

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -144,7 +144,7 @@
       <p>Ubuntu Core benefits from the automatic scanning of all snaps for vulnerable libraries and problematic code.</p>
       <p>
         <a class="p-button--positive is-inline js-invoke-modal" href="/core/contact-us?product=core-overview" style="margin-left: 0;">Contact us</a>
-        <a href="/download/iot/">Get Ubuntu Core&nbsp;&rsaquo;</a>
+        <a href="/download/iot#core">Get Ubuntu Core&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
@@ -428,7 +428,7 @@ store for access to all the standard apps, or curate your own collection.</p>
       <h4>Off-the-shelf board support by Canonical</h4>
       <p class='p-heading--five'>First class enablement for widely used boards and silicon gets you straight to market.</p>
       <p>Low-level development is a distraction in the race to market. Focus all your effort on the experience that differentiates. Pre-certified chipsets keep you out of the weeds.</p>
-      <p><a href="/download/iot">See our supported boards&nbsp;&rsaquo;</a></p>
+      <p><a href="/download/iot#core">See our supported boards&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -63,7 +63,7 @@
     </div>
   </section>
 
-  <section class="p-strip--light">
+  <section id="core" class="p-strip--light">
     <div class="row u-equal-height">
       <div class="col-8">
         <h2>Ubuntu Core</h2>

--- a/templates/takeovers/_ubuntu-core-18-takeover.html
+++ b/templates/takeovers/_ubuntu-core-18-takeover.html
@@ -9,7 +9,7 @@
       </p>
       <p class="u-no-margin--top u-no-margin--bottom"><a href="https://www.brighttalk.com/webcast/6793/339167?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_IOT_UbuntuCore_WBN_Core 18"
           class="p-button--positive">Watch the webinar</a></p>
-      <p class="u-no-margin--top"><a href="/download/iot" class="p-link--inverted">Download Ubuntu Core 18 now&nbsp;&rsaquo;</a></p>
+      <p class="u-no-margin--top"><a href="/download/iot#core" class="p-link--inverted">Download Ubuntu Core 18 now&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}635ce124-IOT_core_infographic+light.svg" alt="Ubuntu Core 18" />


### PR DESCRIPTION
## Done

- Add anchor to on /download/iot for /core links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the links on /core now go to an anchor on http://0.0.0.0:8001/download/iot#core


## Issue / Card

Fixes #5403 


