### PR TITLE
[Engage] Add Commercetools case study page

### DIFF
--- a/templates/engage/casestudy-commercetools.html
+++ b/templates/engage/casestudy-commercetools.html
@@ -1,10 +1,31 @@
-{% extends_with_args "engage/base_engage.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" meta_image="7005c900-pictogram_article01.png" meta_description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels." %}
+{% extends_with_args "engage/base_engage.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" meta_image="d519342f-icon-intro-server.svg" meta_description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5326A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" image="7005c900-pictogram_article01.png" url="#the-form" cta="Download the case study" %}
+<section class="p-strip--light">
+        <div class="row u-equal-height">
+          <div class="col-7  u-vertically-center">
+            <div>
+            <h1 class="u-no-margin--bottom">
+              Commercetools uses Ubuntu Server to power its next-generation ecommerce platform
+            </h1>
+            
+            
+            <br class="u-hide--medium u-hide--large">
+            <p class="u-hide--medium u-hide--large">
+              <a href="#the-form" class="p-button--neutral">
+                Download the case study
+              </a>
+            </p>
+            </div>
+          </div>
+          <div class="col-5 u-hide--small u-align--center u-vertically-center">
+            <img src="https://assets.ubuntu.com/v1/d519342f-icon-intro-server.svg" width="150px" style="max-height: 410px; max-width: 150px;" alt="image for Commercetools uses Ubuntu Server to power its next-generation ecommerce platform">
+          </div>
+        </div>
+      </section>
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/casestudy-commercetools.html
+++ b/templates/engage/casestudy-commercetools.html
@@ -1,0 +1,26 @@
+{% extends_with_args "engage/base_engage.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" meta_image="7005c900-pictogram_article01.png" meta_description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5326A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform" image="7005c900-pictogram_article01.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Today’s shoppers are looking for a consistent experience, no matter which channels they use, whether smartphone, tablet, wearable, digital point of sale, (POS), or other. Commercetools helps enterprises to digitally transform their entire sales operations across all channels. The Software-as-a-Service approach, open source philosophy, and strong support of an API and microservices architecture of Commercetools enable the company’s customers to rapidly build highly individual shopping experiences for their own markets, without having to change their whole IT ecosystem in the process.
+      <h4>Highlights</h4>
+      <p>Learn how Commercetools uses Ubuntu Server to help enterprises to digitally transform their entire sales operations across all channels. </p>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">The commercetools SaaS/PaaS platform with APIs and microservices enables enterprises to easily build ecommerce applications</li>
+        <li class="p-list_item is-ticked">Cloud native solution running on Ubuntu Servers for reliability, performance and ease of upgrade</li>
+        <li class="p-list_item is-ticked">Commercetools gives retailers the tools to offer unique and engaging digital commerce experiences, saving them time and effort, and increasing their profitability </li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2479" returnURL="https://pages.ubuntu.com/TY_Commercetools_CaseStudy.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5326A1LA1
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-commercetools
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
