### PR TITLE
Change slug snappy to snapcraft for topic page

### DIFF
--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -62,7 +62,7 @@ urlpatterns += [
     path(
         "blog/topics/snappy",
         topic,
-        {"slug": "snappy", "template_path": "blog/topics/snappy.html"},
+        {"slug": "snapcraft", "template_path": "blog/topics/snappy.html"},
         name="topic",
     ),
     path(


### PR DESCRIPTION
## Done

Slug change from snappy to snapcraft in blog

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- http://127.0.0.1:8000/blog/topics/snappy
should work

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5487
