### PR TITLE
Add low latency and real time kernels for telco and NFV engage page

### DIFF
--- a/templates/engage/low-latency-report.html
+++ b/templates/engage/low-latency-report.html
@@ -19,7 +19,7 @@
        <blockquote class="p-pull-quote">
            <p class="p-pull-quote__quote">Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</p>
       </blockquote>
-        <img src="http://assets.ubuntu.com/sites/ubuntu/1184/u/img/logos/logo-deutsche-telekom.png">
+        <p><img src="http://assets.ubuntu.com/sites/ubuntu/1184/u/img/logos/logo-deutsche-telekom.png"></p>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2541" returnURL="https://pages.ubuntu.com/LowLatencyReport_TY.html" cta="Download the report" %}

--- a/templates/engage/low-latency-report.html
+++ b/templates/engage/low-latency-report.html
@@ -1,0 +1,27 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Low latency and real time kernels for telco and NFV{% endblock %}
+
+{% block meta_description %}This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5624A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Low latency and real time kernels for telco and NFV" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the report" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Are kernel performance, priority and scheduling of the utmost importance to you? Are you tasked to evaluate real-time and low latency kernel options, amongst others?</p>
+        <p>This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes. Executive overview and executive conclusion are included at the very beginning for business decision makers. Additional technical analysis follows for an in-depth understanding of how the Canonical kernel team has reached its conclusions. </p>
+		<p>The baseline kernel for this special report is the Ubuntu generic Linux kernel. We show that Ubuntu 16.04 LTS offers the necessary kernel choice, with proven reliability. Our kernel team is always testing, reviewing and contributing to the latest kernel technologies. The right kernel selection can enhance the efficiency of VNF operations, as well as other latency and jitter sensitive applications.</p><br>
+        <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
+        <img src="http://assets.ubuntu.com/sites/ubuntu/1184/u/img/logos/logo-deutsche-telekom.png">
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2541" returnURL="https://pages.ubuntu.com/LowLatencyReport_TY.html" cta="Download the report" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/low-latency-report.html
+++ b/templates/engage/low-latency-report.html
@@ -16,7 +16,9 @@
         <p>Are kernel performance, priority and scheduling of the utmost importance to you? Are you tasked to evaluate real-time and low latency kernel options, amongst others?</p>
         <p>This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes. Executive overview and executive conclusion are included at the very beginning for business decision makers. Additional technical analysis follows for an in-depth understanding of how the Canonical kernel team has reached its conclusions. </p>
 		<p>The baseline kernel for this special report is the Ubuntu generic Linux kernel. We show that Ubuntu 16.04 LTS offers the necessary kernel choice, with proven reliability. Our kernel team is always testing, reviewing and contributing to the latest kernel technologies. The right kernel selection can enhance the efficiency of VNF operations, as well as other latency and jitter sensitive applications.</p><br>
-        <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
+       <blockquote class="p-pull-quote">
+           <p class="p-pull-quote__quote">Deutsche Telekom is developing and deploying many new cloud applications on Ubuntu OpenStack as part of its secure and highly scaleable public cloud Business Marketplace ecosystem for SMB customers.</p>
+      </blockquote>
         <img src="http://assets.ubuntu.com/sites/ubuntu/1184/u/img/logos/logo-deutsche-telekom.png">
     </div>
     <div class="col-5" id="the-form">


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5624A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/low-latency-report
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
