### PR TITLE
[Engage] Update metadata syntax on 451 cloud economics page

### DIFF
--- a/templates/engage/451-cloud-economics.html
+++ b/templates/engage/451-cloud-economics.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Busting the myth of private cloud economics{% endblock %}
-
-{% block meta_description %}Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Busting the myth of private cloud economics" meta_image="a5d0d583-451_research_logo.png" meta_description="Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.{% endblock" %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP6252A1LA1{% endblock meta_copydoc %}
 

--- a/templates/engage/451-cloud-economics.html
+++ b/templates/engage/451-cloud-economics.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Busting the myth of private cloud economics" meta_image="a5d0d583-451_research_logo.png" meta_description="Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.{% endblock" %}
+{% extends_with_args "engage/base_engage.html" with title="Busting the myth of private cloud economics" meta_image="a5d0d583-451_research_logo.png" meta_description="Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP6252A1LA1{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/451-cloud-economics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5502 