### PR TITLE
Add NVF and SDN on Openstack engage page

### DIFF
--- a/templates/engage/nfv-sdn-openstack.html
+++ b/templates/engage/nfv-sdn-openstack.html
@@ -1,0 +1,33 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}NFV and SDN on OpenStack<br />for network operators{% endblock %}
+
+{% block meta_description %}Network Functions Virtualisation (NFV) and Software-Defined Networking (SDN) are two of the hottest infrastructure technologies around{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5475A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="NFV and SDN on OpenStack<br />for network operators" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Network Functions Virtualisation (NFV) and Software-Defined Networking (SDN) are two of the hottest infrastructure technologies around, particularly for telecoms and network operators wanting to make their services more efficient, scalable, and cost-effective.</p>
+<p>One of the biggest areas of interest for operators as they look to integrate those technologies is to have a quick and easy way to deploy and map them onto cloud infrastructure, particularly OpenStack. </p>
+      <p>Download this ebook to:</p>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">get an overview of the ever-changing infrastructure landscape for network operators</li>
+        <li class="p-list_item is-ticked">better understand the challenges they face when implementing NFV and SDN technologies</li>
+        <li class="p-list_item is-ticked">review a reference architecture for integrating NFV and SDN technologies onto Ubuntu OpenStack clouds, allowing for maximum flexibility in configuration, management, and scaling.</li>
+      </ul>
+      <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span></span>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
+      <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" 
+ width="200" height="200" align="right">
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2490" returnURL="https://pages.ubuntu.com/sdn_nfv_telco_TY.html" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/nfv-sdn-openstack.html
+++ b/templates/engage/nfv-sdn-openstack.html
@@ -21,7 +21,9 @@
         <li class="p-list_item is-ticked">better understand the challenges they face when implementing NFV and SDN technologies</li>
         <li class="p-list_item is-ticked">review a reference architecture for integrating NFV and SDN technologies onto Ubuntu OpenStack clouds, allowing for maximum flexibility in configuration, management, and scaling.</li>
       </ul>
-      <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span></span>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
+      <blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</p>
+      </blockquote>
       <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" 
  width="200" height="200" align="right">
     </div>

--- a/templates/engage/nfv-sdn-openstack.html
+++ b/templates/engage/nfv-sdn-openstack.html
@@ -24,7 +24,7 @@
       <blockquote class="p-pull-quote">
   <p class="p-pull-quote__quote">Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</p>
       </blockquote>
-      <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" 
+      <p class="u-align--right"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" 
  width="200" height="200" align="right">
     </div>
     <div class="col-5" id="the-form">

--- a/templates/engage/nfv-sdn-openstack.html
+++ b/templates/engage/nfv-sdn-openstack.html
@@ -25,7 +25,7 @@
   <p class="p-pull-quote__quote">Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</p>
       </blockquote>
       <p class="u-align--right"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" 
- width="200" height="200" align="right">
+ width="200" height="200" /></p>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2490" returnURL="https://pages.ubuntu.com/sdn_nfv_telco_TY.html" cta="Download the eBook" %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5475A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/nfv-sdn-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page