### PR TITLE
[Engage] Update metadata syntax for OpenStack security whitepaper page

### DIFF
--- a/templates/engage/openstack-security-whitepaper.html
+++ b/templates/engage/openstack-security-whitepaper.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Private cloud security{% endblock %}
-
-{% block meta_description %}In regulated sectors, private cloud security needs to meet the highest requirements. This Whitepaper explains how to deliver on these with an Openstack cloud.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Private cloud security" meta_description="In regulated sectors, private cloud security needs to meet the highest requirements. This Whitepaper explains how to deliver on these with an Openstack cloud." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1Qg3sgDrvH9w_sgJpb2fp5lyOA5R-xhGZM3aKcyuQT68/edit?ts=5cbee163#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/openstack-security-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5536 