### PR TITLE
[Engage] Update metadata syntax for Ubuntu 18.10 page

### DIFF
--- a/templates/engage/ubuntu-18-10.html
+++ b/templates/engage/ubuntu-18-10.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}An overview of the Ubuntu 18.10 release updates from the Canonical product team. Features of the 18.10 software release focus on multi-cloud deployments, AI software development, a new community desktop theme and richer snap desktop integration.  {% endblock %}
-
-{% block title %}What's New in Ubuntu 18.10{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="What's New in Ubuntu 18.10" meta_description="An overview of the Ubuntu 18.10 release updates from the Canonical product team. Features of the 18.10 software release focus on multi-cloud deployments, AI software development, a new community desktop theme and richer snap desktop integration." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1BMqxhCOJfT43Mj2MFNgdM0X0c0rUYmBQBLeYFTCKfKY/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/ubuntu-18-10
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5520 