### PR TITLE
[Engage] Update metadata syntax for DevOps CI/CD page

### DIFF
--- a/templates/engage/devops-cicd-webinar.html
+++ b/templates/engage/devops-cicd-webinar.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}A webinar to learn how to automate Continuous Integration, Continuous Delivery, and Continuous Deployment with Kubernetes{% endblock %}
-
-{% block title %}Get started with DevOps best practices: CI/CD{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Get started with DevOps best practices: CI/CD" meta_image="c112058c-Automated_DevOp.svg" meta_description="A webinar to learn how to automate Continuous Integration, Continuous Delivery, and Continuous Deployment with Kubernetes" %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1zAv3ouUrzQcQDw2DSefaePXcMu35BAumIMpzqmIkycs/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/devops-cicd-webinar
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5519 