### PR TITLE
Add How to escape from StuckStack ebook engage page

### DIFF
--- a/templates/engage/stuckstack-ebook.html
+++ b/templates/engage/stuckstack-ebook.html
@@ -1,0 +1,31 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}How to escape StuckStack and profit from your OpenStack investment{% endblock %}
+
+{% block meta_description %}This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5282A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="How to escape StuckStack and profit from your OpenStack investment" image="410edf8d-cost_%28piggy-bank%29.png" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>When OpenStack works well, it delivers on its immense promise. However, any software comprised of many different components, third party integrations and revisions needs tight version control. If not, complexity can become its downfall. When an OpenStack deployment falls too far behind the pace of upgrades, it becomes impossible to keep up with the latest versions. We have called this condition StuckStack and
+        it is caused by the difficulty in upgrading from out-of-date software to the latest versions of OpenStack. This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.</p>
+        <h3>What's in this eBook?</h3>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">The reasons why OpenStack can become a StuckStack</li>
+            <li class="p-list_item is-ticked">Challenges your company may be facing </li>
+            <li class="p-list_item is-ticked">Practical advice on how to come unstuck </li>
+            <li class="p-list_item is-ticked">Solutions to help your business and success stories</li>
+        </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2461" returnURL="https://pages.ubuntu.com/stuckstack_download.html" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/stuckstack-ebook.html
+++ b/templates/engage/stuckstack-ebook.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}How to escape StuckStack and profit from your OpenStack investment{% endblock %}
-
-{% block meta_description %}This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="How to escape StuckStack and profit from your OpenStack investment" meta_image="410edf8d-cost_%28piggy-bank%29.png" meta_description="This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5282A1LA1{% endblock meta_copydoc %}
 
@@ -13,15 +9,14 @@
 <section class="p-strip is-shallow">
   <div class="row">
     <div class="col-7">
-        <p>When OpenStack works well, it delivers on its immense promise. However, any software comprised of many different components, third party integrations and revisions needs tight version control. If not, complexity can become its downfall. When an OpenStack deployment falls too far behind the pace of upgrades, it becomes impossible to keep up with the latest versions. We have called this condition StuckStack and
-        it is caused by the difficulty in upgrading from out-of-date software to the latest versions of OpenStack. This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.</p>
-        <h3>What's in this eBook?</h3>
-        <ul class="p-list">
-            <li class="p-list_item is-ticked">The reasons why OpenStack can become a StuckStack</li>
-            <li class="p-list_item is-ticked">Challenges your company may be facing </li>
-            <li class="p-list_item is-ticked">Practical advice on how to come unstuck </li>
-            <li class="p-list_item is-ticked">Solutions to help your business and success stories</li>
-        </ul>
+      <p>When OpenStack works well, it delivers on its immense promise. However, any software comprised of many different components, third party integrations and revisions needs tight version control. If not, complexity can become its downfall. When an OpenStack deployment falls too far behind the pace of upgrades, it becomes impossible to keep up with the latest versions. We have called this condition StuckStack and it is caused by the difficulty in upgrading from out-of-date software to the latest versions of OpenStack. This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.</p>
+      <h4>What's in this eBook?</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">The reasons why OpenStack can become a StuckStack</li>
+        <li class="p-list_item is-ticked">Challenges your company may be facing</li>
+        <li class="p-list_item is-ticked">Practical advice on how to come unstuck </li>
+        <li class="p-list_item is-ticked">Solutions to help your business and success stories</li>
+      </ul>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2461" returnURL="https://pages.ubuntu.com/stuckstack_download.html" cta="Download the eBook" %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5282A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/stuckstack-ebook
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
