### PR TITLE
Links “Deb, snap, and charm packages” to Packages page

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -15,7 +15,7 @@
             <li class="p-list__item">GCC, CLANG</li>
             <li class="p-list__item">Go</li>
             <li class="p-list__item">Python, Ruby, Node.js</li>
-            <li class="p-list__item">Deb, snap, and charm packages</li>
+            <li class="p-list__item"><a href="/about/packages">Deb, snap, and charm packages</a></li>
             <li class="p-list__item">Android development</li>
             <li class="p-list__item">Architectures and ISAs</li>
             <li class="p-list__item">Kernel selection &amp; lifecycle</li>


### PR DESCRIPTION
## Done

- Linked the “Deb, snap, and charm packages” navigation item to the Packages page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Open the “Developer” mega-menu
- In the “Develop on Ubuntu” section, click “Deb, snap, and charm packages”
- Observe that you are now on the “Ubuntu Packages and Repositories” page

## Issue / Card

None, this is a drive-by of something I discovered while investigating [Ubuntu-design#120](https://github.com/CanonicalLtd/Ubuntu-design/issues/120)