### PR TITLE
[Engage] Add public cloud on Ubuntu OpenStack eBook page

### DIFF
--- a/templates/engage/public-cloud.html
+++ b/templates/engage/public-cloud.html
@@ -1,0 +1,26 @@
+{% extends_with_args "engage/base_engage.html" with title="Make IT rain: public cloud on Ubuntu OpenStack" meta_image="9f61b97f-logo-ubuntu.svg" meta_description="Read this eBook to understand the basics about running Ubuntu OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu OpenStack deployment." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5720A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Make IT rain: public cloud on Ubuntu OpenStack" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the case study" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>More and more companies are using public cloud infrastructure to access storage and compute resources on demand, driving revenues for public cloud providers.</p>
+      <p>If you’re planning to build your own public cloud using Ubuntu OpenStack infrastructure the transition from proof-of-concept to production will require careful planning and execution.</p>
+      <p>Read this eBook to understand the basics about running Ubuntu OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu OpenStack deployment.</p>
+      <blockquote class="p-pull-quote has-image">
+        <img class="p-pull-quote__image" src="https://pages.canonical.com/rs/canonical2/images/170px-Numergy-Logo.png">
+        <p class="p-pull-quote__quote">Ubuntu OpenStack is the the foundation for our coming services and Canonical has been an instrumental partner in our work.</p>
+        </blockquote>
+        
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2625" returnURL="https://pages.ubuntu.com/PublicCloud_TY.html" cta="Download the case study" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/engage/public-cloud.html
+++ b/templates/engage/public-cloud.html
@@ -12,14 +12,12 @@
       <p>More and more companies are using public cloud infrastructure to access storage and compute resources on demand, driving revenues for public cloud providers.</p>
       <p>If you’re planning to build your own public cloud using Ubuntu OpenStack infrastructure the transition from proof-of-concept to production will require careful planning and execution.</p>
       <p>Read this eBook to understand the basics about running Ubuntu OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu OpenStack deployment.</p>
-      <blockquote class="p-pull-quote has-image">
-        <img class="p-pull-quote__image" src="https://pages.canonical.com/rs/canonical2/images/170px-Numergy-Logo.png">
+      <blockquote class="p-pull-quote">
         <p class="p-pull-quote__quote">Ubuntu OpenStack is the the foundation for our coming services and Canonical has been an instrumental partner in our work.</p>
-        </blockquote>
-        
+      </blockquote>
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="2625" returnURL="https://pages.ubuntu.com/PublicCloud_TY.html" cta="Download the eBook" %}
+      {% include "engage/shared/_en_engage_form.html" with id="2625" returnURL="https://pages.ubuntu.com/PublicCloud_TY.html" cta="Download the eBook" %}
     </div>
   </div>
 </section>

--- a/templates/engage/public-cloud.html
+++ b/templates/engage/public-cloud.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Make IT rain: public cloud on Ubuntu OpenStack" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the case study" %}
+{% include "engage/shared/_header.html" with title="Make IT rain: public cloud on Ubuntu OpenStack" image="9f61b97f-logo-ubuntu.svg" url="#the-form" cta="Download the eBook" %}
 
 <section class="p-strip is-shallow">
   <div class="row">
@@ -19,7 +19,7 @@
         
     </div>
     <div class="col-5" id="the-form">
-    {% include "engage/shared/_en_engage_form.html" with id="2625" returnURL="https://pages.ubuntu.com/PublicCloud_TY.html" cta="Download the case study" %}
+    {% include "engage/shared/_en_engage_form.html" with id="2625" returnURL="https://pages.ubuntu.com/PublicCloud_TY.html" cta="Download the eBook" %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5720A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
