### PR TITLE
[Engage] Update metadata syntax for DevOps IoT webinar page

### DIFF
--- a/templates/engage/devops-iot-webinar.html
+++ b/templates/engage/devops-iot-webinar.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}The transformation of the DevOps journey in IoT{% endblock %}
-
-{% block meta_description %}Traditional development methods do not scale into the IoT sphere{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="The transformation of the DevOps journey in IoT" meta_description="Traditional development methods do not scale into the IoT sphere" %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1P7tOkSQZwh0vcHUMp2X2wPvGUQORktNRLjPXhrTakF8/edit#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/devops-iot-webinar
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5531 