### PR TITLE
[Engage] Update metadata syntax for snap deltas page

### DIFF
--- a/templates/engage/snap-deltas.html
+++ b/templates/engage/snap-deltas.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}Optimising IoT bandwidth with delta updates{% endblock %}
-
-{% block meta_description %}Learn how snap deltas' over-the-air updates are efficient and effective.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="Optimising IoT bandwidth with delta updates" meta_image="https://assets.ubuntu.com/v1/b511e965-Delta+updates.svg" meta_description="Learn how snap deltas' over-the-air updates are efficient and effective." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1BzilE80HtJ89mPXnhkaK0AYyYuPr8fnJPwnVUaMhJ9Y/edit#t{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/snap-deltas
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5546 