### PR TITLE
Simplify /legal secondary menu

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -500,31 +500,43 @@ legal:
       children:
         - title: Terms and conditions
           path: /legal/terms
+          hidden: True
         - title: Intellectual property
           path: /legal/intellectual-property-policy
+          hidden: True
         - title: Intellectual property - 14th May 2013
           path: /legal/intellectual-property-policy/2013-05-14
           hidden: True
         - title: Online accounts
           path: /legal/online-account-terms
-        - title: U1 Terms of Service
+          hidden: True
+        - title: U1
           path: /legal/terms-of-service
+          hidden: True
         - title: Confidentiality agreement
           path: /legal/confidentiality-agreement
+          hidden: True
         - title: Developers
           path: /legal/developer-terms-and-conditions
+          hidden: True
         - title: Launchpad
           path: /legal/launchpad-terms-of-service
+          hidden: True
         - title: Livepatch
           path: /legal/livepatch-terms-of-service
+          hidden: True
         - title: JAAS
           path: /legal/jaas-beta-terms-of-service
+          hidden: True
         - title: System Information
           path: /legal/systems-information-notice
+          hidden: True
         - title: Partner Portal
           path: /legal/partner-portal-terms
+          hidden: True
         - title: Ubuntu font
           path: /legal/font-licence
+          hidden: True
 
           children:
             - title: FAQ
@@ -542,24 +554,34 @@ legal:
           path: /legal/data-privacy/enquiry
         - title: Newsletter
           path: /legal/data-privacy/newsletter
+          hidden: True
         - title: Webinar
           path: /legal/data-privacy/webinar
+          hidden: True
         - title: ESXi
           path: /legal/data-privacy/esxi
+          hidden: True
         - title: Online purchase
           path: /legal/data-privacy/online-purchase
+          hidden: True
         - title: User surveys
           path: /legal/data-privacy/user-survey
+          hidden: True
         - title: Snap store
           path: /legal/data-privacy/snap-store
+          hidden: True
         - title: Snapcraft NPS
           path: /legal/data-privacy/snapcraft-nps
+          hidden: True
         - title: Partner Portal
           path: /legal/data-privacy/partner-portal
+          hidden: True
         - title: SSO
           path: /legal/data-privacy/sso
+          hidden: True
         - title: Contact us & enquiries
           path: /legal/data-privacy/contact
+          hidden: True
 
     - title: Trademarks
       path: /legal/trademarks


### PR DESCRIPTION
## Done

- Simplify /legal secondary menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the seconary menu is as simple as possible and that the overview page give access to the subfiles
- See that the subfiles all have a simple seconary nav


## Issue / Card

Fixes #5632

## Screenshots

example of 3rd level page that has simple menu
![image](https://user-images.githubusercontent.com/441217/62284983-a88f7980-b44c-11e9-8d6b-b320c2d63638.png)

example of terms and conditions menu overview has no seconary
![image](https://user-images.githubusercontent.com/441217/62285072-ce1c8300-b44c-11e9-8459-6adadb649d43.png)


