### PR TITLE
[Engage] Update metadata syntax for telco cloudification page

### DIFF
--- a/templates/engage/telco-cloudification-ebook.html
+++ b/templates/engage/telco-cloudification-ebook.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Carrier Cloudification: What every telecom executive needs to know{% endblock %}
-
-{% block meta_description %}This eBook&nbsp;is designed to help telecom executives understand industry best practices as they move towards &lsquo;cloudification&rsquo; of their network infrastructure.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Carrier Cloudification: What every telecom executive needs to know" meta_image="9f61b97f-logo-ubuntu.svg" meta_description="This eBook is designed to help telecom executives understand industry best practices as they move towards 'cloudification'; of their network infrastructure." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5612A1LA1{% endblock meta_copydoc %}
 

--- a/templates/engage/telco-cloudification-ebook.html
+++ b/templates/engage/telco-cloudification-ebook.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Carrier Cloudification: What every telecom executive needs to know" meta_image="9f61b97f-logo-ubuntu.svg" meta_description="This eBook is designed to help telecom executives understand industry best practices as they move towards cloudification of their network infrastructure." %}
+{% extends_with_args "engage/base_engage.html" with title="Carrier Cloudification: What every telecom executive needs to know" meta_image="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" meta_description="This eBook is designed to help telecom executives understand industry best practices as they move towards cloudification of their network infrastructure." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5612A1LA1{% endblock meta_copydoc %}
 

--- a/templates/engage/telco-cloudification-ebook.html
+++ b/templates/engage/telco-cloudification-ebook.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Carrier Cloudification: What every telecom executive needs to know" meta_image="9f61b97f-logo-ubuntu.svg" meta_description="This eBook is designed to help telecom executives understand industry best practices as they move towards 'cloudification'; of their network infrastructure." %}
+{% extends_with_args "engage/base_engage.html" with title="Carrier Cloudification: What every telecom executive needs to know" meta_image="9f61b97f-logo-ubuntu.svg" meta_description="This eBook is designed to help telecom executives understand industry best practices as they move towards cloudification of their network infrastructure." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5612A1LA1{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/telco-cloudification-ebook
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5529 