### PR TITLE
[Engage] Update metadata syntax for kernel telco NFV page

### DIFF
--- a/templates/engage/kernel-telco-nfv.html
+++ b/templates/engage/kernel-telco-nfv.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}Which kernel provides the most balanced operational efficiency? A detailed analysis comparing real-time kernel assumptions against test results designed to reflect telco and NFV workloads.{% endblock %}
-
-{% block title %}Low latency and real-time kernels for telco and NFV{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Low latency and real-time kernels for telco and NFV" meta_description="Which kernel provides the most balanced operational efficiency? A detailed analysis comparing real-time kernel assumptions against test results designed to reflect telco and NFV workloads." %}
 
 {% block content %}
 <section class="p-strip p-hero--nfv-kernel js-takeover">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/kernel-telco-nfv
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5517 