### PR TITLE
[Engage] Update metadata syntax for IoT disk encryption page

### DIFF
--- a/templates/engage/iot-disk-encryption.html
+++ b/templates/engage/iot-disk-encryption.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}A technical overview of how Ubuntu Core with full disk encryption and secure boot can be implemented in IoT devices to provide protection in data sensitive scenarios.{% endblock %}
-
-{% block title %}Securing IoT device data against physical access{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Securing IoT device data against physical access" meta_image="84db8ca6-Disc_encryption.svg" meta_description="A technical overview of how Ubuntu Core with full disk encryption and secure boot can be implemented in IoT devices to provide protection in data sensitive scenarios." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1zAv3ouUrzQcQDw2DSefaePXcMu35BAumIMpzqmIkycs/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/iot-disk-encryption
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5514 