### PR TITLE
Set a page_utms context var when links need inheritance of parent page UTMs

### DIFF
--- a/templates/engage/edge-month.html
+++ b/templates/engage/edge-month.html
@@ -51,7 +51,7 @@
       <p>
         In this webinar join Ubuntu MAAS Product Manager, Andres Rodriguez to discuss use cases and how MAAS could benefit your business. 
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362201">Register for the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362201{{ page_utms }}">Register for the webinar</a>
     </div>
   
     <div class="col-4 prefix-1 u-vertically-center">
@@ -84,7 +84,7 @@
       <p>
         Join Canonical’s telco team to hear about the strategies and tactics you can adopt to build an edge that can match your requirements of today and tomorrow.
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362202">Register for the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362202{{ page_utms }}">Register for the webinar</a>
     </div>
   </div>
 </section>
@@ -100,7 +100,7 @@
       <p>
         Join our upcoming webinar hosted by Galem Kayo, Ubuntu Product Manager, to understand what is driving businesses to process their data at the edge and how you can add an edge computing layer to your business's infrastructure.  
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362197">Watch the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362197{{ page_utms }}">Watch the webinar</a>
     </div>
 
     <div class="col-4 prefix-1 u-vertically-center">
@@ -133,7 +133,7 @@
         <p>
           We’ll explore use cases, architecture, and tools that will help you at every stage of your development lifecycle - from development to production deployments at scale. MicroK8s and Charmed Kubernetes will be explored in sufficient detail to get you started with Kubernetes on Ubuntu.
         </p>
-        <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362200">Watch the webinar</a>
+        <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362200{{ page_utms }}">Watch the webinar</a>
       </div>
     </div>
   </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -105,9 +105,22 @@ class UbuntuTemplateFinder(TemplateFinder):
 
         # Add common URL query params to context
         context["product"] = self.request.GET.get("product")
-        context["utm_source"] = self.request.GET.get("utm_source")
-        context["utm_campaign"] = self.request.GET.get("utm_campaign")
-        context["utm_medium"] = self.request.GET.get("utm_medium")
+
+        # Common UTM params
+        common_utms = ["source", "medium", "campaign"]
+        page_utms = ""
+        for param in common_utms:
+            utm_value = self.request.GET.get("utm_" + param)
+            # Pass value to context: {{ utm_<param> }}
+            context["utm_" + param] = utm_value
+            # Build complete string: {{ page_utms }}
+            if utm_value:
+                if page_utms:
+                    page_utms += "&"
+                else:
+                    page_utms += "?"
+                page_utms += "utm_" + param + "=" + utm_value
+        context["page_utms"] = page_utms
 
         # Add level_* context variables
         clean_path = self.request.path.strip("/")


### PR DESCRIPTION
## Done

* Created a "page_utms" context var with a string in the `?utm_...&utm_...` format for when links require page UTMs inheritance to pass them to the target.
* Example use on `/engage/edge-month`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure webinar links on `/engage/edge-month` inherit utm_source, utm_medium and utm_campaign of the page.
