### PR TITLE
[Engage] Add Commercetools case study page

### DIFF
--- a/templates/engage/casestudy-commercetools.html
+++ b/templates/engage/casestudy-commercetools.html
@@ -1,0 +1,26 @@
+{% extends_with_args "engage/base_engage.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" meta_image="7005c900-pictogram_article01.png" meta_description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5326A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" image="7005c900-pictogram_article01.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Today’s shoppers are looking for a consistent experience, no matter which channels they use, whether smartphone, tablet, wearable, digital point of sale, (POS), or other. Commercetools helps enterprises to digitally transform their entire sales operations across all channels. The Software-as-a-Service approach, open source philosophy, and strong support of an API and microservices architecture of Commercetools enable the company’s customers to rapidly build highly individual shopping experiences for their own markets, without having to change their whole IT ecosystem in the process.
+      <h4>Highlights</h4>
+      <p>Learn how Commercetools uses Ubuntu Server to help enterprises to digitally transform their entire sales operations across all channels. </p>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">The commercetools SaaS/PaaS platform with APIs and microservices enables enterprises to easily build ecommerce applications</li>
+        <li class="p-list_item is-ticked">Cloud native solution running on Ubuntu Servers for reliability, performance and ease of upgrade</li>
+        <li class="p-list_item is-ticked">Commercetools gives retailers the tools to offer unique and engaging digital commerce experiences, saving them time and effort, and increasing their profitability </li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2479" returnURL="https://pages.ubuntu.com/TY_Commercetools_CaseStudy.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/casestudy-sensape.html
+++ b/templates/engage/casestudy-sensape.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Sensape uses Landscape to remotely support revolutionary interactive retail displays{% endblock %}
-
-{% block meta_description %}Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" meta_image="811c3501-Sensape_Logo_rgb_Animated.gif" meta_description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5880A1LA1{% endblock meta_copydoc %}
 
@@ -13,14 +9,14 @@
 <section class="p-strip is-shallow">
   <div class="row">
     <div class="col-7">
-        <p>Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.</p> 
-        <p> Powered by Ubuntu Desktop and Landscape, the business results for clients using Sensape are impressive. Up to 70% of the visitors and shoppers interact with the Sensape solution, with all reactions being positive, and over half being very positive. The rate of interaction is also 14.7 times higher than that of traditional digital signage. Client revenue of products advertised via the Sensape platform increases by as much as 900%. Compared to conventional advertising, the increase in revenue can be up to 13.4 times higher.</p>
-        <h3>Highlights</h3>
-        <ul class="p-list">
-            <li class="p-list_item is-ticked">Sensape interactive digital signage senses people’s interests and emotions, adapting the information offered to them</li>
-            <li class="p-list_item is-ticked">Landscape helps keep everything running smoothly on the Sensape retail and trade show infotainment systems powered by Ubuntu Desktop</li>
-            <li class="p-list_item is-ticked">The flexible remote management solution and reliable operating system in turn enable Sensape clients to gain more customers and sales revenue</li>
-         </ul>
+      <p>Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.</p> 
+      <p> Powered by Ubuntu Desktop and Landscape, the business results for clients using Sensape are impressive. Up to 70% of the visitors and shoppers interact with the Sensape solution, with all reactions being positive, and over half being very positive. The rate of interaction is also 14.7 times higher than that of traditional digital signage. Client revenue of products advertised via the Sensape platform increases by as much as 900%. Compared to conventional advertising, the increase in revenue can be up to 13.4 times higher.</p>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">Sensape interactive digital signage senses people’s interests and emotions, adapting the information offered to them</li>
+        <li class="p-list_item is-ticked">Landscape helps keep everything running smoothly on the Sensape retail and trade show infotainment systems powered by Ubuntu Desktop</li>
+        <li class="p-list_item is-ticked">The flexible remote management solution and reliable operating system in turn enable Sensape clients to gain more customers and sales revenue</li>
+      </ul>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2786" returnURL="https://pages.ubuntu.com/Cloud_UA_CS_Sensape_TY.html" cta="Download the case study" %}

--- a/templates/engage/casestudy-sensape.html
+++ b/templates/engage/casestudy-sensape.html
@@ -1,0 +1,30 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Sensape uses Landscape to remotely support revolutionary interactive retail displays{% endblock %}
+
+{% block meta_description %}Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.{% endblock %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5880A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays" image="811c3501-Sensape_Logo_rgb_Animated.gif" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.</p> 
+        <p> Powered by Ubuntu Desktop and Landscape, the business results for clients using Sensape are impressive. Up to 70% of the visitors and shoppers interact with the Sensape solution, with all reactions being positive, and over half being very positive. The rate of interaction is also 14.7 times higher than that of traditional digital signage. Client revenue of products advertised via the Sensape platform increases by as much as 900%. Compared to conventional advertising, the increase in revenue can be up to 13.4 times higher.</p>
+        <h3>Highlights</h3>
+        <ul class="p-list">
+            <li class="p-list_item is-ticked">Sensape interactive digital signage senses people’s interests and emotions, adapting the information offered to them</li>
+            <li class="p-list_item is-ticked">Landscape helps keep everything running smoothly on the Sensape retail and trade show infotainment systems powered by Ubuntu Desktop</li>
+            <li class="p-list_item is-ticked">The flexible remote management solution and reliable operating system in turn enable Sensape clients to gain more customers and sales revenue</li>
+         </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2786" returnURL="https://pages.ubuntu.com/Cloud_UA_CS_Sensape_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5326A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-commercetools
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
