### PR TITLE
Fix typo on BT strip

### DIFF
--- a/templates/takeovers/_bt_announcement.html
+++ b/templates/takeovers/_bt_announcement.html
@@ -2,7 +2,7 @@
   <div class="row u-vertically-center">
     <div class="col-12 u-no-max-width u-vertically-center">
       <a class="p-link--inverted u-vertically-center" href="/blog/bt-turns-to-canonical-ubuntu-to-enable-next-generation-5g-cloud-core">
-        <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}59e0097f-BT_logo_white.svg?h=40" height="40" alt="BT"><span class="u-hide--small">&nbsp;&nbsp;&nbsp;</span><span class="u-vertically-center u-no-max-width p-heading--four" style="margin: 0;">BT turns to Canonical Ubuntu to enable next generation SG Cloud Core&nbsp;&rsaquo;</span>
+        <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}59e0097f-BT_logo_white.svg?h=40" height="40" alt="BT"><span class="u-hide--small">&nbsp;&nbsp;&nbsp;</span><span class="u-vertically-center u-no-max-width p-heading--four" style="margin: 0;">BT turns to Canonical Ubuntu to enable next generation 5G Cloud Core&nbsp;&rsaquo;</span>
       </a>
     </div>
   </div> 


### PR DESCRIPTION


## Done

s/SG/5G/

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that it says 5G not SG
