### PR TITLE
[Engage] Update metadata syntax for Hiri case study page

### DIFF
--- a/templates/engage/hiri-case-study.html
+++ b/templates/engage/hiri-case-study.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Hiri successfully monetises their snap to dispel myths around proprietary Linux apps{% endblock %}
-
-{% block meta_description %}Business focused email client demonstrates that proprietary apps can be monetised on the Linux desktop.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Hiri successfully monetises their snap to dispel myths around proprietary Linux apps" meta_image="https://assets.ubuntu.com/v1/b8255328-download.png" meta_description="Business focused email client demonstrates that proprietary apps can be monetised on the Linux desktop." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1Qg3sgDrvH9w_sgJpb2fp5lyOA5R-xhGZM3aKcyuQT68/edit?ts=5cbee163#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/hiri-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5501 