### PR TITLE
[Engage] Update metadata syntax for openstack telco clouds page

### DIFF
--- a/templates/engage/openstack-telco-clouds.html
+++ b/templates/engage/openstack-telco-clouds.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Telcos and Service Providers expect near 100% uptime{% endblock %}
-
-{% block meta_description %}Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Telcos and Service Providers expect near 100% uptime" meta_image="9f61b97f-logo-ubuntu.svg" meta_description="Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5434A1LA1{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/openstack-telco-clouds
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5496