### PR TITLE
[Engage] Update metadata syntax of DE OpenStack made easy page

### DIFF
--- a/templates/engage/de/openstack-made-easy.html
+++ b/templates/engage/de/openstack-made-easy.html
@@ -1,7 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Mit den richtigen Tools wird OpenStack ganz einfach.{% endblock %}
-{% block meta_description %}Dieses eBook vermittelt Ihnen ein besseres Verständnis dafür, weshalb Installation und Betrieb von OpenStack komplex erscheinen können und wie OpenStack von Canonical Sie beim Aufbau einer modernen, skalierbaren, reproduzierbaren und erschwinglichen Private Cloud Infrastruktur unterstützt.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Mit den richtigen Tools wird OpenStack ganz einfach." meta_image="https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg" meta_description="Dieses eBook vermittelt Ihnen ein besseres Verständnis dafür, weshalb Installation und Betrieb von OpenStack komplex erscheinen können und wie OpenStack von Canonical Sie beim Aufbau einer modernen, skalierbaren, reproduzierbaren und erschwinglichen Private Cloud Infrastruktur unterstützt." %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/de/openstack-made-easy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5545 