### PR TITLE
Add enterprise snap management whitepaper and takeover - 28 August 2019

### DIFF
--- a/templates/engage/enterprise-snap-management.md
+++ b/templates/engage/enterprise-snap-management.md
@@ -1,0 +1,66 @@
+---
+wrapper_template: "_base_engage_markdown.html"
+context:
+     title: "Management of snaps in a controlled, enterprise environment"
+     meta_description: "How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies"
+     meta_image: 5e8b9f4b-enterprise-snap-management-social.png
+     meta_copydoc: https://docs.google.com/document/d/1iSLsV7PD7BhF0OhxfD8KpfdQzDscxvO7UToLF7h_1vU/edit
+     header_title: "Management of snaps in a controlled, enterprise environment"
+     header_subtitle: "How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies"
+     header_image: 9c67dde5-network-snap-logo.svg
+     header_url: '#register-section'
+     header_cta: "Download the whitepaper"
+     header_class: "p-strip--dark p-takeover--ent-snap-mgmt"
+     header_lang: en
+     form_include: en
+     form_id: 3418
+     form_return_url: https://pages.ubuntu.com/EnterpriseSnapsTY.html
+---
+
+Few enterprises want all their computing devices to be fully exposed to the internet. In an environment of ever-growing security threats, isolating internal networks from the wider internet is not simply best practice, but borderline essential.
+
+However, with all the benefits that restricted networks provide, it can pose challenges for enterprises who are looking to take advantage of certain technologies. One of these is the automatic update feature of snaps which enable a low-friction process and a fast release cadence. If an enterprise has a restricted network, then this will prevent snaps being able to automatically update due to the necessity for an external internet connection and potentially upsetting change management policies.
+
+The Snap Store Proxy overcomes these issues and enables enterprises to take full advantage of snaps while maintaining the governance and security control that they require.
+
+In this whitepaper, you will learn:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">
+    The normal snap update cycle in a non-restricted environment
+  </li>
+  <li class="p-list__item is-ticked">
+    The challenges the Snap Store Proxy can solve for enterprises from those working in regulated industries to those that have strict internal release processes
+  </li>
+  <li class="p-list__item is-ticked">
+    How to take advantage of new technologies such as Kubernetes in a controlled environment
+  </li>
+</ul>
+
+<style>
+  .p-takeover--ent-snap-mgmt {
+    background-color: #82BEA0;
+    background-image:
+      linear-gradient(135deg, #106363 0%, #82BEA0 100%);
+  }
+
+  .p-takeover--ent-snap-mgmt img {
+    max-width: 330px !important;
+    width: 330px;
+  }
+
+  .p-takeover--ent-snap-mgmt .p-takeover__title {
+    font-weight: 100;
+  }
+
+  @media (min-width: 768px) {
+    .p-takeover--ent-snap-mgmt {
+      background-image:
+        url('https://assets.ubuntu.com/v1/0313f573-suru-background.svg'),
+        linear-gradient(135deg, #106363 0%, #82BEA0 100%);
+      background-position: right;
+      background-repeat: no-repeat;
+      background-size: contain;
+    }
+  }
+</style>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1084,6 +1084,20 @@
           </div>
         </div>
 
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--internet-of-things'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              whitepaper
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/enterprise-snap-management'>How to manage snaps in an enterprise environment</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies.</p>
+          </div>
+        </div>
+
       </div>
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,8 @@
   {# ALL #}
   {% include "takeovers/_developing-android-on-ubuntu.html" %}
   {% include "takeovers/_maas-hardware-testing_takeover.html" %}
-  {% include "takeovers/_enterprise-snap-management.html" %}
+  {% include "takeovers/_data-pipelines-kubeflow.html" %}
+  {# include "takeovers/_enterprise-snap-management.html" #}
 {% endblock takeover_content %}
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
   {# ALL #}
   {% include "takeovers/_developing-android-on-ubuntu.html" %}
   {% include "takeovers/_maas-hardware-testing_takeover.html" %}
-  {% include "takeovers/_data-pipelines-kubeflow.html" %}
+  {% include "takeovers/_enterprise-snap-management.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/takeovers/_enterprise-snap-management.html
+++ b/templates/takeovers/_enterprise-snap-management.html
@@ -1,0 +1,44 @@
+<section class="p-strip--dark is-dark is-deep p-takeover--ent-snap-mgmt js-takeover">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1 class="p-takeover__title">How to manage snaps in an enterprise environment</h1>
+      <h4>Maintain governance and security control on restricted networks with the Snap Store Proxy</h4>
+      <div class="u-hide--small">
+        <p><a href="/engage/enterprise-snap-management?utm_source=takeover&utm_campaign=CY19_IOT_Snaps_Whitepaper_EnterpriseSnaps" class="p-button">Download the whitepaper</a><p>
+      </div>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center">
+      <img src="{{ ASSET_SERVER_URL }}9c67dde5-network-snap-logo.svg" alt="" style="width: 380px; margin: 1.5rem 0;">
+    </div>
+    <div class="u-hide--medium u-hide--large">
+      <a href="/engage/enterprise-snap-management?utm_source=takeover&utm_campaign=CY19_IOT_Snaps_Whitepaper_EnterpriseSnaps" class="p-button">Download the whitepaper</a>
+    </div>
+  </div>
+  <style>
+    .p-takeover--ent-snap-mgmt {
+      background-color: #82BEA0;
+      background-image:
+        linear-gradient(135deg, #106363 0%, #82BEA0 100%);
+    }
+
+    .p-takeover--ent-snap-mgmt img {
+      max-width: 330px !important;
+      width: 330px;
+    }
+
+    .p-takeover--ent-snap-mgmt .p-takeover__title {
+      font-weight: 100;
+    }
+
+    @media (min-width: 768px) {
+      .p-takeover--ent-snap-mgmt {
+        background-image:
+          url('https://assets.ubuntu.com/v1/0313f573-suru-background.svg'),
+          linear-gradient(135deg, #106363 0%, #82BEA0 100%);
+        background-position: right;
+        background-repeat: no-repeat;
+        background-size: contain;
+      }
+    }
+  </style>
+</section>

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -86,5 +86,6 @@
 {% include "takeovers/_maas-hardware-testing_takeover.html" %}
 {% include "takeovers/_data-pipelines-kubeflow.html" %}
 {% include "takeovers/_developing-android-on-ubuntu.html" %}
+{% include "takeovers/_enterprise-snap-management.html" %}
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Added takeover, engage page for Enterprise Snap Management whitepaper

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View the site locally in your web browser at: http://0.0.0.0:8001 and compare the takeover to the design and the [brief](https://docs.google.com/spreadsheets/d/1v8nou3GCqfXIPVBgAdGwMO8gzGgaduHBFEuR9YG62d0/edit#gid=877682240)
- compare the engage page - http://0.0.0.0:8001/engage/enterprise-snap-management -  to the design and the [copy doc](https://docs.google.com/document/d/1iSLsV7PD7BhF0OhxfD8KpfdQzDscxvO7UToLF7h_1vU/edit)
- see that the takeover is on the [index page](http://0.0.0.0:8001/takeovers) and the engage page on the [engage index page](http://0.0.0.0:8001/engage/)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1502

## Screenshots

### takeover
![image](https://user-images.githubusercontent.com/441217/63038274-adc2de80-beb8-11e9-9be9-bd99834beff6.png)

### engage page
![image](https://user-images.githubusercontent.com/441217/63038230-984db480-beb8-11e9-8e83-f1c5ade07ee0.png)

