### PR TITLE
[Engage] Update metadata syntax for Northstar case study page

### DIFF
--- a/templates/engage/northstar.html
+++ b/templates/engage/northstar.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %} North America&lsquo;s first autonomous runway snowplough{% endblock %}
-
-{% block meta_description %}Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="North America's first autonomous runway snowplough" meta_image="bdbffc9a-northastar-logo.png" meta_description="Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1uxXjTwzzhOQK7x9xpppWgRNVPLpnYA5BN1Mr1Zp2rHI/edit?ts=5ce644a0#heading=h.ud7r143one49{% endblock meta_copydoc %}
 

--- a/templates/engage/northstar.html
+++ b/templates/engage/northstar.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="North America's first autonomous runway snowplough" meta_image="bdbffc9a-northastar-logo.png" meta_description="Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system." %}
+{% extends_with_args "engage/base_engage.html" with title="North America's first autonomous runway snowplough" meta_image="https://assets.ubuntu.com/v1/bdbffc9a-northastar-logo.png" meta_description="Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1uxXjTwzzhOQK7x9xpppWgRNVPLpnYA5BN1Mr1Zp2rHI/edit?ts=5ce644a0#heading=h.ud7r143one49{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/northstar
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5505 