### PR TITLE
[Engage] Update metadata syntax for ITstrategen case study page

### DIFF
--- a/templates/engage/ITstrategen-case-study.html
+++ b/templates/engage/ITstrategen-case-study.html
@@ -1,6 +1,5 @@
-{% extends "engage/base_engage.html" %}
+{% extends_with_args "engage/base_engage.html" with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance" meta_image="9e59756d-shield-ESM.svg" meta_description="ITstrategen keeps legacy applications secure with Extended Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical." %}
 
-{% block meta_description %}ITstrategen keeps legacy applications secure with Extended Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1TIg0rYTrAp7yeu41GFwuCaXgS4SR2rjJrAp7D6zDocQ/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/ITstrategen-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5510 