### PR TITLE
[Engage] Update metadata syntax for deploy AI/ML model page

### DIFF
--- a/templates/engage/deploy-ai-ml-model.html
+++ b/templates/engage/deploy-ai-ml-model.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.{% endblock %}
-
-{% block title %}How to build and deploy your first AI/ML model on Ubuntu{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="How to build and deploy your first AI/ML model on Ubuntu" meta_description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1BMqxhCOJfT43Mj2MFNgdM0X0c0rUYmBQBLeYFTCKfKY/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
    ## Done

    Updated metadata syntax to match the extends_with_args format

    ## QA

    - Check out this feature branch
    - Run the site using the command `./run serve`
    - View the site locally in your web browser at: http://0.0.0.0:8001/engage/deploy-ai-ml-model
    - Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
    - Ensure that the page looks identical to the live one
    - Ensure that the metadata is correct


    ## Issue / Card

    Fixes #5527 