### PR TITLE
Add a new strip for BT on the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -56,7 +56,7 @@
     include "shared/_notice_default.html" with lang="fr" text="À Paris les 18 et 19 mai? Venez à l'Ubuntu Party!" url="https://ubuntu-paris.org/"
 #}
 
-
 {% block notices_content %}
+  {% include "takeovers/_bt_announcement.html" %}
   {% include "shared/_notice_default.html" with lang="ja" text="私たちの日本のウェブサイトを試してみてください" url="https://jp.ubuntu.com" icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
 {% endblock notices_content %}

--- a/templates/takeovers/_bt_announcement.html
+++ b/templates/takeovers/_bt_announcement.html
@@ -1,4 +1,4 @@
-<section class="p-strip--dark" style="background-image: linear-gradient(221deg, #5E2750 0%, #2C001E 100%);">
+<section class="p-strip--dark is-shallow" style="background-image: linear-gradient(221deg, #5E2750 0%, #2C001E 100%);">
   <div class="row u-vertically-center">
     <div class="col-12 u-no-max-width u-vertically-center">
       <a class="p-link--inverted u-vertically-center" href="/blog/">

--- a/templates/takeovers/_bt_announcement.html
+++ b/templates/takeovers/_bt_announcement.html
@@ -1,7 +1,7 @@
 <section class="p-strip--dark is-shallow" style="background-image: linear-gradient(221deg, #5E2750 0%, #2C001E 100%);">
   <div class="row u-vertically-center">
     <div class="col-12 u-no-max-width u-vertically-center">
-      <a class="p-link--inverted u-vertically-center" href="/blog/">
+      <a class="p-link--inverted u-vertically-center" href="/blog/bt-turns-to-canonical-ubuntu-to-enable-next-generation-5g-cloud-cores">
         <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}59e0097f-BT_logo_white.svg?h=40" height="40" alt="BT"><span class="u-hide--small">&nbsp;&nbsp;&nbsp;</span><span class="u-vertically-center u-no-max-width p-heading--four" style="margin: 0;">BT turns to Canonical Ubuntu to enable next generation SG Cloud Core&nbsp;&rsaquo;</span>
       </a>
     </div>

--- a/templates/takeovers/_bt_announcement.html
+++ b/templates/takeovers/_bt_announcement.html
@@ -1,0 +1,9 @@
+<section class="p-strip--dark" style="background-image: linear-gradient(221deg, #5E2750 0%, #2C001E 100%);">
+  <div class="row u-vertically-center">
+    <div class="col-12 u-no-max-width u-vertically-center">
+      <a class="p-link--inverted u-vertically-center" href="/blog/">
+        <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}59e0097f-BT_logo_white.svg?h=40" height="40" alt="BT"><span class="u-hide--small">&nbsp;&nbsp;&nbsp;</span><span class="u-vertically-center u-no-max-width p-heading--four" style="margin: 0;">BT turns to Canonical Ubuntu to enable next generation SG Cloud Core&nbsp;&rsaquo;</span>
+      </a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Added a new small strip for the BT blog post

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the strip is there under the takeover and goes to the blog post (which isn't live yet)

## Issue / Card

Fixes #1329

## Screenshots

![image](https://user-images.githubusercontent.com/441217/61774354-9b401280-adee-11e9-9b7f-e50432527525.png)

