### PR TITLE
[Engage] Update metadata syntax for evolving software page

### DIFF
--- a/templates/engage/evolving-software.html
+++ b/templates/engage/evolving-software.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}Software keeps evolving and management complexity tends to increase with successive stack updates. Learn how using Juju can solve software management complexity and how it provides a familiar approach to managing any type of stack.{% endblock %}
-
-{% block title %}Keep up with evolving software{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Keep up with evolving software" meta_description="Software keeps evolving and management complexity tends to increase with successive stack updates. Learn how using Juju can solve software management complexity and how it provides a familiar approach to managing any type of stack." %}
 
 {% block content %}
 <section class="p-strip--image is-dark p-hero--evolving-software">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/evolving-software
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5509 