### PR TITLE
[Engage] Update metadata syntax for modern cloud page

### DIFF
--- a/templates/engage/modern-cloud.html
+++ b/templates/engage/modern-cloud.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}This webinar discusses how Trilio and Canonical help organisations transition to new, maintainable cloud architecture in just weeks.{% endblock %}
-
-{% block title %}Modernise your cloud{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Modernise your cloud" meta_image="https://assets.ubuntu.com/v1/9f54e0b0-Trilio+Final+Logo_GRAY+GREEN.png" meta_description="This webinar discusses how Trilio and Canonical help organisations transition to new, maintainable cloud architecture in just weeks." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1PfGUgAndvB_dYaCz3wL9vj4gN_O8k34rOgJ6o0DLb7o/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
    ## Done

    Updated metadata syntax to match the extends_with_args format

    ## QA

    - Check out this feature branch
    - Run the site using the command `./run serve`
    - View the site locally in your web browser at: http://0.0.0.0:8001/engage/modern-cloud
    - Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
    - Ensure that the page looks identical to the live one
    - Ensure that the metadata is correct


    ## Issue / Card

    Fixes #5530 