### PR TITLE
Fix-up /training page contact-us

### DIFF
--- a/templates/training/_base_training.html
+++ b/templates/training/_base_training.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1HT_6RTfAa4cqxryCyJVqzIaQWYqiIgQg{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -1,0 +1,28 @@
+{% extends "training/_base_training.html" %}
+
+{% block title %}Contact us | Training{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/10lo3O2TKiR-cc48CqhH3Ghak0xZQaP2n4YthDtdIXpo/edit{% endblock meta_copydoc %}
+
+{% block content %}
+  {% if product == 'openstack-training' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1263" lpId="2163" returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training" %}
+
+  {% elif product == 'openstack-training-classroom' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Register for Ubuntu OpenStack Training" intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we’ll get back to you with available dates and locations." formid="1261" lpId="2161" returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training-classroom" %}
+
+  {% elif product == 'openstack-training-onsite' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1223" lpId="1973" returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" %}
+
+  {% elif product == 'openstack-training-server-admin' %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about our Ubuntu Server Administration training courses" intro_text="Fill in your details below and a member of our training team will be in touch." formid="1448" lpId="2661" returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" %}
+
+  {% else %}
+
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about OpenStack" intro_text="Fill in your details below and a member of our cloud sales team will be in touch." formid='1251'  lpId='2086' returnURL='https://www.ubuntu.com/training/thank-you' %}
+
+  {% endif %}
+{% endblock content %}

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -1,8 +1,8 @@
-{% extends "openstack/_base_openstack.html" %}
+{% extends "training/_base_training.html" %}
 
 {% load versioned_static  %}
 
-{% block title %}Training | OpenStack{% endblock %}
+{% block title %}Training{% endblock %}
 {% block meta_description %}Canonical run OpenStack, Kubernetes and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
 
@@ -49,7 +49,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -72,7 +72,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -104,7 +104,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -132,7 +132,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="row">
@@ -157,7 +157,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -192,7 +192,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -216,7 +216,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/openstack/contact-us?product=/openstack/contact-us?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -226,7 +226,7 @@
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-      <p><a href="/openstack/contact-us?product=openstack-training" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}9b170f06-picto-help-orange.svg" width="135" alt="" />
@@ -235,7 +235,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below -->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you" data-lp-url="https://www.ubuntu.com/training/thank-you">
 </div>
 
 <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -1,0 +1,42 @@
+{% extends "training/_base_training.html" %}
+
+{% block title %}Thank you{% endblock %}
+{% block canonical_url %}https://ubuntu.com/training/contact-us{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1-dWhd0ydDWlYg16rEybPPmkQ6cdxsBmiFOuUz0ApCBM/edit{% endblock meta_copydoc %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+
+{% if product == 'openstack-training' %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about our training courses" %}
+{% elif product == 'openstack-training-classroom' %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about our classroom training courses" %}
+{% elif product == 'openstack-training-onsite' %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about our on-site training courses" %}
+{% elif product == 'openstack-training-server-admin' %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about our server admin training courses" %}
+{% else %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about training" %}
+{% endif %}
+
+{% endblock content %}
+{% block footer_extra %}
+  <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+  <script>
+    /* <![CDATA[ */
+    var google_conversion_id = 1012391776;
+    var google_conversion_language = "en";
+    var google_conversion_format = "3";
+    var google_conversion_color = "ffffff";
+    var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+    var google_conversion_value = 0;
+    /* ]]> */
+  </script>
+  <script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <noscript>
+    <div style="display:inline;">
+      <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    </div>
+  </noscript>
+  {{ marketo }}
+{% endblock footer_extra %}


### PR DESCRIPTION
## Done

- Fix-up /training page contact-us by
    - creating a base template
    - moving the non-js contact-us and thank-you pages/forms in from openstack and trimming them to the right products
    - adding the right forms back to the training page for the js modals

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page looks ok and the modals open with js and statically with no js

## Issue / Card

Fixes #5276 
