### PR TITLE
Add feeds endpoints for authors, groups and topics

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -604,8 +604,8 @@ releases/?: "http://releases.ubuntu.com"
 releaseendoflife/?: "/about/release-cycle"
 robotics/?:  "/internet-of-things/robotics"
 robots.txt?: "/static/files/robots.txt"
-rss\.xml/?: "https://admin.insights.ubuntu.com/feed"
-rss\.xmlsubscribe=feed/?: "https://admin.insights.ubuntu.com/feed"
+rss\.xml/?: "/blog/feed"
+rss\.xmlsubscribe=feed/?: "/blog/feed"
 s/ubuntu.*/?: "https://insights.ubuntu.com"
 screenshots/?: "/desktop/features"
 screenshots/document_view/?: "/desktop"
@@ -682,7 +682,7 @@ syndicated/kubuntu-download/?: "https://kubuntu.org/"
 system/files/.*\.pdf: "https://insights.ubuntu.com"
 tag/.*/?: "https://insights.ubuntu.com"
 take-the-tour/?: "http://tour.ubuntu.com/en/"
-taxonomy/term/.*/.*/feed?: "https://admin.insights.ubuntu.com/feed"
+taxonomy/term/.*/.*/feed?: "/blog/feed"
 taxonomy/term/.*: "https://insights.ubuntu.com"
 telco/?: "/telecommunications"
 telcos/?: "/telecommunications"
@@ -745,7 +745,6 @@ telcos/?: "/telecommunications"
 
 # Blog redirects
 blog/search/?: /search
-blog(?P<page>(/.+)?)/feed?: "https://admin.insights.ubuntu.com{page}/feed"
 
 # Copied from https://github.com/canonical-web-and-design/blog.ubuntu.com/blob/master/redirects.yaml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.3.0
+canonicalwebteam.blog==2.4.0
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -5,7 +5,12 @@ from canonicalwebteam.yaml_responses.django_helpers import (
     create_deleted_views,
     create_redirect_views,
 )
-from canonicalwebteam.blog.django.views import group, topic
+from canonicalwebteam.blog.django.views import (
+    group,
+    group_feed,
+    topic,
+    topic_feed,
+)
 
 # Local code
 from .views import UbuntuTemplateFinder, DownloadView, ResourcesView, search
@@ -47,6 +52,7 @@ urlpatterns += [
         },
         name="group",
     ),
+    path("blog/group/<slug:slug>/feed", group_feed, name="group_feed"),
     path(
         "blog/topics/maas",
         topic,
@@ -77,6 +83,7 @@ urlpatterns += [
         {"slug": "robotics", "template_path": "blog/topics/robotics.html"},
         name="topic",
     ),
+    path("blog/topics/<slug:slug>/feed", topic_feed, name="topic_feed"),
     path("blog", include("canonicalwebteam.blog.django.urls")),
     url(
         r"^(?P<template>download/(desktop|server|cloud)/thank-you)$",


### PR DESCRIPTION
## Done

Added feed endpoints to the blog section of the site.

- `/blog/feed/`
- `/blog/author/<author_name>/feed`
- `/blog/group/<group_slug>/feed`
- `/blog/topic/<topic_slug>/feed`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Go to some different groups, topics and author pages and make sure the feed versions of it contain the same articles.


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
