### PR TITLE
[Engage] Update metadata syntax for LXD whitepaper page

### DIFF
--- a/templates/engage/lxd-whitepaper.html
+++ b/templates/engage/lxd-whitepaper.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}How to build a lightweight system container cluster{% endblock %}
-
-{% block meta_description %}LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="How to build a lightweight system container cluster" meta_image="d85ef015-image-lxd.svg" meta_description="LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gcCaCuOdNBV8pqajXVCdAAxOTmO22cdPRD1h5j3oRbU/edit#heading=h.4ukgkign4yjt{% endblock meta_copydoc %}
 

--- a/templates/engage/lxd-whitepaper.html
+++ b/templates/engage/lxd-whitepaper.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="How to build a lightweight system container cluster" meta_image="d85ef015-image-lxd.svg" meta_description="LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them." %}
+{% extends_with_args "engage/base_engage.html" with title="How to build a lightweight system container cluster" meta_image="https://assets.ubuntu.com/v1/d85ef015-image-lxd.svg" meta_description="LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gcCaCuOdNBV8pqajXVCdAAxOTmO22cdPRD1h5j3oRbU/edit#heading=h.4ukgkign4yjt{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/lxd-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5513 