### PR TITLE
[Engage] Update metadata syntax for multi cloud guide page

### DIFF
--- a/templates/engage/multi-cloud-guide.html
+++ b/templates/engage/multi-cloud-guide.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}What is the right cloud strategy for your business? A whitepaper with objective discussion of the various approaches to cloud computing and a clear definition for each of them: public cloud, private cloud, managed cloud, hybrid cloud and multi-cloud.{% endblock %}
-
-{% block title %}CIO guide to multi-cloud operations{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="CIO guide to multi-cloud operations" meta_image="3899d03f-choosingacloud.svg" meta_description="What is the right cloud strategy for your business? A whitepaper with objective discussion of the various approaches to cloud computing and a clear definition for each of them: public cloud, private cloud, managed cloud, hybrid cloud and multi-cloud." %}
 
 {% block content %}
 <section class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/multi-cloud-guide
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5499