### PR TITLE
Add image Suru strip to IoT digital signage page

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,7 +1,9 @@
+// sass-lint:disable no-color-literals hex-notation
 @mixin ubuntu-p-strip {
   @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-bottomed;
   @include ubuntu-p-strip-suru-image;
+  @include ubuntu-p-strip-suru-half-and-half;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -18,13 +20,12 @@
   .p-strip--suru {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
-    // sass-lint:disable-block no-color-literals
     background-image:
       linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
       linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
       linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 100%),
-      linear-gradient(-89deg, #E95420 0%, #772953 38%, #2C001E 85%); // sass-lint:disable-line hex-notation no-color-literals
+      linear-gradient(-89deg, #e95420 0%, #772953 38%, #2C001e 85%);
     background-position: 0% 0%, top right, right 0 bottom 4rem, right bottom, 0% 0%;
     background-repeat: no-repeat;
     background-size: 100% calc(100% - 4rem), 50% 100%, 100% 4rem, 100% 4rem, auto;
@@ -63,7 +64,6 @@
   .p-strip--suru-bottomed {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
-    // sass-lint:disable-block no-color-literals
     background-image:
       linear-gradient(to top right, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49.5%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
       linear-gradient(to top right, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.5%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
@@ -79,15 +79,63 @@
 @mixin ubuntu-p-strip-suru-image {
   .p-strip--suru-image {
     @extend %vf-strip;
-    background-blend-mode: normal;
+    background-blend-mode: multiply, multiply, normal, normal;
     // sass-lint:disable-block no-color-literals
     background-image:
-      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49.5%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
-      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.5%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%);
-    background-position: right top, right top;
+      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.9%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to bottom left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49.8%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%,),
+      linear-gradient(-89deg, rgba(233, 84, 32, 1) 0%, rgba(119, 41, 83, 1) 38%, rgba(44, 0, 30, 1) 85%);
+    background-position: right top, right top, right top, right top;
     background-repeat: no-repeat;
-    background-size: 37.7% calc(100% - 6rem);
+    background-size: 37.7% calc(100% - 6rem), 42.1% calc(100% - 151px), 49.2% calc(100% - 12rem), 49.2% calc(100% - 192px);
     padding-bottom: 4rem;
     padding-top: 4rem;
   }
 }
+
+@mixin ubuntu-p-strip-suru-half-and-half {
+  .p-strip--suru-half-and-half-reversed {
+    @extend %vf-strip;
+    background-blend-mode: multiply, normal, normal, normal;
+    background-image:
+      linear-gradient(
+        25deg,
+        rgba(119, 41, 83, 0.16) 0%,
+        rgba(119, 41, 83, 0.16) 49.9%,
+        rgba(119, 41, 83, 0) 50%,
+        rgba(119, 41, 83, 0) 100%),
+      linear-gradient(
+        to left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 41.9%,
+        rgba(255, 255, 255, 0) 42%,
+        rgba(255, 255, 255, 0) 100%),
+      linear-gradient(
+        to top left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 49.9%,
+        rgba(255, 255, 255, 0) 50%,
+        rgba(255, 255, 255, 0) 100%),
+      linear-gradient(270deg, #e95420 20%, #772953 63%, #2C001e 100%);
+    background-position: top 60% left, top left, top 10% left 53.6%, center right;
+    background-repeat: no-repeat;
+    background-size: 90% 100%, 100% 100%, 10% 120%, cover;
+
+
+    @media (max-width: $breakpoint-medium) {
+      background-image: linear-gradient(270deg, #e95420 0%, #772953 43%, #2C001e 87%);
+      background-position: center right;
+      background-size: cover;
+    }
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
+  }
+}
+// sass-lint:enable no-color-literals hex-notation

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -91,6 +91,19 @@
     background-size: 37.7% calc(100% - 6rem), 42.1% calc(100% - 151px), 49.2% calc(100% - 12rem), 49.2% calc(100% - 192px);
     padding-bottom: 4rem;
     padding-top: 4rem;
+
+    @media only screen and (max-width: $breakpoint-small) {
+      background-blend-mode: normal;
+      // sass-lint:disable-block no-color-literals
+      background-image:
+        linear-gradient(-89deg, rgba(233, 84, 32, 1) 0%, rgba(119, 41, 83, 1) 38%, rgba(44, 0, 30, 1) 85%);
+      background-position: right top;
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
+      color: $color-x-light;
+      padding-bottom: 4rem;
+      padding-top: 4rem;
+    }
   }
 }
 
@@ -98,6 +111,7 @@
   .p-strip--suru-half-and-half-reversed {
     @extend %vf-strip;
     background-blend-mode: multiply, normal, normal, normal;
+    // sass-lint:disable-block no-color-literals
     background-image:
       linear-gradient(
         25deg,

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -1,6 +1,7 @@
 @mixin ubuntu-p-strip {
   @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-bottomed;
+  @include ubuntu-p-strip-suru-image;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -72,5 +73,21 @@
     background-repeat: no-repeat;
     background-size: 42% 12rem, 65.2% 8rem, 73.7% 8rem, 73.7% 8rem;
     padding-bottom: 8rem;
+  }
+}
+
+@mixin ubuntu-p-strip-suru-image {
+  .p-strip--suru-image {
+    @extend %vf-strip;
+    background-blend-mode: normal;
+    // sass-lint:disable-block no-color-literals
+    background-image:
+      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49.5%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.5%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%);
+    background-position: right top, right top;
+    background-repeat: no-repeat;
+    background-size: 37.7% calc(100% - 6rem);
+    padding-bottom: 4rem;
+    padding-top: 4rem;
   }
 }

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -12,7 +12,7 @@
     <div class="row">
       <div class="u-equal-height">
         <div class="col-7">
-          <h1>Digital signage and smart displays on Ubuntu</h1>
+          <h1>Digital signage and smart <br class="u-hide--large u-hide--medium">displays on Ubuntu</h1>
           <div class="col-5">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Easy out-of-the-box standard kiosk solution on Ubuntu</li>
@@ -22,16 +22,15 @@
             </ul>
           </div>
         </div>
-        <div class="col-6 u-vertically-center u-image-position u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/2c3ad93c-digital-signage-2.png?w=368" class="u-image-position--right"/>
-          <img src="https://assets.ubuntu.com/v1/ec2362cb-digital-signage.png?w=248" class="u-image-position--left"/>
+        <div class="col-5 u-vertically-center u-align--center u-hide--small">
+          <img src="{{ ASSET_SERVER_URL }}2c3ad93c-digital-signage-2.png"/>
         </div>
       </div>
     </div>
   </div>
 </div>
-
-<div class="p-strip is-deep is-bordered">
+  
+<div class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>Learn more about digital signage on Ubuntu</h2>
@@ -76,7 +75,7 @@
   </div>
 </div>
 
-<div class="p-strip--light">
+<div class="p-strip">
   <div class="row">
     <div class="col-12">
       <h2>Digital signage players need the power of Ubuntu</h2>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -7,15 +7,12 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip is-deep is-bordered u-no-padding--top">
+<div class="p-strip is-deep is-bordered u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-image">
     <div class="row">
       <div class="u-equal-height">
         <div class="col-7">
           <h1>Digital signage and smart displays on Ubuntu</h1>
-          <div class="u-hide--medium u-hide--large u-align--center" style="padding-top: 1em;">
-            <img src="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png" alt="" width="260"/>
-          </div>
           <div class="col-5">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Easy out-of-the-box standard kiosk solution on Ubuntu</li>
@@ -25,8 +22,9 @@
             </ul>
           </div>
         </div>
-        <div class="col-5 u-vertically-center u-align--center u-hide--small">
-          <img srcset="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png?w=600 2x" src="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png?w=300" alt="" />
+        <div class="col-6 u-vertically-center u-image-position u-hide--small">
+          <img src="https://assets.ubuntu.com/v1/2c3ad93c-digital-signage-2.png?w=368" class="u-image-position--right"/>
+          <img src="https://assets.ubuntu.com/v1/ec2362cb-digital-signage.png?w=248" class="u-image-position--left"/>
         </div>
       </div>
     </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -7,25 +7,27 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="u-equal-height">
-      <div class="col-7">
-        <h1>Digital signage and smart displays on Ubuntu</h1>
-        <div class="u-hide--medium u-hide--large u-align--center" style="padding-top: 1em;">
-          <img src="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png" alt="" width="260"/>
+<div class="p-strip is-deep is-bordered u-no-padding--top">
+  <div class="p-strip--suru-image">
+    <div class="row">
+      <div class="u-equal-height">
+        <div class="col-7">
+          <h1>Digital signage and smart displays on Ubuntu</h1>
+          <div class="u-hide--medium u-hide--large u-align--center" style="padding-top: 1em;">
+            <img src="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png" alt="" width="260"/>
+          </div>
+          <div class="col-5">
+            <ul class="p-list">
+              <li class="p-list__item is-ticked">Easy out-of-the-box standard kiosk solution on Ubuntu</li>
+              <li class="p-list__item is-ticked">Secure, reliable and remotely upgradable</li>
+              <li class="p-list__item is-ticked">Rich ecosystem of hardware and software solutions</li>
+              <li class="p-list__item is-ticked">Hundreds of thousands of smart displays already deployed on Ubuntu</li>
+            </ul>
+          </div>
         </div>
-        <div class="col-5">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">Easy out-of-the-box standard kiosk solution on Ubuntu</li>
-            <li class="p-list__item is-ticked">Secure, reliable and remotely upgradable</li>
-            <li class="p-list__item is-ticked">Rich ecosystem of hardware and software solutions</li>
-            <li class="p-list__item is-ticked">Hundreds of thousands of smart displays already deployed on Ubuntu</li>
-          </ul>
+        <div class="col-5 u-vertically-center u-align--center u-hide--small">
+          <img srcset="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png?w=600 2x" src="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png?w=300" alt="" />
         </div>
-      </div>
-      <div class="col-5 u-vertically-center u-align--center u-hide--small">
-        <img srcset="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png?w=600 2x" src="{{ ASSET_SERVER_URL }}4a0a6007-digital-signs.png?w=300" alt="" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Added image Suru strip to IoT digital signage page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/digital-signage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the design matches the [specification](https://github.com/canonical-web-and-design/web-squad/issues/1460)


## Issue / Card

Fixes canonical-web-and-design/web-squad#1460

## Screenshots
![image](https://user-images.githubusercontent.com/52562977/62041622-feb5b000-b1f3-11e9-96ad-339d84084d6b.png)
