### PR TITLE
[Engage] Update metadata syntax for future proof IoT page

### DIFF
--- a/templates/engage/future-proof-iot.html
+++ b/templates/engage/future-proof-iot.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}In this webinar, you’ll learn how Fingbox was built with Ubuntu Core and how Fingbox’s key features are updated and improved ongoing using Snaps.{% endblock %}
-
-{% block title %}Future-proofing Fingbox, the IoT home network monitoring device{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Future-proofing Fingbox, the IoT home network monitoring device" meta_description="In this webinar, you’ll learn how Fingbox was built with Ubuntu Core and how Fingbox’s key features are updated and improved ongoing using Snaps." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1f8FiTxhMTDxgM96jhfaEKCdc5LNKXcn0-2_iiSE6ZWs/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/future-proof-iot
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5538 