### PR TITLE
[Engage] Update metadata syntax for robot OS choice page

### DIFF
--- a/templates/engage/robot-operating-system-choice.html
+++ b/templates/engage/robot-operating-system-choice.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}The choice of operating system for a robot affects long-term production performance. Securing a long term, stable and profitable lifespan for your robot requires the right OS. {% endblock %}
-
-{% block title %}Key considerations when choosing a robot’s operating system{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Key considerations when choosing a robot’s operating system" meta_description="The choice of operating system for a robot affects long-term production performance. Securing a long term, stable and profitable lifespan for your robot requires the right OS." %}
 
 {% block content %}
 <section class="p-strip p-takeover--robotics js-takeover">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/robot-operating-system-choice
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5508 