### PR TITLE
[Engage] Add IoT security whitepaper page

### DIFF
--- a/templates/engage/whitepaper-iot-security.html
+++ b/templates/engage/whitepaper-iot-security.html
@@ -1,10 +1,31 @@
-{% extends_with_args "engage/base_engage.html" with title="Taking charge of the IoT's security vulnerabilities" meta_image="040356e8-security_whitepaper.png" meta_description="Canonical's report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed." %}
+{% extends_with_args "engage/base_engage.html" with title="Taking charge of the IoT's security vulnerabilities" meta_image="2217d1c8-Security.svg" meta_description="Canonical's report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP4943A1LA1{% endblock meta_copydoc %}
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Taking charge of the IoT's security vulnerabilities" image="040356e8-security_whitepaper.png" url="#the-form" cta="Download the whitepaper" %}
+<section class="p-strip--light">
+        <div class="row u-equal-height">
+          <div class="col-7  u-vertically-center">
+            <div>
+            <h1 class="u-no-margin--bottom">
+              Taking charge of the IoT's security vulnerabilities
+            </h1>
+            
+            
+            <br class="u-hide--medium u-hide--large">
+            <p class="u-hide--medium u-hide--large">
+              <a href="#the-form" class="p-button--neutral">
+                Download the whitepaper
+              </a>
+            </p>
+            </div>
+          </div>
+          <div class="col-5 u-hide--small u-align--center u-vertically-center">
+            <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150" style="max-height: 150px; max-width: 150px;" alt="image for Taking charge of the IoT's security vulnerabilities">
+          </div>
+        </div>
+      </section>
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/whitepaper-iot-security.html
+++ b/templates/engage/whitepaper-iot-security.html
@@ -1,0 +1,26 @@
+{% extends_with_args "engage/base_engage.html" with title="Taking charge of the IoT's security vulnerabilities" meta_image="040356e8-security_whitepaper.png" meta_description="Canonical's report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP4943A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Taking charge of the IoT's security vulnerabilities" image="040356e8-security_whitepaper.png" url="#the-form" cta="Download the whitepaper" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Canonical's report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed.</p>
+      <h4>Key findings</h4>
+      <p>A recent Canonical survey of 2000 consumers suggests that a shockingly high percentage of connected devices may be vulnerable to botnets, hackers and cyberattacks:</p>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">Only 31% of consumers update the firmware on their connected devices as soon as updates become available</li>
+        <li class="p-list_item is-ticked">40% of consumers have never performed firmware updates on their connected devices</li>
+        <li class="p-list_item is-ticked">40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="1917" returnURL="https://pages.ubuntu.com/IoTSecurityWhitepaper-Fullreport.html" cta="Download the whitepaper" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP4943A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/whitepaper-iot-security
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
