### PR TITLE
Add Carrier Cloudification engage page

### DIFF
--- a/templates/engage/telco-cloudification-ebook.html
+++ b/templates/engage/telco-cloudification-ebook.html
@@ -1,0 +1,44 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Carrier Cloudification: What every telecom executive needs to know{% endblock %}
+
+{% block meta_description %}This eBook&nbsp;is designed to help telecom executives understand industry best practices as they move towards &lsquo;cloudification&rsquo; of their network infrastructure.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5612A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Carrier Cloudification: What every telecom executive needs to know" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p><span style="color:#E95420;font-size:18px;font-weight:bold"></span><span>This eBook&nbsp;is designed to help telecom executives understand industry best practices as they move towards &lsquo;cloudification&rsquo; of their network infrastructure.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold"></span></p>
+        <p>Download this eBook&nbsp;to learn:</p>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">Why telecom service providers must reposition themselves beyond their traditional core business<br /></li>
+            <li class="p-list_item is-ticked">Which six key factors are responsible for disrupting the Telecoms industry<br /></li>
+            <li class="p-list_item is-ticked">How to identify the building blocks for moving towards telecom cloudification<br /></li>
+            <li class="p-list_item is-ticked">How Canonical is helping Deutsche Telekom, Spectrum (formerly Time Warner Cable) and BSkyB increase revenues, reduce operational costs and improve operational efficiencies</li>
+        </ul>
+        <p><span style="color:#E95420;font-size:18px;font-weight:bold"></span><span>Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold"></span></p>
+
+        <br/>
+        <br/>
+
+        <p><center>INCLUDES CASE STUDIES FROM</center></p>
+        <table cellpadding="10" cellspacing="10" border="0">
+            <tr>
+                <td width="33%"  style="background-color: transparent; border: none;"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/deutsche-telekom-logo.png" alt="DT logo" width="250" /></td>
+                <td width="34%"  style="background-color: transparent; border: none;"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/bskyb_logo.jpg" alt="BSkyB logo" width="150" /></td>
+                <td width="33%"  style="background-color: transparent; border: none;"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/spectrum_logo.png" alt="Spectrum logo" width="250" /></td>
+            </tr>
+        </table>
+
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2539" returnURL="https://pages.ubuntu.com/telco-cloudification-ebook-TY.html" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/telco-cloudification-ebook.html
+++ b/templates/engage/telco-cloudification-ebook.html
@@ -21,20 +21,21 @@
             <li class="p-list_item is-ticked">How to identify the building blocks for moving towards telecom cloudification<br /></li>
             <li class="p-list_item is-ticked">How Canonical is helping Deutsche Telekom, Spectrum (formerly Time Warner Cable) and BSkyB increase revenues, reduce operational costs and improve operational efficiencies</li>
         </ul>
-        <p><span style="color:#E95420;font-size:18px;font-weight:bold"></span><span>Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold"></span></p>
-
-        <br/>
-        <br/>
-
-        <p><center>INCLUDES CASE STUDIES FROM</center></p>
-        <table cellpadding="10" cellspacing="10" border="0">
-            <tr>
-                <td width="33%"  style="background-color: transparent; border: none;"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/deutsche-telekom-logo.png" alt="DT logo" width="250" /></td>
-                <td width="34%"  style="background-color: transparent; border: none;"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/bskyb_logo.jpg" alt="BSkyB logo" width="150" /></td>
-                <td width="33%"  style="background-color: transparent; border: none;"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/spectrum_logo.png" alt="Spectrum logo" width="250" /></td>
-            </tr>
-        </table>
-
+        <blockquote class="p-pull-quote">
+            <p class="p-pull-quote__quote">Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.</p>
+        </blockquote>
+        <h5 class="p-muted-heading u-align--center">INCLUDES CASE STUDIES FROM</h5>
+        <ul class="p-inline-images">
+            <li class="p-inline-images__item">
+                <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1ccb6d93-logo-deutschetelekom.svg" width="144" alt="Deutshe Telekom">
+            </li>
+            <li class="p-inline-images__item">
+                <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/be345c7f-bSkyb_logo.png?w=141" width="141" alt="Sky">
+            </li>
+            <li class="p-inline-images__item">
+                <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/3ec677f3-spectrum_logo.png" alt="Spectrum logo" width="250" />
+            </li>
+        </ul>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2539" returnURL="https://pages.ubuntu.com/telco-cloudification-ebook-TY.html" cta="Download the eBook" %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5612A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/telco-cloudification-ebook
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
