### PR TITLE
[Engage] Update metadata syntax for IoT business model page

### DIFF
--- a/templates/engage/iot-business-model.html
+++ b/templates/engage/iot-business-model.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs.{% endblock %}
-
-{% block title %}Establishing a software defined IoT business model{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Establishing a software defined IoT business model" meta_image="6d4f864b-Piggy+Bank+icon.svg" meta_description="Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs." %}
 
 {% block content %}
 <section class="p-strip p-takeover is-deep">

--- a/templates/engage/iot-business-model.html
+++ b/templates/engage/iot-business-model.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Establishing a software defined IoT business model" meta_image="6d4f864b-Piggy+Bank+icon.svg" meta_description="Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs." %}
+{% extends_with_args "engage/base_engage.html" with title="Establishing a software defined IoT business model" meta_image="https://assets.ubuntu.com/v1/6d4f864b-Piggy+Bank+icon.svg" meta_description="Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs." %}
 
 {% block content %}
 <section class="p-strip p-takeover is-deep">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/iot-business-model
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5526 