### PR TITLE
Bump canonicalwebteam.blog to 2.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.0.14
+canonicalwebteam.blog==2.3.0
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4


### PR DESCRIPTION
## Done
Bump blog module version

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Make sure all blog menus work properly.

**QA needs to be done locally since the blog API is no longer accessible from outside the our network**