### PR TITLE
[Engage] Update metadata syntax for VMware to Openstack page

### DIFF
--- a/templates/engage/vmware-to-openstack.html
+++ b/templates/engage/vmware-to-openstack.html
@@ -1,7 +1,5 @@
-{% extends "engage/base_engage.html" %}
+{% extends_with_args "engage/base_engage.html" with title="From VMWare To Canonical OpenStack" meta_description="Ready to make the migration from proprietary virtualisation to OpenStack?" %}
 
-{% block title %}From VMWare To Canonical OpenStack{% endblock %}
-{% block meta_description %}Ready to make the migration from proprietary virtualisation to OpenStack?{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Wt8fkmkTbWJowrujNwsMna8SwHr24VUnPB0GM7sxGco/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/vmware-to-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5493