### PR TITLE
Add essential guide for telecoms adopting big data solutions engage page

### DIFF
--- a/templates/engage/essential-guide-big-data-solutions.html
+++ b/templates/engage/essential-guide-big-data-solutions.html
@@ -18,7 +18,6 @@
         <p>Learn about the difficulties faced by modern telecoms providers and how big data solutions and analytics can mitigate those challenges.</p>
         <p>Opportunities for big data monetization in telecom and dramatically reduce time to identify new markets and solutions are explained using a data-first approach.</p>
 
-        <br/>
 
 <blockquote class="p-pull-quote">
    <p>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</p>

--- a/templates/engage/essential-guide-big-data-solutions.html
+++ b/templates/engage/essential-guide-big-data-solutions.html
@@ -1,0 +1,33 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}The essential guide for Telecoms and Service Providers adopting big data solutions{% endblock %}
+
+{% block meta_description %}This eBook provides telecom and service provider executives with a basic introduction to big data and analytics processing in the telecom industry.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5586A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="The essential guide for Telecoms and Service Providers adopting big data solutions" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>This eBook provides telecom and service provider executives with a basic introduction to big data and analytics processing in the telecom industry.</p>
+        <p>Download this eBook to learn how we identify big data and the importance of the analytics processes that telcos and service providers should be implementing to most benefit from the tremendous amounts of data available to them.</p>
+        <p>Learn about the difficulties faced by modern telecoms providers and how big data solutions and analytics can mitigate those challenges.</p>
+        <P>Opportunities for big data monetization in telecom and dramatically reduce time to identify new markets and solutions are explained using a data-first approach.</P>
+
+        <br/>
+        <br/>
+
+        <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
+ 		<img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" height="200" width="200" align="right" margin-left:"0px"/>
+
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2536" returnURL="https://pages.ubuntu.com/BigDataTelcos_TY.html" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/essential-guide-big-data-solutions.html
+++ b/templates/engage/essential-guide-big-data-solutions.html
@@ -20,7 +20,9 @@
 
         <br/>
 
-        <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
+<blockquote class="p-pull-quote">
+   <p>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</p>
+</blockquote>
  		<img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" height="200" width="200" align="right" margin-left:"0px"/>
 
     </div>

--- a/templates/engage/essential-guide-big-data-solutions.html
+++ b/templates/engage/essential-guide-big-data-solutions.html
@@ -16,7 +16,7 @@
         <p>This eBook provides telecom and service provider executives with a basic introduction to big data and analytics processing in the telecom industry.</p>
         <p>Download this eBook to learn how we identify big data and the importance of the analytics processes that telcos and service providers should be implementing to most benefit from the tremendous amounts of data available to them.</p>
         <p>Learn about the difficulties faced by modern telecoms providers and how big data solutions and analytics can mitigate those challenges.</p>
-        <P>Opportunities for big data monetization in telecom and dramatically reduce time to identify new markets and solutions are explained using a data-first approach.</P>
+        <p>Opportunities for big data monetization in telecom and dramatically reduce time to identify new markets and solutions are explained using a data-first approach.</p>
 
         <br/>
         <br/>

--- a/templates/engage/essential-guide-big-data-solutions.html
+++ b/templates/engage/essential-guide-big-data-solutions.html
@@ -19,7 +19,6 @@
         <p>Opportunities for big data monetization in telecom and dramatically reduce time to identify new markets and solutions are explained using a data-first approach.</p>
 
         <br/>
-        <br/>
 
         <p><span style="color:#E95420;font-size:18px;font-weight:bold">"</span><span>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</font></span><span style="color:#E95420;font-size:18px;font-weight:bold">”</span></p>
  		<img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" height="200" width="200" align="right" margin-left:"0px"/>

--- a/templates/engage/essential-guide-big-data-solutions.html
+++ b/templates/engage/essential-guide-big-data-solutions.html
@@ -23,7 +23,7 @@
 <blockquote class="p-pull-quote">
    <p>Time Warner Cable is running Ubuntu OpenStack and partnering with Canonical as part of our strategy to improve infrastructure utilisation and accelerate service innovation, deployment, and delivery.</p>
 </blockquote>
- 		<img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" height="200" width="200" align="right" margin-left:"0px"/>
+ 		<p class="u-align--right"><img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Time_Warner_Cable_logo.png" height="200" width="200" /></p>
 
     </div>
     <div class="col-5" id="the-form">


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5586A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/essential-guide-big-data-solutions
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
