### PR TITLE
[Engage] Update metadata syntax for FR ESM page

### DIFF
--- a/templates/engage/fr/esm.html
+++ b/templates/engage/fr/esm.html
@@ -1,7 +1,5 @@
-{% extends "engage/base_engage.html" %}
+{% extends_with_args "engage/base_engage.html" with title="Canonical annonce l’Extension Sécurité et Maintenance pour Ubuntu 14.04." meta_image="9e59756d-shield-ESM.svg" meta_description="Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019." %}
 
-{% block title %}Canonical annonce l’Extension Sécurité et Maintenance pour Ubuntu 14.04.{% endblock %}
-{% block meta_description %}Sécurité, conformité, RGPD: gardez vos serveurs en sécurité après la fin de support officielle d'Ubuntu 14.04 LTS en avril 2019.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/14owLexmd5yn9g9Opq2oYAw-oxG2k2YKLgEi9bGqzzMg/edit{% endblock meta_copydoc %}
 
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/fr/esm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5515 