### PR TITLE
Add CTO's guide to SDN, NFV & VNF engage page

### DIFF
--- a/templates/engage/cto-guide-sdn-nfv-vnf.html
+++ b/templates/engage/cto-guide-sdn-nfv-vnf.html
@@ -21,7 +21,9 @@
             <li class="p-list_item is-ticked">understand why it’s important for anyone responsible for a network to understand and embrace this emerging opportunity</li>
             <li class="p-list_item is-ticked">learn about the potential benefits, and some deployment and management solutions for software-enabled networking</li>
         </ul>
-        <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">"</span></p>
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</p>
+</blockquote>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2540" returnURL="https://pages.ubuntu.com/CIO_Report_Thankyou.html" cta="Download the eBook" %}

--- a/templates/engage/cto-guide-sdn-nfv-vnf.html
+++ b/templates/engage/cto-guide-sdn-nfv-vnf.html
@@ -23,9 +23,6 @@
         </ul>
         <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">"</span></p>
     </div>
-    <div class="col-4 u-align-center u-vertically-center">
-      <img src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/logos/logo-pack/logo-ubuntu-orange.png" width="200" height="200" />
-    </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2485" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/eBook_Cio-guide_%28Tom%29_04.16_AW.pdf" cta="Download the eBook" %}
     </div>

--- a/templates/engage/cto-guide-sdn-nfv-vnf.html
+++ b/templates/engage/cto-guide-sdn-nfv-vnf.html
@@ -2,9 +2,9 @@
 
 {% block title %}CTO’s guide to SDN, NFV & VNF{% endblock %}
 
-{% block meta_description %}DESCRIPTION{% endblock %}
+{% block meta_description %}Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital: from function-specific, proprietary devices to software-enabled commodity hardware.{% endblock %}
 
-{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5456A1LA1{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5616A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/engage/cto-guide-sdn-nfv-vnf.html
+++ b/templates/engage/cto-guide-sdn-nfv-vnf.html
@@ -24,7 +24,7 @@
         <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">"</span></p>
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="2485" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/eBook_Cio-guide_%28Tom%29_04.16_AW.pdf" cta="Download the eBook" %}
+    {% include "engage/shared/_en_engage_form.html" with id="2540" returnURL="https://pages.ubuntu.com/CIO_Report_Thankyou.html" cta="Download the eBook" %}
     </div>
   </div>
 </section>

--- a/templates/engage/cto-guide-sdn-nfv-vnf.html
+++ b/templates/engage/cto-guide-sdn-nfv-vnf.html
@@ -1,0 +1,34 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}CTO’s guide to SDN, NFV & VNF{% endblock %}
+
+{% block meta_description %}DESCRIPTION{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5456A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="CTO’s guide to SDN, NFV & VNF" subtitle="Why is the transition happening and why is it important?" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital. The shift is from function-specific, proprietary devices to software-enabled commodity hardware.</p>
+        <p>Read this eBook to:</p>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">familiarise yourself with the three most popular terminologies today – SDN, NFV, and VNF</li>
+            <li class="p-list_item is-ticked">learn why the transition is happening</li>
+            <li class="p-list_item is-ticked">understand why it’s important for anyone responsible for a network to understand and embrace this emerging opportunity</li>
+            <li class="p-list_item is-ticked">learn about the potential benefits, and some deployment and management solutions for software-enabled networking</li>
+        </ul>
+        <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">"</span></p>
+    </div>
+    <div class="col-4 u-align-center u-vertically-center">
+      <img src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/logos/logo-pack/logo-ubuntu-orange.png" width="200" height="200" />
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2485" returnURL="https://pages.ubuntu.com/rs/066-EOV-335/images/eBook_Cio-guide_%28Tom%29_04.16_AW.pdf" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5616A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/cto-guide-sdn-nfv-vnf
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page