### PR TITLE
[Engage] azeti case study page

### DIFF
--- a/templates/engage/casestudy-azeti.html
+++ b/templates/engage/casestudy-azeti.html
@@ -1,0 +1,28 @@
+{% extends_with_args "engage/base_engage.html" with title="Azeti uses Ubuntu Core to improve deployment and security" meta_image="2e90accd-azeti_purple.png" meta_description="Security is fantastic in Ubuntu Core - it's a self contained system that houses all the libraries. %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP4899A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Azeti uses Ubuntu Core to improve deployment and security" image="2e90accd-azeti_purple.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">Security is fantastic in Ubuntu Core - it's a self contained system that houses all the libraries. The Ubuntu stack is read only, isolating it from interference from the outside, that's really important for industrial environments, it prevents people from changing anything vital.</p>
+      </blockquote>
+      <i>Florian Hoenigschmid, Director of Product Management, azeti</i>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">Azeti provides IoT technology to industry allowing constant monitoring and automated maintenance of equipment</li>
+        <li class="p-list_item is-ticked">Azeti switches its Linux distro to Ubuntu Core, to take advantage of easy deployment and additional security</li>
+        <li class="p-list_item is-ticked">New Ubuntu Core distribution allows azeti to more quickly deploy its product to customers saving time and money</li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="1658" returnURL="https://pages.ubuntu.com/IoT-azetiCS-TY_v.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/casestudy-azeti.html
+++ b/templates/engage/casestudy-azeti.html
@@ -12,7 +12,7 @@
       <blockquote class="p-pull-quote">
         <p class="p-pull-quote__quote">Security is fantastic in Ubuntu Core - it's a self contained system that houses all the libraries. The Ubuntu stack is read only, isolating it from interference from the outside, that's really important for industrial environments, it prevents people from changing anything vital.</p>
       </blockquote>
-      <i>Florian Hoenigschmid, Director of Product Management, azeti</i>
+      <p>Florian Hoenigschmid, Director of Product Management, azeti</p>
       <h4>Highlights</h4>
       <ul class="p-list">
         <li class="p-list_item is-ticked">Azeti provides IoT technology to industry allowing constant monitoring and automated maintenance of equipment</li>

--- a/templates/engage/casestudy-azeti.html
+++ b/templates/engage/casestudy-azeti.html
@@ -1,18 +1,18 @@
-{% extends_with_args "engage/base_engage.html" with title="Azeti uses Ubuntu Core to improve deployment and security" meta_image="2e90accd-azeti_purple.png" meta_description="Security is fantastic in Ubuntu Core - it's a self contained system that houses all the libraries. %}
+{% extends_with_args "engage/base_engage.html" with title="Azeti uses Ubuntu Core to improve deployment and security" meta_image="373e2562-2018-logo-azeti.svg" meta_description="Security is fantastic in Ubuntu Core - it's a self contained system that houses all the libraries. %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP4899A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Azeti uses Ubuntu Core to improve deployment and security" image="2e90accd-azeti_purple.png" url="#the-form" cta="Download the case study" %}
+{% include "engage/shared/_header.html" with title="Azeti uses Ubuntu Core to improve deployment and security" image="373e2562-2018-logo-azeti.svg" url="#the-form" cta="Download the case study" %}
 
 <section class="p-strip is-shallow">
   <div class="row">
     <div class="col-7">
       <blockquote class="p-pull-quote">
         <p class="p-pull-quote__quote">Security is fantastic in Ubuntu Core - it's a self contained system that houses all the libraries. The Ubuntu stack is read only, isolating it from interference from the outside, that's really important for industrial environments, it prevents people from changing anything vital.</p>
+        <cite class="p-pull-quote__citation">Florian Hoenigschmid, Director of Product Management, azeti</cite>
       </blockquote>
-      <p>Florian Hoenigschmid, Director of Product Management, azeti</p>
       <h4>Highlights</h4>
       <ul class="p-list">
         <li class="p-list_item is-ticked">Azeti provides IoT technology to industry allowing constant monitoring and automated maintenance of equipment</li>


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP4899A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-azeti
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
