### PR TITLE
Fix suru background on android takeover and engage page

### DIFF
--- a/templates/engage/developing-android-on-ubuntu.md
+++ b/templates/engage/developing-android-on-ubuntu.md
@@ -38,27 +38,23 @@ In this guide, you will learn:
 </ul>
 
 <style>
+.p-takeover--android-on-ubuntu {
+  background-color: #2C001E;
+}
+
+.p-takeover--android-on-ubuntu .p-takeover__title {
+  font-weight: 100;
+}
+
+@media (min-width: 768px) {
   .p-takeover--android-on-ubuntu {
     background-color: #2C001E;
+    background-image:
+            url('https://assets.ubuntu.com/v1/1487c2c6-suru-background.svg'),
+            linear-gradient(199deg, #E95420 0%, #5E2750 25%, #2C001E 50%);
+    background-position: right;
+    background-repeat: no-repeat;
+    background-size: contain;
   }
-
-  .p-takeover--android-on-ubuntu img {
-    max-width: 380px !important;
-    width: 380px;
-  }
-
-  .p-takeover--android-on-ubuntu .p-takeover__title {
-    font-weight: 100;
-  }
-
-  @media (min-width: 768px) {
-    .p-takeover--android-on-ubuntu {
-      background-color: #2C001E;
-      background-image: linear-gradient(199deg, #E95420 0%, #5E2750 25%, #2C001E 50%),
-      url('{{ ASSET_SERVER_URL }}1487c2c6-suru-background.svg');
-      background-position: right;
-      background-repeat: no-repeat;
-      background-size: contain;
-    }
-  }
+}
 </style>

--- a/templates/takeovers/_developing-android-on-ubuntu.html
+++ b/templates/takeovers/_developing-android-on-ubuntu.html
@@ -26,8 +26,9 @@
     @media (min-width: 768px) {
       .p-takeover--android-on-ubuntu {
         background-color: #2C001E;
-        background-image: linear-gradient(199deg, #E95420 0%, #5E2750 25%, #2C001E 50%),
-        url('{{ ASSET_SERVER_URL }}1487c2c6-suru-background.svg');
+        background-image:
+                url('{{ ASSET_SERVER_URL }}1487c2c6-suru-background.svg'),
+                linear-gradient(199deg, #E95420 0%, #5E2750 25%, #2C001E 50%);
         background-position: right;
         background-repeat: no-repeat;
         background-size: contain;


### PR DESCRIPTION
## Done

- Fix suru background on android takeover and engage page as the new markdown version doesn't parse {{ ASSET_SERVER_URL }}

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/developing-android-on-ubuntu?
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that you can see the suru background asset image on the header

## Screenshots

![image](https://user-images.githubusercontent.com/441217/63039826-0fd11300-bebc-11e9-90e5-31d72963fa8a.png)
