### PR TITLE
[Engage] Update metadata syntax for cloud economics page

### DIFF
--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -1,7 +1,5 @@
-{% extends "engage/base_engage.html" %}
+{% extends_with_args "engage/base_engage.html" with title="Busting the myth of private cloud economics" meta_image="c54da84b-451-Research-NEG.png" meta_description="Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark." %}
 
-{% block title %}Busting the myth of private cloud economics{% endblock %}
-{% block meta_description %}Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1NtRmAB4Pkphc8WTU8n4-b10knVqqFhMDc_FtGAwQ7nw/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/cloud-economics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5521 