### PR TITLE
[Engage] Update metadata syntax for industrial drones case study page

### DIFF
--- a/templates/engage/industrial-drones-case-study.html
+++ b/templates/engage/industrial-drones-case-study.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}This case study presents how Apellix, an industrial drone company, engineers safer work environments with Ubuntu.{% endblock %}
-
-{% block title %}Apellix engineers safer work environments with Ubuntu powered aerial robotics{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Apellix engineers safer work environments with Ubuntu powered aerial robotics" meta_image="https://assets.ubuntu.com/v1/5fd2e1aa-apellix_im3.png" meta_description="This case study presents how Apellix, an industrial drone company, engineers safer work environments with Ubuntu." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1cRHdWw8d9OP71lwobO89eJtPENHH3TYzGuWrZgYcvz8{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/industrial-drones-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5533 