### PR TITLE
Add ITstrategen case study engage page

### DIFF
--- a/templates/engage/casestudy-itstratagen.html
+++ b/templates/engage/casestudy-itstratagen.html
@@ -4,7 +4,28 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" image="2217d1c8-Security.svg" url="#the-form" cta="Download the case study" %}
+<section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-7  u-vertically-center">
+        <div>
+        <h1 class="u-no-margin--bottom">
+          ITstrategen keeps legacy applications secure with Extended Security Maintenance
+        </h1>
+        
+        
+        <br class="u-hide--medium u-hide--large">
+        <p class="u-hide--medium u-hide--large">
+          <a href="#the-form" class="p-button--neutral">
+            Download the case study
+          </a>
+        </p>
+        </div>
+      </div>
+      <div class="col-5 u-hide--small u-align--center u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150px" style="max-height: 410px; max-width: 150px;" alt="image for ITstrategen keeps legacy applications secure with Extended Security Maintenance">
+      </div>
+    </div>
+  </section>
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/casestudy-itstratagen.html
+++ b/templates/engage/casestudy-itstratagen.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}ITstrategen keeps legacy applications secure with Extended Security Maintenance{% endblock %}
-
-{% block meta_description %}Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" meta_image="7005c900-pictogram_article01.png" meta_description="Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5353A1LA1{% endblock meta_copydoc %}
 
@@ -13,14 +9,14 @@
 <section class="p-strip is-shallow">
   <div class="row">
     <div class="col-7">
-        <p>Extended Security Maintenance (ESM) extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.</p>
-        <p>As the five-year support window for Ubuntu 12.04 came to an end, some of ITstrategen’s customers still depended on servers running the now out of support operating system and without support, the security of those servers was at risk. To tackle this issue, ITstrategen decided to purchase Extended Support Maintenance (ESM) for Ubuntu 12.04, a service offered as part of their Ubuntu  Advantage subscription.</p>
-        <h3>Highlights</h3>
-        <ul class="p-list">
-            <li class="p-list_item is-ticked">ESM saves ITstrategen’s customers from 6-figure application update costs</li>
-            <li class="p-list_item is-ticked">It eliminates need for time-consuming security workarounds</li>
-            <li class="p-list_item is-ticked">And boosts service quality and customer loyalty</li>
-        </ul>
+      <p>Extended Security Maintenance (ESM) extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.</p>
+      <p>As the five-year support window for Ubuntu 12.04 came to an end, some of ITstrategen’s customers still depended on servers running the now out of support operating system and without support, the security of those servers was at risk. To tackle this issue, ITstrategen decided to purchase Extended Support Maintenance (ESM) for Ubuntu 12.04, a service offered as part of their Ubuntu  Advantage subscription.</p>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">ESM saves ITstrategen’s customers from 6-figure application update costs</li>
+        <li class="p-list_item is-ticked">It eliminates need for time-consuming security workarounds</li>
+        <li class="p-list_item is-ticked">And boosts service quality and customer loyalty</li>
+      </ul>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2495" returnURL="https://pages.ubuntu.com/Cloud_CS_ITstrategen_TY.html" cta="Download the case study" %}

--- a/templates/engage/casestudy-itstratagen.html
+++ b/templates/engage/casestudy-itstratagen.html
@@ -33,7 +33,7 @@
       </ul>
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="2495" returnURL="https://pages.ubuntu.com/Cloud_CS_ITstrategen_TY.html" cta="Download the case study" %}
+      {% include "engage/shared/_en_engage_form.html" with id="2495" returnURL="https://pages.ubuntu.com/Cloud_CS_ITstrategen_TY.html" cta="Download the case study" %}
     </div>
   </div>
 </section>

--- a/templates/engage/casestudy-itstratagen.html
+++ b/templates/engage/casestudy-itstratagen.html
@@ -1,0 +1,30 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}ITstrategen keeps legacy applications secure with Extended Security Maintenance{% endblock %}
+
+{% block meta_description %}Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5353A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" image="7005c900-pictogram_article01.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Extended Security Maintenance (ESM) extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.</p>
+        <p>As the five-year support window for Ubuntu 12.04 came to an end, some of ITstrategen’s customers still depended on servers running the now out of support operating system and without support, the security of those servers was at risk. To tackle this issue, ITstrategen decided to purchase Extended Support Maintenance (ESM) for Ubuntu 12.04, a service offered as part of their Ubuntu  Advantage subscription.</p>
+        <h3>Highlights</h3>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">ESM saves ITstrategen’s customers from 6-figure application update costs</li>
+            <li class="p-list_item is-ticked">It eliminates need for time-consuming security workarounds</li>
+            <li class="p-list_item is-ticked">And boosts service quality and customer loyalty</li>
+        </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2495" returnURL="https://pages.ubuntu.com/Cloud_CS_ITstrategen_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/casestudy-itstratagen.html
+++ b/templates/engage/casestudy-itstratagen.html
@@ -5,27 +5,20 @@
 {% block content %}
 
 <section class="p-strip--light">
-    <div class="row u-equal-height">
-      <div class="col-7  u-vertically-center">
-        <div>
-        <h1 class="u-no-margin--bottom">
-          ITstrategen keeps legacy applications secure with Extended Security Maintenance
-        </h1>
-        
-        
-        <br class="u-hide--medium u-hide--large">
+  <div class="row u-equal-height">
+    <div class="col-7  u-vertically-center">
+      <div>
+        <h1 class="u-no-margin--bottom">ITstrategen keeps legacy applications secure with Extended Security Maintenance</h1>
         <p class="u-hide--medium u-hide--large">
-          <a href="#the-form" class="p-button--neutral">
-            Download the case study
-          </a>
+          <a href="#the-form" class="p-button--neutral">Download the case study</a>
         </p>
-        </div>
-      </div>
-      <div class="col-5 u-hide--small u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150px" style="max-height: 410px; max-width: 150px;" alt="image for ITstrategen keeps legacy applications secure with Extended Security Maintenance">
       </div>
     </div>
-  </section>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150px" style="max-height: 410px; max-width: 150px;" alt="image for ITstrategen keeps legacy applications secure with Extended Security Maintenance">
+    </div>
+  </div>
+</section>
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/casestudy-itstratagen.html
+++ b/templates/engage/casestudy-itstratagen.html
@@ -1,10 +1,10 @@
-{% extends_with_args "engage/base_engage.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" meta_image="7005c900-pictogram_article01.png" meta_description="Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates." %}
+{% extends_with_args "engage/base_engage.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" meta_image="2217d1c8-Security.svg" meta_description="Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5353A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" image="7005c900-pictogram_article01.png" url="#the-form" cta="Download the case study" %}
+{% include "engage/shared/_header.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" image="2217d1c8-Security.svg" url="#the-form" cta="Download the case study" %}
 
 <section class="p-strip is-shallow">
   <div class="row">


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5353A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-itstratagen
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
