### PR TITLE
Email address -> Work email in interactive forms

### DIFF
--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -306,7 +306,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -158,7 +158,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -191,7 +191,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -141,7 +141,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -222,7 +222,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_openstack.html
+++ b/templates/shared/forms/interactive/_openstack.html
@@ -308,7 +308,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -163,7 +163,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_robotics.html
+++ b/templates/shared/forms/interactive/_robotics.html
@@ -175,7 +175,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -534,7 +534,7 @@
                 />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input
                   required
                   id="Email"

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -161,7 +161,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">


### PR DESCRIPTION
## Done

* Replace "email address" by "work email" in interactive forms to improve data quality. Testing has demonstrated it doesn't hurt conversion.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure interactive contact forms ask you for your "Work email" on the last page

