### PR TITLE
[Engage] Update metadata syntax for IoT devops page

### DIFF
--- a/templates/engage/iot-devops.html
+++ b/templates/engage/iot-devops.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}The transformation of the DevOps journey in IoT{% endblock %}
-
-{% block meta_description %}Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="The transformation of the DevOps journey in IoT" meta_description="Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms{% endblock" %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1imuKA06xisHD5RURurRhiJuoVeQ3qGojpOVX6odPxR0/edit?ts=5caa27c6#{% endblock meta_copydoc %}
 

--- a/templates/engage/iot-devops.html
+++ b/templates/engage/iot-devops.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="The transformation of the DevOps journey in IoT" meta_description="Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms{% endblock" %}
+{% extends_with_args "engage/base_engage.html" with title="The transformation of the DevOps journey in IoT" meta_description="Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms" %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1imuKA06xisHD5RURurRhiJuoVeQ3qGojpOVX6odPxR0/edit?ts=5caa27c6#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/iot-devops
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5498