### PR TITLE
Update content to match copy doc

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -156,7 +156,7 @@
 <section class="p-strip is-bordered u-no-padding--top">
   <div class="row">
     <div class="col-12">
-      <h3 class="p-heading--four">Canonical&rsquo;s OpenStack is uniquely flexible and enjoys the widest ecosystem support of any OpenStack offering</h3>
+      <h3 class="p-heading--four">Charmed OpenStack is uniquely flexible and enjoys the widest ecosystem support of any OpenStack offering</h3>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Flexible placement of services across the cluster</li>
         <li class="p-list__item is-ticked">Multiple high availability strategies for different scenarios</li>
@@ -167,13 +167,14 @@
         <li class="p-list__item is-ticked">Fully automated, repeatable deployment and operations</li>
         <li class="p-list__item is-ticked">Direct attach and Ceph storage built-in</li>
         <li class="p-list__item is-ticked">SAN, Nexenta, Pure Storage and StorPool third-party options</li>
-        <li class="p-list__item is-ticked">VLAN, OVS, and TungstenFabric open source SDNs</li>
-        <li class="p-list__item is-ticked">Juniper Contrail and Cisco ACI available as third-party options</li>
+        <li class="p-list__item is-ticked">VLAN, OVS, and open source SDNs</li>
+        <li class="p-list__item is-ticked">Juniper Contrail, Cisco ACI and Nuage available as third-party options</li>
         <li class="p-list__item is-ticked">CI/CD for cloud infrastructure operations</li>
         <li class="p-list__item is-ticked">Wide range of certified hardware</li>
         <li class="p-list__item is-ticked">Hardware recommendations for efficient procurement</li>
         <li class="p-list__item is-ticked">Training, consulting and operations capabilities and services</li>
-        <li class="p-list__item is-ticked">Ubuntu Advantage &mdash; Enterprise Support</li>
+        <li class="p-list__item is-ticked">Ubuntu Advantage for infrastructure &mdash; predictable per-node support and security</li>
+        <li class="p-list__item is-ticked">Managed services available for both OpenStack and Kubernetes</li>
       </ul>
       <p><a href="/openstack/features/" class="p-button--positive">Learn about Canonical OpenStack features</a></p>
     </div>


### PR DESCRIPTION
## Done

Updated Real architectural flexibility, full automation section to match copy doc.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page matches the [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit)


## Issue / Card

Fixes #5627 