### PR TITLE
[Engage] Update metadata syntax for developer desktop page

### DIFF
--- a/templates/engage/developer-desktop.html
+++ b/templates/engage/developer-desktop.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu.{% endblock %}
-
-{% block title %}Six reasons why developers choose Ubuntu Desktop{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Six reasons why developers choose Ubuntu Desktop" meta_image="a68a11b7-Dell+XPS+13-1804-1.png" meta_description="What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1bqD9QKDj6ZfRkn-vbDrHHE_Zrk81cA5hFLRHZYFzzSA{% endblock meta_copydoc %}
 

--- a/templates/engage/developer-desktop.html
+++ b/templates/engage/developer-desktop.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Six reasons why developers choose Ubuntu Desktop" meta_image="a68a11b7-Dell+XPS+13-1804-1.png" meta_description="What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu." %}
+{% extends_with_args "engage/base_engage.html" with title="Six reasons why developers choose Ubuntu Desktop" meta_image="https://assets.ubuntu.com/v1/a68a11b7-Dell+XPS+13-1804-1.png" meta_description="What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1bqD9QKDj6ZfRkn-vbDrHHE_Zrk81cA5hFLRHZYFzzSA{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/developer-desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5507 