### PR TITLE
[Engage] Update metadata syntax for city network case study page

### DIFF
--- a/templates/engage/casestudy-city-network.html
+++ b/templates/engage/casestudy-city-network.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}City Network brings OpenStack cloud hosting to the financial services sector with Canonical{% endblock %}
-
-{% block meta_description %}In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="City Network brings OpenStack cloud hosting to the financial services sector with Canonical" meta_image="7005c900-pictogram_article01.png" meta_description="In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5346A1LA1{% endblock meta_copydoc %}
 

--- a/templates/templates/_extra_metadata.html
+++ b/templates/templates/_extra_metadata.html
@@ -1,21 +1,20 @@
+<meta name="theme-color" content="#E95420" />
+<meta name="twitter:account_id" content="4503599627481511" />
+<meta name="twitter:site" content="@ubuntu">
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://ubuntu.com{{ request.get_full_path }}" />
+<meta property="og:site_name" content="Ubuntu" />
 
-    <meta name="theme-color" content="#E95420" />
-    <meta name="twitter:account_id" content="4503599627481511" />
-    <meta name="twitter:site" content="@ubuntu">
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://ubuntu.com{{ request.get_full_path }}" />
-    <meta property="og:site_name" content="Ubuntu" />
-
-    {% if title %}
-        <meta name="twitter:title" content="{{ title }} | Ubuntu">
-        <meta property="og:title" content="{{ title }} | Ubuntu" />
-    {% endif %}
-    {% if meta_description %}
-        <meta name="twitter:description" content="{{ meta_description }}">
-        <meta property="og:description" content="{{ meta_description }}" />
-    {% endif %}
-    {% if meta_image %}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content="{{ meta_image }}">
-        <meta property="og:image" content="{{ meta_image }}" />
-    {% endif %}
+{% if title %}
+    <meta name="twitter:title" content="{{ title }} | Ubuntu">
+    <meta property="og:title" content="{{ title }} | Ubuntu" />
+{% endif %}
+{% if meta_description %}
+    <meta name="twitter:description" content="{{ meta_description }}">
+    <meta property="og:description" content="{{ meta_description }}" />
+{% endif %}
+{% if meta_image %}
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}">
+    <meta property="og:image" content="{% if "http" not in meta_image %}{{ ASSET_SERVER_URL }}{% endif %}{{ meta_image }}" />
+{% endif %}


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/casestudy-city-network
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5497