### PR TITLE
[Engage] Update metadata syntax for OpenStack made easy page

### DIFF
--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}OpenStack made easy{% endblock %}
-
-{% block meta_description %}The change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge from a different perspective.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="OpenStack made easy" meta_image="https://assets.ubuntu.com/v1/a7916513-picto-openstack.svg" meta_description="The change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge from a different perspective." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5655A1LA1{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/openstack-made-easy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5532 