### PR TITLE
Update banner on /iot/robotics

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -16,9 +16,9 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-7">
-      <h4>Tech visionaries choose Ubuntu to build secure and software-defined robots</h4>
-      <p>Ubuntu is the most popular Linux distribution for embedded systems. As technologies underlying autonomous robots mature, innovate tech companies turn to Ubuntu to start realising their vision of a robotic future. We would be excited to be your partner in innovation.</p>
-      <p><a href="/whitepapers/beta/robotics" class="p-button--positive u-no-margin--bottom">Pick  the right OS for your robot</a></p>
+      <h4>Tech visionaries choose Ubuntu to build ultra-secure and software-defined robots</h4>
+      <p>Ubuntu is the most popular Linux distribution for embedded systems. As technologies underlying autonomous robots mature, innovate tech companies turn to Ubuntu to start realising their vision of a robotic future. We want to be your partner in innovation.</p>
+      <p><a href="/whitepapers/beta/robotics" class="p-button--positive u-no-margin--bottom">Pick the right OS for your robot</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}68703716-robot.svg" width="138px"/>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -11,13 +11,13 @@
 <div class="p-strip--suru-bottomed js-livestream__intro">
   <div class="row">
     <div class="col-12">
-      <h1>Robotic innovation starts with Ubuntu</h1>
+      <h1>Build unhackable robots with Ubuntu</h1>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-7">
-        <p class="p-heading--four">Tech visionaries choose Ubuntu to build robots</p>
-      <p class="u-sv3">Ubuntu is the most popular Linux distribution for embedded systems. As technologies underlying autonomous robots mature, innovate tech companies turn to Ubuntu to start realising their vision of a robotic future. We would be excited to be your partner in innovation.</p>
+      <h4>Tech visionaries choose Ubuntu to build secure and software-defined robots</h4>
+      <p>Ubuntu is the most popular Linux distribution for embedded systems. As technologies underlying autonomous robots mature, innovate tech companies turn to Ubuntu to start realising their vision of a robotic future. We would be excited to be your partner in innovation.</p>
       <p><a href="/whitepapers/beta/robotics" class="p-button--positive u-no-margin--bottom">Pick  the right OS for your robot</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -29,7 +29,7 @@
 <div class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      {% include "shared/_partner-logos.html" with title="Proven in the field - company’s with robots on Ubuntu" json_feed_url="http://partners.ubuntu.com/partners.json?technology__name=Robotics" feed_item_limit=10 %}
+      {% include "shared/_partner-logos.html" with title="Proven in the field - companies with robots on Ubuntu" json_feed_url="http://partners.ubuntu.com/partners.json?technology__name=Robotics" feed_item_limit=10 %}
       <p class="u-align--center"><a href="http://partners.ubuntu.com/find-a-partner?technology=robotics" class="p-link--external">See all of our robotics partners</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Minor copy updates to the banner on robotics page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/robotics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1cDxhPCQbHA0r6n9JXNmO50ANLPZhCFdgwATX6f90guU/edit) only the banner and logo cloud start changed


## Issue / Card

Fixes #5664 	

## Screenshots

![image](https://user-images.githubusercontent.com/441217/62767973-b6b54980-ba8d-11e9-94a7-0d3a12bb8e42.png)

