### PR TITLE
Update vanilla version and spacing variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@canonical/global-nav": "2.0.5",
     "cookie-policy": "1.1.0",
-    "vanilla-framework": "1.8.1"
+    "vanilla-framework": "2.2.0"
   },
   "resolutions": {
     "lodash": "4.17.11",

--- a/static/sass/_layout-documentation.scss
+++ b/static/sass/_layout-documentation.scss
@@ -2,7 +2,7 @@
   @include pattern-sidebar-nav;
 
   .l-documentation {
-    @include row;
+    @extend %row;
     display: flex;
 
     .p-notification,

--- a/static/sass/_layout-legal-pages.scss
+++ b/static/sass/_layout-legal-pages.scss
@@ -33,10 +33,10 @@
       & > li > h4,
       & > li + h5,
       & > li > table {
-        margin-bottom: $spv-intra--condensed;
+        margin-bottom: $spv-inner--x-small;
         margin-left: $sp-medium;
         padding-left: $sp-medium;
-        padding-top: $spv-intra;
+        padding-top: $spv-inner--small;
       }
 
       & > li > h4:first-child {

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -22,11 +22,11 @@
 
       .p-modal__header {
         border-bottom: 1px solid $color-mid-light;
-        margin-bottom: $spv-intra--expanded;
+        margin-bottom: $spv-inner--medium;
       }
 
       .p-modal__title {
-        margin-bottom: $spv-intra;
+        margin-bottom: $spv-inner--small;
       }
 
       &.thank-you {

--- a/static/sass/_pattern_desktop-statistics.scss
+++ b/static/sass/_pattern_desktop-statistics.scss
@@ -120,7 +120,7 @@
   .p-strip--light {
     .p-strip__row {
       >.p-strip__row--item {
-        padding: $spv-intra--condensed;
+        padding: $spv-inner--x-small;
       }
 
       >.p-strip__row--item.col-6 {

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -236,7 +236,7 @@
 @mixin ubuntu-p-list-small {
   .p-text-list--small {
     @extend %small-text-fixed;
-    margin-bottom: $spv-inter--scaleable - $nudge--small + 1 * $sp-unit;
+    margin-bottom: $spv-outer--scaleable - $nudge--small + 1 * $sp-unit;
     margin-left: 0;
     padding-left: 0;
 
@@ -245,7 +245,7 @@
     }
 
     &.is-dense {
-      margin-bottom: $spv-inter--scaleable - $nudge--small;
+      margin-bottom: $spv-outer--scaleable - $nudge--small;
     }
 
     & .p-list__item {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -1,6 +1,6 @@
-$ubuntu-logo-svg-width: 81 * $px; // width in rems
+$ubuntu-logo-svg-width: 81; // width in rems
 $ubuntu-logo-width--desktop: $ubuntu-logo-svg-width + 2 * $grid-margin-width;
-$ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
+$ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
 
 @mixin ubuntu-p-navigation {
   html {
@@ -107,8 +107,8 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
       }
 
       @media only screen and (min-width: $breakpoint-navigation-threshold) {
-        padding-left: $sph-intra;
-        padding-right: $sph-intra - $circle-of-friends-compensation;
+        padding-left: $sph-inner;
+        padding-right: $sph-inner - $circle-of-friends-compensation;
       }
 
       .p-navigation__link {
@@ -128,11 +128,11 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
       display: block;
 
       @media (max-width: $breakpoint-navigation-threshold) {
-        padding: $spv-intra--expanded $grid-margin-width $spv-intra--expanded $grid-margin-width;
+        padding: $spv-inner--medium $grid-margin-width $spv-inner--medium $grid-margin-width;
       }
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {
-        padding: $spv-intra--expanded 2rem $spv-intra--expanded $sph-intra;
+        padding: $spv-inner--medium 2rem $spv-inner--medium $sph-inner;
       }
 
       &:focus,
@@ -241,16 +241,16 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
           @media only screen and (min-width: $breakpoint-navigation-threshold) {
             background-color: $color-light;
             display: block;
-            left: $sph-intra;
+            left: $sph-inner;
             opacity: .3;
-            right: $sph-intra - $circle-of-friends-compensation;
+            right: $sph-inner - $circle-of-friends-compensation;
           }
         }
 
         @media only screen and (min-width: $breakpoint-navigation-threshold) {
-          padding-left: $sph-intra;
-          padding-right: $sph-intra - $circle-of-friends-compensation;
-          width: $ubuntu-logo-svg-width + 2 * $sph-intra - $circle-of-friends-compensation;
+          padding-left: $sph-inner;
+          padding-right: $sph-inner - $circle-of-friends-compensation;
+          width: $ubuntu-logo-svg-width + 2 * $sph-inner - $circle-of-friends-compensation;
         }
       }
 
@@ -294,8 +294,8 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
           font-size: 1rem / pow($ms-ratio, 1); //XXX: move font-sizes to map in vanilla so it can be changed globally
           // line-height: map-get($line-heights, small);
           padding-bottom: map-get($sp-after, small) + $p-small-lh-diff - $nudge--small;
-          padding-left: $spv-intra--expanded;
-          padding-right: $spv-intra--expanded;
+          padding-left: $spv-inner--medium;
+          padding-right: $spv-inner--medium;
           padding-top: $nudge--small;
 
           @media (max-width: $breakpoint-x-small - 1) {
@@ -411,7 +411,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-intra;
       color: $color-dark;
 
       &:last-child {
-        padding-bottom: $spv-inter--shallow-scaleable / 1.5;
+        padding-bottom: $spv-outer--shallow-scaleable / 1.5;
       }
 
       @media (max-width: $breakpoint-x-small - 1) {
@@ -482,8 +482,8 @@ h2,
   @extend %bg--light;
   @include vf-p-card;
   flex-direction: column;
-  margin-bottom: $spv-inter--condensed-scaleable;
-  padding: $spv-intra--scaleable - $px;
+  margin-bottom: $spv-outer--small-scaleable;
+  padding: calc(#{$spv-inner--scaleable} - 1px);
   transition: all .2s;  // sass-lint:disable-line no-transition-all
 }
 
@@ -501,8 +501,8 @@ h2,
 
 .p-logomark {
   display: inline-block;
-  margin-bottom: $spv-intra--scaleable;
-  margin-right: $sph-intra--condensed;
+  margin-bottom: $spv-inner--scaleable;
+  margin-right: $sph-inner--small;
   max-height: 4 * $sp-unit;
   max-width: 4 * $sp-unit;
   position: relative;

--- a/static/sass/_pattern_separator.scss
+++ b/static/sass/_pattern_separator.scss
@@ -1,9 +1,9 @@
 @mixin ubuntu-p-separator {
   .p-separator {
-    margin: $spv-inter--regular-scaleable 0;
+    margin: $spv-outer--regular-scaleable 0;
 
     @media (max-width: $breakpoint-medium) {
-      margin: $spv-inter--shallow-scaleable 0;
+      margin: $spv-outer--shallow-scaleable 0;
     }
   }
 }

--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -1,12 +1,12 @@
 @mixin ubuntu-p-tables {
   tr {
     th {
-      padding-top: $spv-intra;
+      padding-top: $spv-inner--small;
     }
 
     .p-table__cell--highlight {
       background: $color-x-light;
-      padding: $spv-intra $sph-intra--condensed;
+      padding: $spv-inner--small $sph-inner--small;
     }
   }
 }

--- a/static/sass/_vanilla-placeholders.scss
+++ b/static/sass/_vanilla-placeholders.scss
@@ -62,14 +62,14 @@ h4,
 }
 
 %p-strip--very-shallow {
-  padding-top: $spv-inter--regular;
+  padding-top: $spv-outer--medium;
 
   &:not(:last-child) {
-    padding-bottom: $spv-inter--regular;
+    padding-bottom: $spv-outer--medium;
   }
 
   &:last-child {
-    padding-bottom: $spv-inter--scaleable;
+    padding-bottom: $spv-outer--scaleable;
   }
 }
 
@@ -88,7 +88,7 @@ h4,
 }
 
 .p-hr--dense {
-  margin-bottom: - $px;
+  margin-bottom: - 1px;
 }
 
 .u-float--right {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6357,7 +6357,12 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@1.8.1, vanilla-framework@^1.8.1:
+vanilla-framework@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.2.0.tgz#c098b030f261bd321b55f6473e3ce614cb701e1f"
+  integrity sha512-KmQkdJYF8zeBjZaNv+ZGap7mC5rSwq5oymYHkVuu9AqyuyWX1m8feEwlArN1/jFD9lRQdhP9nAh2w0zJToPO2w==
+
+vanilla-framework@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.8.1.tgz#0d7f5885cdbd1355a9f9d42d7596f9a1258b27ea"
   integrity sha512-sYTpiiF+A2PvJ1xYVMywYFuX9sCfFkqBLQrfxfYgWZBQHVVMTtKJKVQMMDYFgFOxAPSsrVKl1VU9eAmGKkAMPw==


### PR DESCRIPTION
## Done

- updated version of Vanilla to 2.2.0
- changed out-of-date spacing variable names to their new analogues, according to [this doc](https://assets.ubuntu.com/v1/d4964abe-Vanilla+2+spacing+variables.pdf?_ga=2.30419519.1642800135.1565004285-833517530.1561371934)
- removed reference to `$px` variable and replaced with `1px` where necessary

## QA

- Verify that the updated `$spv-` and `$sph-` variable names are correct as per the [upgrade guide](https://assets.ubuntu.com/v1/d4964abe-Vanilla+2+spacing+variables.pdf?_ga=2.30419519.1642800135.1565004285-833517530.1561371934)
- Check out this feature branch
- See that `./run` runs successfully

## Issue / Card

Fixes #5644 & #5649 
