### PR TITLE
Shift to app store takeover & engage page

### DIFF
--- a/templates/engage/shift-to-app-store-experience.html
+++ b/templates/engage/shift-to-app-store-experience.html
@@ -1,0 +1,83 @@
+{% extends_with_args "engage/base_engage.html" with title="Linux app stores provide improved application visibility and usage" meta_image="https://assets.ubuntu.com/v1/8b9a82bd-Embedded+social+media+banner.jpg" meta_description="Linux app stores are successfully alleviating historical challenges faced by software developers whilst improving visibility to enterprises and end users." %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1MsQpa3ik8w-jVAmPdsQIz0w_XteBsH-g2xDVigPeo6Q{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-takeover">
+  <div class="p-strip--image is-dark is-deep p-takeover__suru">
+    <div class="row u-equal-height">
+      <div class="col-8 u-vertically-center">
+        <div>
+          <h1>A shift to the Linux app store experience</h1>
+
+          <p class="p-heading--four u-sv2">The key to optimising software applications in a fragmented environment.</p>
+
+          <p class="u-hide--medium u-hide--large u-no-margin--bottom">
+            <a href="#register-section" class="p-button--neutral">Download the whitepaper</a>
+          </p>
+        </div>
+      </div>
+
+      <div class="col-4 u-hide--small u-align--center u-vertically-center">
+        <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" alt="">
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow is-bordered">
+    <div class="row">
+      <div class="col-7">
+        <p>Linux software developers historically have faced a number of challenges including fragmentation, distribution complexity and a lack of metrics into the success of their applications. Once an application is built, the journey does not end there - for companies and individual developers creating apps,  thought needs to be given to promoting their software for maximum visibility, usage and customer experience. </p>
+
+        <blockquote class="p-pull-quote"><p>Applications within the ‘Featured’ section of Linux app stores can see up to 40% install growth within two weeks of being featured.</p></blockquote>
+
+        <p>Self-contained application formats like AppImage, Flatpak and snaps and the shift to an application store model offer a viable, data-driven alternative to the classic methods. This new approach can help overcome some of the historical challenges while improving visibility to enterprises and end users.</p>
+
+        <p>This whitepaper will take a closer look at how software developers targeting the desktop market, in particular, can benefit from moving their applications to a Linux app store including: </p>
+
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">An evaluation of the packaging formats, distributions and considerations that software developers should consider.</li>
+
+          <li class="p-list__item is-ticked">The adoption of application stores: how software developers can maximise their presence and apply lessons from other industries.</li>
+
+          <li class="p-list__item is-ticked">A series of case studies highlighting successful apps that have an optimised store presence including Spotify, Visual Studio Code and Skype. </li>
+        </ul>
+      </div>
+
+      <div class="col-5" id="register-section">
+        {% include "engage/shared/_en_engage_form.html" with id="3407" returnURL="" %}
+      </div>
+    </div>
+  </div>
+  
+  <style>
+    .p-takeover {
+      background-blend-mode: color;
+      background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
+      background-color: #2D6162;
+    }
+
+    @media only screen and (min-width: 768px) {
+      .p-takeover__suru {
+        background-image: url('{{ ASSET_SERVER_URL }}26b969b7-suru.svg');
+        background-position: top right;
+        background-size: auto 100%;
+      }
+    }
+
+    .p-takeover .p-takeover__image {
+      height: 229px;
+      width: 200px;
+    }
+
+    @media only screen and (max-width: 768px) {
+      .p-takeover .p-takeover__image {
+        height: 180px;
+        width: 157px;
+      }
+    }
+  </style>
+</section>
+
+{% endblock content %}

--- a/templates/engage/shift-to-app-store-experience.html
+++ b/templates/engage/shift-to-app-store-experience.html
@@ -35,7 +35,7 @@
         <p>This whitepaper will take a closer look at how software developers targeting the desktop market, in particular, can benefit from moving their applications to a Linux app store including: </p>
 
         <ul class="p-list">
-          <li class="p-list__item is-ticked">An evaluation of the packaging formats, distributions and considerations that software developers should consider.</li>
+          <li class="p-list__item is-ticked">An evaluation of the packaging formats, distributions and considerations that software developers should review.</li>
 
           <li class="p-list__item is-ticked">The adoption of application stores: how software developers can maximise their presence and apply lessons from other industries.</li>
 

--- a/templates/engage/shift-to-app-store-experience.html
+++ b/templates/engage/shift-to-app-store-experience.html
@@ -10,7 +10,7 @@
       <div class="col-7">
         <h1>A shift to the Linux app store experience</h1>
 
-        <p class="p-heading--four u-sv2">The key to optimising software applications in a fragmented environment.</p>
+        <p class="p-heading--four u-sv2">The key to optimising software distribution in a fragmented environment.</p>
 
         <p class="u-hide--medium u-hide--large u-no-margin--bottom">
           <a href="#register-section" class="p-button--neutral">Download the whitepaper</a>
@@ -44,7 +44,7 @@
       </div>
 
       <div class="col-5" id="register-section">
-        {% include "engage/shared/_en_engage_form.html" with id="3407" returnURL="" %}
+        {% include "engage/shared/_en_engage_form.html" with id="3411" returnURL="https://pages.ubuntu.com/Whitepaper_ShifttoAppStore-TY.html" %}
       </div>
     </div>
   </div>

--- a/templates/engage/shift-to-app-store-experience.html
+++ b/templates/engage/shift-to-app-store-experience.html
@@ -7,7 +7,7 @@
 <section class="p-takeover">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-equal-height">
-      <div class="col-8 u-vertically-center">
+      <div class="col-7 u-vertically-center">
         <div>
           <h1>A shift to the Linux app store experience</h1>
 
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      <div class="col-5 u-hide--small u-align--center u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" alt="">
       </div>
     </div>
@@ -53,7 +53,6 @@
   
   <style>
     .p-takeover {
-      background-blend-mode: color;
       background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
       background-color: #2D6162;
     }

--- a/templates/engage/shift-to-app-store-experience.html
+++ b/templates/engage/shift-to-app-store-experience.html
@@ -7,16 +7,14 @@
 <section class="p-takeover">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="row u-equal-height">
-      <div class="col-7 u-vertically-center">
-        <div>
-          <h1>A shift to the Linux app store experience</h1>
+      <div class="col-7">
+        <h1>A shift to the Linux app store experience</h1>
 
-          <p class="p-heading--four u-sv2">The key to optimising software applications in a fragmented environment.</p>
+        <p class="p-heading--four u-sv2">The key to optimising software applications in a fragmented environment.</p>
 
-          <p class="u-hide--medium u-hide--large u-no-margin--bottom">
-            <a href="#register-section" class="p-button--neutral">Download the whitepaper</a>
-          </p>
-        </div>
+        <p class="u-hide--medium u-hide--large u-no-margin--bottom">
+          <a href="#register-section" class="p-button--neutral">Download the whitepaper</a>
+        </p>
       </div>
 
       <div class="col-5 u-hide--small u-align--center u-vertically-center">

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_edge-month_takeover.html" %}
+  {% include "takeovers/_shift-to-app-store_takeover.html" %}
   {% include "takeovers/_active-directory_takeover.html" %}
   {% include "takeovers/_ubuntu-lime-telco_takeover.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,6 @@
   {% include "takeovers/_edge-month_takeover.html" %}
   {% include "takeovers/_shift-to-app-store_takeover.html" %}
   {% include "takeovers/_active-directory_takeover.html" %}
-  {% include "takeovers/_ubuntu-lime-telco_takeover.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/takeovers/_shift-to-app-store_takeover.html
+++ b/templates/takeovers/_shift-to-app-store_takeover.html
@@ -5,7 +5,7 @@
         <h1>A shift to the Linux app store experience</h1>
         <p class="p-heading--four u-sv3">How app stores are providing a viable, data-driven alternative to classic methods of software distribution.</p>
         <p class="u-hide--small">
-          <a href="/engage/a-shift-to-the-app-store" class="p-button--neutral u-no-margin--bottom">Download the whitepaper</a>
+          <a href="/engage/shift-to-app-store-experience" class="p-button--neutral u-no-margin--bottom">Download the whitepaper</a>
         </p>
       </div>
       <div class="col-4">
@@ -13,7 +13,7 @@
           <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
         </div>
         <p class="u-no-margin--bottom u-hide--large u-hide--medium">
-          <a href="/engage/a-shift-to-the-app-store" class="p-button--neutral">Download the whitepaper</a>
+          <a href="/engage/shift-to-app-store-experience" class="p-button--neutral">Download the whitepaper</a>
         </p>
       </div>
     </div>

--- a/templates/takeovers/_shift-to-app-store_takeover.html
+++ b/templates/takeovers/_shift-to-app-store_takeover.html
@@ -20,7 +20,6 @@
 
     <style>
       .p-takeover {
-        background-blend-mode: color;
         background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
         background-color: #2D6162;
       }

--- a/templates/takeovers/_shift-to-app-store_takeover.html
+++ b/templates/takeovers/_shift-to-app-store_takeover.html
@@ -1,0 +1,49 @@
+<section class="js-takeover p-takeover">
+  <div class="p-strip--image is-dark is-deep p-takeover__suru">
+    <div class="row u-equal-height">
+      <div class="col-8">
+        <h1>A shift to the Linux app store experience</h1>
+        <p class="p-heading--four u-sv3">How app stores are providing a viable, data-driven alternative to classic methods of software distribution.</p>
+        <p class="u-hide--small">
+          <a href="/engage/a-shift-to-the-app-store" class="p-button--neutral u-no-margin--bottom">Download the whitepaper</a>
+        </p>
+      </div>
+      <div class="col-4">
+        <div class="u-align-text--center u-sv3 u-vertically-center">
+          <img src="{{ ASSET_SERVER_URL }}44fd30d7-Snap+Store+shopping+icon+darkhandle.svg" class="p-takeover__image" alt="" />
+        </div>
+        <p class="u-no-margin--bottom u-hide--large u-hide--medium">
+          <a href="/engage/a-shift-to-the-app-store" class="p-button--neutral">Download the whitepaper</a>
+        </p>
+      </div>
+    </div>
+
+    <style>
+      .p-takeover {
+        background-blend-mode: color;
+        background-image: linear-gradient(134deg, #2D6162 0%, #83BFA1 100%);
+        background-color: #2D6162;
+      }
+
+      @media only screen and (min-width: 768px) {
+        .p-takeover__suru {
+          background-image: url('{{ ASSET_SERVER_URL }}26b969b7-suru.svg');
+          background-position: top right;
+          background-size: auto 100%;
+        }
+      }
+
+      .p-takeover .p-takeover__image {
+        height: 229px;
+        width: 200px;
+      }
+
+      @media only screen and (max-width: 768px) {
+        .p-takeover .p-takeover__image {
+          height: 180px;
+          width: 157px;
+        }
+      }
+    </style>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- added "Shift to app store" takeover & engage page
- removed "Lime telco" takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the app store takeover
- Ensure it matches the [designs](https://github.com/canonical-web-and-design/web-squad/issues/1352#issuecomment-509298944) and the [copy doc](https://docs.google.com/spreadsheets/d/1t9l_YknhiZ25YGOQqXJCs0b7KVo3eHaSfvi-KRAT8_0/edit?ts=5d0a5ff9#gid=2113339190)
- Follow the CTA to the engage page
- Ensure it matches the [copy doc](https://docs.google.com/document/d/1MsQpa3ik8w-jVAmPdsQIz0w_XteBsH-g2xDVigPeo6Q)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1353 & https://github.com/canonical-web-and-design/web-squad/issues/1355
