### PR TITLE
[Engage] Add server provisioning eBook page

### DIFF
--- a/templates/engage/ebook-maas.html
+++ b/templates/engage/ebook-maas.html
@@ -1,0 +1,26 @@
+{% extends_with_args "engage/base_engage.html" with title="Server Provisioning: What Network Admins & IT Pros Need to Know" meta_image="0aa26309-maas_banners_leaderboard.png" meta_description="Server provisioning tools help organisations to take full advantage of existing investments by maximising hardware efficiency." %}
+
+{% block meta_copydoc %}https://app-sjg.marketo.com/#LP5480A1LA1{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Server Provisioning: What Network Admins & IT Pros Need to Know" image="0aa26309-maas_banners_leaderboard.png" url="#the-form" cta="Download the eBook" %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-7">
+      <p>Server provisioning tools help organisations to take full advantage of existing investments by maximising hardware efficiency. They provide a pathway to leverage the performance and security of operating on their own hardware based solutions with the economics of the cloud.</p>
+      <h4>Read this eBook to:</h4>
+      <ul class="p-list">
+        <li class="p-list_item is-ticked">Understand bare metal server provisioning and its value proposition</li>
+        <li class="p-list_item is-ticked">Learn how companies are using server provisioning solutions within hyperscale environments</li>
+        <li class="p-list_item is-ticked">How to take full advantage of existing hardware investments by maximising hardware efficiency</li>
+        <li class="p-list_item is-ticked">How to leverage the performance and security of operating on your own hardware based solutions with the economics and efficiencies of the cloud</li>
+      </ul>
+    </div>
+    <div class="col-5" id="the-form">
+    {% include "engage/shared/_en_engage_form.html" with id="2483" returnURL="https://pages.ubuntu.com/TY_MAAS_ebook.html" cta="Download the eBook" %}
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- created a u.c version of https://app-sjg.marketo.com/#LP5480A1LA1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/ebook-maas
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has the same content as marketo
- See that the form goes to the correct thank you page
