### PR TITLE
Grid updates pt2 

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -270,3 +270,19 @@ summary {
     }
   }
 }
+
+// Fix trailing quote spacing on pull-quote pattern
+// Being fixed in Vanilla: https://github.com/canonical-web-and-design/vanilla-framework/issues/2426
+.p-pull-quote {
+  .p-pull-quote__quote {
+    position: relative;
+
+    &:first-of-type::before {
+      left: -1.25rem;
+    }
+
+    &:last-of-type::after {
+      bottom: 0.5rem;
+    }
+  }
+}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -6,32 +6,28 @@
   {% block content %}
   <section class="p-strip u-image-position is-deep is-bordered">
     <div class="row">
-      <div class="u-equal-height">
       <div class="col-6">
         <h1>Ubuntu Desktop for&nbsp;developers</h1>
         <p>Whether you&rsquo;re a mobile app developer, an engineering manager, a music or video editor or a financial analyst with large-scale models to run &mdash; in fact, anyone in need of a powerful machine for your work &mdash; Ubuntu is the ideal platform.</p>
         <p><a href="/download/desktop/" class="p-button--positive">Get Ubuntu now</a></p>
       </div>
       <div class="col-6 u-vertically-center u-hide--small">
-        <img class="u-visible--large u-hide--medium u-image-position--top" src="{{ ASSET_SERVER_URL }}79439f53-Dell_XPS_Laptop_Front-Developer.png?w=600" width="600" alt="" style="top: 105px; left: 50%;" />
+        <img class="u-visible--large u-hide--medium" src="{{ ASSET_SERVER_URL }}79439f53-Dell_XPS_Laptop_Front-Developer.png?w=600" width="600" alt="" style="top: 105px; left: 50%;" />
         <img class="u-visible--medium u-hide--large" src="{{ ASSET_SERVER_URL }}79439f53-Dell_XPS_Laptop_Front-Developer.png?w=600" width="600" alt="" style="top: 105px; right: 40px;" />
-      </div>
       </div>
     </div>
   </section>
 
   <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-12">
-        <h2>Why use Ubuntu for development?</h2>
-        <ul class="p-list--divided is-split">
-          <li class="p-list__item is-ticked">The fastest route from development to deployment on desktop, mobile, server or cloud</li>
-          <li class="p-list__item is-ticked">The desktop of choice for developers at some of the world&rsquo;s leading technology companies</li>
-          <li class="p-list__item is-ticked">The broadest and best development tools and libraries</li>
-          <li class="p-list__item is-ticked">Lightweight to either run natively or in a VM, on a PC or a Mac</li>
-          <li class="p-list__item is-ticked">Ideal for any resource-intensive environment, from data mining to large-scale financial modelling</li>
-        </ul>
-      </div>
+    <div class="u-fixed-width">
+      <h2>Why use Ubuntu for development?</h2>
+      <ul class="p-list--divided is-split">
+        <li class="p-list__item is-ticked">The fastest route from development to deployment on desktop, mobile, server or cloud</li>
+        <li class="p-list__item is-ticked">The desktop of choice for developers at some of the world&rsquo;s leading technology companies</li>
+        <li class="p-list__item is-ticked">The broadest and best development tools and libraries</li>
+        <li class="p-list__item is-ticked">Lightweight to either run natively or in a VM, on a PC or a Mac</li>
+        <li class="p-list__item is-ticked">Ideal for any resource-intensive environment, from data mining to large-scale financial modelling</li>
+      </ul>
     </div>
   </section>
 
@@ -59,21 +55,19 @@
         <p>Ubuntu {{ releases.lts.short_version }} is the latest LTS release. Alongside support for the very latest hardware, this release includes new versions of many core apps and developer technologies.</p>
       </div>
     </div>
-    <div class="row">
-      <div class="col-12">
-        <ul class="p-list--divided is-split">
-          <li class="p-list__item is-ticked">Linux 4.15 kernel</li>
-          <li class="p-list__item is-ticked">Core applications packaged as snaps</li>
-          <li class="p-list__item is-ticked">Apps available in store including Spotify, Skype and VLC</li>
-          <li class="p-list__item is-ticked">Latest versions of the popular browsers</li>
-          <li class="p-list__item is-ticked">LibreOffice 6</li>
-          <li class="p-list__item is-ticked">Minimal installation - only essential packages are included reducing disk footprint making it easier to configure your desktop just how you want it</li>
-          <li class="p-list__item is-ticked">Microsoft Hyper-V makes running virtualised guests on Windows easier, faster, and better integrated</li>
-          <li class="p-list__item is-ticked">GNOME Shell 3.28 replaces Unity 7 as the default desktop environment</li>
-          <li class="p-list__item is-ticked">Print without printer-specific drivers on AirPrint, IPP everywhere, Mopria and Wifi Direct printers</li>
-        </ul>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Read the full release notes</a></p>
-      </div>
+    <div class="u-fixed-width">
+      <ul class="p-list--divided is-split">
+        <li class="p-list__item is-ticked">Linux 4.15 kernel</li>
+        <li class="p-list__item is-ticked">Core applications packaged as snaps</li>
+        <li class="p-list__item is-ticked">Apps available in store including Spotify, Skype and VLC</li>
+        <li class="p-list__item is-ticked">Latest versions of the popular browsers</li>
+        <li class="p-list__item is-ticked">LibreOffice 6</li>
+        <li class="p-list__item is-ticked">Minimal installation - only essential packages are included reducing disk footprint making it easier to configure your desktop just how you want it</li>
+        <li class="p-list__item is-ticked">Microsoft Hyper-V makes running virtualised guests on Windows easier, faster, and better integrated</li>
+        <li class="p-list__item is-ticked">GNOME Shell 3.28 replaces Unity 7 as the default desktop environment</li>
+        <li class="p-list__item is-ticked">Print without printer-specific drivers on AirPrint, IPP everywhere, Mopria and Wifi Direct printers</li>
+      </ul>
+      <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Read the full release notes</a></p>
     </div>
   </section>
 
@@ -84,17 +78,15 @@
         <p>Ubuntu {{ releases.latest.short_version }} comes with a host of improvements and bug fixes giving you the snappiest GNOME experience.</p>
       </div>
     </div>
-    <div class="row">
-      <div class="col-12">
-        <ul class="p-list--divided is-split">
-          <li class="p-list__item is-ticked">Thousands of updated snaps and packages such as Spotify, VLC, Skype, Slack, Discord, Visual Studio Code and Telegram</li>
-          <li class="p-list__item is-ticked">The latest version of the GNOME Desktop including many performance upgrades and reduced memory footprint</li>
-          <li class="p-list__item is-ticked">New fractional scaling allows you to scale your displays independently -  available for Wayland and as an experimental option for Xorg</li>
-          <li class="p-list__item is-ticked">Improved experience for alt-tab, Ubuntu dock and right click</li>
-          <li class="p-list__item is-ticked">Installing Ubuntu desktop on VMware will now automatically install <a class="p-link--external" href="https://github.com/vmware/open-vm-tools">open-vm-tools</a> providing greater integration between Ubuntu and the host system</li>
-        </ul>
-        <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Read the full release notes</a></p>
-      </div>
+    <div class="u-fixed-width">
+      <ul class="p-list--divided is-split">
+        <li class="p-list__item is-ticked">Thousands of updated snaps and packages such as Spotify, VLC, Skype, Slack, Discord, Visual Studio Code and Telegram</li>
+        <li class="p-list__item is-ticked">The latest version of the GNOME Desktop including many performance upgrades and reduced memory footprint</li>
+        <li class="p-list__item is-ticked">New fractional scaling allows you to scale your displays independently -  available for Wayland and as an experimental option for Xorg</li>
+        <li class="p-list__item is-ticked">Improved experience for alt-tab, Ubuntu dock and right click</li>
+        <li class="p-list__item is-ticked">Installing Ubuntu desktop on VMware will now automatically install <a class="p-link--external" href="https://github.com/vmware/open-vm-tools">open-vm-tools</a> providing greater integration between Ubuntu and the host system</li>
+      </ul>
+      <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Read the full release notes</a></p>
     </div>
   </section>
 
@@ -116,7 +108,7 @@
     <div class="row">
       <div class="col-10">
         <blockquote class="p-pull-quote">
-          <p>We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
+          <p class="p-pull-quote__quote">We want to be able to deliver the same high-quality experience on Linux as we do on other platforms. Snaps allow us to do just that, by giving us the ability to push the latest features straight to our users, no matter what device or distribution they happen to use.</p>
           <cite class="p-pull-quote__citation">Jonáš Tajrych, Senior Software Engineer at Skype at Microsoft</cite>
         </blockquote>
       </div>
@@ -125,28 +117,25 @@
 
   <section class="p-strip is-bordered">
     <div class="row">
-      <div class="u-equal-height">
-        <div class="col-7 suffix-1">
-          <h2>Package, distribute, and update apps with Snapcraft</h2>
-          <p>Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a single build. They update automatically and roll back gracefully. Whether you’re building for desktop, cloud, or the Internet of Things, publishing as a snap will keep users up to date and make system configuration issues less likely, freeing you to code more and debug less.</p>
-          <p>Snapcraft, the open source tool to publish snaps, picks up from your existing build artefacts or language of choice, be it Python, Go, C/C++, Node.js, or even .NET. With 20 minutes you can have your first app built and released in the Snap Store.</p>
-          <p><a class="p-link--external" href="https://snapcraft.io/">Find out more about snaps</a></p>
-        </div>
-        <div class="col-5 u-vertically-center">
-          <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}bb7f0c54-snaps-hero%403x.png?w=400" width="400" alt="Snap icons">
-        </div>
+      <div class="col-7">
+        <h2>Package, distribute, and update apps with Snapcraft</h2>
+        <p>Snaps are applications packaged with all their dependencies to run on all popular Linux distributions from a single build. They update automatically and roll back gracefully. Whether you’re building for desktop, cloud, or the Internet of Things, publishing as a snap will keep users up to date and make system configuration issues less likely, freeing you to code more and debug less.</p>
+        <p>Snapcraft, the open source tool to publish snaps, picks up from your existing build artefacts or language of choice, be it Python, Go, C/C++, Node.js, or even .NET. With 20 minutes you can have your first app built and released in the Snap Store.</p>
+        <p><a class="p-link--external" href="https://snapcraft.io/">Find out more about snaps</a></p>
+      </div>
+      <div class="col-5 u-vertically-center">
+        <img class="u-hide--small" src="{{ ASSET_SERVER_URL }}bb7f0c54-snaps-hero%403x.png?w=400" width="400" alt="Snap icons">
       </div>
     </div>
   </section>
 
   <section class="p-strip--light is-bordered">
-    <div class="row">
-      <div class="col-12">
-        <h2>Get started with Snaps</h2>
-        <p>The easiest way to build and publish a snap is with snapcraft,<br>
-          which supports building from source and from existing packages.</p>
-      </div>
+    <div class="u-fixed-width">
+      <h2>Get started with Snaps</h2>
+      <p>The easiest way to build and publish a snap is with snapcraft,<br>
+        which supports building from source and from existing packages.</p>
     </div>
+
     <div class="row u-equal-height">
       <div class="col-4 p-card u-align--center">
         <svg class="p-card__icon" viewBox="0 0 46 54">
@@ -198,13 +187,13 @@
   </section>
 
   <section class="p-strip is-bordered">
-    <div class="row">
+    <div class="row u-vertically-center">
       <div class="col-7">
         <h2>By developers, for developers</h2>
         <p>Ubuntu is the result of contributions by thousands of developers, motivated by the desire to create their own perfect developer environment. That&rsquo;s why it&rsquo;s used by some of the world&rsquo;s most exciting technology companies and it&rsquo;s why Valve decided to port its hugely popular Steam virtual games store to Ubuntu. Ubuntu runs on architectures from x86 to ARM and on cloud platforms from OpenStack to Azure and EC2. This versatility makes it the ideal choice for companies with a diverse hardware infrastructure.</p>
         <p><a class="p-link--external" href="https://certification.ubuntu.com/desktop">See all Ubuntu certified PCs</a></p>
       </div>
-      <div class="col-5 u-vertically-center">
+      <div class="col-5">
         <img src="{{ ASSET_SERVER_URL }}89abf289-Dell_XPS_Laptop_Left-Developer.png?w=413" width="413" alt="Developer laptop" />
       </div>
     </div>
@@ -214,7 +203,7 @@
     <div class="row">
       <div class="col-10">
         <blockquote class="p-pull-quote">
-          <p>Ubuntu has been the perfect OS given its popularity with developers and its cloud capabilities. That&rsquo;s why it&rsquo;s preloaded on the 4th generation of our XPS 13 laptop and our new Precision M3800 Mobile Workstation.</p>
+          <p class="p-pull-quote__quote">Ubuntu has been the perfect OS given its popularity with developers and its cloud capabilities. That&rsquo;s why it&rsquo;s preloaded on the 4th generation of our XPS 13 laptop and our new Precision M3800 Mobile Workstation.</p>
           <cite class="p-pull-quote__citation">Barton George, Director of developer programs at Dell services</cite>
         </blockquote>
         <p><a href="/blog/designed-for-developers-dell-launches-two-new-ubuntu-based-systems/" class="p-link--external">Learn more about Dell&rsquo;s developer edition line</a></p>
@@ -223,17 +212,15 @@
   </section>
 
   <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="u-equal-height u-vertically-center">
-        <div class="col-6 suffix-1">
-          <img src="{{ ASSET_SERVER_URL }}bda34a6e-wordpress-apache-mysql-bundle-trans.svg" width="442" height="394" alt="" />
-        </div>
-        <div class="col-6">
-          <h2>Deployment made easy</h2>
-          <p>When it comes to speed and simplicity of deployment, nothing touches Ubuntu.</p>
-          <p>Taking a service developed on the desktop and running it on a server or in the cloud just works. Ubuntu also has developed Juju, a service orchestration tool, that simplifies the often-cumbersome handover between development and ops teams &mdash; and it speeds the process up dramatically.</p>
-          <p><a class="p-link--external" href="https://jujucharms.com/">More about Juju</a></p>
-        </div>
+    <div class="row u-vertically-center">
+      <div class="col-6">
+        <img src="{{ ASSET_SERVER_URL }}bda34a6e-wordpress-apache-mysql-bundle-trans.svg" width="442" height="394" alt="" />
+      </div>
+      <div class="col-6">
+        <h2>Deployment made easy</h2>
+        <p>When it comes to speed and simplicity of deployment, nothing touches Ubuntu.</p>
+        <p>Taking a service developed on the desktop and running it on a server or in the cloud just works. Ubuntu also has developed Juju, a service orchestration tool, that simplifies the often-cumbersome handover between development and ops teams &mdash; and it speeds the process up dramatically.</p>
+        <p><a class="p-link--external" href="https://jujucharms.com/">More about Juju</a></p>
       </div>
     </div>
   </section>
@@ -245,7 +232,7 @@
         <p>With Ubuntu Advantage and Landscape, you can standardise your developer workstations. It helps you manage updates, security patches, and reporting, while minimising downtime. Give your developers the freedom they want while retaining the control you need.</p>
         <p><a href="/support/">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
       </div>
-      <div class="col-6 prefix-1 u-hide--small">
+      <div class="col-6 u-align--right u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}4125e046-landscape_activity.png?w=413" width="413" alt="" />
       </div>
     </div>

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -53,121 +53,117 @@
       <p >Ubuntu offers thousands of apps available for download. Most are available for free and can be installed with just a few clicks.</p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-matrix is-trisected">
-        <li class="p-matrix__item">
-          <a href="https://snapcraft.io/spotify">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}c9be8d47-Spotify_logo_without_text.svg" width="48" alt="Spotify icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/spotify">Spotify</a></h3>
-            <p class="p-matrix__desc">Play and stream your favorite songs, playlists and albums for free with Spotify.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <a href="https://snapcraft.io/skype">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}3d6245f8-skype-icon.svg" width="48" alt="Skype icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/skype">Skype</a></h3>
-            <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item last-row">
-          <a href="https://snapcraft.io/vlc">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}33f5e395-vlc.svg" width="48" alt="VLC icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/vlc">VLC player</a></h3>
-            <p class="p-matrix__desc">No other video player is compatible with as many different file formats.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <a href="https://snapcraft.io/firefox">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/firefox">Firefox</a></h3>
-            <p class="p-matrix__desc">Firefox Quantum is now 2x faster and 30% lighter than Chrome.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <a href="https://snapcraft.io/slack">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="Slack">
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/slack">Slack</a></h3>
-            <p class="p-matrix__desc">Team communication and collaboration in one place so you can get more done.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item last-row">
-          <a href="https://snapcraft.io/atom">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}ccb8872b-Icon_Atom.svg" width="48" alt="Atom icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/atom">Atom</a></h3>
-            <p class="p-matrix__desc">A hackable text editor for the 21st Century.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <a href="https://snapcraft.io/chromium">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}171fcf42-Chromium_11_Logo.svg" width="48" alt="Chromium icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/chromium">Chromium</a></h3>
-            <p class="p-matrix__desc">A fast, simple and secure web browser, built for the modern web.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <a href="https://snapcraft.io/pycharm-community">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}4ecb4f50-PyCharm_Logo.svg" width="48" alt="PyCharm" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/pycharm-community">PyCharm</a></h3>
-            <p class="p-matrix__desc">PyCharm provides all the tools you need for productive Python coding.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item last-row">
-          <a href="https://snapcraft.io/telegram-desktop">
-            <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}3f3a15ef-logo-telegram.svg" width="48" alt="Telegram icon" />
-          </a>
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a href="https://snapcraft.io/telegram-desktop">Telegram</a></h3>
-            <p class="p-matrix__desc">A fast and secure desktop messaging app, perfectly synced with your mobile phone.</p>
-          </div>
-        </li>
-      </ul>
-      <p><a href="https://snapcraft.io/store" class="p-link--external">Discover more apps for Ubuntu at the Snap Store.</a></p>
-    </div>
+  <div class="u-fixed-width">
+    <ul class="p-matrix is-trisected">
+      <li class="p-matrix__item">
+        <a class="p-matrix__img" href="https://snapcraft.io/spotify">
+          <img src="{{ ASSET_SERVER_URL }}c9be8d47-Spotify_logo_without_text.svg" width="48" alt="Spotify icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/spotify">Spotify</a></h3>
+          <p class="p-matrix__desc">Play and stream your favorite songs, playlists and albums for free with Spotify.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <a class="p-matrix__img" href="https://snapcraft.io/skype">
+          <img src="{{ ASSET_SERVER_URL }}3d6245f8-skype-icon.svg" width="48" alt="Skype icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/skype">Skype</a></h3>
+          <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item last-row">
+        <a class="p-matrix__img" href="https://snapcraft.io/vlc">
+          <img src="{{ ASSET_SERVER_URL }}33f5e395-vlc.svg" width="48" alt="VLC icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/vlc">VLC player</a></h3>
+          <p class="p-matrix__desc">No other video player is compatible with as many different file formats.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <a class="p-matrix__img" href="https://snapcraft.io/firefox">
+          <img src="{{ ASSET_SERVER_URL }}a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/firefox">Firefox</a></h3>
+          <p class="p-matrix__desc">Firefox Quantum is now 2x faster and 30% lighter than Chrome.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <a class="p-matrix__img" href="https://snapcraft.io/slack">
+          <img src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="Slack">
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/slack">Slack</a></h3>
+          <p class="p-matrix__desc">Team communication and collaboration in one place so you can get more done.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item last-row">
+        <a class="p-matrix__img" href="https://snapcraft.io/atom">
+          <img src="{{ ASSET_SERVER_URL }}ccb8872b-Icon_Atom.svg" width="48" alt="Atom icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/atom">Atom</a></h3>
+          <p class="p-matrix__desc">A hackable text editor for the 21st Century.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <a class="p-matrix__img" href="https://snapcraft.io/chromium">
+          <img src="{{ ASSET_SERVER_URL }}171fcf42-Chromium_11_Logo.svg" width="48" alt="Chromium icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/chromium">Chromium</a></h3>
+          <p class="p-matrix__desc">A fast, simple and secure web browser, built for the modern web.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <a class="p-matrix__img" href="https://snapcraft.io/pycharm-community">
+          <img src="{{ ASSET_SERVER_URL }}4ecb4f50-PyCharm_Logo.svg" width="48" alt="PyCharm" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/pycharm-community">PyCharm</a></h3>
+          <p class="p-matrix__desc">PyCharm provides all the tools you need for productive Python coding.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item last-row">
+        <a class="p-matrix__img" href="https://snapcraft.io/telegram-desktop">
+          <img src="{{ ASSET_SERVER_URL }}3f3a15ef-logo-telegram.svg" width="48" alt="Telegram icon" />
+        </a>
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a href="https://snapcraft.io/telegram-desktop">Telegram</a></h3>
+          <p class="p-matrix__desc">A fast and secure desktop messaging app, perfectly synced with your mobile phone.</p>
+        </div>
+      </li>
+    </ul>
+    <p><a href="https://snapcraft.io/store" class="p-link--external">Discover more apps for Ubuntu at the Snap Store.</a></p>
   </div>
 </section>
 
 <section class="p-strip">
   <div class="row u-vertically-center">
-    <div class="col-5 suffix-1">
+    <div class="col-5">
       <div>
         <h2>Office software</h2>
         <p>Create professional documents, spreadsheets and presentations on Ubuntu with LibreOffice, the open source office suite that&rsquo;s compatible with Microsoft Office.   That means you can open and edit files like Word documents, Excel spreadsheets and PowerPoint presentations and share them with other users quickly and easily. You can also use Google docs directly from your desktop.</p>
       </div>
     </div>
-    <div class="col-7">
+    <div class="col-7 u-align--right">
       <img src="{{ ASSET_SERVER_URL }}c1471906-libreoffice.jpg?w=556" height="414" width="556" alt="Office Apps" />
     </div>
   </div>
 </section>
 
 <section class="p-strip--image is-dark is-deep" style="background-image:url('{{ ASSET_SERVER_URL }}0a98afcd-screenshot_desktop.jpg')">
-  <div class="row">
-    <div class="u-equal-height u-vertically-center">
-      <div class="col-6 u-align--center">
-        <img src="{{ ASSET_SERVER_URL }}849e20c6-news.png?w=500" class="u-hide--small" width="500" alt="" />
-      </div>
-      <div class="col-6 prefix-1">
-        <div class="p-card--overlay">
-          <h2>Web browsing</h2>
-          <p>Renowned for speed and security, Ubuntu and Firefox make browsing the web a pleasure again.  Ubuntu also includes Chrome, Opera and other browsers that can be installed from the Ubuntu Software Centre.</p>
-        </div>
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center">
+      <img src="{{ ASSET_SERVER_URL }}849e20c6-news.png?w=500" class="u-hide--small" width="500" alt="" />
+    </div>
+    <div class="col-6">
+      <div class="p-card--overlay">
+        <h2>Web browsing</h2>
+        <p>Renowned for speed and security, Ubuntu and Firefox make browsing the web a pleasure again.  Ubuntu also includes Chrome, Opera and other browsers that can be installed from the Ubuntu Software Centre.</p>
       </div>
     </div>
   </div>
@@ -175,11 +171,11 @@
 
 <section class="p-strip">
   <div class="row u-vertically-center">
-    <div class="col-6 suffix-1">
+    <div class="col-5">
       <h2>Email</h2>
       <p>Ubuntu comes with Thunderbird, Mozilla&rsquo;s popular email application, so you&rsquo;ll have fast desktop access to your email. No matter which email services you use; Microsoft Exchange, Gmail, Hotmail, POP or IMAP, email just works.</p>
     </div>
-    <div class="col-6 u-vertically-center">
+    <div class="col-7 u-vertically-center u-align--right">
       <img src="{{ ASSET_SERVER_URL }}04339b8f-emaill+screenshot.jpg?w=520"  alt="" height="398" width="520" />
     </div>
   </div>
@@ -226,22 +222,20 @@
 </section>
 
 <section class="p-strip--light is-deep">
-  <div class="row">
-    <div class="u-equal-height u-vertically-center">
-      <div class="col-5 suffix-1">
-        <h2>Videos</h2>
-        <p>Watch all your favourite content on Ubuntu with apps for playing, managing and sharing your videos. Edit your movies with PiTiVi and then watch them in Movie Player &mdash; or add VLC and OpenShot from the Ubuntu Software Centre, for compatibility with even more file formats.</p>
-      </div>
-      <div class="col-7 u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png?w=542" width="542" alt="" />
-      </div>
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-5">
+      <h2>Videos</h2>
+      <p>Watch all your favourite content on Ubuntu with apps for playing, managing and sharing your videos. Edit your movies with PiTiVi and then watch them in Movie Player &mdash; or add VLC and OpenShot from the Ubuntu Software Centre, for compatibility with even more file formats.</p>
+    </div>
+    <div class="col-7 u-hide--small u-align--right">
+      <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png?w=542" width="542" alt="" />
     </div>
   </div>
 </section>
 
 <section class="p-strip p-gaming">
   <div class="row">
-    <div class="col-12 prefix-6 p-gaming__content">
+    <div class="col-6 col-start-large-7 p-gaming__content">
       <div class="p-card--overlay">
         <h2>Gaming</h2>
         <p>From Sudoku to shoot-em-ups, we&rsquo;ve got loads of games that&rsquo;ll keep you busy for hours.  There are thousands of games available for Ubuntu, including titles from the Unity and Steam platforms.  Pick from critically acclaimed titles such as Dota 2, Civilization V, Kerbal Space Program, Football Manager 2018 and Borderlands: The Pre-Sequel.</p>

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -23,16 +23,14 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="u-equal-height">
-      <div class="col-8 u-vertically-center u-hide--small">
-        <img src="{{ ASSET_SERVER_URL }}3a05fc34-Dell_XPS_Laptop_Front-news.png?w=681" width="681" alt="The Guardian website on Firefox in 16.04 LTS" />
-      </div>
-      <div class="col-4">
-        <h2>Complete</h2>
-        <p>Ubuntu comes with everything you need to run your organisation, school, home or enterprise. All the essential applications, like an office suite, browsers, email and media apps come pre-installed and thousands more games and applications are available
-          in the Ubuntu Software Centre.</p>
-          <p><a href="/desktop/features">Explore features&nbsp;&rsaquo;</a></p>
-        </div>
+    <div class="col-8 u-vertically-center u-hide--small">
+      <img src="{{ ASSET_SERVER_URL }}3a05fc34-Dell_XPS_Laptop_Front-news.png?w=681" width="681" alt="The Guardian website on Firefox in 16.04 LTS" />
+    </div>
+    <div class="col-4">
+      <h2>Complete</h2>
+      <p>Ubuntu comes with everything you need to run your organisation, school, home or enterprise. All the essential applications, like an office suite, browsers, email and media apps come pre-installed and thousands more games and applications are available
+        in the Ubuntu Software Centre.</p>
+        <p><a href="/desktop/features">Explore features&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </section>
@@ -56,33 +54,30 @@
 
   <section class="p-strip is-bordered">
     <div class="row">
-      <div class="u-equal-height">
-        <div class="col-7">
-          <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png?w=592" width="592" alt="">
-        </div>
-        <div class="col-5 prefix-1 u-vertically-center">
-          <div>
-            <h2>Looks great on the latest devices</h2>
-            <p>Ubuntu is designed to work beautifully on the latest laptops, desktops and touch screen devices, it looks incredible on high resolution screens &mdash; and with touch screen enhancements and interface refinements, it&rsquo;s now even easier to use.</p>
-          </div>
+      <div class="col-7">
+        <img src="{{ ASSET_SERVER_URL }}d4f0c4b1-movie.png?w=592" width="592" alt="">
+      </div>
+      <div class="col-5 u-vertically-center">
+        <div>
+          <h2>Looks great on the latest devices</h2>
+          <p>Ubuntu is designed to work beautifully on the latest laptops, desktops and touch screen devices, it looks incredible on high resolution screens &mdash; and with touch screen enhancements and interface refinements, it&rsquo;s now even easier to use.</p>
         </div>
       </div>
     </div>
   </section>
 
   <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-12">
-        <h2>Available on a huge range of&nbsp;hardware</h2>
-      </div>
+    <div class="u-fixed-width">
+      <h2>Available on a huge range of&nbsp;hardware</h2>
     </div>
+
     <div class="row">
-      <div class="col-7 suffix-1">
+      <div class="col-6">
         <p>Canonical works with the world&rsquo;s leading computer manufacturers to certify that Ubuntu works on a huge range of devices. It means that Ubuntu is now available at thousands of retailers across China, India, South East Asia and Latin America.</p>
         <p>And Ubuntu isn&rsquo;t just for the desktop, it is used in data centres around the world powering every kind of server imaginable and is by far, the most popular operating system in the cloud.</p>
         <p><a href="https://partners.ubuntu.com/programmes" class="p-link--external">Find out more about our partners</a></p>
       </div>
-      <div class="col-5 u-vertically-center u-hide--small">
+      <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
         <img src="{{ ASSET_SERVER_URL }}d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" width="413" alt="Photo of laptop running Ubuntu" />
       </div>
     </div>

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -8,7 +8,7 @@
 
 <section class="p-strip is-deep" style="background-image: url('https://assets.ubuntu.com/v1/214648ba-_M8A2368-final.jpg?w=1280'); background-repeat: no-repeat; background-size: cover; background-position: bottom center;">
   <div class="row">
-    <div class="col-12 suffix-7">
+    <div class="col-5">
       <div class="p-card--overlay">
         <h1>Ubuntu in organisations</h1>
         <p>Ubuntu is adopted by small and large teams alike because it is easy to use, highly secure, has a low cost of ownership and a huge range of apps.</p>
@@ -20,110 +20,105 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>All essentials built-in</h2>
-      <ul class="p-list--divided is-split">
-        <li class="p-list__item is-ticked">
-          Long Term Support releases come with five years of security patches and updates
-        </li>
-        <li class="p-list__item is-ticked">
-          Only essential packages are included reducing disk footprint and install times
-        </li>
-        <li class="p-list__item is-ticked">
-          Open source &mdash; free from licensing restrictions
-        </li>
-        <li class="p-list__item is-ticked">
-          Microsoft-compatible office productivity suite
-        </li>
-        <li class="p-list__item is-ticked">
-          Fully translated into 100+ languages
-        </li>
-        <li class="p-list__item is-ticked">
-          On-site consulting services and training available
-        </li>
-        <li class="p-list__item is-ticked">
-          Virus free and highly secure
-        </li>
-      </ul>
-    </div>
+  <div class="u-fixed-width">
+    <h2>All essentials built-in</h2>
+    <ul class="p-list--divided is-split">
+      <li class="p-list__item is-ticked">
+        Long Term Support releases come with five years of security patches and updates
+      </li>
+      <li class="p-list__item is-ticked">
+        Only essential packages are included reducing disk footprint and install times
+      </li>
+      <li class="p-list__item is-ticked">
+        Open source &mdash; free from licensing restrictions
+      </li>
+      <li class="p-list__item is-ticked">
+        Microsoft-compatible office productivity suite
+      </li>
+      <li class="p-list__item is-ticked">
+        Fully translated into 100+ languages
+      </li>
+      <li class="p-list__item is-ticked">
+        On-site consulting services and training available
+      </li>
+      <li class="p-list__item is-ticked">
+        Virus free and highly secure
+      </li>
+    </ul>
   </div>
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Countless apps available</h2>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Countless apps available</h2>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-matrix is-trisected">
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}be731535-Logo-libreoffice.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">LibreOffice</h3>
-            <p class="p-matrix__desc">The free office productivity suite that’s compatible with Microsoft Office.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Slack</h3>
-            <p class="p-matrix__desc">Team communication for the 21st century.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}09b7a2e3-wavebox-logo.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Wavebox</h3>
-            <p class="p-matrix__desc">The web communication client that brings together Gmail, Inbox, Outlook, O365, Trello and Slack.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}c9be8d47-Spotify_logo_without_text.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Spotify</h3>
-            <p class="p-matrix__desc">Play and stream your favorite songs and albums for free with Spotify.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}171fcf42-Chromium_11_Logo.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Chromium</h3>
-            <p class="p-matrix__desc">A fast, simple and secure web browser, built for the modern web.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}3d6245f8-skype-icon.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Skype</h3>
-            <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}11d81b4e-IntelliJ_IDEA_Logo.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Intellij</h3>
-            <p class="p-matrix__desc">Capable and ergonomic Integrated Development Environment for Java.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}6e5fe7ef-logo-dropbox.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Dropbox</h3>
-            <p class="p-matrix__desc">The world’s favourite cloud backup and file sharing service.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}27848067-Ora_logo.svg" width="48" alt="">
-          <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Ora</h3>
-            <p class="p-matrix__desc">Agile task management and visual team collaboration, Ora is your team’s command center.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+
+  <div class="u-fixed-width">
+    <ul class="p-matrix is-trisected">
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}be731535-Logo-libreoffice.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">LibreOffice</h3>
+          <p class="p-matrix__desc">The free office productivity suite that’s compatible with Microsoft Office.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}5672e723-Slack_Mark.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Slack</h3>
+          <p class="p-matrix__desc">Team communication for the 21st century.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}09b7a2e3-wavebox-logo.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Wavebox</h3>
+          <p class="p-matrix__desc">The web communication client that brings together Gmail, Inbox, Outlook, O365, Trello and Slack.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}c9be8d47-Spotify_logo_without_text.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Spotify</h3>
+          <p class="p-matrix__desc">Play and stream your favorite songs and albums for free with Spotify.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}171fcf42-Chromium_11_Logo.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Chromium</h3>
+          <p class="p-matrix__desc">A fast, simple and secure web browser, built for the modern web.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}3d6245f8-skype-icon.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Skype</h3>
+          <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}11d81b4e-IntelliJ_IDEA_Logo.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Intellij</h3>
+          <p class="p-matrix__desc">Capable and ergonomic Integrated Development Environment for Java.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}6e5fe7ef-logo-dropbox.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Dropbox</h3>
+          <p class="p-matrix__desc">The world’s favourite cloud backup and file sharing service.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="{{ ASSET_SERVER_URL }}27848067-Ora_logo.svg" width="48" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Ora</h3>
+          <p class="p-matrix__desc">Agile task management and visual team collaboration, Ora is your team’s command center.</p>
+        </div>
+      </li>
+    </ul>
   </div>
 </section>
 

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -7,53 +7,50 @@
 {% block content %}
 <section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="u-equal-height">
-      <div class="col-6">
-        <h1>Ubuntu for partners</h1>
-        <p>We partner with the world’s leading hardware manufacturers and silicon vendors to help deliver an extensive range of Ubuntu certified desktops, notebooks and servers. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimised performance of all your hardware for the life of the OS.</p>
-        <p><a href="https://partners.ubuntu.com/find-a-partner?service-offered=hardware-manufacturer" class="p-link--external">Learn more about our desktop partners</a></p>
-      </div>
-      <div class="col-6 u-hide--small u-vertically-center">
-        <ul class="p-inline-images">
-          <li class="p-inline-images__item u-no-margin--right">
-            <img src="{{ ASSET_SERVER_URL }}52d4cc16-Nvidia_Logo_Horizontal.svg" alt="" class="p-inline-images__logo" width="150">
-          </li>
-          <li class="p-inline-images__item u-no-margin--right">
-            <img src="{{ ASSET_SERVER_URL }}5e92614c-amd-logo.svg" width="95" alt="" class="p-inline-images__logo">
-          </li>
-          <li class="p-inline-images__item u-no-margin--right">
-            <img src="{{ ASSET_SERVER_URL }}5ddba83a-logo-dell.svg" alt="" class="p-inline-images__logo" width="100">
-          </li>
-        </ul>
-      </div>
+    <div class="col-6">
+      <h1>Ubuntu for partners</h1>
+      <p>We partner with the world’s leading hardware manufacturers and silicon vendors to help deliver an extensive range of Ubuntu certified desktops, notebooks and servers. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimised performance of all your hardware for the life of the OS.</p>
+      <p><a href="https://partners.ubuntu.com/find-a-partner?service-offered=hardware-manufacturer" class="p-link--external">Learn more about our desktop partners</a></p>
+    </div>
+    <div class="col-6 u-hide--small u-vertically-center">
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item u-no-margin--right">
+          <img src="{{ ASSET_SERVER_URL }}52d4cc16-Nvidia_Logo_Horizontal.svg" alt="" class="p-inline-images__logo" width="150">
+        </li>
+        <li class="p-inline-images__item u-no-margin--right">
+          <img src="{{ ASSET_SERVER_URL }}5e92614c-amd-logo.svg" width="95" alt="" class="p-inline-images__logo">
+        </li>
+        <li class="p-inline-images__item u-no-margin--right">
+          <img src="{{ ASSET_SERVER_URL }}5ddba83a-logo-dell.svg" alt="" class="p-inline-images__logo" width="100">
+        </li>
+      </ul>
     </div>
   </div>
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>What our partners are saying</h2>
-    </div>
+  <div class="u-fixed-width">
+    <h2>What our partners are saying</h2>
   </div>
+
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <blockquote class="p-pull-quote">
-        <p>We are happy about this partnership as our customers in India will have access to Ubuntu preloaded Thinkpad L450 laptop series.</p>
+        <p class="p-pull-quote__quote">We are happy about this partnership as our customers in India will have access to Ubuntu preloaded Thinkpad L450 laptop series.</p>
         <cite class="p-pull-quote__citation">Rahul Agarwal, Managing Director at Lenovo India</cite>
       </blockquote>
       <p><a href="/blog/ubuntu-to-ship-on-lenovo-laptops-in-india/" class="p-link--external">Read the full article <span class="u-off-screen"> 'Ubuntu to ship on Lenovo laptops in India'</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <blockquote class="p-pull-quote">
-        <p>Ubuntu has been the perfect OS from the start given its popularity with developers and its cloud capabilities.</p>
+        <p class="p-pull-quote__quote">Ubuntu has been the perfect OS from the start given its popularity with developers and its cloud capabilities.</p>
         <cite class="p-pull-quote__citation">Barton George, Director of developer programs at Dell services</cite>
       </blockquote>
       <p><a href="/blog/designed-for-developers-dell-launches-two-new-ubuntu-based-systems/" class="p-link--external">Read the full article<span class="u-off-screen"> 'Designed for developers &mdash; Dell launches two new Ubuntu-based systems'</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <blockquote class="p-pull-quote">
-        <p>This is another milestone in our productive partnership with Canonical with the introduction of the the Intel<sup>&reg;</sup> Compute Stick with Ubuntu.</p>
+        <p class="p-pull-quote__quote">This is another milestone in our productive partnership with Canonical with the introduction of the the Intel<sup>&reg;</sup> Compute Stick with Ubuntu.</p>
         <cite class="p-pull-quote__citation">Joel Christensen, General Manager of Intel NUC and Intel Compute Stick Products</cite>
       </blockquote>
       <p><a href="/blog/intel-compute-stick-now-comes-with-ubuntu/" class="p-link--external">Read the full article<span class="u-off-screen"> 'Intel Compute Stick now comes with Ubuntu'</span></a></p>
@@ -62,10 +59,8 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Commercial information</h2>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Commercial information</h2>
   </div>
   <div class="row">
     <div class="col-4">
@@ -80,10 +75,9 @@
       <h3>Ongoing support</h3>
       <p>The ability to update your devices is central to your security and long-term competitiveness. Canonical takes care of all security and critical bug fixes to the base platform offering and provides the infrastructure to support your update management strategy. Ubuntu has a world-class track record maintaining a secure and stable operating system.</p>
     </div>
-  <div class="row">
-    <div class="col-12">
-      <p><a href="https://partners.ubuntu.com/programmes/hardware" class="p-link--external">Learn more about working with Canonical</a></p>
-    </div>
+  </div>
+  <div class="u-fixed-width">
+    <p><a href="https://partners.ubuntu.com/programmes/hardware" class="p-link--external">Learn more about working with Canonical</a></p>
   </div>
 </section>
 

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -19,25 +19,26 @@ Ubuntu 18.04 LTS.{% endblock %}
 </section>
 
 <nav class="p-tabs p-sticky-nav">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#user-report">User report</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#desktop-specs">Desktop specs</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#configuration">Configuration</a>
-    </li>
-  </ul>
+  <div class="u-fixed-width">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#user-report">User report</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#desktop-specs">Desktop specs</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#configuration">Configuration</a>
+      </li>
+    </ul>
+  </div>
 </nav>
 
 <section id="user-report" class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <h2>User Report</h2>
-    </div>
+  <div class="u-fixed-width">
+    <h2>User Report</h2>
   </div>
+
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3>How many users opted in?</h3>
@@ -85,13 +86,11 @@ Ubuntu 18.04 LTS.{% endblock %}
         identifiable IP address.</p>
     </div>
   </div>
-  <div class="row">
-    <div class="p-strip-scroll--wrapper">
-      <div class="col-12 p-strip-scroll--wrapper__svg">
-        <div style="height: 500px; width: 1000px; position: relative;" id="where-are-users">
-        </div>
-        <div class="p-scale"></div>
+  <div class="u-fixed-width p-strip-scroll--wrapper">
+    <div class="p-strip-scroll--wrapper__svg">
+      <div style="height: 500px; width: 1000px; position: relative;" id="where-are-users">
       </div>
+      <div class="p-scale"></div>
     </div>
   </div>
 </section>
@@ -101,14 +100,12 @@ Ubuntu 18.04 LTS.{% endblock %}
       <h3>What language do they use?</h3>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 u-align--center">
-      <svg id="language-list-chart" height="250"></svg>
-    </div>
+  <div class="u-fixed-width u-align--center">
+    <svg id="language-list-chart" height="250"></svg>
   </div>
 </section>
 <section id="desktop-specs" class="p-strip--image">
-  <div class="row">
+  <div class="u-fixed-width">
     <h2>Desktop specs</h2>
     <p>This data was collected from user’s machines.</p>
   </div>
@@ -133,11 +130,11 @@ Ubuntu 18.04 LTS.{% endblock %}
 <section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-6">
-      <div class="u-equal-height u-align--center">
-        <div class="col-6 u-align--center">
+      <div class="row u-equal-height u-align--center">
+        <div class="col-3 u-align--center">
           <svg id="firmware-hw"></svg>
         </div>
-        <div class="col-6 u-align--center">
+        <div class="col-3 u-align--center">
           <svg id="firmware-vm"></svg>
         </div>
       </div>
@@ -148,7 +145,7 @@ Ubuntu 18.04 LTS.{% endblock %}
         </ul>
       </div>
     </div>
-    <div class="col-5 prefix-1">
+    <div class="col-5 col-start-large-7">
       <h3>Firmware</h3>
       <p>Firmware initialises hardware components and the operating system at startup.</p>
     </div>
@@ -178,22 +175,22 @@ Ubuntu 18.04 LTS.{% endblock %}
   </div>
 </section>
 <section class="p-strip--light">
-  <div class="row">
+  <div class="u-fixed-width">
     <h3>Popular screen sizes</h3>
     <p>This data set shows the 15 most popular screen sizes.</p>
   </div>
   <div class="row u-equal-height">
-    <div class="col-6 suffix-1">
+    <div class="col-5">
       <svg id="popular-screen-sizes" height="600"></svg>
     </div>
-    <div class="col-5 prefix-1">
+    <div class="col-5 col-start-large-8">
       <h4>Pixel density</h4>
       <svg id="pixel-density" height="320"></svg>
     </div>
   </div>
 </section>
 <section class="p-strip">
-  <div class="row">
+  <div class="u-fixed-width">
     <h3>What CPU and memory do users have?</h3>
   </div>
   <div class="row p-mobile-flex-col u-equal-height p-divider">
@@ -212,7 +209,7 @@ Ubuntu 18.04 LTS.{% endblock %}
   </div>
 </section>
 <section class="p-strip--light">
-  <div class="row">
+  <div class="u-fixed-width">
     <h3>What physical disks do people have?</h3>
   </div>
   <div class="row p-mobile-flex-col u-equal-height u-vertically-center">
@@ -227,7 +224,7 @@ Ubuntu 18.04 LTS.{% endblock %}
   </div>
 </section>
 <section class="p-strip--light u-no-padding">
-  <div class="row">
+  <div class="u-fixed-width">
     <hr class="u-no-margin--bottom" />
   </div>
 </section>
@@ -238,14 +235,12 @@ Ubuntu 18.04 LTS.{% endblock %}
       <p>There are a number of ways to partition a disk when installing Ubuntu depending on what the user wants to do.</p>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <svg id="partition-type" height="250"></svg>
-    </div>
+  <div class="u-fixed-width">
+    <svg id="partition-type" height="250"></svg>
   </div>
 </section>
 <section class="p-strip--light u-no-padding">
-  <div class="row">
+  <div class="u-fixed-width">
     <hr class="u-no-margin--bottom" />
   </div>
 </section>
@@ -262,13 +257,13 @@ Ubuntu 18.04 LTS.{% endblock %}
   </div>
 </section>
 <section id="configuration" class="p-strip">
-  <div class="row">
+  <div class="u-fixed-width">
     <h2>Configuring Ubuntu</h2>
     <p>Users configure Ubuntu in many different ways, we recorded some key points and this will help inform the design
       of future releases.</p>
   </div>
 </section>
-<div class="row">
+<div class="u-fixed-width">
   <hr class="u-no-margin--bottom" />
 </div>
 <section class="p-strip">
@@ -284,7 +279,7 @@ Ubuntu 18.04 LTS.{% endblock %}
     </div>
   </div>
 </section>
-<div class="row">
+<div class="u-fixed-width">
   <hr class="u-no-margin--bottom" />
 </div>
 <section class="p-strip">
@@ -300,25 +295,23 @@ Ubuntu 18.04 LTS.{% endblock %}
     </div>
   </div>
 </section>
-<div class="row">
+<div class="u-fixed-width">
   <hr class="u-no-margin--bottom" />
 </div>
 <section class="p-strip">
-  <div class="row">
-    <div class="row u-equal-height u-vertically-center">
-      <div class="col-6">
-        <p class="p-heading--four">Users who auto-login on start-up</p>
-      </div>
-      <div class="col-3 u-align--center">
-        <svg id="auto-login-hw"></svg>
-      </div>
-      <div class="col-3 u-align--center">
-        <svg id="auto-login-vm"></svg>
-      </div>
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <p class="p-heading--four">Users who auto-login on start-up</p>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="auto-login-hw"></svg>
+    </div>
+    <div class="col-3 u-align--center">
+      <svg id="auto-login-vm"></svg>
     </div>
   </div>
 </section>
-<div class="row">
+<div class="u-fixed-width">
   <hr class="u-no-margin--bottom" />
 </div>
 <section class="p-strip">
@@ -335,7 +328,7 @@ Ubuntu 18.04 LTS.{% endblock %}
     </div>
   </div>
 </section>
-<div class="row">
+<div class="u-fixed-width">
   <hr class="u-no-margin--bottom" />
 </div>
 <section class="p-strip">
@@ -351,12 +344,12 @@ Ubuntu 18.04 LTS.{% endblock %}
     </div>
   </div>
 </section>
-<div class="row">
+<div class="u-fixed-width">
   <hr class="u-no-margin--bottom" />
 </div>
 <section class="p-strip">
   <div class="row">
-    <div class="col-6 prefix-1">
+    <div class="col-6">
       <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}f3f53a95-ubuntu-18.04-survey-metrics.png?w=411" width="411" alt="User survey report">
     </div>
     <div class="col-6">

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -8,10 +8,8 @@
 <section class="p-strip--image u-no-background--small is-deep is-bordered" style="background-image: url('{{ ASSET_SERVER_URL}}1d2ab6ba-suru-background.png'); background-size: 100% 100%;">
   <div class="row u-equal-height">
     <div class="col-8">
-      <div>
-        <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
-        <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, Oracle, Rackspace and IBM Cloud. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
-      </div>
+      <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
+      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, Oracle, Rackspace and IBM Cloud. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}1c786630-image-cloud.svg" width="323" alt="Ubuntu cloud">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -10,10 +10,10 @@
       <h1>Download Ubuntu Desktop</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card--highlighted">
+  <div class="u-fixed-width">
+    <div class="p-card--highlighted">
       <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-      <div class="u-equal-height p-divider">
+      <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
         <div class="col-8 p-divider__block">
           <p class="p-card__content">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
           <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
@@ -34,23 +34,23 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col-12 p-card--highlighted">
-        <h2>Ubuntu {{ releases.latest.full_version }}</h2>
-        <div class="u-equal-height p-divider">
-          <div class="col-8 p-divider__block">
-            <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
-            <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
-            <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</p>
-          </div>
-          <div class="col-4">
-            <p class="p-card__content">
-              <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download</a>
-            </p>
-            <p class="p-card__content">
-              <small><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></small>
-            </p>
-          </div>
+  </div>
+  <div class="u-fixed-width">
+    <div class="p-card--highlighted">
+      <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+      <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
+        <div class="col-8 p-divider__block">
+          <p class="p-card__content">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
+          <p class="p-card__content"><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
+          <p class="p-card__content">Recommended system requirements are the same as for Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</p>
+        </div>
+        <div class="col-4">
+          <p class="p-card__content">
+            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download</a>
+          </p>
+          <p class="p-card__content">
+            <small><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></small>
+          </p>
         </div>
       </div>
     </div>
@@ -58,55 +58,51 @@
 </div>
 
 <div class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Easy ways to switch to Ubuntu</h2>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Easy ways to switch to Ubuntu</h2>
   </div>
 
-  <div class="row">
-    <div class="u-equal-height">
-      <div class="col-4 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}cb3ecebb-picto-ubuntu.svg" width="60" alt="" />
-            <h3 class="p-heading-icon__title">From an older version</h3>
-          </div>
+  <div class="row u-equal-height">
+    <div class="col-4 p-card">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}cb3ecebb-picto-ubuntu.svg" width="60" alt="" />
+          <h3 class="p-heading-icon__title">From an older version</h3>
         </div>
-        <p>If you&rsquo;re already running Ubuntu, you can upgrade in a few clicks from <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Software Updater</a>.</p>
-        <ul class="p-list">
-          <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">How to create a bootable USB stick on Ubuntu</a></li>
-        </ul>
       </div>
+      <p>If you&rsquo;re already running Ubuntu, you can upgrade in a few clicks from <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Software Updater</a>.</p>
+      <ul class="p-list">
+        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">How to create a bootable USB stick on Ubuntu</a></li>
+      </ul>
+    </div>
 
-      <div class="col-4 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}08563efa-picto-windows.svg" width="60"  alt="" />
-            <h3 class="p-heading-icon__title">From Windows</h3>
-          </div>
+    <div class="col-4 p-card">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}08563efa-picto-windows.svg" width="60"  alt="" />
+          <h3 class="p-heading-icon__title">From Windows</h3>
         </div>
-        <p>If you&rsquo;re using Windows 8 or any computer with a 64-bit processor, we recommend the 64-bit download.</p>
-        <ul class="p-list">
-          <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">How to create a bootable USB stick on Windows</a></li>
-        </ul>
       </div>
+      <p>If you&rsquo;re using Windows 8 or any computer with a 64-bit processor, we recommend the 64-bit download.</p>
+      <ul class="p-list">
+        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">How to create a bootable USB stick on Windows</a></li>
+      </ul>
+    </div>
 
-      <div class="col-4 p-card">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}4239507e-picto-mac.svg" width="60"  alt="" />
-            <h3 class="p-heading-icon__title">From macOS</h3>
-          </div>
+    <div class="col-4 p-card">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}4239507e-picto-mac.svg" width="60"  alt="" />
+          <h3 class="p-heading-icon__title">From macOS</h3>
         </div>
-        <p>Most Macs with Intel processors will work with either 64-bit or Mac images. If the 64-bit image doesn't work, try the Mac image.</p>
-        <ul class="p-list">
-          <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">How to create a bootable USB stick on macOS</a></li>
-        </ul>
       </div>
+      <p>Most Macs with Intel processors will work with either 64-bit or Mac images. If the 64-bit image doesn't work, try the Mac image.</p>
+      <ul class="p-list">
+        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">How to create a bootable USB stick on macOS</a></li>
+      </ul>
     </div>
   </div>
 </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -57,7 +57,7 @@ Thank you for your contribution
 
 <section class="p-strip--light is-bordered">
   <div class="row">
-    <div class="col-8 suffix-1">
+    <div class="col-7">
       <h2 class="p-heading--three">Help us to keep Ubuntu free to download, share and use by contributing to ...</h2>
       <noscript>
         <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
@@ -168,12 +168,12 @@ Thank you for your contribution
         </div>
       </form>
     </div>
-    <div class="col-4" style="position: sticky; top: 2rem;">
+    <div class="col-4 col-start-large-9" style="position: sticky; top: 2rem;">
       <div class="p-card">
         <header class="p-card__header">
           <h5 class="p-muted-heading">Newsletter signup</h5>
         </header>
-        <h3 class="p-card--title">Select topics you&rsquo;re interested in</h3>
+        <h3 class="p-card--title u-no-margin--top">Select topics you&rsquo;re interested in</h3>
         <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
           <div class="p-card--content">
             <ul class="p-list">
@@ -262,7 +262,6 @@ Thank you for your contribution
             errorClass: "p-form-validation__message"
           });
         </script>
-      </div>
     </div>
   </section>
 
@@ -533,25 +532,23 @@ Thank you for your contribution
   </script>
 
   <div class="p-strip is-shallow">
-    <div class="row">
-      <div class="u-equal-height">
-        <div class="col-4 p-card--highlighted">
-          <h3>Learn how to try Ubuntu before you install</h3>
-          <p class="p-card__content">Run Ubuntu directly from either a USB stick or a DVD for a quick and easy way to experience how Ubuntu works.</p>
-          <p class="p-card__content"><a class="p-link--external"  href="https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install">Follow our simple guide</a></p>
-        </div>
-        <div class="col-4 p-card--highlighted">
-          <h3>Do you want to upgrade your OS?</h3>
-          <p class="p-card__content">If you are already running Ubuntu, you can upgrade with the Software Updater.</p>
-          <p class="p-card__content"><a href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop" class="p-link--external">Installation instructions</a></p>
-        </div>
-        <div class="col-4 p-card--highlighted">
-          <h3>Let’s connect</h3>
-          <p class="p-card__content">If you get stuck, help is always at hand.</p>
-          <p class="p-card__content"><a href="https://askubuntu.com" class="p-link--external">Ask Ubuntu</a></p>
-          <p class="p-card__content"><a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a></p>
-          <p class="p-card__content"><a href="https://wiki.ubuntu.com/IRC/ChannelList" class="p-link--external">IRC-based support</a></p>
-        </div>
+    <div class="row u-equal-height">
+      <div class="col-4 p-card--highlighted">
+        <h3>Learn how to try Ubuntu before you install</h3>
+        <p class="p-card__content">Run Ubuntu directly from either a USB stick or a DVD for a quick and easy way to experience how Ubuntu works.</p>
+        <p class="p-card__content"><a class="p-link--external"  href="https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install">Follow our simple guide</a></p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3>Do you want to upgrade your OS?</h3>
+        <p class="p-card__content">If you are already running Ubuntu, you can upgrade with the Software Updater.</p>
+        <p class="p-card__content"><a href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop" class="p-link--external">Installation instructions</a></p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3>Let’s connect</h3>
+        <p class="p-card__content">If you get stuck, help is always at hand.</p>
+        <p class="p-card__content"><a href="https://askubuntu.com" class="p-link--external">Ask Ubuntu</a></p>
+        <p class="p-card__content"><a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a></p>
+        <p class="p-card__content"><a href="https://wiki.ubuntu.com/IRC/ChannelList" class="p-link--external">IRC-based support</a></p>
       </div>
     </div>
   </div>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -6,13 +6,13 @@
 {% block content %}
 
 <section class="p-strip">
-  <div class="row">
+  <div class="u-fixed-width">
     <h1>Get Ubuntu for IoT</h1>
   </div>
 </section>
 <section class="p-strip--light is-shallow">
-  <div class="row u-equal-height  u-vertically-center">
-    <div class="col-7 suffix-1">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg"  alt="Raspberry Pi">
@@ -23,7 +23,7 @@
         Get started with an Ubuntu Server image for a familiar development environment.</p>
       <p><a class="p-button--positive" href="/download/iot/raspberry-pi-2-3">Install on Raspberry Pi 2 or 3</a></p>
     </div>
-    <div class="col-5 u-align--center u-hide--small">
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small">
       <img src="{{ ASSET_SERVER_URL }}37373e4d-raspberry-pi.png?w=408" width="420" alt="">
     </div>
   </section>
@@ -81,10 +81,10 @@
   </section>
 
   <section class="p-strip">
-    <div class="row">
+    <div class="u-fixed-width">
       <h3>Supported platforms</h3>
     </div>
-    <div class="row">
+    <div class="u-fixed-width">
       <ul class="p-matrix u-clearfix">
         <li class="p-matrix__item">
           <div class="p-matrix__content">

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -7,231 +7,224 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Create installation media for Ubuntu</h1>
-        <p>These steps will walk you through creating a bootable Ubuntu image SD Card or USB flash drive.</p>
-        <div class="p-notification--caution">
-          <p class="p-notification__response">
-            <span class="p-notification__status">WARNING:</span>This will erase any existing content on the removable drive!
-          </p>
-        </div>
-        <p>View instructions for: <a href="#ubuntu">Ubuntu</a>, <a href="#windows">Windows</a>, or <a href="#macos">macOS</a>.</p>
+      <h1>Create installation media for Ubuntu</h1>
+      <p>These steps will walk you through creating a bootable Ubuntu image SD Card or USB flash drive.</p>
+      <div class="p-notification--caution">
+        <p class="p-notification__response">
+          <span class="p-notification__status">WARNING:</span>This will erase any existing content on the removable drive!
+        </p>
       </div>
+      <p>View instructions for: <a href="#ubuntu">Ubuntu</a>, <a href="#windows">Windows</a>, or <a href="#macos">macOS</a>.</p>
     </div>
   </div>
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="row" id="ubuntu">
-    <div class="col-12">
-      <h2>On Ubuntu</h2>
-      <ol class="p-list-step">
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+  <div class="u-fixed-width" id="ubuntu">
+    <h2>On Ubuntu</h2>
+    <ol class="p-list-step">
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Insert your SD card or USB flash drive
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Insert your SD card or USB flash drive
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
-          </p>
-          <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
+        </p>
+        <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Else, run:
-          </p>
-          <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Else, run:
+        </p>
+        <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Then, run the <code>sync</code> command to finalize the process
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Then, run the <code>sync</code> command to finalize the process
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-          </p>
-        </li>
-      </ol>
-    </div>
+          You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+        </p>
+      </li>
+    </ol>
   </div>
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row" id="windows">
-    <div class="col-12">
-      <h2>On Windows</h2>
-      <ol class="p-list-step">
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+  <div class="u-fixed-width" id="windows">
+    <h2>On Windows</h2>
+    <ol class="p-list-step">
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Insert your SD card or USB flash drive
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Insert your SD card or USB flash drive
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
-          </p>
-          <p>
-            <img alt="" src="http://i.imgur.com/QXLkLsa.png?w=138" width="138" />
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
+        </p>
+        <p>
+          <img alt="" src="http://i.imgur.com/QXLkLsa.png?w=138" width="138" />
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
-          </p>
-          <ol>
-            <li>an <strong>Image File</strong>: navigate to your <code>Downloads</code> folder and select the image you have just extracted</li>
-            <li>a <strong>Device</strong>: the location of your SD card. Select the drive on which your SD card is mounted</li>
-            <p><img alt="" src="http://i.imgur.com/ebeQHKT.png?w=421" width="421" /></p>
-          </ol>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
+        </p>
+        <ol>
+          <li>an <strong>Image File</strong>: navigate to your <code>Downloads</code> folder and select the image you have just extracted</li>
+          <li>a <strong>Device</strong>: the location of your SD card. Select the drive on which your SD card is mounted</li>
+          <p><img alt="" src="http://i.imgur.com/ebeQHKT.png?w=421" width="421" /></p>
+        </ol>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            When ready click on <strong>Write</strong> and wait for the process to complete.
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          When ready click on <strong>Write</strong> and wait for the process to complete.
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-            You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-          </p>
-        </li>
-      </ol>
-    </section>
+          You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+        </p>
+      </li>
+    </ol>
+  </div>
+</section>
 
-    <section class="p-strip--light is-bordered">
-      <div class="row" id="macos">
-        <div class="col-12">
-          <h2>On macOS</h2>
-          <ol class="p-list-step">
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+<section class="p-strip--light is-bordered">
+  <div class="u-fixed-width" id="macos">
+    <h2>On macOS</h2>
+    <ol class="p-list-step">
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                Download the Ubuntu image for your device in your <strong>Downloads</strong> folder
-              </p>
-            </li>
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+          Download the Ubuntu image for your device in your <strong>Downloads</strong> folder
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                Insert your SD card or USB flash drive
-              </p>
-            </li>
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+          Insert your SD card or USB flash drive
+        </p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run this command:
-              </p>
-              <p><pre><code>diskutil list</code></pre></p>
-            </li>
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+          Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run this command:
+        </p>
+        <p><pre><code>diskutil list</code></pre></p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
-              </p>
-              <pre>
-                <code>/dev/disk0
-                  #:                       TYPE NAME                    SIZE       IDENTIFIER
-                  0:      GUID_partition_scheme                        *500.3 GB   disk0
-                  /dev/disk2
-                  #:                       TYPE NAME                    SIZE       IDENTIFIER
-                  0:                  Apple_HFS Macintosh HD           *428.8 GB   disk1
-                  Logical Volume on disk0s2
-                  E2E7C215-99E4-486D-B3CC-DAB8DF9E9C67
-                  Unlocked Encrypted
-                  /dev/disk3
-                  #:                       TYPE NAME                    SIZE       IDENTIFIER
-                  0:     FDisk_partition_scheme                        *7.9 GB     disk3
-                  1:                 DOS_FAT_32 NO NAME                 7.9 GB     disk3s1
-                </code></pre>
-                <p>Your removable drive must be <code>DOS_FAT_32</code> formatted. In this example, <code>/dev/disk3</code> is the drive address of an 8GB SD card.</p>
-              </li>
-              <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
+          In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
+        </p>
+        <pre><code>/dev/disk0
+#:                       TYPE NAME                    SIZE       IDENTIFIER
+0:      GUID_partition_scheme                        *500.3 GB   disk0
+/dev/disk2
+#:                       TYPE NAME                    SIZE       IDENTIFIER
+0:                  Apple_HFS Macintosh HD           *428.8 GB   disk1
+Logical Volume on disk0s2
+E2E7C215-99E4-486D-B3CC-DAB8DF9E9C67
+Unlocked Encrypted
+/dev/disk3
+#:                       TYPE NAME                    SIZE       IDENTIFIER
+0:     FDisk_partition_scheme                        *7.9 GB     disk3
+1:                 DOS_FAT_32 NO NAME                 7.9 GB     disk3s1</code></pre>
+        <p>Your removable drive must be <code>DOS_FAT_32</code> formatted. In this example, <code>/dev/disk3</code> is the drive address of an 8GB SD card.</p>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                  Unmount your SD card with this command:
-                </p>
-                <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
-              </li>
-              <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
+          Unmount your SD card with this command:
+        </p>
+        <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                  When successful, you should see a message similar to this:
-                </p>
-                <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
-              </li>
-              <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
+          When successful, you should see a message similar to this:
+        </p>
+        <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                  You can now copy the image to the SD card:
-                </p>
-                <pre><code>sudo sh -c 'gunzip ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
-                <p>When finished you will see this message:</p>
-                <pre>
-                  <code>3719+1 records in
-                    3719+1 records out
-                    3899999744 bytes transferred in 642.512167 secs (6069924 bytes/sec)
-                  </code></pre>
-                </li>
-                <li class="p-list-step__item col-8">
-                  <p class="p-list-step__title">
+          You can now copy the image to the SD card:
+        </p>
+        <pre><code>sudo sh -c 'gunzip ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
+        <p>When finished you will see this message:</p>
+        <pre><code>3719+1 records in
+3719+1 records out
+3899999744 bytes transferred in 642.512167 secs (6069924 bytes/sec)</code></pre>
+      </li>
+      <li class="p-list-step__item col-8">
+        <p class="p-list-step__title">
 
-                    You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-                  </p>
-                </li>
-              </section>
+          You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+        </p>
+      </li>
+    </ol>
+  </div>
+</section>
 
-              {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 
-              {% endblock content %}
+{% endblock content %}

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -12,7 +12,7 @@
   </div>
   <div class="row">
     <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+      <div class="u-equal-height row p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on an Intel IEI TANK 870. At the end of this process, you will have a board ready for production or testing snaps.</p>

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -7,9 +7,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on an Intel IEI TANK 870</h1>
-      </div>
+      <h1>Install Ubuntu Core on an Intel IEI TANK 870</h1>
     </div>
   </div>
   <div class="row">

--- a/templates/download/iot/intel-joule-desktop.html
+++ b/templates/download/iot/intel-joule-desktop.html
@@ -11,9 +11,9 @@
       <p>There are two install options for the Intel Joule: <a href="intel-joule">Ubuntu Core</a> or <a href="#desktop">Ubuntu Desktop</a>. This page is for Ubuntu Desktop.</p>
     </div>
   </div>
-  <div class="row" id="desktop">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width" id="desktop">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right"> 
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Desktop</h2>
           <p>As an alternative to Ubuntu Core, you can install Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>, where you can use your favourite development tools to create and run snaps.</p>
@@ -38,70 +38,68 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Desktop image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/tuchuck/desktop-final/tuchuck-xenial-desktop-iso-20170317-0.iso">Intel Joule - Ubuntu Desktop 16.04 LTS image</a></li>
-              <li>MD5SUM: 07e4895b2921117288ff611c6f5fea28</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Flash the USB drive with Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download and copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
-            <ol class="u-no-margin--left">
-              <li>Boot the system from the USB flash drive.</li>
-              <li>The system will automatically execute the first stage of installation, including eMMC storage partitioning and image installation. After installation is complete, a prompt dialog will be shown and you will need to restart the system.</li>
-              <li>Boot the system on the eMMC storage and finish the install configuration.</li>
-              <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
-              <li>Pick a hostname, user account and password.</li>
-              <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system.</li>
-              <li>Ubuntu is installed. Use your account and password to log in.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Change the default audio output
-          </h3>
-          <div class="p-list-step__content">
-            <p>In the current release, the analog audio port on mezzanine board is chosen as the default audio output. To use HDMI audio, you need to modify the Joule sound configuration file: <code>/etc/modprobe.d/joule-snd.conf</code></p>
-            <h4>Edit configuration</h4>
-            <ol class="u-no-margin--left">
-              <li>
-                <p>Open an editor to modify the configuration file:</p>
-                <pre><code>sudo nano /etc/modprobe.d/joule-snd.conf</pre></code>
-              </li>
-              <li>To use HDMI audio, uncomment the line <code>#blacklist snd_sock_skl</code> and comment the line <code>softdep snd_hda_intel pre: snd_sock_skl</code>. You can revert these changes if you want to change your sound output back to defaults.</li>
-              <li>Reboot the system to apply the new setting.</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Download Ubuntu Desktop
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Desktop image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/tuchuck/desktop-final/tuchuck-xenial-desktop-iso-20170317-0.iso">Intel Joule - Ubuntu Desktop 16.04 LTS image</a></li>
+            <li>MD5SUM: 07e4895b2921117288ff611c6f5fea28</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Flash the USB drive with Ubuntu Desktop
+        </h3>
+        <div class="p-list-step__content">
+          <p>Download and copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Install Ubuntu Desktop
+        </h3>
+        <div class="p-list-step__content">
+          <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
+          <ol class="u-no-margin--left">
+            <li>Boot the system from the USB flash drive.</li>
+            <li>The system will automatically execute the first stage of installation, including eMMC storage partitioning and image installation. After installation is complete, a prompt dialog will be shown and you will need to restart the system.</li>
+            <li>Boot the system on the eMMC storage and finish the install configuration.</li>
+            <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
+            <li>Pick a hostname, user account and password.</li>
+            <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system.</li>
+            <li>Ubuntu is installed. Use your account and password to log in.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Change the default audio output
+        </h3>
+        <div class="p-list-step__content">
+          <p>In the current release, the analog audio port on mezzanine board is chosen as the default audio output. To use HDMI audio, you need to modify the Joule sound configuration file: <code>/etc/modprobe.d/joule-snd.conf</code></p>
+          <h4>Edit configuration</h4>
+          <ol class="u-no-margin--left">
+            <li>
+              <p>Open an editor to modify the configuration file:</p>
+              <pre><code>sudo nano /etc/modprobe.d/joule-snd.conf</pre></code>
+            </li>
+            <li>To use HDMI audio, uncomment the line <code>#blacklist snd_sock_skl</code> and comment the line <code>softdep snd_hda_intel pre: snd_sock_skl</code>. You can revert these changes if you want to change your sound output back to defaults.</li>
+            <li>Reboot the system to apply the new setting.</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-joule.html
+++ b/templates/download/iot/intel-joule.html
@@ -7,15 +7,13 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on the Intel<sup>&reg;</sup> Joule</h1>
-        <p>There are two install options for the Intel Joule: <a href="#core">Ubuntu Core</a> or <a href="intel-joule-desktop">Ubuntu Desktop</a>. This page is for Ubuntu Core.</p>
-      </div>
+      <h1>Install Ubuntu Core on the Intel<sup>&reg;</sup> Joule</h1>
+      <p>There are two install options for the Intel Joule: <a href="#core">Ubuntu Core</a> or <a href="intel-joule-desktop">Ubuntu Desktop</a>. This page is for Ubuntu Core.</p>
     </div>
   </div>
-  <div  id="core" class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div id="core" class="u-fixed-width row">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on an Intel Joule. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -41,59 +39,57 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/ubuntu-core-16-joule.img.xz">Ubuntu Core 16 image for Intel Joule</a></li>
-              <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/ubuntu-core-16-joule.img.xz">Ubuntu Core 16 image for Intel Joule</a></li>
+            <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Flash the USB drives
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
-              <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Flash the USB drives
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+            <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
-              <li>Insert the first USB flash drive, containing Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
-              <li>Power-up the Joule board, boot-up the device from USB and select “Try Ubuntu without installing” in the first boot menu.</li>
-              <li>Once the system is ready, insert the second USB flash drive.</li>
-              <li>
-                <p>Open a terminal and run the following command, where &lt;disk label&gt; is the name of the second USB flash drive:</p>
-                <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/ubuntu-core-16-joule.img.xz | sudo dd of=/dev/mmcblk0 bs=32M status=progress; sync</code></pre>
-              </li>
-              <li>Remove all USB flash drives and reboot the system, it will reboot from the internal memory now containing Ubuntu Core.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=4 %}
-        {% include "./_login.html" with number=5 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
+            <li>Insert the first USB flash drive, containing Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
+            <li>Power-up the Joule board, boot-up the device from USB and select “Try Ubuntu without installing” in the first boot menu.</li>
+            <li>Once the system is ready, insert the second USB flash drive.</li>
+            <li>
+              <p>Open a terminal and run the following command, where &lt;disk label&gt; is the name of the second USB flash drive:</p>
+              <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/ubuntu-core-16-joule.img.xz | sudo dd of=/dev/mmcblk0 bs=32M status=progress; sync</code></pre>
+            </li>
+            <li>Remove all USB flash drives and reboot the system, it will reboot from the internal memory now containing Ubuntu Core.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=4 %}
+      {% include "./_login.html" with number=5 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -7,15 +7,13 @@
 <section class="p-strip--light is-bordered" id="core">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Desktop on the Intel<sup>&reg;</sup> NUC</h1>
-        <p>There are two install options for the Intel NUC: <a href="intel-nuc">Ubuntu Core</a> or <a href="#desktop">Ubuntu Desktop</a>  This page is for Ubuntu Desktop.</p>
-      </div>
+      <h1>Install Ubuntu Desktop on the Intel<sup>&reg;</sup> NUC</h1>
+      <p>There are two install options for the Intel NUC: <a href="intel-nuc">Ubuntu Core</a> or <a href="#desktop">Ubuntu Desktop</a>  This page is for Ubuntu Desktop.</p>
     </div>
   </div>
-  <div class="row" id="desktop">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width" id="desktop">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Desktop</h2>
           <p>Use your favourite development tools, install snaps and access the vast Ubuntu ecosystem with your NUC.</p>
@@ -37,53 +35,51 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download the correct Ubuntu image for your device:</p>
-            <ul class="u-no-margin--left u-no-margin--top">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
-              <br>Certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE, NUC7i3DNBE and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Flash the USB drive
-          </h3>
-          <div class="p-list-step__content">
-            <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions</a>.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the system from the USB flash drive will start the Ubuntu installer.</p>
-            <ol class="u-no-margin--left">
-              <li>Insert the USB flash drive in the NUC.</li>
-              <li>Start the NUC and push F10 to enter the boot menu.</li>
-              <li>Select the USB flash drive as a boot option.</li>
-              <li>The system will automatically execute the first stage of installation and prompt for an acknowledgement of a complete system recovery.</li>
-              <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
-              <li>Pick a hostname, user account and password.</li>
-              <li>Wait for the configuration to finish. If you are connected to an active network, it will take several minutes to download and apply additional updates.</li>
-              <li>Ubuntu is installed. Use your account and password to log in.</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Download Ubuntu Desktop
+        </h3>
+        <div class="p-list-step__content">
+          <p>Download the correct Ubuntu image for your device:</p>
+          <ul class="u-no-margin--left u-no-margin--top">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
+            <br>Certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE, NUC7i3DNBE and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Flash the USB drive
+        </h3>
+        <div class="p-list-step__content">
+          <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions</a>.</p>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Install Ubuntu Desktop
+        </h3>
+        <div class="p-list-step__content">
+          <p>Booting the system from the USB flash drive will start the Ubuntu installer.</p>
+          <ol class="u-no-margin--left">
+            <li>Insert the USB flash drive in the NUC.</li>
+            <li>Start the NUC and push F10 to enter the boot menu.</li>
+            <li>Select the USB flash drive as a boot option.</li>
+            <li>The system will automatically execute the first stage of installation and prompt for an acknowledgement of a complete system recovery.</li>
+            <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
+            <li>Pick a hostname, user account and password.</li>
+            <li>Wait for the configuration to finish. If you are connected to an active network, it will take several minutes to download and apply additional updates.</li>
+            <li>Ubuntu is installed. Use your account and password to log in.</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -7,15 +7,13 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on the Intel<sup>&reg;</sup> NUC</h1>
-        <p>There are two install options for the Intel NUC: <a href="#core">Ubuntu Core</a> or <a href="intel-nuc-desktop">Ubuntu Desktop</a>  This page is for Ubuntu Core.</p>
-      </div>
+      <h1>Install Ubuntu Core on the Intel<sup>&reg;</sup> NUC</h1>
+      <p>There are two install options for the Intel NUC: <a href="#core">Ubuntu Core</a> or <a href="intel-nuc-desktop">Ubuntu Desktop</a>  This page is for Ubuntu Core.</p>
     </div>
   </div>
-  <div class="row" id="core">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width" id="core">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on an Intel NUC. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -42,81 +40,79 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download the <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz">Ubuntu Core 18 image for Intel Dawson Canyon and June Canyon NUC</a></p>
-            <p>This image is certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE, NUC7i3DNHE, NUC7i3DNKE, and NUC7i3DNBE, and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH</p>
-            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Download the <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz">Ubuntu Core 18 image for Intel Dawson Canyon and June Canyon NUC</a></p>
+          <p>This image is certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE, NUC7i3DNHE, NUC7i3DNKE, and NUC7i3DNBE, and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH</p>
+          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Flash the USB drives
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
-              <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Flash the USB drives
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+            <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
-              <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
-              <li>Connect the USB hub, keyboard, mouse and the monitor to the NUC.</li>
-              <li>Insert the Live USB Ubuntu Desktop flash drive in the NUC.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Install Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
+            <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
+            <li>Connect the USB hub, keyboard, mouse and the monitor to the NUC.</li>
+            <li>Insert the Live USB Ubuntu Desktop flash drive in the NUC.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Boot from the Live USB flash drive
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Start the NUC and push F10 to enter the boot menu.</li>
-              <li>Select the USB flash drive as a boot option.</li>
-              <li>Select "Try Ubuntu without installing”.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Boot from the Live USB flash drive
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Start the NUC and push F10 to enter the boot menu.</li>
+            <li>Select the USB flash drive as a boot option.</li>
+            <li>Select "Try Ubuntu without installing”.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Flash Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
-              <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
-              <pre><code>sudo fdisk -l</code></pre></li>
-              <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
-              <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/dawson-uc18-m7-20190122-10.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
-              <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=7 %}
-        {% include "./_login.html" with number=8 %}
-      </ol>
-    </div>
+          Flash Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
+            <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
+            <pre><code>sudo fdisk -l</code></pre></li>
+            <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
+            <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/dawson-uc18-m7-20190122-10.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
+            <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=7 %}
+      {% include "./_login.html" with number=8 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/kvm.html
+++ b/templates/download/iot/kvm.html
@@ -7,14 +7,13 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-10">
-      <div>
-        <h1>Install Ubuntu Core on KVM</h1>
-      </div>
+      <h1>Install Ubuntu Core on KVM</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of installing Ubuntu Core on your Linux desktop in a virtual machine.</p>
@@ -32,89 +31,87 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ul class="u-no-margin--left">
-              <li>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-              <li>
-                <p>Uncompress the image with the following command:</p>
-                <pre><code>unxz ubuntu-core-18-amd64.img.xz</code></pre>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-
-            Install KVM
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>
-                <p>Install the qemu-kvm package with the following command:</p>
-                <pre><code>sudo apt install qemu-kvm</code></pre>
-              </li>
-              <li>
-                <p>Then, run the kvm-ok command to check KVM status and your hardware:</p>
-                <pre><code>kvm-ok</code></pre>
-              </li>
-              <li>
-                <p>The message should say:</p>
-                <pre><code>INFO: /dev/kvm exists
-KVM acceleration can be used</code></pre>
-                <p>This is the best outcome — it means that Ubuntu Core will run fast on your system, taking advantage of hardware acceleration in your CPU.</p>
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ul class="u-no-margin--left">
+            <li>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+            <li>
+              <p>Uncompress the image with the following command:</p>
+              <pre><code>unxz ubuntu-core-18-amd64.img.xz</code></pre>
             </li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Launch KVM
-          </h3>
-          <div class="p-list-step__content">
-            <p>You can now launch a virtual machine with KVM, using the following command:</p>
-            <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-18-amd64.img,format=raw</code></pre>
-            <p>
-              Note: this command sets up port redirections:
-              <ul>
-                <li><code>localhost:8022</code> is redirecting to port <code>22</code> of the virtual machine for accessing it through SSH</li>
-                <li><code>localhost:8090</code> is redirecting to its port <code>80</code></li>
-              </ul>
-            </p>
-            <p>
-              Note: this command is required for graphics such as mir-kiosk:
-              <ul>
-                <li><code>-vga qxl</code> sets the paravirtual graphics driver qxl</li>
-              </ul>
-            </p>
-            <p>You should now see a window, with your Ubuntu Core virtual machine booting inside it.</p>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Install KVM
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>
+              <p>Install the qemu-kvm package with the following command:</p>
+              <pre><code>sudo apt install qemu-kvm</code></pre>
+            </li>
+            <li>
+              <p>Then, run the kvm-ok command to check KVM status and your hardware:</p>
+              <pre><code>kvm-ok</code></pre>
+            </li>
+            <li>
+              <p>The message should say:</p>
+              <pre><code>INFO: /dev/kvm exists
+KVM acceleration can be used</code></pre>
+              <p>This is the best outcome — it means that Ubuntu Core will run fast on your system, taking advantage of hardware acceleration in your CPU.</p>
+          </li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Login
-          </h3>
-          <div class="p-list-step__content">
-            <p>Once setup is done, you can login with SSH into Ubuntu Core, using the following command:</p>
-            <pre><code>ssh -p 8022 &lt;Ubuntu SSO user name&gt;@localhost</code></pre>
-            <p>Your user name is your Ubuntu SSO user name, it has been reminded to you at the end of the account configuration step.</p>
-          </div>
-        </li>
-      </ol>
-    </div>
+          Launch KVM
+        </h3>
+        <div class="p-list-step__content">
+          <p>You can now launch a virtual machine with KVM, using the following command:</p>
+          <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-18-amd64.img,format=raw</code></pre>
+          <p>
+            Note: this command sets up port redirections:
+            <ul>
+              <li><code>localhost:8022</code> is redirecting to port <code>22</code> of the virtual machine for accessing it through SSH</li>
+              <li><code>localhost:8090</code> is redirecting to its port <code>80</code></li>
+            </ul>
+          </p>
+          <p>
+            Note: this command is required for graphics such as mir-kiosk:
+            <ul>
+              <li><code>-vga qxl</code> sets the paravirtual graphics driver qxl</li>
+            </ul>
+          </p>
+          <p>You should now see a window, with your Ubuntu Core virtual machine booting inside it.</p>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+
+          Login
+        </h3>
+        <div class="p-list-step__content">
+          <p>Once setup is done, you can login with SSH into Ubuntu Core, using the following command:</p>
+          <pre><code>ssh -p 8022 &lt;Ubuntu SSO user name&gt;@localhost</code></pre>
+          <p>Your user name is your Ubuntu SSO user name, it has been reminded to you at the end of the account configuration step.</p>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/orange-pi-zero.html
+++ b/templates/download/iot/orange-pi-zero.html
@@ -7,14 +7,12 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-10">
-      <div>
-        <h1>Install Ubuntu on the Orange Pi Zero</h1>
-      </div>
+      <h1>Install Ubuntu on the Orange Pi Zero</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on an Orange Pi Zero. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -37,49 +35,47 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://www.orangepi.org/downloadresources/orangepizero/2017-08-18/orangepizero_97899291e57c7a56ec9073f.html">Ubuntu Core 16 for Orange Pi Zero</a></li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://www.orangepi.org/downloadresources/orangepizero/2017-08-18/orangepizero_97899291e57c7a56ec9073f.html">Ubuntu Core 16 for Orange Pi Zero</a></li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Insert the SD card into the board.</li>
-              <li>Connect the Ethernet cable to the board and to the network.</li>
-              <li>Connect the TTL end of the TTL to USB cable, to the three pins next to the Ethernet port. On this diagram, they are identified by the label "Debug serial port". The pin layout is, from the outside to the inside:
-                <ul>
-                  <li><code>GND</code> (black wire)</li>
-                  <li><code>RX</code> (white wire)</li>
-                  <li><code>TX</code> (green wire)</li>
-                </ul>
-              </li>
-              <li>Connect the USB end of the cable into your host computer, open a terminal and run <code>sudo screen /dev/ttyUSB0 115200</code> to open a listening connection to the board.</li>
-              <li>Power on the board. The terminal on your host computer should display the boot sequence. If not, please ensure the TTL to USB cable is correctly connected.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Insert the SD card into the board.</li>
+            <li>Connect the Ethernet cable to the board and to the network.</li>
+            <li>Connect the TTL end of the TTL to USB cable, to the three pins next to the Ethernet port. On this diagram, they are identified by the label "Debug serial port". The pin layout is, from the outside to the inside:
+              <ul>
+                <li><code>GND</code> (black wire)</li>
+                <li><code>RX</code> (white wire)</li>
+                <li><code>TX</code> (green wire)</li>
+              </ul>
+            </li>
+            <li>Connect the USB end of the cable into your host computer, open a terminal and run <code>sudo screen /dev/ttyUSB0 115200</code> to open a listening connection to the board.</li>
+            <li>Power on the board. The terminal on your host computer should display the boot sequence. If not, please ensure the TTL to USB cable is correctly connected.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/qualcomm-dragonboard-410c.html
+++ b/templates/download/iot/qualcomm-dragonboard-410c.html
@@ -7,14 +7,12 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on the Qualcomm DragonBoard 410c</h1>
-      </div>
+      <h1>Install Ubuntu Core on the Qualcomm DragonBoard 410c</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on a DragonBoard 410c. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -38,43 +36,41 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz">Ubuntu Core 18 image for DragonBoard 410c</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz">Ubuntu Core 18 image for DragonBoard 410c</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Make sure the DragonBoard is unplugged from power.</li>
-              <li>Set the S6 switch to 0-1-0-0, where 1 is the "SD boot" option.</li>
-              <li>Attach the monitor and keyboard to the board.</li>
-              <li>Insert the SD card and plug the power adaptor into the board.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Make sure the DragonBoard is unplugged from power.</li>
+            <li>Set the S6 switch to 0-1-0-0, where 1 is the "SD boot" option.</li>
+            <li>Attach the monitor and keyboard to the board.</li>
+            <li>Insert the SD card and plug the power adaptor into the board.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/raspberry-pi-2-3-core.html
+++ b/templates/download/iot/raspberry-pi-2-3-core.html
@@ -7,14 +7,12 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on a Raspberry Pi 2 or 3</h1>
-      </div>
+      <h1>Install Ubuntu Core on a Raspberry Pi 2 or 3</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2 or 3. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -36,44 +34,42 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
-              </li>
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
-              </li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
+            </li>
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+            </li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
-              <li>Insert the microSD card and plug the power adaptor into the board.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+            <li>Insert the microSD card and plug the power adaptor into the board.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -7,17 +7,15 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Server on a Raspberry Pi 2 or 3</h1>
-      </div>
+      <h1>Install Ubuntu Server on a Raspberry Pi 2 or 3</h1>
     </div>
-    <div class="col-4 u-vertically-center">
+    <div class="col-4">
       <img src="{{ ASSET_SERVER_URL }}31bd2627-logo-raspberry-pi.svg" width="100" alt="Raspberry Pi">
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Server</h2>
           <p>We will walk you through the steps of flashing Ubuntu Server on a Raspberry Pi 2 or 3. At the end of this process, you will have a fully fledged development or production environment..</p>
@@ -39,50 +37,48 @@
 </section>
 
 <section class="p-strip--light is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Server image for your board:</p>
-            <ul class="u-no-margin--left" style="list-style-type: disc;">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-armhf+raspi2.img.xz">Ubuntu Server image for Raspberry Pi 2.</a>
-              </li>
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-arm64+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 3</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
-              </li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Server
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Server image for your board:</p>
+          <ul class="u-no-margin--left" style="list-style-type: disc;">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-armhf+raspi2.img.xz">Ubuntu Server image for Raspberry Pi 2.</a>
+            </li>
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-arm64+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 3</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+            </li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Install Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
-              <li>Insert the microSD card and plug the power adaptor into the board.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Install Ubuntu Server
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+            <li>Insert the microSD card and plug the power adaptor into the board.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Login
-          </h3>
-          <div class="p-list-step__content">
-            <p>When prompted to log in, use "ubuntu" for the username and the password. You will be asked to change this default password after you log in.</p>
-          </div>
-        </li>
-      </ol>
-    </div>
+          Login
+        </h3>
+        <div class="p-list-step__content">
+          <p>When prompted to log in, use "ubuntu" for the username and the password. You will be asked to change this default password after you log in.</p>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/raspberry-pi-compute-module-3.html
+++ b/templates/download/iot/raspberry-pi-compute-module-3.html
@@ -7,14 +7,12 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on the Raspberry Pi Compute Module 3</h1>
-      </div>
+      <h1>Install Ubuntu Core on the Raspberry Pi Compute Module 3</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on a Compute Module 3. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -40,98 +38,96 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item" id="step2">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-list-step__item" id="step2">
+        <h3 class="p-list-step__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+cm3.img.xz">Ubuntu Core 18 image for Compute Module 3</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+cm3.img.xz">Ubuntu Core 18 image for Compute Module 3</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Setup USBboot on your host system
-          </h3>
-          <div class="p-list-step__content">
-            <p>On the host system: Ubuntu Desktop 16.04 or above:</p>
-            <ol>
-              <li>
-                <p>In a terminal, download the USBboot tool you will use to setup the board, and install its build dependencies:</p>
-                <pre><code>git clone --depth=1 https://github.com/raspberrypi/usbboot.git
+          Setup USBboot on your host system
+        </h3>
+        <div class="p-list-step__content">
+          <p>On the host system: Ubuntu Desktop 16.04 or above:</p>
+          <ol>
+            <li>
+              <p>In a terminal, download the USBboot tool you will use to setup the board, and install its build dependencies:</p>
+              <pre><code>git clone --depth=1 https://github.com/raspberrypi/usbboot.git
 sudo apt install libusb-1.0-0-dev</code></pre>
-              </li>
-              <li>
-                <p>Then <code>cd</code into the USBboot directory, build with <code>make</code> and start the resulting binary as root:</p>
-                <pre><code>cd usbboot
+            </li>
+            <li>
+              <p>Then <code>cd</code into the USBboot directory, build with <code>make</code> and start the resulting binary as root:</p>
+              <pre><code>cd usbboot
 make
 sudo ./rpiboot</code></pre>
-              </li>
-              <li>Once started, it will wait for the Compute Module to be attached to the machine.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+            </li>
+            <li>Once started, it will wait for the Compute Module to be attached to the machine.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Setup the Compute Module IO board
-          </h3>
-          <div class="p-list-step__content">
-            <p>On the Compute Module IO board:</p>
-            <ol>
-              <li>Position the Compute Module on the IO board.</li>
-              <li>Attach the USB hub, RJ45 adaptor, keyboard and monitor (HDMI) to the board.</li>
-              <li>
-                <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
-                <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"></p>
-              </li>
-              <li>
-                <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
-                <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"></p>
-              </li>
-              <li>With the second micro USB to USB cable, power on the IO board.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Setup the Compute Module IO board
+        </h3>
+        <div class="p-list-step__content">
+          <p>On the Compute Module IO board:</p>
+          <ol>
+            <li>Position the Compute Module on the IO board.</li>
+            <li>Attach the USB hub, RJ45 adaptor, keyboard and monitor (HDMI) to the board.</li>
+            <li>
+              <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
+              <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"></p>
+            </li>
+            <li>
+              <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
+              <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"></p>
+            </li>
+            <li>With the second micro USB to USB cable, power on the IO board.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
 
-            Flash the board from your host system
-          </h3>
-          <div class="p-list-step__content">
-            <p>On your host system:</p>
-            <ol>
-              <li>The USBboot tool should have recognized the attached Compute Module and mounted the EMMC partition as a new device.</li>
-              <li>Identify the device by opening the "Disks" application:
-                <ul>
-                  <li>Locate the EMMC partition of the Compute Module in the left pane.</li>
-                  <li>Note down its "Device" address on the right pane.</li>
-                  <li>If the partition is mounted, unmount it by clicking the square icon below the partition diagram or the eject icon in a file manager</li>
-                </ul>
-              </li>
-              <li>Download the <a href="#step2">Ubuntu Core image</a>. When this is done you should have an <code>ubuntu-core-18-armhf+cm3.img.xz</code> file in your <code>~/Downloads</code> directory</li>
-              <li>
-                <p>Flash Ubuntu Core on the EMMC partition with:</p>
-                <pre><code>xzcat ~/Downloads/&lt;image file .xz&gt; | sudo dd of=&lt;device address&gt; bs=32M; sync</code></pre>
-              </li>
-              <li>This process will take some time. After completion, you can reboot your Compute Module IO board and follow the first boot process with the display, keyboard and RJ45/WiFI dongle attached to it.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=6 %}
-        {% include "./_login.html" with number=7 %}
-      </ol>
-    </div>
+          Flash the board from your host system
+        </h3>
+        <div class="p-list-step__content">
+          <p>On your host system:</p>
+          <ol>
+            <li>The USBboot tool should have recognized the attached Compute Module and mounted the EMMC partition as a new device.</li>
+            <li>Identify the device by opening the "Disks" application:
+              <ul>
+                <li>Locate the EMMC partition of the Compute Module in the left pane.</li>
+                <li>Note down its "Device" address on the right pane.</li>
+                <li>If the partition is mounted, unmount it by clicking the square icon below the partition diagram or the eject icon in a file manager</li>
+              </ul>
+            </li>
+            <li>Download the <a href="#step2">Ubuntu Core image</a>. When this is done you should have an <code>ubuntu-core-18-armhf+cm3.img.xz</code> file in your <code>~/Downloads</code> directory</li>
+            <li>
+              <p>Flash Ubuntu Core on the EMMC partition with:</p>
+              <pre><code>xzcat ~/Downloads/&lt;image file .xz&gt; | sudo dd of=&lt;device address&gt; bs=32M; sync</code></pre>
+            </li>
+            <li>This process will take some time. After completion, you can reboot your Compute Module IO board and follow the first boot process with the display, keyboard and RJ45/WiFI dongle attached to it.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=6 %}
+      {% include "./_login.html" with number=7 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/samsung-artik-5-10-server.html
+++ b/templates/download/iot/samsung-artik-5-10-server.html
@@ -7,15 +7,13 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Server on the Samsung Artik 5 or 10</h1>
-        <p>There are two install options for the Samsung Artik: <a href="samsung-artik-5-10">Ubuntu Core</a> or <a href="#server">Ubuntu Server</a>. This page is for Ubuntu Server.</p>
-      </div>
+      <h1>Install Ubuntu Server on the Samsung Artik 5 or 10</h1>
+      <p>There are two install options for the Samsung Artik: <a href="samsung-artik-5-10">Ubuntu Core</a> or <a href="#server">Ubuntu Server</a>. This page is for Ubuntu Server.</p>
     </div>
   </div>
-  <div class="row" id="server">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width" id="server">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Server</h2>
           <p>As an alternative to Ubuntu Core, you can also install Ubuntu Server 16.04 LTS, where you can use your favourite development tools to create and run snaps.</p>
@@ -35,54 +33,52 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik5-ubuntu-server.img.tar.xz">ARTIK 5 - Ubuntu Server 16.04 LTS image</a></li>
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik10-ubuntu-server.img.tar.xz">ARTIK 10 - Ubuntu Server 16.04 LTS image</a></li>
-              <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Set your board to boot from the SD card
-          </h3>
-          <div class="p-list-step__content">
-            <p>Before installing Ubuntu, you need to set your Artik to boot from the SD card, to do so, set the "SW2" switches to <code>1:on</code> and <code>2:on</code>.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the board from the SD Card will start the Ubuntu installer:</p>
-            <ol class="u-no-margin--left">
-              <li>Insert the SD card in your Samsung ARTIK</li>
-              <li>Connect the 5V power supply to the board, then use the power button on the board to switch on your Samsung ARTIK</li>
-              <li>The system will automatically execute the first stage of installation</li>
-              <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout</li>
-              <li>Pick a hostname, user account and password</li>
-              <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system</li>
-              <li>Ubuntu is installed. Use your account and password to log in</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" with number=1 %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik5-ubuntu-server.img.tar.xz">ARTIK 5 - Ubuntu Server 16.04 LTS image</a></li>
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik10-ubuntu-server.img.tar.xz">ARTIK 10 - Ubuntu Server 16.04 LTS image</a></li>
+            <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Set your board to boot from the SD card
+        </h3>
+        <div class="p-list-step__content">
+          <p>Before installing Ubuntu, you need to set your Artik to boot from the SD card, to do so, set the "SW2" switches to <code>1:on</code> and <code>2:on</code>.</p>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Install Ubuntu Server
+        </h3>
+        <div class="p-list-step__content">
+          <p>Booting the board from the SD Card will start the Ubuntu installer:</p>
+          <ol class="u-no-margin--left">
+            <li>Insert the SD card in your Samsung ARTIK</li>
+            <li>Connect the 5V power supply to the board, then use the power button on the board to switch on your Samsung ARTIK</li>
+            <li>The system will automatically execute the first stage of installation</li>
+            <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout</li>
+            <li>Pick a hostname, user account and password</li>
+            <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system</li>
+            <li>Ubuntu is installed. Use your account and password to log in</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/samsung-artik-5-10.html
+++ b/templates/download/iot/samsung-artik-5-10.html
@@ -7,15 +7,13 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Core on the Samsung Artik 5 or 10</h1>
-        <p>There are two install options for the Samsung Artik: <a href="#core">Ubuntu Core</a> or <a href="samsung-artik-5-10-server">Ubuntu Server</a>. This page is for Ubuntu Core.</p>
-      </div>
+      <h1>Install Ubuntu Core on the Samsung Artik 5 or 10</h1>
+      <p>There are two install options for the Samsung Artik: <a href="#core">Ubuntu Core</a> or <a href="samsung-artik-5-10-server">Ubuntu Server</a>. This page is for Ubuntu Core.</p>
     </div>
   </div>
-  <div class="row" id="core">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width" id="core">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
           <p>We will walk you through the steps of flashing Ubuntu Core on a Samsung Artik 5 or 10. At the end of this process, you will have a board ready for production or testing snaps.</p>
@@ -35,43 +33,41 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik5.img.xz">Ubuntu Core 16 image for Samsung Artik 5</a></li>
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik10.img.xz">Ubuntu Core 16 image for Samsung Artik 10</a></li>
-              <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="SD card" number=3 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Prepare your Artik to boot from the SD card, by setting the "SW2" switches to <code>1:on</code> and <code>2:on</code></li>
-              <li>Insert the SD card</li>
-              <li>Connect the 5V power supply to the board, then use the power button on the board to switch it on</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" with number=1 %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Download Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik5.img.xz">Ubuntu Core 16 image for Samsung Artik 5</a></li>
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik10.img.xz">Ubuntu Core 16 image for Samsung Artik 10</a></li>
+            <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="SD card" number=3 %}
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Install Ubuntu Core
+        </h3>
+        <div class="p-list-step__content">
+          <ol class="u-no-margin--left">
+            <li>Prepare your Artik to boot from the SD card, by setting the "SW2" switches to <code>1:on</code> and <code>2:on</code></li>
+            <li>Insert the SD card</li>
+            <li>Connect the 5V power supply to the board, then use the power button on the board to switch it on</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/up-squared-iot-grove-server.html
+++ b/templates/download/iot/up-squared-iot-grove-server.html
@@ -7,14 +7,12 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <div>
-        <h1>Install Ubuntu Server on an UP<sup>2</sup> IoT Grove Development Kit</h1>
-      </div>
+      <h1>Install Ubuntu Server on an UP<sup>2</sup> IoT Grove Development Kit</h1>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12 p-card">
-      <div class="u-equal-height p-divider">
+  <div class="u-fixed-width">
+    <div class="p-card">
+      <div class="u-equal-height p-divider row u-no-padding--left u-no-padding--right">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Server</h2>
           <p>We will walk you through the steps of installing Ubuntu Server on the UP<sup>2</sup> IoT Grove Development Kit. At the end of this process, you will have a fully fledged development or production environment.</p>
@@ -33,39 +31,37 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Server image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li>Intel provides a modified Ubuntu Server 16.04.3 LTS image shipped with a custom 4.10 kernel and the Intel IoT Developer Kit.</li>
-              <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
-            <ol class="u-no-margin--left">
-              <li>Insert the USB flash drive in the Up<sup>2</sup> board.</li>
-              <li>Power on the board.</li>
-              <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Download Ubuntu Server
+        </h3>
+        <div class="p-list-step__content">
+          <p>Get the correct Ubuntu Server image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li>Intel provides a modified Ubuntu Server 16.04.3 LTS image shipped with a custom 4.10 kernel and the Intel IoT Developer Kit.</li>
+            <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-list-step__item">
+        <h3 class="p-list-step__title">
+          
+          Install Ubuntu Server
+        </h3>
+        <div class="p-list-step__content">
+          <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
+          <ol class="u-no-margin--left">
+            <li>Insert the USB flash drive in the Up<sup>2</sup> board.</li>
+            <li>Power on the board.</li>
+            <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -10,7 +10,7 @@
 {% block content %}
 
 <section class="p-strip--suru-half-and-half-reversed is-dark">
-  <div class="row u-equal-height">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
       <h1>Embedded Linux 2.0</h1>
       <p class="p-heading--four">
@@ -18,24 +18,26 @@
         More reliable updates. Much better security.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align--right u-vertically-center">
+    <div class="col-6 u-hide--small u-align--right">
       <img src="{{ ASSET_SERVER_URL }}4e2131b0-3B-Embedded+Linux.svg" alt="" width="335px">
     </div>
   </div>
 </section>
 
 <nav class="p-tabs p-sticky-nav">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#developers">Developers</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#apps">Apps</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#hardware">Hardware</a>
-    </li>
-  </ul>
+  <div class="u-fixed-width">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#developers">Developers</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#apps">Apps</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#hardware">Hardware</a>
+      </li>
+    </ul>
+  </div>
 </nav>
 
 <section class="p-strip u-no-padding--bottom">
@@ -52,62 +54,57 @@
       </ul>
     </div>
   </div>
-  <div class="row" style="margin-top: 3rem;">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Save time</h4>
-            <p class="p-matrix__desc">Developers are much more productive on Ubuntu than handcrafted embedded Linux.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Save money</h4>
-            <p class="p-matrix__desc">Sharing a platform shares the cost. Licensing is cheaper, updates more tested and maintenance shared.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Raise quality</h4>
-            <p class="p-matrix__desc">Familiar and widely used Ubuntu means easy CI/CD, better tools, faster updates and better kernels.</p>
-          </div>
-        </li>
+  <div class="u-fixed-width" style="margin-top: 3rem;">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Save time</h4>
+          <p class="p-matrix__desc">Developers are much more productive on Ubuntu than handcrafted embedded Linux.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Save money</h4>
+          <p class="p-matrix__desc">Sharing a platform shares the cost. Licensing is cheaper, updates more tested and maintenance shared.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Raise quality</h4>
+          <p class="p-matrix__desc">Familiar and widely used Ubuntu means easy CI/CD, better tools, faster updates and better kernels.</p>
+        </div>
+      </li>
 
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Pre-enabled boards</h4>
-            <p class="p-matrix__desc">Linux is not a differentiator. Use pre-enabled boards and focus on software unique to your story.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Simplify operations</h4>
-            <p class="p-matrix__desc">Managing a familiar environment and platform is easier and cheaper than a specialist OS. Naturally.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">More talent</h4>
-            <p class="p-matrix__desc">More Linux developers choose Ubuntu, so the talent pool is deeper and broader.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p><a class="p-button--positive js-invoke-modal" href="/internet-of-things/contact-us">Get in touch</a></p>
-      </div>
-    </div>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Pre-enabled boards</h4>
+          <p class="p-matrix__desc">Linux is not a differentiator. Use pre-enabled boards and focus on software unique to your story.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Simplify operations</h4>
+          <p class="p-matrix__desc">Managing a familiar environment and platform is easier and cheaper than a specialist OS. Naturally.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">More talent</h4>
+          <p class="p-matrix__desc">More Linux developers choose Ubuntu, so the talent pool is deeper and broader.</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="u-fixed-width">
+    <p><a class="p-button--positive js-invoke-modal" href="/internet-of-things/contact-us">Get in touch</a></p>
   </div>
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <h3>Explore what snaps bring to Embedded Linux</h3>
-    </div>
+  <div class="u-fixed-width">
+    <h3>Explore what snaps bring to Embedded Linux</h3>
   </div>
+
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <!-- rtp section left start -->
@@ -158,52 +155,52 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">More developers</h4>
-            <p class="p-matrix__desc">Tap the biggest talent pool. Ubuntu is ahead of the pack by every measure.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">More packages</h4>
-            <p class="p-matrix__desc">Productivity starts with reuse. Accelerate developers with the world’s largest package selection.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Better tools</h4>
-            <p class="p-matrix__desc">Every compiler and language developers use today is there, free, in Ubuntu.</p>
-          </div>
-        </li>
+  <div class="u-fixed-width">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">More developers</h4>
+          <p class="p-matrix__desc">Tap the biggest talent pool. Ubuntu is ahead of the pack by every measure.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">More packages</h4>
+          <p class="p-matrix__desc">Productivity starts with reuse. Accelerate developers with the world’s largest package selection.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Better tools</h4>
+          <p class="p-matrix__desc">Every compiler and language developers use today is there, free, in Ubuntu.</p>
+        </div>
+      </li>
 
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Cloud compatible</h4>
-            <p class="p-matrix__desc">Developers use Ubuntu in the cloud for CI/CD and build systems &mdash; iterate faster, deliver sooner.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Latest software</h4>
-            <p class="p-matrix__desc">Ubuntu is renowned for being the place where you get the best and the latest bits.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Container friendly</h4>
-            <p class="p-matrix__desc">The people who drive docker hardest do it on Ubuntu. Make cloud-native things.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Cloud compatible</h4>
+          <p class="p-matrix__desc">Developers use Ubuntu in the cloud for CI/CD and build systems &mdash; iterate faster, deliver sooner.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Latest software</h4>
+          <p class="p-matrix__desc">Ubuntu is renowned for being the place where you get the best and the latest bits.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Container friendly</h4>
+          <p class="p-matrix__desc">The people who drive docker hardest do it on Ubuntu. Make cloud-native things.</p>
+        </div>
+      </li>
+    </ul>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
+
   <div class="row u-vertically-center u-equal-height">
     <div class="col-6">
       <h3>Classic Ubuntu Server<br /> or new Ubuntu Core</h3>
@@ -228,9 +225,11 @@
       <p><a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a></p>
     </div>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
+
   <div class="row u-equal-height">
     <div class="col-6">
       <h3>Security matters most</h3>
@@ -241,49 +240,49 @@
       <img src="{{ ASSET_SERVER_URL }}c53664cd-Security_updates.svg" alt="" width="335px">
     </div>
   </div>
-  <div class="row" style="margin-top: 3rem;">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Fast fixes</h4>
-            <p class="p-matrix__desc">Canonical publishes security updates for Ubuntu every day. You choose when they get installed on your devices.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Binary package updates</h4>
-            <p class="p-matrix__desc">Canonical builds and tests binary package updates for Ubuntu. No need to integrate a mountain of source code patches every year.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">CVE tracking</h4>
-            <p class="p-matrix__desc">A database of fixes supports your customer compliance policy by making it clear which issue is addressed in any update.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Trusted Compute</h4>
-            <p class="p-matrix__desc">Ubuntu provides a verified boot sequence and full disk encryption with optional hardware keys.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Strict confinement</h4>
-            <p class="p-matrix__desc">Keep your custom software strictly confined as snaps to ensure any problem stays isolated.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">10 year maintenance</h4>
-            <p class="p-matrix__desc">No other embedded Linux comes close to Canonical’s commitment to long term security.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+
+  <div class="u-fixed-width" style="margin-top: 3rem;">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Fast fixes</h4>
+          <p class="p-matrix__desc">Canonical publishes security updates for Ubuntu every day. You choose when they get installed on your devices.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Binary package updates</h4>
+          <p class="p-matrix__desc">Canonical builds and tests binary package updates for Ubuntu. No need to integrate a mountain of source code patches every year.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">CVE tracking</h4>
+          <p class="p-matrix__desc">A database of fixes supports your customer compliance policy by making it clear which issue is addressed in any update.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Trusted Compute</h4>
+          <p class="p-matrix__desc">Ubuntu provides a verified boot sequence and full disk encryption with optional hardware keys.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Strict confinement</h4>
+          <p class="p-matrix__desc">Keep your custom software strictly confined as snaps to ensure any problem stays isolated.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">10 year maintenance</h4>
+          <p class="p-matrix__desc">No other embedded Linux comes close to Canonical’s commitment to long term security.</p>
+        </div>
+      </li>
+    </ul>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
 
@@ -296,29 +295,28 @@
       <img src="{{ ASSET_SERVER_URL }}2697f642-Compliance.svg" alt="" width="335px" />
     </div>
   </div>
-  <div class="row" style="margin-top: 3rem;">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Automatic source publication</h4>
-            <p class="p-matrix__desc">Meet GPL requirements automatically.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Annotations</h4>
-            <p class="p-matrix__desc">Know what licenses are used in each package.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Scanning</h4>
-            <p class="p-matrix__desc">Let us check for undocumented or unauthorised code combinations.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+
+  <div class="u-fixed-width" style="margin-top: 3rem;">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Automatic source publication</h4>
+          <p class="p-matrix__desc">Meet GPL requirements automatically.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Annotations</h4>
+          <p class="p-matrix__desc">Know what licenses are used in each package.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Scanning</h4>
+          <p class="p-matrix__desc">Let us check for undocumented or unauthorised code combinations.</p>
+        </div>
+      </li>
+    </ul>
   </div>
 </section>
 
@@ -351,11 +349,12 @@
       </p>
     </div>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
 
-  <div class='row u-equal-height'>
+  <div class="row u-equal-height">
     <div class="col-6">
       <h3>DevOps for devices</h3>
       <p>Build, test and publish applications automatically. Bring CI/CD to your IoT and appliances. Give your developers a pipeline to deliver updates to customers straight from their standard process, and empower customers to test beta and pre-release versions.</p>
@@ -366,9 +365,11 @@
       <img src="{{ ASSET_SERVER_URL }}0df476e6-DevOps.svg" alt="" width="335px">
     </div>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
+
   <div class="row">
     <div class="col-6">
       <h3>All kinds of containers</h3>
@@ -400,6 +401,7 @@
       </div>
     </div>
   </div>
+
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <img class="p-card__thumbnail" src="{{ ASSET_SERVER_URL }}dba11aee-kubernetes.svg" alt="" style="max-height: 4rem;">
@@ -416,9 +418,11 @@
       <p><a class="p-link--external" href="https://linuxcontainers.org/lxd/introduction/">Learn more about LXD</a></p>
     </div>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
+
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
       <h3>Ultra-reliable updates</h3>
@@ -427,48 +431,47 @@
       <img src="{{ ASSET_SERVER_URL }}77faea7a-Reliable_updates.svg" alt="" width="335px">
     </div>
   </div>
-  <div class="row" style="margin-top: 3rem;">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Transactional</h4>
-            <p class="p-matrix__desc">Failed updates roll back to the last working version automatically, allowing for rapid deployment.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Auditable</h4>
-            <p class="p-matrix__desc">All snaps are digitally signed and can be verified at any time. On Ubuntu Core, the entire device is immutable and traceable.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Secured</h4>
-            <p class="p-matrix__desc">Every application is confined to its own area for heightened security. On Ubuntu Core, the OS is locked down too.</p>
-          </div>
-        </li>
 
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Snap deltas</h4>
-            <p class="p-matrix__desc">Binary deltas mean we transmit the least possible data per update, saving you time and money.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Snapshots</h4>
-            <p class="p-matrix__desc">Backup device data at any time. Integrate with your existing data management strategy.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Update control</h4>
-            <p class="p-matrix__desc">Schedule snap updates to align with planned maintenance windows.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+  <div class="u-fixed-width" style="margin-top: 3rem;">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Transactional</h4>
+          <p class="p-matrix__desc">Failed updates roll back to the last working version automatically, allowing for rapid deployment.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Auditable</h4>
+          <p class="p-matrix__desc">All snaps are digitally signed and can be verified at any time. On Ubuntu Core, the entire device is immutable and traceable.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Secured</h4>
+          <p class="p-matrix__desc">Every application is confined to its own area for heightened security. On Ubuntu Core, the OS is locked down too.</p>
+        </div>
+      </li>
+
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Snap deltas</h4>
+          <p class="p-matrix__desc">Binary deltas mean we transmit the least possible data per update, saving you time and money.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Snapshots</h4>
+          <p class="p-matrix__desc">Backup device data at any time. Integrate with your existing data management strategy.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Update control</h4>
+          <p class="p-matrix__desc">Schedule snap updates to align with planned maintenance windows.</p>
+        </div>
+      </li>
+    </ul>
   </div>
 </section>
 
@@ -507,9 +510,11 @@
       <p><a class="p-button--positive js-invoke-modal" href="/core/contact-us">Get in touch about certification</a></p>
     </div>
   </div>
-  <div class="row">
+
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
+
   <div class="row u-equal-height">
     <div class="col-6">
       <h3>Unleash your hardware</h3>
@@ -519,48 +524,47 @@
       <img src="{{ ASSET_SERVER_URL }}122d89aa-Unleash_hardware.svg" alt="" width="335px" />
     </div>
   </div>
-  <div class="row" style="margin-top: 3rem;">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Super connected</h4>
-            <p class="p-matrix__desc">Bluetooth, WiFi, LTE. It’s all at your fingertips. Standard system services with long term maintenance included.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Sensor integration</h4>
-            <p class="p-matrix__desc">Get your real-world data streams flowing with the UPM and MRAA packages for Ubuntu.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Architectures</h4>
-            <p class="p-matrix__desc">Our entire platform is certified on both x86 and ARM. Pick your favorite, or use both in a product family with little overhead.</p>
-          </div>
-        </li>
 
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Right size silicon</h4>
-            <p class="p-matrix__desc">Start on Ubuntu and select the right silicon close to physical shipment, when your performance needs are better defined.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Performance optimised</h4>
-            <p class="p-matrix__desc">Canonical works with the leading silicon providers to optimise the entire stack &mdash; from metal and kernel to computer vision and AI.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Secure appliances</h4>
-            <p class="p-matrix__desc">Full disk encryption, secure boot and hardware key management raise the bar for trusted computing at the edge.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+  <div class="u-fixed-width" style="margin-top: 3rem;">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Super connected</h4>
+          <p class="p-matrix__desc">Bluetooth, WiFi, LTE. It’s all at your fingertips. Standard system services with long term maintenance included.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Sensor integration</h4>
+          <p class="p-matrix__desc">Get your real-world data streams flowing with the UPM and MRAA packages for Ubuntu.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Architectures</h4>
+          <p class="p-matrix__desc">Our entire platform is certified on both x86 and ARM. Pick your favorite, or use both in a product family with little overhead.</p>
+        </div>
+      </li>
+
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Right size silicon</h4>
+          <p class="p-matrix__desc">Start on Ubuntu and select the right silicon close to physical shipment, when your performance needs are better defined.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Performance optimised</h4>
+          <p class="p-matrix__desc">Canonical works with the leading silicon providers to optimise the entire stack &mdash; from metal and kernel to computer vision and AI.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Secure appliances</h4>
+          <p class="p-matrix__desc">Full disk encryption, secure boot and hardware key management raise the bar for trusted computing at the edge.</p>
+        </div>
+      </li>
+    </ul>
   </div>
 </section>
 
@@ -577,48 +581,46 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-matrix">
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Frictionless development</h4>
-            <p class="p-matrix__desc">Standard images of Ubuntu are free to download, get started with no friction.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">FIPS, EAL, HIPAA</h4>
-            <p class="p-matrix__desc">We are trusted by the world’s most demanding institutions to deliver platforms for regulated services.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Managed maintenance</h4>
-            <p class="p-matrix__desc">Updates and support from Canonical, for the life of your device.</p>
-          </div>
-        </li>
+  <div class="u-fixed-width">
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Frictionless development</h4>
+          <p class="p-matrix__desc">Standard images of Ubuntu are free to download, get started with no friction.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">FIPS, EAL, HIPAA</h4>
+          <p class="p-matrix__desc">We are trusted by the world’s most demanding institutions to deliver platforms for regulated services.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Managed maintenance</h4>
+          <p class="p-matrix__desc">Updates and support from Canonical, for the life of your device.</p>
+        </div>
+      </li>
 
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Enterprise management</h4>
-            <p class="p-matrix__desc">Thousands of companies manage Ubuntu every day. Your appliance will feel right at home.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Global support</h4>
-            <p class="p-matrix__desc">No matter where you ship, no matter where your customers, we can be there when you need us.</p>
-          </div>
-        </li>
-        <li class="p-matrix__item">
-          <div>
-            <h4 class="p-matrix__title">Edge pioneers</h4>
-            <p class="p-matrix__desc">The intelligent edge is born on Ubuntu. From telco to retail, the trailblazers choose Canonical.</p>
-          </div>
-        </li>
-      </ul>
-    </div>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Enterprise management</h4>
+          <p class="p-matrix__desc">Thousands of companies manage Ubuntu every day. Your appliance will feel right at home.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Global support</h4>
+          <p class="p-matrix__desc">No matter where you ship, no matter where your customers, we can be there when you need us.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div>
+          <h4 class="p-matrix__title">Edge pioneers</h4>
+          <p class="p-matrix__desc">The intelligent edge is born on Ubuntu. From telco to retail, the trailblazers choose Canonical.</p>
+        </div>
+      </li>
+    </ul>
     <p><a class="p-button--positive js-invoke-modal" href="/internet-of-things/contact-us">Get in touch</a></p>
   </div>
 </section>

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -24,20 +24,22 @@
 </section>
 
 <nav class="p-tabs p-sticky-nav">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#benefits">Security and compliance</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#enable-esm">Enable ESM</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#get-esm">Get ESM</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#faq">FAQ</a>
-    </li>
-  </ul>
+  <div class="u-fixed-width">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#benefits">Security and compliance</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#enable-esm">Enable ESM</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#get-esm">Get ESM</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#faq">FAQ</a>
+      </li>
+    </ul>
+  </div>
 </nav>
 
 <section class="p-strip is-deep is-bordered" id="benefits">

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -18,37 +18,33 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-        <h2 class="p-muted-heading u-align--center">Ubuntu is used by</h2>
-        <ul class="p-inline-images">
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg" />
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png" width="144" alt="City Network" />
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0c18b0ae-paypal_logo.svg" width="144" alt="PayPal" />
-          </li>
-          <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}62ca4529-16-11-02_R3_Master-Logo.png" width="65" alt="R3" style="max-height:50px;" />
-          </li>
-        </ul>
-    </div>
+  <div class="u-fixed-width">
+    <h2 class="p-muted-heading u-align--center">Ubuntu is used by</h2>
+    <ul class="p-inline-images">
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png" width="144" alt="City Network" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}0c18b0ae-paypal_logo.svg" width="144" alt="PayPal" />
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ ASSET_SERVER_URL }}62ca4529-16-11-02_R3_Master-Logo.png" width="65" alt="R3" style="max-height:50px;" />
+      </li>
+    </ul>
   </div>
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Resources</h2>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Resources</h2>
     <div class="p-strip is-shallow row u-equal-height">
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="" />
+            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="" />
             <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
         </div>
@@ -56,7 +52,7 @@
         <p>Learn how to keep up with the pace of change as you adopt new development methodologies, new technologies and new infrastructure.</p>
         <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/290063" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch now on demand', 'eventLabel' : 'Hybrid cloud and financial services: How to compete on the cloud', 'eventValue' : undefined });">Watch now on demand</a></p>
       </div>
-      <div class="col-4 prefix-1 u-vertically-center">
+      <div class="col-4 u-align--right u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}7d6041a7-image-cloud.svg" width="234" alt="" />
       </div>
     </div>
@@ -65,7 +61,7 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" width="32" alt="" />
+            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}75902002-news-feed-strip-stock_ebook.svg" width="32" alt="" />
             <h4 class="p-heading-icon__title">Article</h4>
           </div>
         </div>
@@ -73,7 +69,7 @@
         <p>Find out why Bloomberg chooses Ubuntu-based OpenStack to handle customisation and integration with their internal systems.</p>
         <p><a class="p-link--external" href="http://superuser.openstack.org/articles/openstack-at-bloomberg/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read article', 'eventLabel' : 'Bloomberg’s OpenStack deployment', 'eventValue' : undefined });">Read article</a></p>
       </div>
-      <div class="col-4 prefix-1 u-vertically-center">
+      <div class="col-4 u-align--right u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}b7693339-logo-bloomberg.svg" width="186" alt="" />
       </div>
     </div>
@@ -82,7 +78,7 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" width="32" alt="" />
+            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}cd7a3a3c-white-paper-icon.svg" width="32" alt="" />
             <h4 class="p-heading-icon__title">Whitepaper</h4>
           </div>
         </div>
@@ -90,7 +86,7 @@
         <p>Discover how Linux container technologies offer control and flexible provisioning while driving greater density, efficiency and manageability, without additional hardware or infrastructure investment.</p>
         <p><a class="p-link--external" href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Accelerate your business with containers', 'eventValue' : undefined });">Download whitepaper</a></p>
       </div>
-      <div class="col-4 prefix-1 u-vertically-center">
+      <div class="col-4 u-align--right u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}a9aff224-Containers-illustration.svg" width="234" alt="" />
       </div>
     </div>
@@ -99,7 +95,7 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" width="34" alt="" />
+            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}5cf7bd32-news-feed-strip-case-study.svg" width="34" alt="" />
             <h4 class="p-heading-icon__title">Case study</h4>
           </div>
         </div>
@@ -107,7 +103,7 @@
         <p>Read about how Canonical ensured that City Network stood out from the crowd thanks to superb service quality and a unique focus on industry-specific regulatory compliance.</p>
         <p><a class="p-link--external" href="https://pages.ubuntu.com/Casestudy_CityNetworks.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the case study', 'eventLabel' : 'OpenStack in the financial services sector', 'eventValue' : undefined });">Read the case study</a></p>
       </div>
-      <div class="col-4 prefix-1 u-vertically-center">
+      <div class="col-4 u-align--right u-vertically-center">
         <img src="{{ ASSET_SERVER_URL }}69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png?w=234" width="234" alt="" />
       </div>
     </div>
@@ -124,7 +120,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" width="32" alt="" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}623e36f9-OpenStack_Logo_Mark+%281%29.svg" width="32" alt="" />
           <h3 class="p-heading-icon__title">OpenStack</h3>
         </div>
         <p>
@@ -135,7 +131,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg"  width="32" alt="" />
+            <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg"  width="32" alt="" />
             <h3 class="p-heading-icon__title">Kubernetes</h3>
         </div>
         <p>
@@ -148,7 +144,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg"  width="32" alt="" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}0de4fcd5-logo-maas-icon.svg"  width="32" alt="" />
           <h3 class="p-heading-icon__title">Server provisioning</h3>
         </div>
         <p>
@@ -159,7 +155,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg"  width="32" alt="" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg"  width="32" alt="" />
           <h3 class="p-heading-icon__title">Live automatic security fixes</h3>
         </div>
         <p>
@@ -180,7 +176,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" width="32" alt="" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}d6146a84-icon-talk-to-us.svg" width="32" alt="" />
           <h3 class="p-heading-icon__title">Consultation services</h3>
         </div>
         <p>
@@ -191,7 +187,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png?w=32" width="32" alt="" style="max-width: 3rem;" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}c5838368-openstack-cloud.png?w=32" width="32" alt="" style="max-width: 3rem;" />
           <h3 class="p-heading-icon__title">Managed cloud services</h3>
         </div>
         <p>
@@ -204,7 +200,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" width="32" alt="" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}f46d02f4-solution-kubernetes.svg" width="32" alt="" />
           <h3 class="p-heading-icon__title">Managed Kubernetes services</h3>
         </div>
         <p>
@@ -215,7 +211,7 @@
     <div class="col-6 p-card">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg" width="32" alt="" />
+          <img class="p-heading-icon__img" src="{{ ASSET_SERVER_URL }}e60711e6-pictogram-support-orange.svg" width="32" alt="" />
           <h3 class="p-heading-icon__title">Support</h3>
         </div>
         <p>
@@ -232,7 +228,7 @@
       <p class="p-heading--three">Talk to us about how Canonical can help you build a secure, agile infrastructure designed for scale.</p>
       <p><a href="/contact-us" class="p-button js-invoke-modal">Contact us</a></p>
     </div>
-    <div class="col-4 prefix-1 suffix-1 u-vertically-center">
+    <div class="col-4 u-align--right suffix-1 u-vertically-center">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="144" class="u-hide--small" alt="" />
     </div>
   </div>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -40,7 +40,7 @@
 <section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>Resources</h2>
-    <div class="p-strip is-shallow row u-equal-height">
+    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-pa">
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
@@ -57,7 +57,7 @@
       </div>
     </div>
     <hr />
-    <div class="p-strip is-shallow row u-equal-height">
+    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
@@ -74,7 +74,7 @@
       </div>
     </div>
     <hr />
-    <div class="p-strip is-shallow row u-equal-height">
+    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
@@ -91,7 +91,7 @@
       </div>
     </div>
     <hr />
-    <div class="p-strip is-shallow row u-equal-height">
+    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -3,7 +3,7 @@
 <div class="p-strip--light is-deep is-bordered">
   <div class="row">
     <div class="col-12">
-      <h2 id="a-release-schedule-you-can-depend-on">A release schedule you can depend</h2>
+      <h2 id="a-release-schedule-you-can-depend-on">A release schedule you can depend on</h2>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

- updated grid layouts on /desktop, /download, /embedded, /esm and /financial-services pages in line with Vanilla 2's new grid patterns (see point 2 of [the upgrade guide](https://ubuntu.com/blog/vanilla-framework-2-0-upgrade-guide))

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the grid/column layouts on these pages look correct/not broken:
  - /desktop
  - /desktop/contact-us
  - /desktop/developers
  - /desktop/features
  - /desktop/organisations
  - /desktop/partners
  - /desktop/statistics
  - /desktop/thank-you
  - /download
  - /download/cloud
  - /download/desktop
  - /download/desktop/thank-you
  - /download/iot
  - /download/iot/installation
  - /download/iot/intel-iei-tank-870
  - /download/iot/intel-joule-desktop
  - /download/iot/intel-joule
  - /download/iot/intel-nuc-desktop
  - /download/iot/intel-nuc
  - /download/iot/kvm
  - /download/iot/orange-pi-zero
  - /download/iot/qualcomm-dragonboard-410c
  - /download/iot/raspberry-pi-2-3-core
  - /download/iot/raspberry-pi-2-3
  - /download/iot/raspberry-pi-compute-module-3
  - /download/iot/samsung-artik-5-10-server
  - /download/iot/samsung-artik-5-10
  - /download/iot/up-squared-iot-grove-server
  - /embedded
  - /esm
  - /financial-services

## Issue / Card

Fixes #5668 
