### PR TITLE
[Engage] Update metadata syntax for financial services month page

### DIFF
--- a/templates/engage/financial-services-month.html
+++ b/templates/engage/financial-services-month.html
@@ -1,6 +1,5 @@
-{% extends "engage/base_engage.html" %}
-{% block meta_description %}The fintech infrastructure is moving on. A series of webinars to have an understanding of the emerging technologies: multi-cloud, AI/ML, Blockchain and Containers, and their impact on the financial services industry.{% endblock %}
-{% block title %}Canonical presents Financial Services Month{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Canonical presents Financial Services Month" meta_image="https://assets.ubuntu.com/v1/bac38d84-financial-cloud.svg" meta_description="The fintech infrastructure is moving on. A series of webinars to have an understanding of the emerging technologies: multi-cloud, AI/ML, Blockchain and Containers, and their impact on the financial services industry." %}
+
 {% block content %}
 <section class="p-strip--dark is-deep p-takeover--financial-services">
   <div class="row u-equal-height u-vertically-center">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/financial-services-month
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5534 