### PR TITLE
[Engage] Update metadata syntax for FR OpenStack made easy page

### DIFF
--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -1,7 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Avec les bons outils, OpenStack est un jeu d'enfant.{% endblock %}
-{% block meta_description %}Cet eBook vous permettra de mieux comprendre pourquoi l'installation et l'exécution d'OpenStack peut sembler complexe, et comment Canonical OpenStack simplifie les choses et peut vous aider à construire une infrastructure cloud privée moderne, évolutive, répliquable et abordable.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Avec les bons outils, OpenStack est un jeu d'enfant." meta_image="35515576-openstack-cloud.svg" meta_description="Cet eBook vous permettra de mieux comprendre pourquoi l'installation et l'exécution d'OpenStack peut sembler complexe, et comment Canonical OpenStack simplifie les choses et peut vous aider à construire une infrastructure cloud privée moderne, évolutive, répliquable et abordable." %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/fr/openstack-made-easy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5518 