### PR TITLE
Add 451 cloud economics engage page

### DIFF
--- a/templates/engage/451-cloud-economics.html
+++ b/templates/engage/451-cloud-economics.html
@@ -1,0 +1,34 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Busting the myth of private cloud economics{% endblock %}
+
+{% block meta_description %}Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP6252A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Busting the myth of private cloud economics" image="a5d0d583-451_research_logo.png" url="#the-form" cta="Download the case study" lang="en" %}
+
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Private and managed cloud expense has dropped significantly and now offer a highly compelling alternative to spiralling public cloud costs.</p>
+        <p>Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.</p>
+        <p>One of the significant issues with private cloud infrastructure is the up-front cost of consulting and integration required. Canonical addresses this with a fixed-price, highly automated but flexible OpenStack deployment process that greatly reduces the number of people required for both deployment and ongoing operations.</p>
+        <p>Canonical can spin up an OpenStack private cloud of tens or hundreds of hosts in two weeks with just two engineers, which reduces the up-front costs of its remote on-premise cloud management service, Bootstack. As a fully managed service, Bootstack allows customer-engineers to provide only a supporting role in private cloud operations so they are free to work on other projects.</p>
+        <h3>Case study highlights</h3>
+        <p>Benchmark analysis from the findings showcased Canonical's approach to private infrastructure:</p>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">Canonical’s managed private cloud was found to be cheaper than 25 of the public cloud providers included in the CPI price distributions.</li>
+            <li class="p-list_item is-ticked">Canonical is well known as a pioneer in model-driven operations which reduce the amount of fragmentation and customisation required for diverse OpenStack architectures and deployments. That underpins our finding that Canonical was priced competitively against other hosted private cloud providers having the second lowest total cost for managed compute, block and object storage in the Cloud Price Index.</li>
+            <li class="p-list_item is-ticked">Canonical was priced competitively against other hosted private cloud providers, having the second-lowest total cost for managed compute, block and object storage in the 451 Cloud Price Index.</li>
+        </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="3216" returnURL="https://pages.ubuntu.com/CloudEconomics_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP6252A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/451-cloud-economics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page

