### PR TITLE
Fix broken link

### DIFF
--- a/templates/download/iot/intel-joule.html
+++ b/templates/download/iot/intel-joule.html
@@ -66,7 +66,7 @@
           </h3>
           <div class="p-list-step__content">
             <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+              <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
               <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
             </ol>
           </div>


### PR DESCRIPTION
## Done

Fixed broken "Ubuntu" hyperlink in the "Step 3- Flash the USB Drives" section of the download/iot/intel-joule page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot/intel-joule
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the the Ubuntu link leads to the correct tutorial.


## Issue / Card

Fixes #5471 