### PR TITLE
Add half-and-half-reverse-suru strip

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -94,7 +94,7 @@ rules:
   placeholder-in-extend: 1
 
   # Disallows
-  no-color-literals: 1
+  no-color-literals: 0
   no-transition-all: 1
   no-universal-selectors: 0
   no-vendor-prefixes: 1

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -103,7 +103,7 @@
       linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
     background-position: top 60% left, top left, top 10% left 53.6%, center right;
     background-repeat: no-repeat;
-    background-size: 70% 200%, 100% 100%, 10% 120%, cover;
+    background-size: 90% 100%, 100% 100%, 10% 120%, cover;
 
 
     @media (max-width: $breakpoint-medium) {

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,6 +1,8 @@
+// sass-lint:disable no-color-literals hex-notation
 @mixin ubuntu-p-strip {
   @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-bottomed;
+  @include ubuntu-p-strip-suru-half-and-half;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -74,3 +76,48 @@
     padding-bottom: 8rem;
   }
 }
+
+@mixin ubuntu-p-strip-suru-half-and-half {
+  .p-strip--suru-half-and-half-reversed {
+    @extend %vf-strip;
+    background-blend-mode: multiply, normal, normal, normal;
+    background-image:
+      linear-gradient(
+        to top right,
+        rgba(119, 41, 83, 0.16) 0%,
+        rgba(119, 41, 83, 0.16) 49.9%,
+        rgba(119, 41, 83, 0) 50%,
+        rgba(119, 41, 83, 0) 100%),
+      linear-gradient(
+        to left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 41.9%,
+        rgba(255, 255, 255, 0) 42%,
+        rgba(255, 255, 255, 0) 100%),
+      linear-gradient(
+        to top left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 49.9%,
+        rgba(255, 255, 255, 0) 50%,
+        rgba(255, 255, 255, 0) 100%),
+      linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
+    background-position: top 10% left 10%, top left, top 10% left 53.6%, center right;
+    background-repeat: no-repeat;
+    background-size: 60% 120%, 100% 100%, 10% 120%, cover;
+
+
+    @media (max-width: $breakpoint-medium) {
+      background-color: #2C001E;
+      background-image: linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
+    }
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
+  }
+}
+// sass-lint:enable no-color-literals hex-notation

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -19,13 +19,12 @@
   .p-strip--suru {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
-    // sass-lint:disable-block no-color-literals
     background-image:
       linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
       linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%); // sass-lint:disable-line hex-notation no-color-literals
+      linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%);
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
     background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem, auto;
@@ -64,7 +63,6 @@
   .p-strip--suru-bottomed {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
-    // sass-lint:disable-block no-color-literals
     background-image:
       linear-gradient(to top right, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49.5%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
       linear-gradient(to top right, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.5%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -24,7 +24,7 @@
       linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%);
+      linear-gradient(-89deg, #e95420 0%, #772953 38%, #2C001e 85%);
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
     background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem, auto;
@@ -98,14 +98,14 @@
         rgba(255, 255, 255, 1) 49.9%,
         rgba(255, 255, 255, 0) 50%,
         rgba(255, 255, 255, 0) 100%),
-      linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
+      linear-gradient(270deg, #e95420 20%, #772953 63%, #2C001e 100%);
     background-position: top 60% left, top left, top 10% left 53.6%, center right;
     background-repeat: no-repeat;
     background-size: 90% 100%, 100% 100%, 10% 120%, cover;
 
 
     @media (max-width: $breakpoint-medium) {
-      background-image: linear-gradient(270deg, #E95420 0%, #772953 43%, #2C001E 87%);
+      background-image: linear-gradient(270deg, #e95420 0%, #772953 43%, #2C001e 87%);
       background-position: center right;
       background-size: cover;
     }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -83,7 +83,7 @@
     background-blend-mode: multiply, normal, normal, normal;
     background-image:
       linear-gradient(
-        to top right,
+        25deg,
         rgba(119, 41, 83, 0.16) 0%,
         rgba(119, 41, 83, 0.16) 49.9%,
         rgba(119, 41, 83, 0) 50%,
@@ -101,9 +101,9 @@
         rgba(255, 255, 255, 0) 50%,
         rgba(255, 255, 255, 0) 100%),
       linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
-    background-position: top 30% left 30%, top left, top 10% left 53.6%, center right;
+    background-position: top 60% left, top left, top 10% left 53.6%, center right;
     background-repeat: no-repeat;
-    background-size: 60% 160%, 100% 100%, 10% 120%, cover;
+    background-size: 70% 200%, 100% 100%, 10% 120%, cover;
 
 
     @media (max-width: $breakpoint-medium) {

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -101,14 +101,15 @@
         rgba(255, 255, 255, 0) 50%,
         rgba(255, 255, 255, 0) 100%),
       linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
-    background-position: top 10% left 10%, top left, top 10% left 53.6%, center right;
+    background-position: top 30% left 30%, top left, top 10% left 53.6%, center right;
     background-repeat: no-repeat;
-    background-size: 60% 120%, 100% 100%, 10% 120%, cover;
+    background-size: 60% 160%, 100% 100%, 10% 120%, cover;
 
 
     @media (max-width: $breakpoint-medium) {
-      background-color: #2C001E;
-      background-image: linear-gradient(270deg, #E95420 20%, #772953 63%, #2C001E 100%);
+      background-image: linear-gradient(270deg, #E95420 0%, #772953 43%, #2C001E 87%);
+      background-position: center right;
+      background-size: cover;
     }
 
     &.is-light {

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<section class="p-strip--image is-dark is-deep p-banner-core-hero">
+<section class="p-strip--suru-half-and-half-reversed is-dark">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>Embedded Linux 2.0</h1>
@@ -18,8 +18,8 @@
         More reliable updates. Much better security.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}6e93d63c-Embedded+Linux+white.svg" alt="" width="335px">
+    <div class="col-6 u-hide--small u-align--right u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}4e2131b0-3B-Embedded+Linux.svg" alt="" width="335px">
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Add the half and half reverse strip to the hero of embedded

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/embedded
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the new hero matches [the design](https://github.com/canonical-web-and-design/web-squad/issues/1464)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/1464

## Screenshots
![Screenshot_2019-07-24 Ubuntu is the new standard for embedded Linux Ubuntu](https://user-images.githubusercontent.com/1413534/61802479-651f8480-ae28-11e9-8c61-9f4e0bb9b8c6.png)

