### PR TITLE
[Engage] Update metadata syntax for Fingbox case study page

### DIFF
--- a/templates/engage/fingbox-case-study.html
+++ b/templates/engage/fingbox-case-study.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Fing serves 30,000 customers with a secure, future-proof IoT device" meta_image="b73c04bf-Screenshot+from+2018-07-02+16-12-59.png" meta_description="Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades." %}
+{% extends_with_args "engage/base_engage.html" with title="Fing serves 30,000 customers with a secure, future-proof IoT device" meta_image="https://assets.ubuntu.com/v1/b73c04bf-Screenshot+from+2018-07-02+16-12-59.png" meta_description="Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gbdgX7y1s22YBcm4N1dzuqgDwQwhJRMaNreHObZ8SdA/edit{% endblock meta_copydoc %}
 

--- a/templates/engage/fingbox-case-study.html
+++ b/templates/engage/fingbox-case-study.html
@@ -1,7 +1,5 @@
-{% extends "engage/base_engage.html" %}
+{% extends_with_args "engage/base_engage.html" with title="Fing serves 30,000 customers with a secure, future-proof IoT device" meta_image="b73c04bf-Screenshot+from+2018-07-02+16-12-59.png" meta_description="Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades." %}
 
-{% block meta_description %}Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades.{% endblock %}
-{% block title %}Fing serves 30,000 customers with a secure, future-proof IoT device{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1gbdgX7y1s22YBcm4N1dzuqgDwQwhJRMaNreHObZ8SdA/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/fingbox-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5524 