### PR TITLE
[Engage] Add Nexiona case study page

### DIFF
--- a/templates/engage/casestudy-nexiona.html
+++ b/templates/engage/casestudy-nexiona.html
@@ -1,0 +1,28 @@
+{% extends_with_args "engage/base_engage.html" with title="NEXIONA® collaborates with Canonical and Dell to create MIIMETIQ® EDGE" meta_image="3f9fed86-mimetiqedge.jpg" meta_description="IoT is delivering real value for many smart businesses and is capturing people’s imagination because of its immense openness and flexibility. " %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP4910A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="NEXIONA® collaborates with Canonical and Dell to create MIIMETIQ® EDGE" image="3f9fed86-mimetiqedge.jpg" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">When people think of the IoT, they think of projects of millions upon millions of connected devices. However, I don’t believe this to be the case. In reality, there will only ever be a small handful of projects that will incorporate millions of devices. Instead, the vast majority of IoT projects will incorporate only a few hundred devices at most.</p>
+        <cite class="p-pull-quote__citation">Jaume Rey, the founder of NEXIONA</cite>
+      </blockquote>
+      <h4>Highlights</h4>
+      <p>IoT is delivering real value for many smart businesses and is capturing people’s imagination because of its immense openness and flexibility. However, when SMEs start thinking about IoT they often see something that is intimidating and out of reach, given its sheer vastness and scale. However, the reality is far more practical.</p>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">All-in-one IoT Solution, packaged within a single box</li>
+        <li class="p-list_item is-ticked">Perfect for small/mid-sized projects looking to securely connect and maintain IoT devices</li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2023" returnURL="https://pages.ubuntu.com/IoT-NexionaCS-TY_v.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP4910A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-nexiona
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
