### PR TITLE
Add Mir engage page

### DIFF
--- a/templates/engage/mir-for-iot.html
+++ b/templates/engage/mir-for-iot.html
@@ -10,7 +10,7 @@
   <div class="row">
     <div class="col-7">
       <p>
-        Industrial robots, home appliances, advertising screens, office information boards&helip; devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display. As the amount of code required to build these displays, the production time and maintenance burden have increased, this has prompted device manufacturers to reconsider how they can build smart display devices faster and, more securely based on open source frameworks.
+        Industrial robots, home appliances, advertising screens, office information boards&hellip; devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display. As the amount of code required to build these displays, the production time and maintenance burden have increased, this has prompted device manufacturers to reconsider how they can build smart display devices faster and, more securely based on open source frameworks.
       </p>
       <p>
         Mir is a library for writing graphical shells for Linux and similar operating systems. Compared to traditional display servers, it offers numerous benefits that are important for IoT devices: efficiency, speed of development, security, performance, and flexibility. All  are required by the devices of today, and even more so for the devices of tomorrow.

--- a/templates/engage/mir-for-iot.html
+++ b/templates/engage/mir-for-iot.html
@@ -1,0 +1,49 @@
+{% extends_with_args "engage/base_engage.html" with title="Build smart display devices with Mir Whitepaper" meta_image="https://assets.ubuntu.com/v1/8b2a5baf-61620202-4f636100-ac68-11e9-9c88-ffdccb58ecdf.jpg" meta_description="Mir is an open-source library that simplifies the creation of graphical interfaces for secure, smart display devices." %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/11E9O_mVN_U63ZLsZOvwsdXAyNtpRv0aF8_VWBDfrnRc{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Build smart display devices with Mir: fast to production, secure, open-source" url="#the-form" cta="Download the whitepaper" class="p-strip--dark p-takeover--mir"%}
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <p>
+        Industrial robots, home appliances, advertising screens, office information boards...devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display. As the amount of code required to build these displays, the production time and maintenance burden have increased, this has prompted device manufacturers to reconsider how they can build smart display devices faster and, more securely based on open source frameworks.
+      </p>
+      <p>
+        Mir is a library for writing graphical shells for Linux and similar operating systems. Compared to traditional display servers, it offers numerous benefits that are important for IoT devices: efficiency, speed of development, security, performance, and flexibility. All  are required by the devices of today, and even more so for the devices of tomorrow.
+      </p>
+      <p>
+        In this white paper we’ll explain how Mir, alongside Ubuntu Core and Snapcraft, lets developers build devices that are ready for the future of IoT, while offering stable, secure and performant solutions to the problems the industry faces today.
+      </p>
+      <h4>
+        In this whitepaper you will learn:
+      </h4>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          The history of Mir and why it was developed to solve reusability and security issues in IoT
+        </li>
+        <li class="p-list__item is-ticked">
+          The technical architecture of the Mir display library and how Mir compares to alternative IoT technologies
+        </li>
+        <li class="p-list__item is-ticked">
+          Example use cases of Mir and how to get started on your smart display project with Mir
+        </li>
+      </ul>
+    </div>
+    <!-- Update this when info is available -->
+    <div class="col-5" id="the-form">
+      {% include "engage/shared/_en_engage_form.html" with id="3400" returnURL="https://pages.ubuntu.com/ActiveDirectory-TY.html" %}
+    </div>
+  </div>
+
+  <style>
+    .p-takeover--mir {
+      background-image: linear-gradient(44deg, #171717 0%, #181818 9%, #262626 34%, #2D2D2D 67%, #383838 88%, #2E2E2E 100%, #393939 100%);
+    }
+  </style>
+</section>
+
+{% endblock content %}

--- a/templates/engage/mir-for-iot.html
+++ b/templates/engage/mir-for-iot.html
@@ -4,13 +4,13 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Build smart display devices with Mir: fast to production, secure, open-source" url="#the-form" cta="Download the whitepaper" class="p-strip--dark p-takeover--mir"%}
+{% include "engage/shared/_header.html" with title="Build smart display devices with Mir: fast to production, secure, open-source" url="#the-form" cta="Download the whitepaper" class="p-strip--dark p-takeover--mir" %}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
     <div class="col-7">
       <p>
-        Industrial robots, home appliances, advertising screens, office information boards...devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display. As the amount of code required to build these displays, the production time and maintenance burden have increased, this has prompted device manufacturers to reconsider how they can build smart display devices faster and, more securely based on open source frameworks.
+        Industrial robots, home appliances, advertising screens, office information boards&helip; devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display. As the amount of code required to build these displays, the production time and maintenance burden have increased, this has prompted device manufacturers to reconsider how they can build smart display devices faster and, more securely based on open source frameworks.
       </p>
       <p>
         Mir is a library for writing graphical shells for Linux and similar operating systems. Compared to traditional display servers, it offers numerous benefits that are important for IoT devices: efficiency, speed of development, security, performance, and flexibility. All  are required by the devices of today, and even more so for the devices of tomorrow.


### PR DESCRIPTION
## Done

- Add Mir engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/engage/mir-for-iot](http://0.0.0.0:8001/engage/mir-for-iot)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [brief](https://docs.google.com/document/d/11E9O_mVN_U63ZLsZOvwsdXAyNtpRv0aF8_VWBDfrnRc/edit#)
- Compare to [design](https://github.com/canonical-web-and-design/web-squad/issues/1181)
- Test it on [https://socialdebug.com/](https://socialdebug.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1182
