### PR TITLE
[Engage] Update metadata syntax for events page

### DIFF
--- a/templates/engage/events.html
+++ b/templates/engage/events.html
@@ -1,5 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Book a meeting with the Ubuntu team" meta_description="The choice of operating system for a robot affects long-term production performance.
-Securing a long term, stable and profitable lifespan for your robot requires the right OS." %}
+{% extends_with_args "engage/base_engage.html" with title="Book a meeting with the Ubuntu team" meta_description="The choice of operating system for a robot affects long-term production performance. Securing a long term, stable and profitable lifespan for your robot requires the right OS." %}
 
 {% block content %}
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/templates/engage/events.html
+++ b/templates/engage/events.html
@@ -1,9 +1,5 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}The choice of operating system for a robot affects long-term production performance.
-Securing a long term, stable and profitable lifespan for your robot requires the right OS. {% endblock %}
-
-{% block title %}Book a meeting with the Ubuntu team{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Book a meeting with the Ubuntu team" meta_description="The choice of operating system for a robot affects long-term production performance.
+Securing a long term, stable and profitable lifespan for your robot requires the right OS." %}
 
 {% block content %}
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/events
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5504 