### PR TITLE
[Engage] Update metadata syntax for DE VMware to OpenStack page

### DIFF
--- a/templates/engage/de/vmware-to-openstack.html
+++ b/templates/engage/de/vmware-to-openstack.html
@@ -1,8 +1,4 @@
-  {% extends "engage/base_engage.html" %}
-
-  {% block meta_description %}Sind Sie bereit für die Migration von proprietärer Virtualisierung auf OpenStack?{% endblock %}
-
-{% block title %}Von VMware zu Canonical OpenStack{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Von VMware zu Canonical OpenStack" meta_description="Sind Sie bereit für die Migration von proprietärer Virtualisierung auf OpenStack?" %}
 
 {% block content %}
 <section class="p-strip p-takeover--vmware-to-os">


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/de/vmware-to-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5544 