### PR TITLE
Corrects Kubernetes “Contact us” page headings

### DIFF
--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -17,12 +17,8 @@
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install' %}
   {% elif product == 'kubernetes-features' %}
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features' %}
-  {% elif product == 'kubernetes-explorer' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes Explorer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-explorer' %}
-  {% elif product == 'kubernetes-discoverer' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes discoverer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-discoverer' %}
-  {% elif product == 'kubernetes-pioneer' %}
-      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes pioneer" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-pioneer' %}
+  {% elif product == 'kubernetes-consulting' %}
+      {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes consulting" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting' %}
   {% elif product == 'kubernetes-add-on' %}
       {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about Kubernetes with AI/ML" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on' %}
   {% elif product == 'kubernetes-support' %}

--- a/templates/kubernetes/thank-you.html
+++ b/templates/kubernetes/thank-you.html
@@ -17,12 +17,8 @@
       {% include "shared/_thank_you.html" with thanks_context="contacting us about multicloud." %}
   {% elif product == 'kubernetes-features' %}
       {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes" %}
-  {% elif product == 'kubernetes-explorer' %}
-      {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes explorer" %}
-  {% elif product == 'kubernetes-discoverer' %}
-      {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes discoverer" %}
-  {% elif product == 'kubernetes-pioneer' %}
-      {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes pioneer" %}
+  {% elif product == 'kubernetes-consulting' %}
+      {% include "shared/_thank_you.html" with thanks_context="enquiring about Kubernetes consulting" %}
   {% elif product == 'kubernetes-add-on' %}
       {% include "shared/_thank_you.html" with thanks_context="enquiring about the Kubernetes AI/ML add-on" %}
   {% elif product == 'kubernetes-support' %}

--- a/templates/shared/pricing/_kubernetes-consulting-add-ons.html
+++ b/templates/shared/pricing/_kubernetes-consulting-add-ons.html
@@ -28,5 +28,5 @@
       </div>
     </div>
   </div>
-  <p><a href="/support/contact-us?product=kubeflow" class="js-invoke-modal p-button--positive">Get in touch</a></p>
+  <p><a href="/kubernetes/contact-us?product=kubernetes-add-on" class="js-invoke-modal p-button--positive">Get in touch</a></p>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -50,5 +50,5 @@
   </div>
 </div>
 <div class="row">
-  <a href="/support/contact-us?product=kubernetes" class="js-invoke-modal p-button--positive">Get in touch</a>
+  <a href="/support/contact-us?product=kubernetes-consulting" class="js-invoke-modal p-button--positive">Get in touch</a>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -50,5 +50,5 @@
   </div>
 </div>
 <div class="row">
-  <a href="/support/contact-us?product=kubernetes-consulting" class="js-invoke-modal p-button--positive">Get in touch</a>
+  <a href="/kubernetes/contact-us?product=kubernetes-consulting" class="js-invoke-modal p-button--positive">Get in touch</a>
 </div>


### PR DESCRIPTION
## Done

- Combines the “Contact us” and “Thanks for enquiring” headings for the three Kubernetes consulting plans, since they now share one contact button
- Corrects the Kubernetes consulting contact form to use the combined heading
- Corrects the Kubernetes AI/ML contact form to use the Kubernetes AI/ML heading

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Go to http://0.0.0.0:8001/kubernetes
- Right-click each “Get in touch” button and choose “Open in New Tab”/“Open in New Window”
- Observe that the contact forms say “Contact us about Kubernetes consulting” and “Contact us about Kubernetes with AI/ML”, rather than the incorrect “Contact us about Ubuntu Advantage”

## Issue / Card

Fixes _part of_ #5641.