### PR TITLE
Add City Network OpenStack cloud hosting case study engage page

### DIFF
--- a/templates/engage/casestudy-city-network.html
+++ b/templates/engage/casestudy-city-network.html
@@ -1,0 +1,34 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}City Network brings OpenStack cloud hosting to the financial services sector with Canonical{% endblock %}
+
+{% block meta_description %}In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5346A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="City Network brings OpenStack cloud hosting to the financial services sector with Canonical" image="7005c900-pictogram_article01.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p> In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance. Always on the lookout for new ways to enhance this competitive edge, City Network realised Ubuntu offered a highly compelling alternative to its existing, legacy Linux operating system. Easier to use, easier to manage, and backed by Canonical’s expert support, Ubuntu is helping City Network reach new heights of quality and customer satisfaction.</p>
+
+        <h3>Highlights</h3>
+        <p>Learn how Canonical and Ubuntu is helping City Network reach new heights of quality and customer satisfaction. </p>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">Boosts service quality while      reducing costs compared to
+            previous operating system</li>
+            <li class="p-list_item is-ticked">Improves customer satisfaction</li>
+            <li class="p-list_item is-ticked">Happier employees thanks to improved ease of use </li>
+            <li class="p-list_item is-ticked">Unlocks new revenue streams through selling Canonical support services</li>
+        </ul>
+
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2494" returnURL="https://pages.ubuntu.com/CS_CityNetworks_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5346A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-city-network
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
