### PR TITLE
Add Sensape case study engage page

### DIFF
--- a/templates/engage/casestudy-sensape.html
+++ b/templates/engage/casestudy-sensape.html
@@ -1,10 +1,10 @@
-{% extends_with_args "engage/base_engage.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" meta_image="811c3501-Sensape_Logo_rgb_Animated.gif" meta_description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly." %}
+{% extends_with_args "engage/base_engage.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" meta_image="bcdbf966-Sensape_Logo_rgb_Animated-nobackground.gif" meta_description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5880A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" image="811c3501-Sensape_Logo_rgb_Animated.gif" url="#the-form" cta="Download the case study" %}
+{% include "engage/shared/_header.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" image="bcdbf966-Sensape_Logo_rgb_Animated-nobackground.gif" url="#the-form" cta="Download the case study" %}
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/casestudy-sensape.html
+++ b/templates/engage/casestudy-sensape.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Sensape uses Landscape to remotely support revolutionary interactive retail displays{% endblock %}
-
-{% block meta_description %}Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" meta_image="811c3501-Sensape_Logo_rgb_Animated.gif" meta_description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5880A1LA1{% endblock meta_copydoc %}
 
@@ -13,14 +9,14 @@
 <section class="p-strip is-shallow">
   <div class="row">
     <div class="col-7">
-        <p>Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.</p> 
-        <p> Powered by Ubuntu Desktop and Landscape, the business results for clients using Sensape are impressive. Up to 70% of the visitors and shoppers interact with the Sensape solution, with all reactions being positive, and over half being very positive. The rate of interaction is also 14.7 times higher than that of traditional digital signage. Client revenue of products advertised via the Sensape platform increases by as much as 900%. Compared to conventional advertising, the increase in revenue can be up to 13.4 times higher.</p>
-        <h3>Highlights</h3>
-        <ul class="p-list">
-            <li class="p-list_item is-ticked">Sensape interactive digital signage senses people’s interests and emotions, adapting the information offered to them</li>
-            <li class="p-list_item is-ticked">Landscape helps keep everything running smoothly on the Sensape retail and trade show infotainment systems powered by Ubuntu Desktop</li>
-            <li class="p-list_item is-ticked">The flexible remote management solution and reliable operating system in turn enable Sensape clients to gain more customers and sales revenue</li>
-         </ul>
+      <p>Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.</p> 
+      <p> Powered by Ubuntu Desktop and Landscape, the business results for clients using Sensape are impressive. Up to 70% of the visitors and shoppers interact with the Sensape solution, with all reactions being positive, and over half being very positive. The rate of interaction is also 14.7 times higher than that of traditional digital signage. Client revenue of products advertised via the Sensape platform increases by as much as 900%. Compared to conventional advertising, the increase in revenue can be up to 13.4 times higher.</p>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">Sensape interactive digital signage senses people’s interests and emotions, adapting the information offered to them</li>
+        <li class="p-list_item is-ticked">Landscape helps keep everything running smoothly on the Sensape retail and trade show infotainment systems powered by Ubuntu Desktop</li>
+        <li class="p-list_item is-ticked">The flexible remote management solution and reliable operating system in turn enable Sensape clients to gain more customers and sales revenue</li>
+      </ul>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2786" returnURL="https://pages.ubuntu.com/Cloud_UA_CS_Sensape_TY.html" cta="Download the case study" %}

--- a/templates/engage/casestudy-sensape.html
+++ b/templates/engage/casestudy-sensape.html
@@ -1,0 +1,30 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Sensape uses Landscape to remotely support revolutionary interactive retail displays{% endblock %}
+
+{% block meta_description %}Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5880A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" image="811c3501-Sensape_Logo_rgb_Animated.gif" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.</p> 
+        <p> Powered by Ubuntu Desktop and Landscape, the business results for clients using Sensape are impressive. Up to 70% of the visitors and shoppers interact with the Sensape solution, with all reactions being positive, and over half being very positive. The rate of interaction is also 14.7 times higher than that of traditional digital signage. Client revenue of products advertised via the Sensape platform increases by as much as 900%. Compared to conventional advertising, the increase in revenue can be up to 13.4 times higher.</p>
+        <h3>Highlights</h3>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">Sensape interactive digital signage senses people’s interests and emotions, adapting the information offered to them</li>
+            <li class="p-list_item is-ticked">Landscape helps keep everything running smoothly on the Sensape retail and trade show infotainment systems powered by Ubuntu Desktop</li>
+            <li class="p-list_item is-ticked">The flexible remote management solution and reliable operating system in turn enable Sensape clients to gain more customers and sales revenue</li>
+         </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2786" returnURL="https://pages.ubuntu.com/Cloud_UA_CS_Sensape_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5880A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-sensape
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
