### PR TITLE
[Engage] Update metadata syntax for 19.04 webinar page

### DIFF
--- a/templates/engage/19-04-webinar.html
+++ b/templates/engage/19-04-webinar.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block title %}With the release of Ubuntu 19.04{% endblock %}
-
-{% block meta_description %}Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="With the release of Ubuntu 19.04" meta_description="Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1z3PfG2SbTphLfbUMO9CyGbpYA5u9muBTCLxG8rRmZ7E/edit#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/19-04-webinar
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5547 