### PR TITLE
[Engage] Update metadata syntax for CTO's guide to SDN, NFV and VNF page

### DIFF
--- a/templates/engage/cto-guide-sdn-nfv-vnf.html
+++ b/templates/engage/cto-guide-sdn-nfv-vnf.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}CTO’s guide to SDN, NFV & VNF{% endblock %}
-
-{% block meta_description %}Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital: from function-specific, proprietary devices to software-enabled commodity hardware.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="CTO’s guide to SDN, NFV & VNF" meta_image="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" meta_description="Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital: from function-specific, proprietary devices to software-enabled commodity hardware." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5616A1LA1{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/cto-guide-sdn-nfv-vnf
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5535 