### PR TITLE
Add half-and-half suru strip to IoT Appstore page

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -5,6 +5,7 @@
   @include ubuntu-p-strip-suru-bottomed;
   @include ubuntu-p-strip-suru-half-and-half-reversed;
   @include ubuntu-p-strip-suru-half-and-half;
+  @include ubuntu-p-strip-suru-half-and-half-small;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -146,14 +147,35 @@
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
     background-image:
-      linear-gradient(to bottom left, rgba(228, 228, 228, 1) 0%, rgba(228, 228, 228, 1) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
       linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.9%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
       linear-gradient(to bottom right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.8%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
       linear-gradient(90deg, rgba(44, 0, 30, 1) 18%, rgba(114, 41, 83, 1) 63%, rgba(233, 84, 32, 1) 100%);
     background-position: right top, right top, 71.5% top, right top;
     background-repeat: no-repeat;
-    background-size: 49.2% 67.6%, 38.4% 100%, 16.8% 100%, 40.5% 100%;
+    background-size: 46.2% 68.6%, 38.4% 100%, 16.8% 100%, 40.5% 100%;
     padding-bottom: 13px;
+  }
+}
+
+@mixin ubuntu-p-strip-suru-half-and-half-small {
+  .p-strip--suru-half-and-half-small {
+    @extend %vf-strip;
+    background-blend-mode: normal;
+    background-image:
+      linear-gradient(90deg, rgba(44, 0, 30, 1) 18%, rgba(114, 41, 83, 1) 63%, rgba(233, 84, 32, 1) 100%);
+    background-position: right top;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    padding-bottom: 13px;
+
+    &.is-light {
+      color: $color-x-dark;
+    }
+
+    &.is-dark {
+      color: $color-x-light;
+    }
   }
 }
 

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -3,6 +3,7 @@
   @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-topped;
   @include ubuntu-p-strip-suru-bottomed;
+  @include ubuntu-p-strip-suru-half-and-half-reversed;
   @include ubuntu-p-strip-suru-half-and-half;
 }
 
@@ -95,7 +96,7 @@
   }
 }
 
-@mixin ubuntu-p-strip-suru-half-and-half {
+@mixin ubuntu-p-strip-suru-half-and-half-reversed {
   .p-strip--suru-half-and-half-reversed {
     @extend %vf-strip;
     background-blend-mode: multiply, normal, normal, normal;
@@ -139,4 +140,21 @@
     }
   }
 }
+
+@mixin ubuntu-p-strip-suru-half-and-half {
+  .p-strip--suru-half-and-half {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal;
+    background-image:
+      linear-gradient(to bottom left, rgba(228, 228, 228, 1) 0%, rgba(228, 228, 228, 1) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.9%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to bottom right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.8%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(90deg, rgba(44, 0, 30, 1) 18%, rgba(114, 41, 83, 1) 63%, rgba(233, 84, 32, 1) 100%);
+    background-position: right top, right top, 71.5% top, right top;
+    background-repeat: no-repeat;
+    background-size: 49.2% 67.6%, 38.4% 100%, 16.8% 100%, 40.5% 100%;
+    padding-bottom: 13px;
+  }
+}
+
 // sass-lint:enable no-color-literals hex-notation

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -5,7 +5,6 @@
   @include ubuntu-p-strip-suru-bottomed;
   @include ubuntu-p-strip-suru-half-and-half-reversed;
   @include ubuntu-p-strip-suru-half-and-half;
-  @include ubuntu-p-strip-suru-half-and-half-small;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -155,26 +154,16 @@
     background-repeat: no-repeat;
     background-size: 46.2% 68.6%, 38.4% 100%, 16.8% 100%, 40.5% 100%;
     padding-bottom: 13px;
-  }
-}
 
-@mixin ubuntu-p-strip-suru-half-and-half-small {
-  .p-strip--suru-half-and-half-small {
-    @extend %vf-strip;
-    background-blend-mode: normal;
-    background-image:
-      linear-gradient(90deg, rgba(44, 0, 30, 1) 18%, rgba(114, 41, 83, 1) 63%, rgba(233, 84, 32, 1) 100%);
-    background-position: right top;
-    background-repeat: no-repeat;
-    background-size: 100% 100%;
-    padding-bottom: 13px;
-
-    &.is-light {
-      color: $color-x-dark;
-    }
-
-    &.is-dark {
+    @media only screen and (max-width: $breakpoint-small) {
+      background-blend-mode: normal;
+      background-image:
+        linear-gradient(90deg, rgba(44, 0, 30, 1) 18%, rgba(114, 41, 83, 1) 63%, rgba(233, 84, 32, 1) 100%);
+      background-position: right top;
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
       color: $color-x-light;
+      padding-bottom: 13px;
     }
   }
 }

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -9,10 +9,10 @@
 {% block content %}
 
 <section class="p-strip u-no-padding--top u-no-padding--bottom">
-  <div class="p-strip--suru-half-and-half u-hide--small">
+  <div class="p-strip--suru-half-and-half">
     <div class="row u-equal-height">
       <div class="col-6">
-        <h1>An IoT app store for all your devices</h1>
+        <h1>An IoT app store for <br class="u-hide--medium u-hide--large">all your devices</h1>
         <p>Manufacturers can cut the cost of managing software updates on their devices and take advantage of new revenue opportunities by selling services via their own branded IoT app store &mdash; hosted by Canonical.</p>
         <ul class="p-inline-list">
           <li class="p-inline-list__item">
@@ -24,26 +24,10 @@
         </ul>
       </div>
       <div class="col-6 u-align--center u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/c3b8a9dd-Snap_Store_shopping_icon.svg" width="250" alt="">
+        <img src="{{ ASSET_SERVER_URL }}c3b8a9dd-Snap_Store_shopping_icon.svg" width="250" alt="">
       </div>
     </div>
   </div>
-  <div class="p-strip--suru-half-and-half-small u-hide--medium u-hide--large is-dark">
-      <div class="row u-equal-height">
-        <div class="col-6">
-          <h1>An IoT app store for all your devices</h1>
-          <p>Manufacturers can cut the cost of managing software updates on their devices and take advantage of new revenue opportunities by selling services via their own branded IoT app store &mdash; hosted by Canonical.</p>
-          <ul class="p-inline-list">
-            <li class="p-inline-list__item">
-              <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290087" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Webinar', 'eventLabel' : 'Watch the Path to IoT revenue webinar', 'eventValue' : undefined });"><span class="p-link--external">Watch the 'Path to IoT revenue' webinar</span></a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="/internet-of-things/contact-us?product=appstore" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
 </section>
 
 <section class="p-strip--light is-deep is-bordered">

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -8,8 +8,8 @@
 
 {% block content %}
 
-<section class="p-strip is-deep u-no-padding--top u-no-padding--bottom">
-  <div class="p-strip--suru-half-and-half">
+<section class="p-strip u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-half-and-half u-hide--small">
     <div class="row u-equal-height">
       <div class="col-6">
         <h1>An IoT app store for all your devices</h1>
@@ -24,10 +24,26 @@
         </ul>
       </div>
       <div class="col-6 u-align--center u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" width="250" alt="">
+        <img src="https://assets.ubuntu.com/v1/c3b8a9dd-Snap_Store_shopping_icon.svg" width="250" alt="">
       </div>
     </div>
   </div>
+  <div class="p-strip--suru-half-and-half-small u-hide--medium u-hide--large is-dark">
+      <div class="row u-equal-height">
+        <div class="col-6">
+          <h1>An IoT app store for all your devices</h1>
+          <p>Manufacturers can cut the cost of managing software updates on their devices and take advantage of new revenue opportunities by selling services via their own branded IoT app store &mdash; hosted by Canonical.</p>
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item">
+              <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290087" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Webinar', 'eventLabel' : 'Watch the Path to IoT revenue webinar', 'eventValue' : undefined });"><span class="p-link--external">Watch the 'Path to IoT revenue' webinar</span></a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="/internet-of-things/contact-us?product=appstore" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
 </section>
 
 <section class="p-strip--light is-deep is-bordered">

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -8,27 +8,29 @@
 
 {% block content %}
 
-<section class="p-strip--light is-deep">
-  <div class="row u-equal-height">
-    <div class="col-8">
-      <h1>An IoT app store for all your devices</h1>
-      <p>Manufacturers can cut the cost of managing software updates on their devices and take advantage of new revenue opportunities by selling services via their own branded IoT app store &mdash; hosted by Canonical.</p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item">
-          <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290087" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Webinar', 'eventLabel' : 'Watch the Path to IoT revenue webinar', 'eventValue' : undefined });"><span class="p-link--external">Watch the 'Path to IoT revenue' webinar</span></a>
-        </li>
-        <li class="p-inline-list__item">
-          <a href="/internet-of-things/contact-us?product=appstore" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
-        </li>
-      </ul>
-    </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img class="hero-image" src="{{ ASSET_SERVER_URL }}1570841c-icon-app-store.svg" width="212" alt="">
+<section class="p-strip is-deep u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-half-and-half">
+    <div class="row u-equal-height">
+      <div class="col-6">
+        <h1>An IoT app store for all your devices</h1>
+        <p>Manufacturers can cut the cost of managing software updates on their devices and take advantage of new revenue opportunities by selling services via their own branded IoT app store &mdash; hosted by Canonical.</p>
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item">
+            <a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290087" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Webinar', 'eventLabel' : 'Watch the Path to IoT revenue webinar', 'eventValue' : undefined });"><span class="p-link--external">Watch the 'Path to IoT revenue' webinar</span></a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/internet-of-things/contact-us?product=appstore" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6 u-align--center u-vertically-center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/08af835e-Snap+Store+shopping+icon.svg" width="250" alt="">
+      </div>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h2 class="p-heading--three">Control the user&rsquo;s experience</h2>


### PR DESCRIPTION
## Done

Added half-and-half Suru strip to IoT digital signage page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/appstore
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the design matches the [specification](https://github.com/canonical-web-and-design/web-squad/issues/1463)


## Issue / Card

Fixes canonical-web-and-design/web-squad#1463

## Screenshots
![image](https://user-images.githubusercontent.com/52562977/62051672-c28e4980-b20b-11e9-8bbf-771cb85b63f4.png)
