### PR TITLE
Add bottomed suru strip to IoT robotics page

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -72,7 +72,7 @@
       linear-gradient(-89deg, rgb(233, 84, 32) 0%, rgb(119, 41, 83) 38%, rgb(44, 0, 30) 85%);
     background-position: left bottom, left bottom, right bottom, left, top, 0% 0%;
     background-repeat: no-repeat;
-    background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 26.3% 100%, 100% calc(100% - 8rem), auto;
+    background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 26.4% 100%, 100% calc(100% - 8rem), auto;
     padding-bottom: 8rem;
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,9 +1,9 @@
 @mixin ubuntu-p-strip {
-  @include ubuntu-p-strip;
+  @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-bottomed;
 }
 
-@mixin ubuntu-p-strip {
+@mixin ubuntu-p-strip-suru {
   [class^='p-strip'].is-x-shallow {
     padding: 1.5rem 0;
   }
@@ -17,11 +17,12 @@
   .p-strip--suru {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
+    // sass-lint:disable-block no-color-literals
     background-image:
-      linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), // sass-lint:disable-line no-color-literals
-      linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%), // sass-lint:disable-line no-color-literals
-      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), // sass-lint:disable-line no-color-literals
-      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%), // sass-lint:disable-line no-color-literals
+      linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
+      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%),
       linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%); // sass-lint:disable-line hex-notation no-color-literals
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
@@ -60,5 +61,18 @@
 @mixin ubuntu-p-strip-suru-bottomed {
   .p-strip--suru-bottomed {
     @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal, normal, normal;
+    // sass-lint:disable-block no-color-literals
+    background-image:
+      linear-gradient(to top right, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to top right, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.9%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to top left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49.9%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
+      linear-gradient(0deg, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 1) 100%),
+      linear-gradient(0deg, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 1) 100%),
+      linear-gradient(-89deg, rgb(233, 84, 32) 0%, rgb(119, 41, 83) 38%, rgb(44, 0, 30) 85%);
+    background-position: left bottom, left bottom, right bottom, left, top, 0% 0%;
+    background-repeat: no-repeat;
+    background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 26.3% 100%, 100% calc(100% - 8rem), auto;
+    padding-bottom: 8rem;
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,5 +1,6 @@
 @mixin ubuntu-p-strip {
   @include ubuntu-p-strip;
+  @include ubuntu-p-strip-suru-bottomed;
 }
 
 @mixin ubuntu-p-strip {
@@ -53,5 +54,11 @@
         padding-bottom: ($padding * 3) !important;
       }
     }
+  }
+}
+
+@mixin ubuntu-p-strip-suru-bottomed {
+  .p-strip--suru-bottomed {
+    @extend %vf-strip;
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -61,18 +61,16 @@
 @mixin ubuntu-p-strip-suru-bottomed {
   .p-strip--suru-bottomed {
     @extend %vf-strip;
-    background-blend-mode: multiply, multiply, normal, normal, normal, normal;
+    background-blend-mode: multiply, multiply, normal, normal;
     // sass-lint:disable-block no-color-literals
     background-image:
-      linear-gradient(to top right, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
-      linear-gradient(to top right, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.9%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
-      linear-gradient(to top left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49.9%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(0deg, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(0deg, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 1) 100%),
+      linear-gradient(to top right, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49.5%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to top right, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.5%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to top left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49.5%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
       linear-gradient(-89deg, rgb(233, 84, 32) 0%, rgb(119, 41, 83) 38%, rgb(44, 0, 30) 85%);
-    background-position: left bottom, left bottom, right bottom, left, top, 0% 0%;
+    background-position: left bottom, left bottom, right bottom, right bottom;
     background-repeat: no-repeat;
-    background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 26.4% 100%, 100% calc(100% - 8rem), auto;
+    background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 73.7% 8rem;
     padding-bottom: 8rem;
   }
 }

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -16,7 +16,7 @@
       <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive u-no-margin--bottom js-invoke-modal">Contact us to find out more</a></p>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/5b16cbb9-robot_2px.svg" width="138px"/>
+      <img src="https://assets.ubuntu.com/v1/68703716-robot.svg" width="138px"/>
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -10,12 +10,12 @@
 
 <div class="p-strip--suru-bottomed js-livestream__intro">
   <div class="row u-equal-height">
-    <div class="col-6">
+    <div class="col-7">
       <h1>Smart Robots run Ubuntu</h1>
       <p>Autonomous, secure, and upgradeable, Ubuntu powers a new wave of apps on robots and drones with machine learning and AI for advanced industrial applications and intelligence.</p>
       <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive u-no-margin--bottom js-invoke-modal">Contact us to find out more</a></p>
     </div>
-    <div class="col-6 u-align--center u-vertically-center">
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/68703716-robot.svg" width="138px"/>
     </div>
   </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -9,11 +9,14 @@
 {% block content %}
 
 <div class="p-strip--suru-bottomed js-livestream__intro">
-  <div class="row">
-    <div class="col-6 p-card--overlay">
+  <div class="row u-equal-height">
+    <div class="col-6">
       <h1>Smart Robots run Ubuntu</h1>
       <p>Autonomous, secure, and upgradeable, Ubuntu powers a new wave of apps on robots and drones with machine learning and AI for advanced industrial applications and intelligence.</p>
       <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive u-no-margin--bottom js-invoke-modal">Contact us to find out more</a></p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/5b16cbb9-robot_2px.svg" width="138px"/>
     </div>
   </div>
 </div>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<div class="p-strip--image is-deep is-dark js-livestream__intro" style="background-position: center center; background-image:url('{{ ASSET_SERVER_URL }}ecdbd3cb-robotics.jpg?w=984')">
+<div class="p-strip--suru-bottomed js-livestream__intro">
   <div class="row">
     <div class="col-6 p-card--overlay">
       <h1>Smart Robots run Ubuntu</h1>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -139,9 +139,6 @@
 <div class="p-strip--accent is-deep">
   <div class="row">
     <div class="u-equal-height u-vertically-center">
-      <div class="col-3">
-        <img src="{{ ASSET_SERVER_URL }}04927a56-robot_2px-white.svg" width="161" alt="robots are cool ;-)" class="u-hide--small" />
-      </div>
       <div class="col-9">
         <h2>Will your next robot run on Ubuntu?</h2>
         <p><a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive js-invoke-modal">Contact us to find out more</a></p>


### PR DESCRIPTION
## Done

Added bottomed suru strip and image to IoT robotics page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/robotics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the design matches the [specification](https://github.com/canonical-web-and-design/web-squad/issues/1461)


## Issue / Card

Fixes canonical-web-and-design/web-squad#1461

## Screenshots
![image](https://user-images.githubusercontent.com/52562977/61887581-d5e2a180-aef9-11e9-9c5f-41c2a180b37a.png)


