### PR TITLE
Button text to "Watch the webinar"

### DIFF
--- a/templates/engage/edge-month.html
+++ b/templates/engage/edge-month.html
@@ -51,7 +51,7 @@
       <p>
         In this webinar join Ubuntu MAAS Product Manager, Andres Rodriguez to discuss use cases and how MAAS could benefit your business. 
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362201{{ page_utms }}">Register for the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362201{{ page_utms }}">Watch the webinar</a>
     </div>
   
     <div class="col-4 prefix-1 u-vertically-center">
@@ -84,7 +84,7 @@
       <p>
         Join Canonical’s telco team to hear about the strategies and tactics you can adopt to build an edge that can match your requirements of today and tomorrow.
       </p>
-      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362202{{ page_utms }}">Register for the webinar</a>
+      <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/362202{{ page_utms }}">Watch the webinar</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Changed the button text from _Register for the webinar_ to _Watch the webinar_

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5611

