### PR TITLE
Fix typo

### DIFF
--- a/templates/takeovers/_edge-month_takeover.html
+++ b/templates/takeovers/_edge-month_takeover.html
@@ -5,7 +5,7 @@
         Edge&nbsp;cloud? Edge&nbsp;computing?
       </h1>
       <p class="p-heading--four u-sv3">
-        Join us for a series of webinars about the deployment, operations and effeciencies of compute at the edge.
+        Join us for a series of webinars about the deployment, operations and efficiencies of compute at the edge.
       </p>
       <ul class="p-inline-list u-hide--small">
         <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

-Fixed a typo in efficiencies on the takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that efficiencies is spelled correctly on the edge takeover
