### PR TITLE
[Engage] Update metadata syntax for Ubuntu Core and Kura page

### DIFF
--- a/templates/engage/ubuntu-core-and-kura.html
+++ b/templates/engage/ubuntu-core-and-kura.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices.{% endblock %}
-
-{% block title %}Ubuntu Core and Kura: A framework for IoT gateways{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Ubuntu Core and Kura: A framework for IoT gateways" meta_image="6f00f039-Edge+gateway.svg" meta_description="A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices." %}
 
 {% block content %}
 <section class="p-strip p-takeover--stats is-deep">

--- a/templates/engage/ubuntu-core-and-kura.html
+++ b/templates/engage/ubuntu-core-and-kura.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Ubuntu Core and Kura: A framework for IoT gateways" meta_image="6f00f039-Edge+gateway.svg" meta_description="A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices." %}
+{% extends_with_args "engage/base_engage.html" with title="Ubuntu Core and Kura: A framework for IoT gateways" meta_image="https://assets.ubuntu.com/v1/6f00f039-Edge+gateway.svg" meta_description="A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices." %}
 
 {% block content %}
 <section class="p-strip p-takeover--stats is-deep">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/ubuntu-core-and-kura
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5506 