### PR TITLE
Updates Ubuntu Core link

### DIFF
--- a/templates/shared/contextual_footers/_iot_developers.html
+++ b/templates/shared/contextual_footers/_iot_developers.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Want to learn more about developing with Ubuntu Core?</h3>
   <p>Learn how to build or port apps for the next generation of Ubuntu.</p>
-  <p><a href="https://developer.ubuntu.com/en/snappy/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'dev.u.c/snappy', 'eventLabel' : 'Develop with Ubuntu core', 'eventValue' : undefined });">Try snappy Ubuntu Core</a></p>
+  <p><a href="/core" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'u.c/core', 'eventLabel' : 'Develop with Ubuntu core', 'eventValue' : undefined });">Try Ubuntu Core</a></p>
 </div>


### PR DESCRIPTION
## Done

- Corrects broken link to Ubuntu Core on IoT page.
- Removes external-link class since the replacement page is on ubuntu.com.

## QA

1. Check out this feature branch
1. Run the site using the command `./run serve`
1. Go to http://0.0.0.0:8001/internet-of-things
1. In the footer choose “Try Ubuntu Core”

## Issue / Card

Fixes #5484.