### PR TITLE
Moved the verify checksum into an accordian

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -250,15 +250,6 @@ abbr[title] {
 }
 
 // Fix-up html default accordian on download thank-you pages
-details[open] {
-  border: 1px solid $color-mid-light;
-}
-
-details {
-  margin-left: -$sp-medium;
-  padding: $sp-medium $sp-x-large $sp-medium $sp-medium;
-}
-
 summary {
   margin: $sp-medium 0;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -248,3 +248,17 @@ abbr[title] {
   @extend %max-width--p;
   text-align: center;
 }
+
+// Fix-up html default accordian on download thank-you pages
+details[open] {
+  border: 1px solid $color-mid-light;
+}
+
+details {
+  margin-left: -$sp-medium;
+  padding: $sp-medium $sp-x-large $sp-medium $sp-medium;
+}
+
+summary {
+  margin: $sp-medium 0;
+}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -31,7 +31,7 @@
       </p>
       {% endif %}
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-align--center">
       <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg"
         alt="smile" width="200" height="200" />
     </div>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,5 +1,5 @@
-<div class="p-card">
-  <h4 class="p-card__title">Verify your download</h4>
+<details>
+  <summary>Verify your download</summary>
   <div class="p-card__content">
     <p><small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small></p>
     <div class="p-code-snippet">
@@ -10,4 +10,4 @@
     <pre><code>ubuntu-{{ version }}-{{ system }}-{{ architecture }}.iso: OK</code></pre>
     <p><small>Or follow this tutorial to learn <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small></p>
   </div>
-</div>
+</details>


### PR DESCRIPTION
## Done

- Moved the verify checksum into a `<details>` tag so people can see more of the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop/thank-you?version=18.04.2&architecture=amd64 and http://0.0.0.0:8001/download/server/thank-you?version=18.04.2&architecture=amd64
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the accordian works and the details visible

## Screenshots

closed 
![image](https://user-images.githubusercontent.com/441217/61445793-f3d26400-a945-11e9-82a4-b545430dfd7d.png)

open
![image](https://user-images.githubusercontent.com/441217/61445817-0351ad00-a946-11e9-9e09-1f2830349e44.png)


