### PR TITLE
Add modal contact-us form for /openstack/storage

### DIFF
--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -14,6 +14,7 @@
       <div class="col-7">
         <h1>Software-Defined Storage for OpenStack</h1>
         <p>The Ubuntu Advantage Storage support package from Canonical embeds proven software-defined storage (SDS) technologies into a 24x7-supported software solution with a fixed or metered pricing model.</p>
+        <p><a href="/openstack/contact-us?product=ubuntu-advantage-storage" class="js-invoke-modal p-button">Get in touch</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         <img class="hero-image" width="100%" src="{{ ASSET_SERVER_URL }}c2d50399-storage.svg" alt="Lots of server pictos in a cloud" />
@@ -94,7 +95,7 @@
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_bootstack" second_item="_cloud_rfp" third_item="_cloud_further_reading" %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1233" data-lp-id="2001" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_storage.html" data-form-id="1233" data-lp-id="2001" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" data-lp-url="https://www.ubuntu.com/openstack/contact-us?product=ubuntu-advantage-storage">
 </div>
 
 <script src="{% versioned_static 'js/build/dynamic-contact-form.min.js' %}"></script>

--- a/templates/shared/forms/interactive/_storage.html
+++ b/templates/shared/forms/interactive/_storage.html
@@ -51,10 +51,11 @@
             <input type="checkbox" id="storage-solutions-Other-SAN">
             <label for="storage-solutions-Other-SAN">Other SAN</label>
             <input type="checkbox" id="storage-solutions-Local-storage">
-            <label for="storage-solutions-Local storage">Local-storage</label>
+            <label for="storage-solutions-Local-storage">Local storage</label>
             <div class="js-other-container">
               <input type="checkbox" id="storage-solutions-other" class="js-other-container__checkbox">
-              <label for="storage-solutions-other">Other</label>              <input type="text" id="storage-solutions-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other">
+              <label for="storage-solutions-other">Other</label>
+              <input type="text" id="storage-solutions-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other">
             </div>
           </div>
         </div>
@@ -75,8 +76,8 @@
             <label for="compute-infrastructure-LXD">LXD</label>
             <input type="checkbox" id="compute-infrastructure-Docker">
             <label for="compute-infrastructure-Docker">Docker</label>
-            <input type="checkbox" id="compute-infrastructure-Public cloud">
-            <label for="compute-infrastructure-Public cloud">Public cloud</label>
+            <input type="checkbox" id="compute-infrastructure-Public-cloud">
+            <label for="compute-infrastructure-Public-cloud">Public cloud</label>
             <div class="js-other-container">
               <input type="checkbox" class="js-other-container__checkbox" id="compute-infrastructure-other">
               <label for="compute-infrastructure-other">Other</label>

--- a/templates/shared/forms/interactive/_storage.html
+++ b/templates/shared/forms/interactive/_storage.html
@@ -1,0 +1,213 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <hr />
+      <h2 class="p-modal__title" id="modal-title">Software-defined storage</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Which storage solutions are you currently using?</h3>
+        <div class="row u-no-padding">
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="storage-solutions-Ceph">
+            <label for="storage-solutions-Ceph">Ceph</label>
+            <input type="checkbox" id="storage-solutions-Swift">
+            <label for="storage-solutions-Swift">Swift</label>
+            <input type="checkbox" id="storage-solutions-Nexenta">
+            <label for="storage-solutions-Nexenta">Nexenta</label>
+            <input type="checkbox" id="storage-solutions-SwiftStack">
+            <label for="storage-solutions-SwiftStack">SwiftStack</label>
+            <input type="checkbox" id="storage-solutions-Public-cloud">
+            <label for="storage-solutions-Public-cloud">Public cloud (e.g. S3)</label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="storage-solutions-IBM-RedHat">
+            <label for="storage-solutions-IBM-RedHat">IBM/RedHat</label>
+            <input type="checkbox" id="storage-solutions-Hitachi">
+            <label for="storage-solutions-Hitachi">Hitachi</label>
+            <input type="checkbox" id="storage-solutions-EMC">
+            <label for="storage-solutions-EMC">EMC</label>
+            <input type="checkbox" id="storage-solutions-Hedvig">
+            <label for="storage-solutions-Hedvig">Hedvig</label>
+            <input type="checkbox" id="storage-solutions-VMware ">
+            <label for="storage-solutions-VMware ">VMware </label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="storage-solutions-Scality-RING">
+            <label for="storage-solutions-Scality-RING">Scality RING</label>
+            <input type="checkbox" id="storage-solutions-Caringo">
+            <label for="storage-solutions-Caringo">Caringo</label>
+            <input type="checkbox" id="storage-solutions-Portworx">
+            <label for="storage-solutions-Portworx">Portworx</label>
+            <input type="checkbox" id="storage-solutions-StorageOS">
+            <label for="storage-solutions-StorageOS">StorageOS</label>
+            <input type="checkbox" id="storage-solutions-Rook.io">
+            <label for="storage-solutions-Rook.io">Rook.io</label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="storage-solutions-Other-NAS">
+            <label for="storage-solutions-Other-NAS">Other NAS</label>
+            <input type="checkbox" id="storage-solutions-Other-SAN">
+            <label for="storage-solutions-Other-SAN">Other SAN</label>
+            <input type="checkbox" id="storage-solutions-Local-storage">
+            <label for="storage-solutions-Local storage">Local-storage</label>
+            <div class="js-other-container">
+              <input type="checkbox" id="storage-solutions-other" class="js-other-container__checkbox">
+              <label for="storage-solutions-other">Other</label>              <input type="text" id="storage-solutions-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Tell us a little about your compute infrastructure.</h3>
+        <div class="row u-no-padding">
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="compute-infrastructure-OpenStack">
+            <label for="compute-infrastructure-OpenStack">OpenStack</label>
+            <input type="checkbox" id="compute-infrastructure-Kubernetes">
+            <label for="compute-infrastructure-Kubernetes">Kubernetes</label>
+            <input type="checkbox" id="compute-infrastructure-KVM ">
+            <label for="compute-infrastructure-KVM ">KVM </label>
+          </div>
+          <div class="col-3 u-sv3">
+            <input type="checkbox" id="compute-infrastructure-LXD">
+            <label for="compute-infrastructure-LXD">LXD</label>
+            <input type="checkbox" id="compute-infrastructure-Docker">
+            <label for="compute-infrastructure-Docker">Docker</label>
+            <input type="checkbox" id="compute-infrastructure-Public cloud">
+            <label for="compute-infrastructure-Public cloud">Public cloud</label>
+            <div class="js-other-container">
+              <input type="checkbox" class="js-other-container__checkbox" id="compute-infrastructure-other">
+              <label for="compute-infrastructure-other">Other</label>
+              <input type="text" id="compute-infrastructure-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <div class="js-formfield">
+        <h3 class="p-heading--five">How are you consuming your storage?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="consuming-storage-Object-store">
+            <label for="consuming-storage-Object-store">Object store (S3 or Swift)</label>
+            <input type="checkbox" id="consuming-storage-Virtual-volumes-SAN">
+            <label for="consuming-storage-Virtual-volumes-SAN">Virtual volumes (SAN)</label>
+            <input type="checkbox" id="consuming-storage-File-system-NAS">
+            <label for="consuming-storage-File-system-NAS">File system (NAS)</label>
+            <div class="js-other-container">
+              <input type="checkbox" class="js-other-container__checkbox" id="consuming-storage-other">
+              <label for="consuming-storage-other">Other</label>
+              <input type="text" id="consuming-storage-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Are you currently paying for redundant data storage?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="radio" id="storage-Yes" name="redundant-storage" value="Yes">
+            <label for="storage-Yes">Yes</label>
+            <input type="radio" id="storage-No" name="redundant-storage" value="No">
+            <label for="storage-No">No</label>
+            <input type="radio" id="storage-Dont-know" name="redundant-storage" value="I don’t know">
+            <label for="storage-Dont-know">I don’t know</label>
+          </div>
+        </div>
+      </div>
+      <div class="row u-no-padding">
+        <div class="u-sv3 js-formfield">
+          <h3 class="p-heading--five">Tell us about your project and team</h3>
+          <textarea id="about-your-project-or-interest" name="sector-specific-requirements" aria-label="Tell us about your project and team" placeholder="Where are you located? Do you already have OpenStack? Is this initiative for a specific workload or for the business as a whole? Do you have particular regulatory constraints or priorities?" rows="3"></textarea>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Work email:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--4 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about Storage solutions</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            <img src="{{ ASSET_SERVER_URL }}cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>

--- a/templates/shared/forms/interactive/_storage.html
+++ b/templates/shared/forms/interactive/_storage.html
@@ -42,8 +42,8 @@
             <label for="storage-solutions-Portworx">Portworx</label>
             <input type="checkbox" id="storage-solutions-StorageOS">
             <label for="storage-solutions-StorageOS">StorageOS</label>
-            <input type="checkbox" id="storage-solutions-Rook.io">
-            <label for="storage-solutions-Rook.io">Rook.io</label>
+            <input type="checkbox" id="storage-solutions-Rook-io">
+            <label for="storage-solutions-Rook-io">Rook.io</label>
           </div>
           <div class="col-3 u-sv3">
             <input type="checkbox" id="storage-solutions-Other-NAS">


### PR DESCRIPTION
## Done

Add modal form for /openstack/storage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:http://0.0.0.0:8001/openstack/storage#get-in-touch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](chrome-extension://klbibkeccnjlkjkiokjodocebajanakg/suspended.html#ttl=storage%20-%20Google%20Docs&pos=0&uri=https://docs.google.com/document/d/1Pfay_PfsE7Tw8gU82wENRCcCUEXbe2gf804uGzM_PqY/edit#) and test the output


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1409

