### PR TITLE
[Engage] Update metadata syntax for core18 security page

### DIFF
--- a/templates/engage/core18-security.html
+++ b/templates/engage/core18-security.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Why Ubuntu Core is the most secure choice for IoT{% endblock %}
-
-{% block meta_description %}Join this webinar hosted by Alex Murray, Technical Lead of the Ubuntu Security Team to find out about the latest security features of Ubuntu Core, the tiny, transactional version of Ubuntu designed specifically for IoT.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Why Ubuntu Core is the most secure choice for IoT" meta_description="Join this webinar hosted by Alex Murray, Technical Lead of the Ubuntu Security Team to find out about the latest security features of Ubuntu Core, the tiny, transactional version of Ubuntu designed specifically for IoT." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1i_Zo_IdVsGJlMtDKXQh77H_LtbNyS4_vie6vBTHnxbw{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/core18-security
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5494