### PR TITLE
Replace Edge takeover with Maas

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,6 @@
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_maas-hardware-testing_takeover.html" %}
-  {% include "takeovers/_edge-month_takeover.html" %}
   {% include "takeovers/_shift-to-app-store_takeover.html" %}
   {% include "takeovers/_active-directory_takeover.html" %}
 {% endblock takeover_content %}


### PR DESCRIPTION
## Done

- Replace Edge takeover with Maas takeover
## QA

- Make sure Edge takeover was replaced with Maas takeover


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1533

