### PR TITLE
Add OpenStack made easy engage page

### DIFF
--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -14,11 +14,17 @@
   <div class="row">
     <div class="col-7">
         <p>The phase change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge of deployment, integration and operations from a different perspective.</p>
-        <p>This eBook explains how we used to do things, why that is no longer an economically viable approach, and what can be done to achieve technical scalability without the large economic overhead of traditional approaches to modern software.</p>
-		<p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical’s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
+        <p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical’s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
+        
+        <h5>Building clouds for the world's leading companies</h5>
+        <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Logos 450 BW.png" alt="Spectrum logo" width="450" />
+        <br>
+        <br>
+        <p><span>Want to speak to a customer representative right now? Call us on +44 207 093 5161 (UK), +1 781 761 9427 (US) or email <a href="mailto:sales@ubuntu.com" target="_blank" style="font-family: Ubuntu; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px;">sales@ubuntu.com</a></span></p>
+
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="2547" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/ebook_OpenStack_Made_Easy_20160726.pdf" cta="Download the eBook" %}
+    {% include "engage/shared/_en_engage_form.html" with id="2547" returnURL="https://pages.ubuntu.com/OpenStack-Made-Easy-eBook-TY.html" cta="Download the eBook" %}
     </div>
   </div>
 </section>

--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -1,0 +1,25 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}OpenStack made easy{% endblock %}
+
+{% block meta_description %}The change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge from a different perspective.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5655A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="OpenStack made easy" subtitle="With the right tools, OpenStack can be easy" image="a7916513-picto-openstack.svg" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>The phase change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge of deployment, integration and operations from a different perspective.</p>
+        <p>This eBook explains how we used to do things, why that is no longer an economically viable approach, and what can be done to achieve technical scalability without the large economic overhead of traditional approaches to modern software.</p>
+		<p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical’s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2547" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/ebook_OpenStack_Made_Easy_20160726.pdf?utm_source=Marketo&utm_medium=LP&utm_campaign=Business-Reviewer-Video&" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -20,7 +20,7 @@
         <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Logos 450 BW.png" alt="Spectrum logo" width="450" />
         <br>
         <br>
-        <p><span>Want to speak to a customer representative right now? Call us on +44 207 093 5161 (UK), +1 781 761 9427 (US) or email <a href="mailto:sales@ubuntu.com" target="_blank" style="font-family: Ubuntu; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; line-height: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px;">sales@ubuntu.com</a></span></p>
+       
 
     </div>
     <div class="col-5" id="the-form">

--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -18,7 +18,7 @@
 		<p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical’s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="1584" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/ebook_OpenStack_Made_Easy_20160726.pdf" cta="Download the eBook" %}
+    {% include "engage/shared/_en_engage_form.html" with id="2547" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/ebook_OpenStack_Made_Easy_20160726.pdf" cta="Download the eBook" %}
     </div>
   </div>
 </section>

--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -18,7 +18,7 @@
 		<p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical’s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="2547" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/ebook_OpenStack_Made_Easy_20160726.pdf?utm_source=Marketo&utm_medium=LP&utm_campaign=Business-Reviewer-Video&" cta="Download the eBook" %}
+    {% include "engage/shared/_en_engage_form.html" with id="1584" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/ebook_OpenStack_Made_Easy_20160726.pdf" cta="Download the eBook" %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5655A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/openstack-made-easy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page