### PR TITLE
[Engage] Update metadata syntax for FR VMware page

### DIFF
--- a/templates/engage/fr/vmware-to-openstack.html
+++ b/templates/engage/fr/vmware-to-openstack.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Migrer de VMware à Openstack{% endblock %}
-
-{% block meta_description %}Quels sont les différences entre VMWare et OpenStack et les bénéfices d'une migration de l'un vers l'autre. Un webinar gratuit pour mieux comprendre les technologies du cloud privé.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Migrer de VMware à Openstack" meta_description="Quels sont les différences entre VMWare et OpenStack et les bénéfices d'une migration de l'un vers l'autre. Un webinar gratuit pour mieux comprendre les technologies du cloud privé." %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/fr/vmware-to-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5516 