### PR TITLE
[Engage] Add BotsAndUs case study page

### DIFF
--- a/templates/engage/casestudy-botsandus.html
+++ b/templates/engage/casestudy-botsandus.html
@@ -1,0 +1,26 @@
+{% extends_with_args "engage/base_engage.html" with title="BotsAndUs builds a social robot on Ubuntu" meta_image="781d61a8-botsandus_logo.jpg" meta_description="To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5959A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="BotsAndUs builds a social robot on Ubuntu" image="781d61a8-botsandus_logo.jpg" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Manufacturing a hardware product is a complicated process – especially for a start-up building a ground-breaking customer service robot.</p>
+      <p>To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects. With Ubuntu, choosing and integrating hardware and software is easy, guaranteeing a smooth path to production for Bo.</p>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">BotsAndUs chose Ubuntu as the OS for its flagship robot, Bo</li>
+        <li class="p-list_item is-ticked">Ubuntu offers extensive hardware support, widespread support from third-party vendors, and compatibility with ROS</li>
+        <li class="p-list_item is-ticked">Selecting and integrating hardware and software is easy with Ubuntu – significantly streamlining the path to production</li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2814" returnURL="https://pages.ubuntu.com/BotsAndUs_CS-TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/casestudy-botsandus.html
+++ b/templates/engage/casestudy-botsandus.html
@@ -1,10 +1,31 @@
-{% extends_with_args "engage/base_engage.html" with title="BotsAndUs builds a social robot on Ubuntu" meta_image="781d61a8-botsandus_logo.jpg" meta_description="To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects." %}
+{% extends_with_args "engage/base_engage.html" with title="BotsAndUs builds a social robot on Ubuntu" meta_image="4d0d4cc5-botsandus-logo.svg" meta_description="To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5959A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="BotsAndUs builds a social robot on Ubuntu" image="781d61a8-botsandus_logo.jpg" url="#the-form" cta="Download the case study" %}
+<section class="p-strip--light">
+        <div class="row u-equal-height">
+          <div class="col-7  u-vertically-center">
+            <div>
+            <h1 class="u-no-margin--bottom">
+              BotsAndUs builds a social robot on Ubuntu
+            </h1>
+            
+            
+            <br class="u-hide--medium u-hide--large">
+            <p class="u-hide--medium u-hide--large">
+              <a href="#the-form" class="p-button--neutral">
+                Download the case study
+              </a>
+            </p>
+            </div>
+          </div>
+          <div class="col-5 u-hide--small u-align--center u-vertically-center">
+            <img src="https://assets.ubuntu.com/v1/4d0d4cc5-botsandus-logo.svg" width="340" style="max-height: 410px; max-width: 340px;" alt="image for BotsAndUs builds a social robot on Ubuntu">
+          </div>
+        </div>
+      </section>
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/casestudy-botsandus.html
+++ b/templates/engage/casestudy-botsandus.html
@@ -22,7 +22,7 @@
             </div>
           </div>
           <div class="col-5 u-hide--small u-align--center u-vertically-center">
-            <img src="https://assets.ubuntu.com/v1/4d0d4cc5-botsandus-logo.svg" width="340" style="max-height: 410px; max-width: 340px;" alt="image for BotsAndUs builds a social robot on Ubuntu">
+            <img src="https://assets.ubuntu.com/v1/4d0d4cc5-botsandus-logo.svg" width="340px" style="max-height: 410px; max-width: 340px;" alt="image for BotsAndUs builds a social robot on Ubuntu">
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5959A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-botsandus
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
