### PR TITLE
Update iot index with new illustrations

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -35,6 +35,7 @@
     overflow: hidden;
     padding-bottom: 12rem !important;
     position: relative;
+    z-index: -1;
 
     &.is-light {
       color: $color-x-dark;

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -12,9 +12,9 @@
   <div class="row  u-vertically-center">
     <div class="col-7 suffix-1">
       <h1>Ubuntu for the Internet&nbsp;of&nbsp;Things</h1>
-      <p>From home control to drones, robots and industrial systems, Ubuntu is the <a href="/embedded">new standard for embedded Linux</a>. Whether you choose the classic Ubuntu Server or the new Ubuntu Core you get robust security, app stores and reliable updates.</p>
+      <p>From home control to drones, robots and industrial systems, Ubuntu is the <a class="p-link--inverted" href="/embedded">new standard for embedded Linux</a>. Whether you choose the classic Ubuntu Server or the new Ubuntu Core you get robust security, app stores and reliable updates.</p>
     </div>
-    <div class="col-5 u-align--center">
+    <div class="col-5 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}27b51b01-IOT_Ubuntu_devices_inforgrapic.svg" width="488" alt="" />
     </div>
   </div>
@@ -54,7 +54,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row ">
     <div class="col-4">
       <img src="{{ ASSET_SERVER_URL }}33007e71-Internet+of+Things_digital-screens.svg" alt="" style="height: 180px; margin-bottom: 24px;">
@@ -77,7 +77,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep">
+<section class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
       <h2>App stores for software-defined things</h2>
@@ -86,7 +86,7 @@
   </div>
   <div class="row">
     <div class="col-12 u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}903e5697-limenet-appstore-2x.png?w=1040" width="1040" alt="Snap store screenshot" />
+      <img src="{{ ASSET_SERVER_URL }}6a4925fa-limenet-appstore.png?w=1040" width="1040" alt="Snap store screenshot" style="border-color: #cdcdcd; border-style: solid; border-width: 1px;" />
       <p><a href="http://snapcraft.io/store" class="p-link--external">Visit the Snap Store</a></p>
     </div>
   </div>
@@ -220,15 +220,10 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <div class="u-equal-height">
-      <div class="col-7">
-        <h2>Best for developers</h2>
-        <p>With Ubuntu Core, you can develop a packaged application on your laptop, then monetise it by publishing it directly to the snap store.</p>
-        <p><a class="p-link--external" href="https://developer.ubuntu.com/core?from=iotpage">Learn about developing with Ubuntu Core</a></p>
-      </div>
-      <div class="col-3 prefix-1 u-align--right u-vertically-align u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}527fbcef-picto-developer-warmgrey.svg" width="150"  alt="" />
-      </div>
+    <div class="col-7">
+      <h2>Best for developers</h2>
+      <p>With Ubuntu Core, you can develop a packaged application on your laptop, then monetise it by publishing it directly to the snap store.</p>
+      <p><a class="p-link--external" href="https://developer.ubuntu.com/core?from=iotpage">Learn about developing with Ubuntu Core</a></p>
     </div>
   </div>
 </section>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -8,42 +8,76 @@
 
 {% block content %}
 
-<div class="p-strip--suru is-dark is-deep">
+<section class="p-strip--suru is-dark is-deep">
   <div class="row  u-vertically-center">
     <div class="col-7 suffix-1">
       <h1>Ubuntu for the Internet&nbsp;of&nbsp;Things</h1>
-      <p>From home control to drones, robots and industrial systems, Ubuntu Core provides robust security, app stores and reliable updates. Ubuntu makes development easy, and snap packages make Ubuntu Core secure and reliable for widely distributed devices.</p>
+      <p>From home control to drones, robots and industrial systems, Ubuntu is the <a href="/embedded">new standard for embedded Linux</a>. Whether you choose the classic Ubuntu Server or the new Ubuntu Core you get robust security, app stores and reliable updates.</p>
     </div>
     <div class="col-5 u-align--center">
       <img src="{{ ASSET_SERVER_URL }}27b51b01-IOT_Ubuntu_devices_inforgrapic.svg" width="488" alt="" />
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-deep is-bordered">
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <img src="{{ ASSET_SERVER_URL }}2def20f4-iot_digital_signage_overview.jpg?w=307" width="307" alt="" />
-      <h3>Digital signage</h3>
-      <p>A small footprint and full OpenGL with reliable updates across a diverse range of hardware make Ubuntu Core a perfect platform for millions of digital signs.</p>
-      <p><a href="/internet-of-things/digital-signage">Digital signage on Ubuntu&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <img src="{{ ASSET_SERVER_URL }}1e37ff95-iot_overview_robotics.jpg?w=307" width="307" alt="" />
-      <h3>Robotics</h3>
-      <p>With ROS and snapcraft, it&rsquo;s easy to enable apps on robots and drones, creating new ecosystems and business models.</p>
-      <p><a href="/internet-of-things/robotics">Robots and drones, rocking Ubuntu&nbsp;Core&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <img src="{{ ASSET_SERVER_URL }}3e480882-iot_gateways_product_image.jpg?w=307" width="307" alt="" />
-      <h3>Gateways</h3>
-      <p>Rich networking and protocol support make Ubuntu Core the perfect choice for your industrial gateways. Create the next wave of industrial control and intelligence with Ubuntu Core.</p>
-      <p><a href="/internet-of-things/gateways">IoT gateways on Ubuntu&nbsp;&rsaquo;</a></p>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h4 class="p-muted-heading u-align--center">Leading brands choose Ubuntu Core for security, apps and updates</h4>
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}5ddba83a-logo-dell.svg" width="88" alt="Dell" >
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}ee23142d-logo-ibm-large.png" width="110" alt="IBM">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}3cf238fd-Qualcomm-Logo.svg" alt="Qualcomm" width="110">
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}e71bd588-logo-samsung.svg" width="110" alt="Samsung">
+        </li>
+        <li class="p-inline-images__item">
+          <img  class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}c24cb4b9-logo-intel.svg" alt="Intel" style="max-width: 110px;" width="110" />
+        </li>
+        <li class="p-inline-images__item">
+          <img  class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}4efbd291-Arm_logo_blue_cropped.svg" style="max-width: 110px;" alt="arm" width="110" />
+        </li>
+        <li class="p-inline-images__item">
+          <img  class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}1f876369-advantech.svg" alt="Advantech" style="max-width:180px; min-width:10rem;max-height:180px;" width="180" />
+        </li>
+        <li class="p-inline-images__item">
+          <img  class="p-inline-images__logos" src="{{ ASSET_SERVER_URL }}45fd87b5-2018-logo-rigado.svg" alt="Rigado" style="max-width: 140px; max-height:140px;" width="140" />
+        </li>
+      </ul>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--light is-deep">
+<section class="p-strip is-deep is-bordered">
+  <div class="row ">
+    <div class="col-4">
+      <img src="{{ ASSET_SERVER_URL }}33007e71-Internet+of+Things_digital-screens.svg" alt="" style="height: 180px; margin-bottom: 24px;">
+      <h3>Digital signage</h3>
+      <p>A small footprint and full OpenGL with reliable updates across a diverse range of hardware make Ubuntu Core a perfect platform for millions of digital signs.</p>
+      <p><a href="/internet-of-things/digital-signage">Digital signage on Ubuntu&nbsp;›</a></p>
+    </div>
+    <div class="col-4">
+      <img src="{{ ASSET_SERVER_URL }}9a250d1b-Internet+of+Things_digital-drone.svg" alt="" style="height: 180px; margin-bottom: 24px;">
+      <h3>Robotics</h3>
+      <p>With ROS and snapcraft, it’s easy to enable apps on robots and drones, creating new ecosystems and business models.</p>
+      <p><a href="/internet-of-things/robotics">Robots and drones, rocking Ubuntu&nbsp;Core&nbsp;›</a></p>
+    </div>
+    <div class="col-4">
+      <img src="{{ ASSET_SERVER_URL }}d40fc8b9-Internet+of+Things_digital-gateways.svg" alt="" style="height: 180px; margin-bottom: 24px;">
+      <h3>Gateways</h3>
+      <p>Rich networking and protocol support make Ubuntu Core the perfect choice for your industrial gateways. Create the next wave of industrial control and intelligence with Ubuntu Core.</p>
+      <p><a href="/internet-of-things/gateways">IoT gateways on Ubuntu&nbsp;›</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
   <div class="row">
     <div class="col-8">
       <h2>App stores for software-defined things</h2>
@@ -56,9 +90,9 @@
       <p><a href="http://snapcraft.io/store" class="p-link--external">Visit the Snap Store</a></p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--accent is-deep">
+<section class="p-strip--accent is-deep">
   <div class="row">
     <div class="col-12">
       <blockquote class="p-pull-quote">
@@ -67,18 +101,18 @@
       </blockquote>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-6">
       <h2>Update Control, and peace of mind included</h2>
       <p>Regular updates for the operating system and apps defend devices from ongoing attacks, addressing security issues automatically. Update Control ensures that changes are certified by manufacturers or ISVs. When a single security flaw can compromise millions of devices, or a bad update require a product recall, robust platform assurances provide confidence in the integrity of critical infrastructure.</p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--light is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="u-equal-height">
       <div class="col-6 suffix-1 u-align--center u-vertically-center u-hide--small">
@@ -98,9 +132,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-deep is-bordered">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Look who&rsquo;s leading</h2>
@@ -134,9 +168,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--light is-deep is-bordered">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
       <h2>From prototype to production on all major platforms</h2>
@@ -182,9 +216,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-bordered">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="u-equal-height">
       <div class="col-7">
@@ -197,9 +231,9 @@
       </div>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip">
+<section class="p-strip">
   <div class="row">
     <div class="col-3 suffix-1 u-align--left u-vertically-align u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />
@@ -210,7 +244,7 @@
       <p><a href="/internet-of-things/contact-us?product=iot-overview" class="p-button--neutral js-invoke-modal">Get in touch</a></p>
     </div>
   </div>
-</div>
+</section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
 


### PR DESCRIPTION
## Done

- Update iot index with new illustrations
- Add logo cloud back
- Update text on top half of the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit#) and the [design](https://github.com/canonical-web-and-design/web-squad/issues/1417)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1417 and https://github.com/canonical-web-and-design/web-squad/issues/1434

## Screenshots

![image](https://user-images.githubusercontent.com/441217/62296858-e948bc00-b467-11e9-8e16-fe1973685710.png)

