### PR TITLE
[Engage] Update metadata syntax for heading help page

### DIFF
--- a/templates/engage/_heading-help.html
+++ b/templates/engage/_heading-help.html
@@ -1,9 +1,8 @@
-{% extends "templates/base.html" %}
+{% extends_with_args "engage/base_engage.html" with title="Heading help" %}
 
 {% block head_extra %}
 <meta name="robots" content="noindex, nofollow">
 {% endblock %}
-{% block title %}Heading help{% endblock %}
 {% block outer_content %}
 <section class="p-strip--light">
   <div class="row">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/_heading-help
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5523 