### PR TITLE
[Engage] Update metadata syntax for AI and ML with Ubuntu page

### DIFF
--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -1,8 +1,4 @@
-{% extends "engage/base_engage.html" %}
-
-{% block meta_description %}An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.{% endblock %}
-
-{% block title %}AI, ML and Ubuntu: Everything you need to know{% endblock %}
+{% extends_with_args "engage/base_engage.html" with title="AI, ML and Ubuntu: Everything you need to know" meta_description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack." %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Updated metadata syntax to match the extends_with_args format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/ai-ml-ubuntu
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page looks identical to the live one
- Ensure that the metadata is correct


## Issue / Card

Fixes #5548 