### PR TITLE
Add deepsense.ai webinar takeover and landing page

### DIFF
--- a/templates/engage/data-pipelines-kubeflow.html
+++ b/templates/engage/data-pipelines-kubeflow.html
@@ -4,11 +4,11 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Data Pipelines" subtitle="How Kubeflow and machine learning help you get the most out of your data" image="745c785b-Machine+learning.svg" class="p-takeover--deepsense-ai" url="#register-section" cta="Watch the webinar" %}
+{% include "engage/shared/_header.html" with title="Data Pipelines" subtitle="How Kubeflow and machine learning help you get the most out of your data" image="141f8edb-machine-learning.svg" class="p-takeover--deepsense-ai" url="#register-section" cta="Watch the webinar" %}
 
 <section class="p-strip is-bordered">
   <div class="row u-vertically-center">
-    <div class="col-8">
+    <div class="col-7">
       <p>AI is transforming industries with rapid innovation cycles and unprecedented automation capabilities. With the right frameworks, tools, and processes, machine learning with Kubeflow can help you accelerate your AI business objectives. Kubeflow is a Kubernetes-native platform that includes the most popular machine learning tools and frameworks, like Tensorflow and PyTorch, and is available on your workstation or in the cloud. Recent use cases include expert systems, workflow automation, pattern recognition across real-time data sets, customer relationship management with predictive behavior, and many more.</p>
       <p>The models at the core of this revolution require data - data is the fuel that powers accurate models. How do you get the most from data and ensure it meets your requirements?
         In this webinar we will discuss:</p>
@@ -20,7 +20,7 @@
           <li class="p-list__item is-ticked">What external sources you should use in your data pipeline</li>
         </ul>
       </div>
-      <div class="col-4 u-align--center">
+      <div class="col-5 u-align--center">
         <p class="p-muted-heading">Webinar presented with<span class="u-hide"> DeepSense.ai</span></p>
         <img src="{{ ASSET_SERVER_URL }}feed1918-DS_logo_color.svg" width="150" alt="" />
     </div>

--- a/templates/engage/data-pipelines-kubeflow.html
+++ b/templates/engage/data-pipelines-kubeflow.html
@@ -1,0 +1,53 @@
+{% extends_with_args "engage/base_engage.html" with title="Data Pipelines" meta_image="0481b70b-ai-deepsense-social.jpg" meta_description="How Kubeflow and machine learning help you get the most out of your data" %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ie6XPTPIyj7ZE08or7Qf9WVi96D-PTIPslopw2X8yBc/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include "engage/shared/_header.html" with title="Data Pipelines" subtitle="How Kubeflow and machine learning help you get the most out of your data" image="745c785b-Machine+learning.svg" class="p-takeover--deepsense-ai" url="#register-section" cta="Watch the webinar" %}
+
+<section class="p-strip is-bordered">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <p>AI is transforming industries with rapid innovation cycles and unprecedented automation capabilities. With the right frameworks, tools, and processes, machine learning with Kubeflow can help you accelerate your AI business objectives. Kubeflow is a Kubernetes-native platform that includes the most popular machine learning tools and frameworks, like Tensorflow and PyTorch, and is available on your workstation or in the cloud. Recent use cases include expert systems, workflow automation, pattern recognition across real-time data sets, customer relationship management with predictive behavior, and many more.</p>
+      <p>The models at the core of this revolution require data - data is the fuel that powers accurate models. How do you get the most from data and ensure it meets your requirements?
+        In this webinar we will discuss:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">How to get started with defining AI project requirements and objectives</li>
+          <li class="p-list__item is-ticked">How to prioritize analytical projects in your company</li>
+          <li class="p-list__item is-ticked">The challenges involved in collecting and storing data and how to avoid them</li>
+          <li class="p-list__item is-ticked">How to extract values and eliminate complexities</li>
+          <li class="p-list__item is-ticked">What external sources you should use in your data pipeline</li>
+        </ul>
+      </div>
+      <div class="col-4 u-align--center">
+        <p class="p-muted-heading">Webinar presented with<span class="u-hide"> DeepSense.ai</span></p>
+        <img src="{{ ASSET_SERVER_URL }}feed1918-DS_logo_color.svg" width="150" alt="" />
+    </div>
+  </section>
+
+  <section class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 365533, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+      </div>
+    </div>
+  </section>
+  <style>
+    .p-takeover--deepsense-ai {
+      background-color: #f7f7f7;
+      color: 	#111;
+      font-weight: 100;
+    }
+
+    @media (min-width: 768px) {
+      .p-takeover--deepsense-ai {
+        background-color: #f7f7f7;
+        background-image: url('{{ ASSET_SERVER_URL }}bc4ce721-suru-background.svg');
+        background-position: right;
+        background-repeat: no-repeat;
+        background-size: contain;
+      }
+    }
+  </style>
+  {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1054,6 +1054,19 @@
             <p class='u-no-padding--bottom u-hide--small'>For organisations looking to turn the management of bare-metal server resources into a cloud-like environment, hardware testing is a must-do.</p>
           </div>
         </div>
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--desktop'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              webinar
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/data-pipelines-kubeflow'>Creating accurate AI models with data</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>Learn how Kubeflow and machine learning help you maximise your data</p>
+          </div>
+        </div>
       </div>
 
     </section>

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -20,7 +20,7 @@
       </div>
     </div>
     {% if image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if image != "http" %}{{ ASSET_SERVER_URL }}{% endif %}{{ image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for (( title ))" >
+      <img src="{% if image != "http" %}{{ ASSET_SERVER_URL }}{% endif %}{{ image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for {{ title }}" >
     </div>{% endif %}
   </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
   {# ALL #}
   {% include "takeovers/_maas-hardware-testing_takeover.html" %}
   {% include "takeovers/_shift-to-app-store_takeover.html" %}
-  {% include "takeovers/_active-directory_takeover.html" %}
+  {% include "takeovers/_data-pipelines-kubeflow.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/takeovers/_data-pipelines-kubeflow.html
+++ b/templates/takeovers/_data-pipelines-kubeflow.html
@@ -11,7 +11,7 @@
       <img src="{{ ASSET_SERVER_URL }}4028fd74-kubeflow+ai-h.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
     </div>
     <div class="u-hide--medium u-hide--large">
-      <a href="/engage/data-pipelines-kubeflow=takeover&utm_campaign=CY19_DC_AI_WBN_Deepsense_Takeover" class="p-button--positive">Register for the webinar</a>
+      <a href="/engage/data-pipelines-kubeflow?utm_source=takeover&utm_campaign=CY19_DC_AI_WBN_Deepsense_Takeover" class="p-button--positive">Register for the webinar</a>
     </div>
   </div>
   <style>

--- a/templates/takeovers/_data-pipelines-kubeflow.html
+++ b/templates/takeovers/_data-pipelines-kubeflow.html
@@ -1,13 +1,13 @@
 <section class="p-strip is-deep p-takeover--deepsense-ai js-takeover">
   <div class="row u-equal-height">
     <div class="col-7">
-      <h1 class="p-takeover__title">Creating accurate AI models with data</h1>
+      <h1 class="p-takeover__title">Creating accurate AI models with&nbsp;data</h1>
       <p class="p-heading--four">Learn how Kubeflow and machine learning help you maximise your data</p>
       <div class="u-hide--small">
         <a href="/engage/data-pipelines-kubeflow?utm_source=takeover&utm_campaign=CY19_DC_AI_WBN_Deepsense_Takeover" class="p-button--positive">Register for the webinar</a>
       </div>
     </div>
-    <div class="col-5 suffix-1 u-align--center u-vertically-center">
+    <div class="col-5 u-align--center u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}4028fd74-kubeflow+ai-h.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
     </div>
     <div class="u-hide--medium u-hide--large">

--- a/templates/takeovers/_data-pipelines-kubeflow.html
+++ b/templates/takeovers/_data-pipelines-kubeflow.html
@@ -1,0 +1,37 @@
+<section class="p-strip is-deep p-takeover--deepsense-ai js-takeover">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1 class="p-takeover__title">Creating accurate AI models with data</h1>
+      <p class="p-heading--four">Learn how Kubeflow and machine learning help you maximise your data</p>
+      <div class="u-hide--small">
+        <a href="/engage/data-pipelines-kubeflow?utm_source=takeover&utm_campaign=CY19_DC_AI_WBN_Deepsense_Takeover" class="p-button--positive">Register for the webinar</a>
+      </div>
+    </div>
+    <div class="col-5 suffix-1 u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}4028fd74-kubeflow+ai-h.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
+    </div>
+    <div class="u-hide--medium u-hide--large">
+      <a href="/engage/data-pipelines-kubeflow=takeover&utm_campaign=CY19_DC_AI_WBN_Deepsense_Takeover" class="p-button--positive">Register for the webinar</a>
+    </div>
+  </div>
+  <style>
+    .p-takeover--deepsense-ai {
+      background-color: #f7f7f7;
+    }
+
+    .p-takeover--deepsense-ai .p-takeover__title {
+      color: 	#111;
+      font-weight: 100;
+    }
+
+    @media (min-width: 768px) {
+      .p-takeover--deepsense-ai {
+        background-color: #f7f7f7;
+        background-image: url('{{ ASSET_SERVER_URL }}bc4ce721-suru-background.svg');
+        background-position: right;
+        background-repeat: no-repeat;
+        background-size: contain;
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -1,0 +1,88 @@
+{% extends "templates/one-column.html" %}
+
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block title %}Takeover index | Ubuntu{% endblock %}
+
+{% block content %}
+
+{% include "takeovers/_14-04-esm.html" %}
+{% include "takeovers/_1704_takeover.html" %}
+{# include "takeovers/_1710_takeover.html" #}
+{% include "takeovers/_1804-takeover.html" %}
+{% include "takeovers/_1810-takeover.html" %}
+{% include "takeovers/_1810-webinar-takeover.html" %}
+{% include "takeovers/_1904-takeover.html" %}
+{% include "takeovers/_1904-webinar_takeover.html" %}
+{% include "takeovers/_451-automotive_takeover.html" %}
+{% include "takeovers/_active-directory_takeover.html" %}
+{% include "takeovers/_advantage.html" %}
+{% include "takeovers/_ai_webinar-2018-10-01.html" %}
+{% include "takeovers/_ai_webinar.html" %}
+{% include "takeovers/_appelix-takeover.html" %}
+{% include "takeovers/_broadsign-arrow_takeover.html" %}
+{% include "takeovers/_bt_announcement.html" %}
+{% include "takeovers/_ci-cd-webinar.html" %}
+{% include "takeovers/_cloud_default.html" %}
+{% include "takeovers/_cloud-init-takeover.html" %}
+{% include "takeovers/_compliance-webinar.html" %}
+{% include "takeovers/_core18-security_takeover.html" %}
+{% include "takeovers/_core.html" %}
+{% include "takeovers/_desktop-developer-takeover.html" %}
+{% include "takeovers/_de-vmware-to-os.html" %}
+{% include "takeovers/_devops-iot-webinar_takeover.html" %}
+{% include "takeovers/_edge-month_takeover.html" %}
+{% include "takeovers/_enterprise-kubernetes.html" %}
+{% include "takeovers/_financial-services.html" %}
+{% include "takeovers/_fing_webinar.html" %}
+{% include "takeovers/_fin-serv-whitepaper-takeover.html" %}
+{% include "takeovers/_french_14-04-esm.html" %}
+{% include "takeovers/_french-k8s-case-study.html" %}
+{% include "takeovers/_french_takeover_openstack_made_easy.html" %}
+{% include "takeovers/_french_vmware-to-os.html" %}
+{% include "takeovers/_german_ai_webinar.html" %}
+{% include "takeovers/_german-compliance-webinar.html" %}
+{% include "takeovers/_german_openstack_security_takeover.html" %}
+{% include "takeovers/_german_takeover_k8.html" %}
+{% include "takeovers/_german_takeover_openstack_made_easy.html" %}
+{% include "takeovers/_improving_productivity_kubernetes.html" %}
+{% include "takeovers/_iot-business.html" %}
+{% include "takeovers/_iot-devops_takeover.html" %}
+{% include "takeovers/_juju-generic-takeover.html" %}
+{% include "takeovers/_juju-webinar-takeover.html" %}
+{% include "takeovers/_kubernetes-enterprise-takeover.html" %}
+{% include "takeovers/_kubernetes-month.html" %}
+{% include "takeovers/_kubernetes_takeover.html" %}
+{% include "takeovers/_kubernetes_webinar.html" %}
+{% include "takeovers/_lxd-takeover.html" %}
+{% include "takeovers/_maas_may_2017.html" %}
+{% include "takeovers/_maas_takeover.html" %}
+{% include "takeovers/_microk8s-takeover.html" %}
+{% include "takeovers/_multicloud-operations.html" %}
+{% include "takeovers/_multicloud-solutions.html" %}
+{% include "takeovers/_openstack-queens.html" %}
+{% include "takeovers/_openstack_security_takeover.html" %}
+{% include "takeovers/_openstack_takeover.html" %}
+{% include "takeovers/_private_cloud_economics.html" %}
+{% include "takeovers/_rigado_webinar.html" %}
+{% include "takeovers/_robotics-takeover.html" %}
+{% include "takeovers/_shift-to-app-store_takeover.html" %}
+{% include "takeovers/_snapcraft-brand-store_takeover.html" %}
+{% include "takeovers/_snap-deltas-takeover.html" %}
+{% include "takeovers/_spicule_takeover.html" %}
+{% include "takeovers/_starting-with-ai-takeover.html" %}
+{% include "takeovers/_starting-with-ai-webinar_takeover.html" %}
+{% include "takeovers/_tackling_iot.html" %}
+{# include "takeovers/_takeover-help.html" #}
+{% include "takeovers/_tell-us-your-story.html" %}
+{# include "takeovers/_template.html" #}
+{% include "takeovers/_trilio_takeover.html" %}
+{% include "takeovers/_ubuntu-core-18-takeover.html" %}
+{% include "takeovers/_ubuntu-core-full-disk-encryption.html" %}
+{% include "takeovers/_ubuntu-lime-telco_takeover.html" %}
+{% include "takeovers/_ubuntu-product-month.html" %}
+{% include "takeovers/_ues_takeover.html" %}
+{% include "takeovers/_vmware-to-os.html" %}
+
+
+{% endblock %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -7,8 +7,8 @@
 {% block content %}
 
 {% include "takeovers/_14-04-esm.html" %}
-{% include "takeovers/_1704_takeover.html" %}
-{# include "takeovers/_1710_takeover.html" #}
+{# include "takeovers/_1704_takeover.html" #}
+{% include "takeovers/_1710_takeover.html" %}
 {% include "takeovers/_1804-takeover.html" %}
 {% include "takeovers/_1810-takeover.html" %}
 {% include "takeovers/_1810-webinar-takeover.html" %}
@@ -83,6 +83,8 @@
 {% include "takeovers/_ubuntu-product-month.html" %}
 {% include "takeovers/_ues_takeover.html" %}
 {% include "takeovers/_vmware-to-os.html" %}
+{% include "takeovers/_maas-hardware-testing_takeover.html" %}
+{% include "takeovers/_data-pipelines-kubeflow.html" %}
 
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Add deepsense.ai webinar takeover and landing page
- Added index of takeovers at http://0.0.0.0:8001/takeovers/
- Added page to the http://0.0.0.0:8001/enage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and http://0.0.0.0:8001/engage/data-pipelines-kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Here is the [brief](https://docs.google.com/spreadsheets/d/1JAqg2L3QlH6aTVva2GzinyxN5pBR6iKBQbaF8fQZaEc/edit#gid=2113339190) and the [copy doc](https://docs.google.com/document/d/1Ie6XPTPIyj7ZE08or7Qf9WVi96D-PTIPslopw2X8yBc/edit)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1499
