### PR TITLE
Corrects PaddlePaddle link and text

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -152,7 +152,7 @@
                 <a href="https://mxnet.incubator.apache.org/install/index.html">MXNet on Ubuntu</a> with <a href="https://www.nvidia.com/en-us/data-center/gpu-accelerated-applications/mxnet/">Nvidia</a>
               </li>
               <li class="p-list__item">
-                <a href="https://pytorch.org/">Pytorch</a> &middot; <a href="http://www.paddlepaddle.org/">PaddPaddle</a> &middot; <a href="https://chainer.org/">Chainer</a>
+                <a href="https://pytorch.org/">Pytorch</a> &middot; <a href="http://en.paddlepaddle.org/">PaddlePaddle</a> &middot; <a href="https://chainer.org/">Chainer</a>
               </li>
             </ul>
             <p><a class="p-button--positive p-button--small" href="/kubeflow">Develop for AI/ML</a></p>


### PR DESCRIPTION
## Done

- Changed “PaddPaddle” to the correct spelling “PaddlePaddle”
- Changed the link target from the Chinese http://www.paddlepaddle.org/ to the English http://en.paddlepaddle.org/ (since this is ubuntu.com and not cn.ubuntu.com)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Open “Developer”
- in the “AI & MACHINE LEARNING” section, choose “PaddlePaddle”

## Issue / Card

None, this is a drive-by of another problem discovered while investigating [Ubuntu-design#120](https://github.com/CanonicalLtd/Ubuntu-design/issues/120)