### PR TITLE
Change color on datapipelines takeover

### DIFF
--- a/templates/engage/data-pipelines-kubeflow.html
+++ b/templates/engage/data-pipelines-kubeflow.html
@@ -35,15 +35,21 @@
   </section>
   <style>
     .p-takeover--deepsense-ai {
-      background-color: #f7f7f7;
-      color: 	#111;
+      background-color: #213D7A;
+      background-image:
+        linear-gradient(199deg, #004BD1 0%, #0027AA 25%, #213D7A 50%);
+      color: #f7f7f7;
+      }
+
+    .p-takeover--deepsense-ai .p-takeover__title {
       font-weight: 100;
     }
 
     @media (min-width: 768px) {
       .p-takeover--deepsense-ai {
-        background-color: #f7f7f7;
-        background-image: url('{{ ASSET_SERVER_URL }}bc4ce721-suru-background.svg');
+        background-image:
+          url('{{ ASSET_SERVER_URL }}cbe63376-suru-background-white.svg'),
+          linear-gradient(199deg, #004BD1 0%, #0027AA 25%, #213D7A 50%);
         background-position: right;
         background-repeat: no-repeat;
         background-size: contain;

--- a/templates/engage/data-pipelines-kubeflow.html
+++ b/templates/engage/data-pipelines-kubeflow.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-{% include "engage/shared/_header.html" with title="Data Pipelines" subtitle="How Kubeflow and machine learning help you get the most out of your data" image="141f8edb-machine-learning.svg" class="p-takeover--deepsense-ai" url="#register-section" cta="Watch the webinar" %}
+{% include "engage/shared/_header.html" with title="Data Pipelines" subtitle="How Kubeflow and machine learning help you get the most out of your data" image="3f586cec-Machine+learning+-+white.svg" class="p-takeover--deepsense-ai" url="#register-section" cta="Watch the webinar" %}
 
 <section class="p-strip is-bordered">
   <div class="row u-vertically-center">

--- a/templates/takeovers/_data-pipelines-kubeflow.html
+++ b/templates/takeovers/_data-pipelines-kubeflow.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--deepsense-ai js-takeover">
+<section class="p-strip--dark is-deep p-takeover--deepsense-ai js-takeover">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1 class="p-takeover__title">Creating accurate AI models with&nbsp;data</h1>
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="col-5 u-align--center u-vertically-center">
-      <img src="{{ ASSET_SERVER_URL }}4028fd74-kubeflow+ai-h.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
+      <img src="{{ ASSET_SERVER_URL }}ec5310fc-kubeflow+ai-h-white.svg" alt="" style="width: 500px; margin: 1.5rem 0;">
     </div>
     <div class="u-hide--medium u-hide--large">
       <a href="/engage/data-pipelines-kubeflow?utm_source=takeover&utm_campaign=CY19_DC_AI_WBN_Deepsense_Takeover" class="p-button--positive">Register for the webinar</a>
@@ -16,18 +16,20 @@
   </div>
   <style>
     .p-takeover--deepsense-ai {
-      background-color: #f7f7f7;
-    }
+      background-color: #213D7A;
+      background-image:
+        linear-gradient(199deg, #004BD1 0%, #0027AA 25%, #213D7A 50%);
+      }
 
     .p-takeover--deepsense-ai .p-takeover__title {
-      color: 	#111;
       font-weight: 100;
     }
 
     @media (min-width: 768px) {
       .p-takeover--deepsense-ai {
-        background-color: #f7f7f7;
-        background-image: url('{{ ASSET_SERVER_URL }}bc4ce721-suru-background.svg');
+        background-image:
+          url('{{ ASSET_SERVER_URL }}cbe63376-suru-background-white.svg'),
+          linear-gradient(199deg, #004BD1 0%, #0027AA 25%, #213D7A 50%);
         background-position: right;
         background-repeat: no-repeat;
         background-size: contain;


### PR DESCRIPTION
## Done

- Updated the background of the takeover and engage header from white to blue.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and http://0.0.0.0:8001/engage/data-pipelines-kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it follows the design and looks ok on mobile.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1539

## Screenshots
### takeover
![image](https://user-images.githubusercontent.com/441217/63228743-5477e980-c1ef-11e9-9916-656223080c9d.png)

### engage page
![image](https://user-images.githubusercontent.com/441217/63228737-2befef80-c1ef-11e9-807b-4a5ea1359817.png)

