### PR TITLE
Add topped suru strip to IoT gateways page

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,8 +1,9 @@
 @mixin ubuntu-p-strip {
-  @include ubuntu-p-strip;
+  @include ubuntu-p-strip-suru;
+  @include ubuntu-p-strip-suru-topped;
 }
 
-@mixin ubuntu-p-strip {
+@mixin ubuntu-p-strip-suru {
   [class^='p-strip'].is-x-shallow {
     padding: 1.5rem 0;
   }
@@ -16,11 +17,12 @@
   .p-strip--suru {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
+    // sass-lint:disable-block no-color-literals
     background-image:
-      linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), // sass-lint:disable-line no-color-literals
-      linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%), // sass-lint:disable-line no-color-literals
-      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%), // sass-lint:disable-line no-color-literals
-      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%), // sass-lint:disable-line no-color-literals
+      linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
+      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%),
       linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%); // sass-lint:disable-line hex-notation no-color-literals
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
@@ -53,5 +55,23 @@
         padding-bottom: ($padding * 3) !important;
       }
     }
+  }
+}
+
+@mixin ubuntu-p-strip-suru-topped {
+  .p-strip--suru-topped {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal;
+    // sass-lint:disable-block no-color-literals
+    background-image:
+      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to bottom right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
+      linear-gradient(90deg, rgba(60, 0, 30, 1) 4%, rgba(119, 41, 83, 1) 50%, rgba(233, 84, 32, 1) 88%);
+    background-position: top right, top right, top left, top left;
+    background-repeat: no-repeat;
+    background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;
+    padding-bottom: 4rem;
+    padding-top: 6rem;
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,6 +1,9 @@
+// sass-lint:disable no-color-literals hex-notation
 @mixin ubuntu-p-strip {
   @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-topped;
+  @include ubuntu-p-strip-suru-bottomed;
+  @include ubuntu-p-strip-suru-half-and-half;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -23,7 +26,7 @@
       linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%); // sass-lint:disable-line hex-notation no-color-literals
+      linear-gradient(-89deg, #e95420 0%, #772953 38%, #2C001e 85%);
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
     background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem, auto;
@@ -75,3 +78,65 @@
     padding-top: 6rem;
   }
 }
+
+@mixin ubuntu-p-strip-suru-bottomed {
+  .p-strip--suru-bottomed {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal;
+    background-image:
+      linear-gradient(to top right, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49.5%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to top right, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.5%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to top left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49.5%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%),
+      linear-gradient(-89deg, rgb(233, 84, 32) 0%, rgb(119, 41, 83) 38%, rgb(44, 0, 30) 85%);
+    background-position: left bottom, left bottom, right bottom, right bottom;
+    background-repeat: no-repeat;
+    background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 73.7% 8rem;
+    padding-bottom: 8rem;
+  }
+}
+
+@mixin ubuntu-p-strip-suru-half-and-half {
+  .p-strip--suru-half-and-half-reversed {
+    @extend %vf-strip;
+    background-blend-mode: multiply, normal, normal, normal;
+    background-image:
+      linear-gradient(
+        25deg,
+        rgba(119, 41, 83, 0.16) 0%,
+        rgba(119, 41, 83, 0.16) 49.9%,
+        rgba(119, 41, 83, 0) 50%,
+        rgba(119, 41, 83, 0) 100%),
+      linear-gradient(
+        to left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 41.9%,
+        rgba(255, 255, 255, 0) 42%,
+        rgba(255, 255, 255, 0) 100%),
+      linear-gradient(
+        to top left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 49.9%,
+        rgba(255, 255, 255, 0) 50%,
+        rgba(255, 255, 255, 0) 100%),
+      linear-gradient(270deg, #e95420 20%, #772953 63%, #2C001e 100%);
+    background-position: top 60% left, top left, top 10% left 53.6%, center right;
+    background-repeat: no-repeat;
+    background-size: 90% 100%, 100% 100%, 10% 120%, cover;
+
+
+    @media (max-width: $breakpoint-medium) {
+      background-image: linear-gradient(270deg, #e95420 0%, #772953 43%, #2C001e 87%);
+      background-position: center right;
+      background-size: cover;
+    }
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
+  }
+}
+// sass-lint:enable no-color-literals hex-notation

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -8,19 +8,21 @@
 
 {% block content %}
 
-<section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="u-equal-height">
-      <div class="col-7 suffix-1">
-        <h1>IoT gateways on Ubuntu</h1>
-        <div class="col-7 u-hide--medium u-hide--large u-align--center" style="padding-top: 1em;">
-          <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="300" alt="" />
+<section class="p-strip is-deep is-bordered u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-topped">
+    <div class="row">
+      <div class="u-vertically-center">
+        <div class="col-7 suffix-1">
+          <h1>IoT gateways on Ubuntu</h1>
+          <div class="col-7 u-hide--medium u-hide--large u-align--center" style="padding-top: 1em;">
+            <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="300" alt="" />
+          </div>
+          <p>From industrial automation and building control to transportation and healthcare, gateways connect sensors and actuators to clouds while providing edge analytics and intelligence. Offload decision making to the gateway to ensure continuity and low-latency, and reduce the cost of backhaul for low-value data.</p>
+          <p>Ubuntu Core offers a secure, reliable and remotely upgradeable platform for intelligent edge devices.</p>
         </div>
-        <p>From industrial automation and building control to transportation and healthcare, gateways connect sensors and actuators to clouds while providing edge analytics and intelligence. Offload decision making to the gateway to ensure continuity and low-latency, and reduce the cost of backhaul for low-value data.</p>
-        <p>Ubuntu Core offers a secure, reliable and remotely upgradeable platform for intelligent edge devices.</p>
-      </div>
-      <div class="u-vertically-center col-5 u-align--center u-hide--small">
-        <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="413" alt="" />
+        <div class="u-vertically-center col-5 u-align--center u-hide--small">
+          <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}b181a602-iot_edge_gateways_infographic.svg" width="446" alt="" />
+        </div>
       </div>
     </div>
   </div>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -28,7 +28,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Webinars and case studies</h2>
@@ -71,7 +71,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-12">
       <blockquote class="p-pull-quote">


### PR DESCRIPTION
## Done

Added topped suru strip to IoT gateways page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/gateways
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the design matches the [specification](https://github.com/canonical-web-and-design/web-squad/issues/1462)


## Issue / Card

Fixes canonical-web-and-design/web-squad#1462

## Screenshots

![image](https://user-images.githubusercontent.com/52562977/61944363-6cb06c00-af95-11e9-9799-04b3ce9b86e6.png)
