### PR TITLE
[Engage] Add Cinergy case study page

### DIFF
--- a/templates/engage/casestudy-cinergy.html
+++ b/templates/engage/casestudy-cinergy.html
@@ -1,0 +1,25 @@
+{% extends_with_args "engage/base_engage.html" with title="Cinergy makes significant digital signage saving with Screenly Pro and Ubuntu Core" meta_image="10f74cab-Cinergy_transparent_logo.png" meta_description="Find out why Cinergy turned to Screenly Pro and Ubuntu Core to help with their content management needs in such a marketing driven business." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5402A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Cinergy makes significant digital signage saving with Screenly Pro and Ubuntu Core" image="10f74cab-Cinergy_transparent_logo.png" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Cinema entertainment centres (CECs) are an all in one venue incorporating cinemas, restaurants, bowling and other activities such as escape rooms and are a growing market. Based in Dallas, Texas, Cinergy operates three 90,000 square feet CECs with ambitious expansion plans to come. With so many activities to communicate including the latest promotions and film times, Cinergy's digital signage set up needs to be efficient, secure and effective. Find out why they turned to Screenly Pro and Ubuntu Core to help with their content management needs in such a marketing driven business.</p>
+      <h4>Highlights</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">New solution’s low management overhead and entry cost crucial to Cinergy’s expansion plans</li>
+        <li class="p-list_item is-ticked">Screenly’s adoption of Ubuntu Core gave Cinergy complete confidence in the provision of robust security updates</li>
+        <li class="p-list_item is-ticked">Cinergy’s digital signage content now able to update in minutes rather than days changing the way marketing teams can push content and promotions</li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2503" returnURL="https://pages.ubuntu.com/IoT_Vertical_DS_CS_Cinergy_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5402A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-cinergy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
