### PR TITLE
[Engage] Update metadata syntax for Cloud-init page

### DIFF
--- a/templates/engage/cloud-init-whitepaper.html
+++ b/templates/engage/cloud-init-whitepaper.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Cloud-init" meta_image="28e89608-cloud-init.svg" meta_description="Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast." %}
+{% extends_with_args "engage/base_engage.html" with title="Cloud-init" meta_image="https://assets.ubuntu.com/v1/28e89608-cloud-init.svg" meta_description="Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gcCaCuOdNBV8pqajXVCdAAxOTmO22cdPRD1h5j3oRbU/edit#heading=h.4ukgkign4yjt{% endblock meta_copydoc %}
 

--- a/templates/engage/cloud-init-whitepaper.html
+++ b/templates/engage/cloud-init-whitepaper.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Cloud-init{% endblock %}
-
-{% block meta_description %}Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Cloud-init" meta_image="28e89608-cloud-init.svg" meta_description="Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gcCaCuOdNBV8pqajXVCdAAxOTmO22cdPRD1h5j3oRbU/edit#heading=h.4ukgkign4yjt{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/cloud-init-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5525 