### PR TITLE
[Engage] Update metadata syntax for DE what can you do with Kubernetes page

### DIFF
--- a/templates/engage/de/what-can-you-do-with-kubernetes.html
+++ b/templates/engage/de/what-can-you-do-with-kubernetes.html
@@ -1,4 +1,4 @@
-{% extends_with_args "engage/base_engage.html" with title="Wofür können Sie Kubernetes einsetzen?" meta_image="https://assets.ubuntu.com/v1/73fe5532-business+icon.svg" meta_description="Ein umfassenden Überblick, Demos und Ideen für Kubernetes den praktischen Einsatz." %}
+{% extends_with_args "engage/base_engage.html" with title="Wofür können Sie Kubernetes einsetzen?" meta_image="https://assets.ubuntu.com/v1/782c04fc-business-icon-dark-background.png" meta_description="Ein umfassenden Überblick, Demos und Ideen für Kubernetes den praktischen Einsatz." %}
 
 {% block content %}
 

--- a/templates/engage/de/what-can-you-do-with-kubernetes.html
+++ b/templates/engage/de/what-can-you-do-with-kubernetes.html
@@ -1,8 +1,4 @@
-  {% extends "engage/base_engage.html" %}
-
-  {% block meta_description %}Ein umfassenden Überblick, Demos und Ideen für Kubernetes den praktischen Einsatz.{% endblock %}
-
-{% block title %}Wofür können Sie Kubernetes einsetzen?{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Wofür können Sie Kubernetes einsetzen?" meta_image="https://assets.ubuntu.com/v1/73fe5532-business+icon.svg" meta_description="Ein umfassenden Überblick, Demos und Ideen für Kubernetes den praktischen Einsatz." %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/de/what-can-you-do-with-kubernetes
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5542 