### PR TITLE
Update Nuc and Tank870 UC18 images locations

### DIFF
--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -46,8 +46,8 @@
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
-            <p>Download the <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
-            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://people.canonical.com/~chih/intel_kassel/kassel-uc18-m6-20190121.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+            <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64+kassel.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
+            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/MD5SUMS">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
           </div>
         </li>
         <li class="p-list-step__item">

--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -53,9 +53,9 @@
             Download Ubuntu Core
           </h3>
           <div class="p-list-step__content">
-            <p>Download the <a class="p-link--external" href="http://people.canonical.com/~chih/intel_dawson/dawson-uc18-m7-20190122-10.img.xz">Ubuntu Core 18 image for Intel Dawson Canyon and June Canyon NUC</a></p>
+            <p>Download the <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz">Ubuntu Core 18 image for Intel Dawson Canyon and June Canyon NUC</a></p>
             <p>This image is certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE, NUC7i3DNHE, NUC7i3DNKE, and NUC7i3DNBE, and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH</p>
-            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://people.canonical.com/~chih/intel_dawson/dawson-uc18-m7-20190122-10.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
           </div>
         </li>
         <li class="p-list-step__item">


### PR DESCRIPTION
## Done

* Update tank and nuc UC18 images location

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure download and checksum links on [/download/iot/intel-nuc](https://ubuntu-com-canonical-web-and-design-pr-5429.run.demo.haus/download/iot/intel-nuc) and [/download/iot/intel-iei-tank-870](https://ubuntu-com-canonical-web-and-design-pr-5429.run.demo.haus/download/iot/intel-iei-tank-870) are working 

