### PR TITLE
Center align and max-width for wordpress figures

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -242,3 +242,9 @@ abbr[title] {
   height: auto !important;
   width: 100% !important;
 }
+
+// Override for wordpress use of <figure>
+.blog-article figure {
+  max-width: 37rem;
+  text-align: center;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -245,6 +245,6 @@ abbr[title] {
 
 // Override for wordpress use of <figure>
 .blog-article figure {
-  max-width: 37rem;
+  @extend %max-width--p;
   text-align: center;
 }

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,6 +1,8 @@
 {% extends_with_args "templates/one-column.html" with title=article.title.rendered meta_description=article.excerpt.raw  meta_image=article.image.source_url %}
 
 {# Change canonical URL for "snapcraft.io" articles (2996 is the ID of the "snapcraft.io" tag) #}
+
+{% block body_class %}blog-article{% endblock %}
 {% block canonical_url %}{% if 2996 in article.tags %}https://snapcraft.io/blog/{{ article.slug }}{% else %}{{ block.super }}{% endif %}{% endblock canonical_url %}
 
 {% block content %}
@@ -11,7 +13,7 @@
         <h1>{{ article.title.rendered|safe }}</h1>
       </div>
     </div>
-    
+
     <div class="row">
       <div class="col-8">
         <div class="p-media-object">


### PR DESCRIPTION
## Done

- Center align and max-width for wordpress figures

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/deploying-kubernetes-at-the-edge-part-i-building-blocks
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the figures are center aligned and fit in the column

## Issue / Card

Fixes #5443

## Screenshots
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/441217/61111730-21b93380-a482-11e9-8fc3-568e5a03ce7e.png)|
![image](https://user-images.githubusercontent.com/441217/61114112-8f1b9300-a487-11e9-932e-89b241b8c32a.png)|
|![image](https://user-images.githubusercontent.com/441217/61111665-fdf5ed80-a481-11e9-9e9c-f10390d08434.png)|
![image](https://user-images.githubusercontent.com/441217/61114159-a8bcda80-a487-11e9-9f41-e0969d0127f0.png)|
|![image](https://user-images.githubusercontent.com/441217/61111706-0fd79080-a482-11e9-9316-8c9815b6b2ee.png)|
![image](https://user-images.githubusercontent.com/441217/61114202-be320480-a487-11e9-9ceb-43a36177bd2d.png)
|