### PR TITLE
Change 32M to 32m for macs

### DIFF
--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Create installation media for Ubuntu{% endblock %}}
-{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1GEJ-raGZDkcFeedEk_Ja_4DJYzqjeUa-GIHVDV7r7Vo/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip is-bordered">

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -28,57 +28,57 @@
       <ol class="p-list-step">
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Insert your SD card or USB flash drive
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
           </p>
           <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Else, run:
           </p>
           <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Then, run the <code>sync</code> command to finalize the process
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
           </p>
         </li>
@@ -94,31 +94,31 @@
       <ol class="p-list-step">
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Insert your SD card or USB flash drive
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
           </p>
           <p>
@@ -127,7 +127,7 @@
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
           </p>
           <ol>
@@ -138,13 +138,13 @@
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             When ready click on <strong>Write</strong> and wait for the process to complete.
           </p>
         </li>
         <li class="p-list-step__item col-8">
           <p class="p-list-step__title">
-            
+
             You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
           </p>
         </li>
@@ -158,26 +158,26 @@
           <ol class="p-list-step">
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                
+
                 Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
               </p>
             </li>
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                
+
                 Insert your SD card or USB flash drive
               </p>
             </li>
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                
+
                 Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run the following command:
               </p>
               <p><pre><code>diskutil list</code></pre></p>
             </li>
             <li class="p-list-step__item col-8">
               <p class="p-list-step__title">
-                
+
                 In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
               </p>
               <pre>
@@ -199,24 +199,24 @@
               </li>
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  
+
                   Unmount your SD card with the following command
                 </p>
                 <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
               </li>
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  
+
                   When successful, you should see a message similar to this one:
                 </p>
                 <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
               </li>
               <li class="p-list-step__item col-8">
                 <p class="p-list-step__title">
-                  
+
                   You can now copy the image to the SD card, using the following command:
                 </p>
-                <pre><code>sudo sh -c 'xzcat ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32M'</code></pre>
+                <pre><code>sudo sh -c 'xzcat ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
                 <p>When finalised you will see the following message:</p>
                 <pre>
                   <code>3719+1 records in
@@ -226,7 +226,7 @@
                 </li>
                 <li class="p-list-step__item col-8">
                   <p class="p-list-step__title">
-                    
+
                     You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
                   </p>
                 </li>


### PR DESCRIPTION
## Done

- Updated the mac dd command to use 32m (lower case) from 32M
- Added the copy doc url to the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot/installation-media
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1GEJ-raGZDkcFeedEk_Ja_4DJYzqjeUa-GIHVDV7r7Vo/edit)

## Issue / Card

Fixes #5334 

