### PR TITLE
Add OpenStack for telcos engage page

### DIFF
--- a/templates/engage/openstack-telco-clouds.html
+++ b/templates/engage/openstack-telco-clouds.html
@@ -1,0 +1,34 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Telcos and Service Providers expect near 100% uptime{% endblock %}
+
+{% block meta_description %}Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5434A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Telcos and Service Providers expect near 100% uptime" subtitle="This requires a proven cloud platform that minimises time-to-revenue and ensures predictable costs." image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Here’s why you should consider Ubuntu OpenStack for your next cloud project:</p>
+   <ul class="p-list">
+           <li class="p-list_item is-ticked">Up to 75% of OpenStack clouds are built on Ubuntu OpenStack.</li>
+           <li class="p-list_item is-ticked">Up to 70% of leading public cloud workloads run on Ubuntu OpenStack.</li>
+           <li class="p-list_item is-ticked">We work with seven of the top 10 service providers globally.</li>
+           <li class="p-list_item is-ticked">Ubuntu’s state-of-the-art management tools make hardware provisioning and cloud services orchestration quick, easy, and hassle-free.</li>
+    </ul>
+    <p>Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.</p>
+
+            <p>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</p>
+            <img src="http://assets.ubuntu.com/sites/ubuntu/1184/u/img/logos/logo-deutsche-telekom.png" 
+            width="200" height="200" align="right">
+        </div>
+        <div class="col-5" id="the-form">
+            {% include "engage/shared/_en_engage_form.html" with id="2482" returnURL="https://pages.ubuntu.com/DeliveringSuccess_TY.html" cta="Download the eBook" %}
+        </div>
+    </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5434A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/openstack-telco-clouds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page