### PR TITLE
Adding whitepaper and moving a link

### DIFF
--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -25,7 +25,7 @@
         >
         <a
           class="p-link--external"
-          href="https://ubuntu.com/engage/starting-with-ai?utm_source=bubble&utm_campaign=CY19_DC_AI_Whitepaper_AIConsulting"
+          href="/engage/starting-with-ai?utm_source=bubble&utm_campaign=CY19_DC_AI_Whitepaper_AIConsulting"
           >Download the Getting started with AI whitepaper</a
         >
       </p>

--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -25,8 +25,8 @@
         >
         <a
           class="p-link--external"
-          href="{{ ASSET_SERVER_URL }}62e71815-Kubernetes-for-the-Enterprise.pdf"
-          >Read our consulting datasheet</a
+          href="https://ubuntu.com/engage/starting-with-ai?utm_source=bubble&utm_campaign=CY19_DC_AI_Whitepaper_AIConsulting"
+          >Download the Getting started with AI whitepaper</a
         >
       </p>
     </div>
@@ -52,6 +52,13 @@
       </p>
       <p class="u-sv3">
         With our structured program, we can approach any situation and provide the infrastructure and capabilities that your business needs. Proven best practices mean that we can take the guesswork and experimentation out of your AI adoption, and fast-track you to value without breaking your budget.
+      </p>
+      <p>
+        <a
+           class="p-link--external"
+           href="{{ ASSET_SERVER_URL }}62e71815-Kubernetes-for-the-Enterprise.pdf"
+           >Read our consulting datasheet</a
+        >
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Changed the  Read our consulting datasheet to Download the Getting started with AI whitepaper 
- Moved the  Read our consulting datasheet down the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare this to the changes in the the [copy doc](https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5618

