### PR TITLE
Update design of /download page

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -7,6 +7,7 @@
   @include ubuntu-p-strip-suru-image;
   @include ubuntu-p-strip-suru-half-and-half;
   @include ubuntu-p-strip-suru-background;
+  @include ubuntu-p-strip-suru-half-top;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -225,6 +226,65 @@
       background-size: 100% 100%;
       color: $color-x-light;
       padding-bottom: 3rem;
+      padding-top: 3rem;
+    }
+  }
+}
+
+@mixin ubuntu-p-strip-suru-half-top {
+  .p-strip-suru-half-top {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal;
+    background-image:
+      linear-gradient(
+        to bottom right,
+        rgba(119, 41, 83, 0.16) 0%,
+        rgba(119, 41, 83, 0.16) 49.5%,
+        rgba(119, 41, 83, 0) 50%,
+        rgba(119, 41, 83, 0) 100%
+        ),
+      linear-gradient(
+        to bottom left,
+        rgba(228, 228, 228, 0.5) 0,
+        rgba(228, 228, 228, 0.5) 49.5%,
+        transparent 50%
+        ),
+      linear-gradient(
+        to top left,
+        $color-light 0%,
+        $color-light 49.5%,
+        transparent 50%
+      ),
+      linear-gradient(
+        251deg,
+        #E95422 0%,
+        #772953 49.5%,
+        #2C001E 100%
+        );
+    background-position: top left, top right, center 67%, left top;
+    background-repeat: no-repeat;
+    background-size: 63% 97%, 100% 66%, 100% 30%, 100% 76.5%;
+    padding-bottom: 10rem;
+    padding-top: 6rem;
+
+    h1 {
+      color: $color-light;
+      font-weight: 100;
+    }
+
+    @media only screen and (max-width: $breakpoint-small) {
+      background-blend-mode: normal;
+      background-image:
+        linear-gradient(
+          251deg,
+          #E95422 0%,
+          #772953 49.5%,
+          #2C001E 100%
+          );
+      background-position: left top;
+      background-repeat: no-repeat;
+      background-size: 100% 76.5%;
+      padding-bottom: 5rem;
       padding-top: 3rem;
     }
   }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -235,6 +235,7 @@
   .p-strip-suru-half-top {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
+    background-color: $color-light;
     background-image:
       linear-gradient(
         to bottom right,

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -265,13 +265,9 @@
     background-position: top left, top right, center 67%, left top;
     background-repeat: no-repeat;
     background-size: 63% 97%, 100% 66%, 100% 30%, 100% 76.5%;
+    color: $color-light;
     padding-bottom: 10rem;
     padding-top: 6rem;
-
-    h1 {
-      color: $color-light;
-      font-weight: 100;
-    }
 
     @media only screen and (max-width: $breakpoint-small) {
       background-blend-mode: normal;

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -4,55 +4,87 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-12">
-      <h1>Ubuntu downloads</h1>
+<section class="p-strip--light u-no-padding--top">
+  <div class="p-strip-suru-half-top">
+    <div class="row">
+      <div class="col-12">
+        <h1>
+          Ubuntu downloads
+        </h1>
+      </div>
     </div>
   </div>
-</div>
+  <div class="row u-vertically-center" style="margin-top: -2rem;" >
+    <div class="col-6">
+      <h2>
+        <a href="/download/desktop">
+          Ubuntu Desktop&nbsp;&rsaquo;
+        </a>
+      </h2>
+      <p>
+        Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside it.
+      </p>
+      <p>
+        <strong>Do you want to upgrade?</strong> <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
+      </p>
+    </div>
+    <div class="col-6 u-align--center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}db6764bc-disco-dingo-grad.svg"
+    </div>
+  </div>
+</section>
 
-<div class="p-strip u-no-padding--top u-no-padding--bottom">
-
+<section class="p-strip">
   <div class="row">
-    <div class="col-12">
-      <div class="p-card">
-        <h2 class="p-card__title"><a href="/download/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside it.</p>
-        <hr class="u-sv1">
-        <p class="u-no-margin--bottom"><strong>Do you want to upgrade?</strong> <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
-      </div>
+    <div class="col-6">
+      <h2>
+        <a href="/download/server">
+          Ubuntu Server&nbsp;&rsaquo;
+        </a>
+      </h2>
+      <p>
+        Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.
+      </p>
     </div>
   </div>
-  <div class="row u-equal-height u-no-margin--bottom">
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-      </div>
-    </div>
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.</p>
-      </div>
+  <div class="row">
+    <div class="col-6">
+      <h2>
+        <a href="/download/cloud">
+          Ubuntu Cloud&nbsp;&rsaquo;
+        </a>
+      </h2>
+      <p>
+        Ubuntu is the reference OS for OpenStack. Try Canonical&rsquo;s OpenStack on a single machine or start building a production cloud on a cluster &mdash; just add servers.
+      </p>
     </div>
   </div>
-  <div class="row u-equal-height u-no-margin--top u-no-margin--bottom">
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/ubuntu-flavours">Ubuntu flavours&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.</p>
-      </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2>
+        <a href="/download/ubuntu-flavours">
+          Ubuntu flavours&nbsp;&rsaquo;
+        </a>
+      </h2>
+      <p>
+        Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.
+      </p>
     </div>
-    <div class="col-6 p-card u-equal-height">
-      <div>
-        <h2 class="p-card__title"><a href="/download/core">Ubuntu for IoT&nbsp;&rsaquo;</a></h2>
-        <p class="p-card__content">Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.</p>
-      </div>
+    <div class="col-6">
+      <h2>
+        <a href="/download/core">
+          Ubuntu for IoT&nbsp;&rsaquo;
+        </a>
+      </h2>
+      <p>
+        Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.
+      </p>
     </div>
   </div>
-</div>
+</section>
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_enterprise_support" second_item="_download_documentation" third_item="_download_helping_hands" %}
 

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -35,7 +35,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
       <h2>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -4,17 +4,18 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--light u-no-padding--top">
-  <div class="p-strip-suru-half-top">
-    <div class="row">
-      <div class="col-12">
-        <h1>
-          Ubuntu downloads
-        </h1>
-      </div>
+<section class="p-strip-suru-half-top">
+  <div class="row">
+    <div class="col-12">
+      <h1>
+        Ubuntu downloads
+      </h1>
     </div>
   </div>
-  <div class="row u-vertically-center" style="margin-top: -2rem;" >
+</section>
+
+<section class="p-strip--light u-no-padding--top">
+  <div class="row u-vertically-center" style="position: relative; top: -2rem;" >
     <div class="col-6">
       <h2>
         <a href="/download/desktop">

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -29,7 +29,7 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="{{ ASSET_SERVER_URL }}db6764bc-disco-dingo-grad.svg"
+      <img src="{{ ASSET_SERVER_URL }}db6764bc-disco-dingo-grad.svg" width="216" alt="" />
     </div>
   </div>
 </section>
@@ -46,8 +46,6 @@
         Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.
       </p>
     </div>
-  </div>
-  <div class="row">
     <div class="col-6">
       <h2>
         <a href="/download/cloud">


### PR DESCRIPTION
## Done

Update design of /download page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the design in the issue #5615 *Note, multipass isn't ready yet*


## Issue / Card

Fixes #5615 

## Screenshots

large
![image](https://user-images.githubusercontent.com/441217/62807853-69b58f80-baee-11e9-95e4-0462491fc5a4.png)

mobile
![image](https://user-images.githubusercontent.com/441217/62807877-7df98c80-baee-11e9-9081-9faee3d2e7ad.png)
