### PR TITLE
[Engage] Update metadata syntax for low latency report page

### DIFF
--- a/templates/engage/low-latency-report.html
+++ b/templates/engage/low-latency-report.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Low latency and real time kernels for telco and NFV{% endblock %}
-
-{% block meta_description %}This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Low latency and real time kernels for telco and NFV" meta_image="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" meta_description="This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes." %}
 
 {% block meta_copydoc %}https://app-sjg.marketo.com/#LP5624A1LA1{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/low-latency-report
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5537 