### PR TITLE
[Engage] Add InnovaPOS case study page

### DIFF
--- a/templates/engage/casestudy-innovapos.html
+++ b/templates/engage/casestudy-innovapos.html
@@ -9,13 +9,13 @@
 <section class="p-strip is-shallow">
   <div class="row">
     <div class="col-7">
-        <p>The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period. It is this opportunity that Spanish company InnovaPOS, founded in 2014, was created to spearhead. Their vision and creativity has seen them do this successfully, now operating over 30,000 smart vending machines for big brands such as Coca-Cola, Audi and LVMH in more than 120 countries.</p>
-        <h4>Highlights</h4>
-        <ul class="p-list">
-          <li class="p-list_item is-ticked">InnovaPOS re-inventing the traditional vending machine for the benefit of consumers and brands</li>
-          <li class="p-list_item is-ticked">Advanced functionality enhances personalisation, interaction and operational management</li>
-          <li class="p-list_item is-ticked">Desire for innovation, security and stability led InnovaPOS to use Ubuntu</li>
-        </ul>
+      <p>The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period. It is this opportunity that Spanish company InnovaPOS, founded in 2014, was created to spearhead. Their vision and creativity has seen them do this successfully, now operating over 30,000 smart vending machines for big brands such as Coca-Cola, Audi and LVMH in more than 120 countries.</p>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">InnovaPOS re-inventing the traditional vending machine for the benefit of consumers and brands</li>
+        <li class="p-list_item is-ticked">Advanced functionality enhances personalisation, interaction and operational management</li>
+        <li class="p-list_item is-ticked">Desire for innovation, security and stability led InnovaPOS to use Ubuntu</li>
+      </ul>
     </div>
     <div class="col-5" id="the-form">
     {% include "engage/shared/_en_engage_form.html" with id="2050" returnURL="https://pages.ubuntu.com/IoT-InnovaPOS-CS-TY.html" cta="Download the case study" %}

--- a/templates/engage/casestudy-innovapos.html
+++ b/templates/engage/casestudy-innovapos.html
@@ -1,0 +1,25 @@
+{% extends_with_args "engage/base_engage.html" with title="How Ubuntu helped InnovaPOS revolutionise the vending machine industry" meta_image="9adee0e2-innova+_POS.png" meta_description="The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP4877A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="How Ubuntu helped InnovaPOS revolutionise the vending machine industry" image="9adee0e2-innova+_POS.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+        <p>The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period. It is this opportunity that Spanish company InnovaPOS, founded in 2014, was created to spearhead. Their vision and creativity has seen them do this successfully, now operating over 30,000 smart vending machines for big brands such as Coca-Cola, Audi and LVMH in more than 120 countries.</p>
+        <h4>Highlights</h4>
+        <ul class="p-list">
+          <li class="p-list_item is-ticked">InnovaPOS re-inventing the traditional vending machine for the benefit of consumers and brands</li>
+          <li class="p-list_item is-ticked">Advanced functionality enhances personalisation, interaction and operational management</li>
+          <li class="p-list_item is-ticked">Desire for innovation, security and stability led InnovaPOS to use Ubuntu</li>
+        </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2050" returnURL="https://pages.ubuntu.com/IoT-InnovaPOS-CS-TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP4877A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-innovapos
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
