### PR TITLE
Update the /about/release-cycle

### DIFF
--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -85,12 +85,6 @@ export var serverAndDesktopReleases = [
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
   {
-    startDate: new Date('2018-10-01T00:00:00'),
-    endDate: new Date('2019-07-01T00:00:00'),
-    taskName: 'Ubuntu 18.10',
-    status: 'INTERIM_RELEASE'
-  },
-  {
     startDate: new Date('2019-04-01T00:00:00'),
     endDate: new Date('2020-01-01T00:00:00'),
     taskName: 'Ubuntu 19.04',
@@ -286,27 +280,21 @@ export var kernelReleases = [
     status: 'EXTENDED_SECURITY_MAINTENANCE_FOR_CUSTOMERS'
   },
   {
-    startDate: new Date('2018-10-01T00:00:00'),
-    endDate: new Date('2019-07-01T00:00:00'),
-    taskName: 'Ubuntu 18.10 (v4.18)',
-    status: 'INTERIM_RELEASE'
-  },
-  {
     startDate: new Date('2019-02-01T00:00:00'),
     endDate: new Date('2019-08-01T00:00:00'),
-    taskName: 'Ubuntu 18.04.2 LTS',
+    taskName: 'Ubuntu 18.04.2 LTS (v4.18)',
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
     startDate: new Date('2019-04-01T00:00:00'),
     endDate: new Date('2020-01-01T00:00:00'),
-    taskName: 'Ubuntu 19.04',
+    taskName: 'Ubuntu 19.04 (v5.0)',
     status: 'INTERIM_RELEASE'
   },
   {
     startDate: new Date('2019-08-01T00:00:00'),
     endDate: new Date('2020-02-01T00:00:00'),
-    taskName: 'Ubuntu 18.04.3 LTS',
+    taskName: 'Ubuntu 18.04.3 LTS (v5.0)',
     status: 'UBUNTU_LTS_RELEASE_SUPPORT'
   },
   {
@@ -459,7 +447,7 @@ export var openStackReleases = [
   {
     startDate: new Date('2019-08-01T00:00:00'),
     endDate: new Date('2021-02-01T00:00:00'),
-    taskName: 'OpenStack T',
+    taskName: 'OpenStack Train',
     status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
   },
   {
@@ -524,13 +512,13 @@ export var kubernetesReleases = [
     startDate: new Date('2018-07-01T00:00:00'),
     endDate: new Date('2019-03-01T00:00:00'),
     taskName: 'Kubernetes 1.11',
-    status: 'CDK_SUPPORT'
+    status: 'CDK_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2018-09-01T00:00:00'),
     endDate: new Date('2019-06-01T00:00:00'),
     taskName: 'Kubernetes 1.12',
-    status: 'CDK_SUPPORT'
+    status: 'CDK_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2018-12-01T00:00:00'),
@@ -572,7 +560,6 @@ export var desktopServerReleaseNames = [
   'Ubuntu 20.04 LTS',
   'Ubuntu 19.10',
   'Ubuntu 19.04',
-  'Ubuntu 18.10',
   'Ubuntu 18.04 LTS',
   'Ubuntu 16.04 LTS',
   'Ubuntu 14.04 LTS',
@@ -585,10 +572,9 @@ export var kernelReleaseNames = [
   'Ubuntu 20.04 LTS',
   'Ubuntu 18.04.4 LTS',
   'Ubuntu 19.10',
-  'Ubuntu 18.04.3 LTS',
-  'Ubuntu 19.04',
-  'Ubuntu 18.04.2 LTS',
-  'Ubuntu 18.10 (v4.18)',
+  'Ubuntu 18.04.3 LTS (v5.0)',
+  'Ubuntu 19.04 (v5.0)',
+  'Ubuntu 18.04.2 LTS (v4.18)',
   'Ubuntu 18.04.1 LTS (v4.15)',
   'Ubuntu 16.04.5 LTS (v4.15)',
   'Ubuntu 18.04.0 LTS (v4.15)',
@@ -606,7 +592,7 @@ export var openStackReleaseNames = [
   'OpenStack U LTS',
   'Ubuntu 20.04 LTS',
   'OpenStack U',
-  'OpenStack T',
+  'OpenStack Train',
   'OpenStack Stein',
   'OpenStack Rocky',
   'OpenStack Queens LTS',

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -526,6 +526,18 @@ export var kubernetesReleases = [
     taskName: 'Kubernetes 1.13',
     status: 'CDK_SUPPORT'
   },
+  {
+    startDate: new Date('2019-03-01T00:00:00'),
+    endDate: new Date('2019-12-01T00:00:00'),
+    taskName: 'Kubernetes 1.14',
+    status: 'CDK_SUPPORT'
+  },
+  {
+    startDate: new Date('2019-06-14T00:00:00'),
+    endDate: new Date('2020-03-02T00:00:00'),
+    taskName: 'Kubernetes 1.15',
+    status: 'CDK_SUPPORT'
+  }
 ];
 
 export var desktopServerStatus = {
@@ -611,6 +623,8 @@ export var openStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  'Kubernetes 1.15',
+  'Kubernetes 1.14',
   'Kubernetes 1.13',
   'Kubernetes 1.12',
   'Kubernetes 1.11',

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -37,7 +37,7 @@
   <div class="row">
     <div class="col-10" style="overflow: auto;">
       <div class="u-hide--small" id="server-desktop-eol"></div>
-      <table class="u-hide--medium u-hide--large" style="width: auto;">
+      <table class="u-hide--medium u-hide--large">
         <thead>
           <tr>
             <td>&nbsp;</td>
@@ -49,74 +49,74 @@
         <tbody>
           <tr>
             <td><strong>Ubuntu 22.04 LTS</strong></td>
-            <td>April 2022</td>
-            <td>April 2027</td>
+            <td>Apr 2022</td>
+            <td>Apr 2027</td>
             <td></td>
           </tr>
           <tr>
             <td>Ubuntu 21.10</td>
-            <td>October 2021</td>
-            <td>July 2022</td>
+            <td>Oct 2021</td>
+            <td>Jul 2022</td>
             <td></td>
           </tr>
           <tr>
             <td>Ubuntu 21.04</td>
-            <td>April 2021</td>
-            <td>January 2022</td>
+            <td>Apr 2021</td>
+            <td>Jan 2022</td>
             <td></td>
           </tr>
           <tr>
             <td>Ubuntu 20.10</td>
-            <td>October 2020</td>
-            <td>July 2021</td>
+            <td>Oct 2020</td>
+            <td>Jul 2021</td>
             <td></td>
           </tr>
           <tr>
             <td><strong>Ubuntu 20.04 LTS</strong></td>
-            <td>April 2020</td>
-            <td>April 2025</td>
-            <td>April 2030</td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
+            <td>Apr 2030</td>
           </tr>
           <tr>
             <td>Ubuntu 19.10</td>
-            <td>October 2019</td>
-            <td>July 2020</td>
+            <td>Oct 2019</td>
+            <td>Jul 2020</td>
             <td></td>
           </tr>
           <tr>
             <td>Ubuntu 19.04</td>
-            <td>April 2019</td>
-            <td>January 2020</td>
+            <td>Apr 2019</td>
+            <td>Jan 2020</td>
             <td></td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04 LTS</strong></td>
-            <td>April 2018</td>
-            <td>April 2023</td>
-            <td>April 2028</td>
+            <td>Apr 2018</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04 LTS</strong></td>
-            <td>April 2016</td>
-            <td>April 2021</td>
-            <td>April 2024</td>
+            <td>Apr 2016</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04 LTS</strong></td>
-            <td>April 2014</td>
-            <td>April 2019</td>
-            <td>April 2022</td>
+            <td>Apr 2014</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04 LTS</strong></td>
-            <td>April 2012</td>
-            <td>April 2017</td>
-            <td>April 2019</td>
+            <td>Apr 2012</td>
+            <td>Apr 2017</td>
+            <td>Apr 2019</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 10.04 LTS</strong></td>
-            <td>April 2010</td>
-            <td>April 2015</td>
+            <td>Apr 2010</td>
+            <td>Apr 2015</td>
             <td></td>
           </tr>
         </tbody>
@@ -156,7 +156,7 @@
   </div>
   <div class="row">
     <div class="col-10" style="overflow: auto;">
-      <table style="margin-top: 1rem; width: auto;">
+      <table style="margin-top: 1rem;">
         <thead>
           <tr>
             <th>&nbsp;</th>
@@ -232,7 +232,7 @@
   <div class="row">
     <div class="col-10" style="overflow: auto;">
       <div class="u-hide--small" id="kernel-eol"></div>
-      <table class="u-hide--medium u-hide--large" style="width: auto;">
+      <table class="u-hide--medium u-hide--large">
         <thead>
           <tr>
             <th>Release</th>
@@ -244,111 +244,117 @@
         <tbody>
           <tr>
             <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-            <td>August 2020</td>
-            <td>April 2023</td>
-            <td>April 2028</td>
+            <td>Aug 2020</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 20.04 LTS</strong></td>
-            <td>April 2020</td>
-            <td>April 2025</td>
-            <td>April 2030</td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
+            <td>Apr 2030</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04.4 LTS</strong></td>
-            <td>February 2020</td>
-            <td>August 2020</td>
+            <td>Feb 2020</td>
+            <td>Aug 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 19.10</td>
-            <td>October 2019</td>
-            <td>July 2020</td>
+            <td>Oct 2019</td>
+            <td>Jul 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
-            <td>August 2019</td>
-            <td>February 2020</td>
+            <td>Aug 2019</td>
+            <td>Feb 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>Ubuntu 19.04 (v5.0)</td>
-            <td>April 2019</td>
-            <td>January 2020</td>
+            <td>Apr 2019</td>
+            <td>Jan 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-            <td>February 2019</td>
-            <td>August 2019</td>
+            <td>Feb 2019</td>
+            <td>Aug 2019</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.10 (v4.18)</td>
+            <td>Oct 2018</td>
+            <td>Jul 2019</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-            <td>July 2018</td>
-            <td>April 2023</td>
-            <td>April 2028</td>
+            <td>Jul 2018</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-            <td>August 2018</td>
-            <td>April 2021</td>
-            <td>April 2024</td>
+            <td>Aug 2018</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-            <td>April 2018</td>
-            <td>April 2023</td>
-            <td>April 2028</td>
+            <td>Apr 2018</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-            <td>August 2016</td>
-            <td>April 2021</td>
-            <td>April 2024</td>
+            <td>Aug 2016</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
-            <td>August 2016</td>
-            <td>April 2019</td>
-            <td>April 2022</td>
+            <td>Aug 2016</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-            <td>April 2016</td>
-            <td>April 2021</td>
-            <td>April 2024</td>
+            <td>Apr 2016</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-            <td>August 2014</td>
-            <td>April 2019</td>
-            <td>April 2022</td>
+            <td>Aug 2014</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04.5 LTS (v3.13)</strong></td>
-            <td>August 2014</td>
-            <td>April 2017</td>
-            <td>April 2019</td>
+            <td>Aug 2014</td>
+            <td>Apr 2017</td>
+            <td>Apr 2019</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-            <td>April 2014</td>
-            <td>April 2019</td>
-            <td>April 2022</td>
+            <td>Apr 2014</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04.1 LTS (v3.2)</strong></td>
-            <td>August 2012</td>
-            <td>April 2017</td>
-            <td>April 2019</td>
+            <td>Aug 2012</td>
+            <td>Apr 2017</td>
+            <td>Apr 2019</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04.0 LTS (v3.2)</strong></td>
-            <td>April 2012</td>
-            <td>April 2017</td>
-            <td>April 2019</td>
+            <td>Apr 2012</td>
+            <td>Apr 2017</td>
+            <td>Apr 2019</td>
           </tr>
         </tbody>
       </table>
@@ -372,7 +378,7 @@
   <div class="row">
     <div class="col-10" style="overflow: auto;">
       <div class="u-hide--small" id="openstack-eol"></div>
-      <table class="u-hide--medium u-hide--large" style="width: auto;">
+      <table class="u-hide--medium u-hide--large">
         <thead>
           <tr>
             <th>Release</th>
@@ -384,158 +390,158 @@
         <tbody>
           <tr>
             <td>OpenStack U LTS</td>
-            <td>April 2020</td>
-            <td>April 2025</td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04 LTS</strong></td>
-            <td>April 2020</td>
-            <td>April 2025</td>
+            <td>Ubuntu 20.04 LTS</td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack U</td>
-            <td>Feburary 2020</td>
-            <td>April 2023</td>
+            <td>Feb 2020</td>
+            <td>Apr 2023</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Train</td>
-            <td>August 2019</td>
-            <td>February 2021</td>
+            <td>Aug 2019</td>
+            <td>Feb 2021</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Stein</td>
-            <td>April 2019</td>
-            <td>October 2020</td>
-            <td>April 2022</td>
+            <td>Apr 2019</td>
+            <td>Oct 2020</td>
+            <td>Apr 2022</td>
           </tr>
           <tr>
             <td>OpenStack Rocky</td>
-            <td>August 2018</td>
-            <td>February 2020</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Queens LTS</td>
-            <td>April 2018</td>
-            <td>April 2023</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04 LTS</strong></td>
-            <td>April 2018</td>
-            <td>April 2023</td>
+            <td>Aug 2018</td>
+            <td>Feb 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Queens</td>
-            <td>March 2018</td>
-            <td>April 2021</td>
+            <td>Apr 2018</td>
+            <td>Apr 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04 LTS</strong></td>
+            <td>Apr 2018</td>
+            <td>Apr 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>OpenStack Queens</td>
+            <td>Feb 2018</td>
+            <td>Apr 2021</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Pike</td>
-            <td>August 2017</td>
-            <td>February 2019</td>
+            <td>Aug 2017</td>
+            <td>Feb 2019</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Ocata</td>
-            <td>February 2017</td>
-            <td>August 2018</td>
-            <td>February 2020</td>
+            <td>Feb 2017</td>
+            <td>Aug 2018</td>
+            <td>Feb 2020</td>
           </tr>
           <tr>
             <td>OpenStack Newton</td>
-            <td>October 2016</td>
-            <td>April 2018</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Mitaka LTS</td>
-            <td>April 2016</td>
-            <td>April 2021</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 16.04 LTS</strong></td>
-            <td>April 2016</td>
-            <td>April 2021</td>
+            <td>Oct 2016</td>
+            <td>Apr 2018</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Mitaka</td>
-            <td>April 2016</td>
-            <td>April 2019</td>
+            <td>Apr 2016</td>
+            <td>Apr 2021</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04 LTS</strong></td>
+            <td>Apr 2016</td>
+            <td>Apr 2021</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>OpenStack Mitaka</td>
+            <td>Apr 2016</td>
+            <td>Apr 2019</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Liberty</td>
-            <td>October 2015</td>
-            <td>April 2017</td>
+            <td>Oct 2015</td>
+            <td>Apr 2017</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Kilo</td>
-            <td>April 2015</td>
-            <td>October 2016</td>
-            <td>April 2018</td>
+            <td>Apr 2015</td>
+            <td>Oct 2016</td>
+            <td>Apr 2018</td>
           </tr>
           <tr>
             <td>OpenStack Juno</td>
-            <td>October 2014</td>
-            <td>April 2016</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Icehouse LTS</td>
-            <td>April 2014</td>
-            <td>April 2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 14.10 LTS</strong></td>
-            <td>April 2014</td>
-            <td>April 2019</td>
+            <td>Oct 2014</td>
+            <td>Apr 2016</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Icehouse</td>
-            <td>April 2014</td>
-            <td>April 2017</td>
+            <td>Apr 2014</td>
+            <td>Apr 2019</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.10 LTS</strong></td>
+            <td>Apr 2014</td>
+            <td>Apr 2019</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>OpenStack Icehouse</td>
+            <td>Apr 2014</td>
+            <td>Apr 2017</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Havana</td>
-            <td>October 2013</td>
-            <td>July 2014</td>
+            <td>Oct 2013</td>
+            <td>Jul 2014</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Grizzly</td>
             <td>May 2013</td>
-            <td>August 2014</td>
+            <td>Aug 2014</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Folsom</td>
-            <td>September 2012</td>
-            <td>June 2014</td>
+            <td>Sep 2012</td>
+            <td>Jun 2014</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td>OpenStack Essex</td>
-            <td>April 2012</td>
-            <td>April 2017</td>
+            <td>Apr 2012</td>
+            <td>Apr 2017</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
             <td><strong>Ubuntu 12.04 LTS</strong></td>
-            <td>April 2012</td>
-            <td>April 2017</td>
+            <td>Apr 2012</td>
+            <td>Apr 2017</td>
             <td>&nbsp;</td>
           </tr>
         </tbody>
@@ -562,7 +568,7 @@
         <div class="row">
           <div class="col-10" style="overflow: auto;">
             <div class="u-hide--small" id="kubernetes-eol"></div>
-            <table class="u-hide--medium u-hide--large" style="width: auto;">
+            <table class="u-hide--medium u-hide--large">
               <thead>
                 <tr>
                   <th>Release</th>
@@ -572,49 +578,59 @@
               </thead>
               <tbody>
                 <tr>
-                  <td>Kubernetes 1.5</td>
-                  <td>December 2016</td>
-                  <td>September 2017</td>
+                  <td><strong>Kubernetes 1.15</strong></td>
+                  <td>Jun 2019</td>
+                  <td>Mar 2020</td>
                 </tr>
                 <tr>
-                  <td>Kubernetes 1.6</td>
-                  <td>March 2017</td>
-                  <td>December 2017</td>
+                  <td><strong>Kubernetes 1.14</strong></td>
+                  <td>Mar 2019</td>
+                  <td>Dec 2019</td>
                 </tr>
                 <tr>
-                  <td>Kubernetes 1.7</td>
-                  <td>June 2017</td>
-                  <td>March 2018</td>
-                </tr>
-                <tr>
-                  <td>Kubernetes 1.8</td>
-                  <td>September 2017</td>
-                  <td>July 2018</td>
-                </tr>
-                <tr>
-                  <td>Kubernetes 1.9</td>
-                  <td>December 2017</td>
-                  <td>September 2018</td>
-                </tr>
-                <tr>
-                  <td>Kubernetes 1.10</td>
-                  <td>March 2018</td>
-                  <td>December 2018</td>
-                </tr>
-                <tr>
-                  <td>Kubernetes 1.11</td>
-                  <td>July 2018</td>
-                  <td>March 2019</td>
+                  <td><strong>Kubernetes 1.13</strong></td>
+                  <td>Dec 2018</td>
+                  <td>Sep 2019</td>
                 </tr>
                 <tr>
                   <td>Kubernetes 1.12</td>
-                  <td>September 2018</td>
-                  <td>July 2019</td>
+                  <td>Sep 2018</td>
+                  <td>Jul 2019</td>
                 </tr>
                 <tr>
-                  <td>Kubernetes 1.13</td>
-                  <td>December 2018</td>
-                  <td>September 2019</td>
+                  <td>Kubernetes 1.11</td>
+                  <td>Jul 2018</td>
+                  <td>Mar 2019</td>
+                </tr>
+                <tr>
+                  <td>Kubernetes 1.10</td>
+                  <td>Mar 2018</td>
+                  <td>Dec 2018</td>
+                </tr>
+                <tr>
+                  <td>Kubernetes 1.9</td>
+                  <td>Dec 2017</td>
+                  <td>Sep 2018</td>
+                </tr>
+                <tr>
+                  <td>Kubernetes 1.8</td>
+                  <td>Sep 2017</td>
+                  <td>Jul 2018</td>
+                </tr>
+                <tr>
+                  <td>Kubernetes 1.7</td>
+                  <td>Jun 2017</td>
+                  <td>Mar 2018</td>
+                </tr>
+                <tr>
+                  <td>Kubernetes 1.6</td>
+                  <td>Mar 2017</td>
+                  <td>Dec 2017</td>
+                </tr>
+                <tr>
+                  <td>Kubernetes 1.5</td>
+                  <td>Dec 2016</td>
+                  <td>Sep 2017</td>
                 </tr>
               </tbody>
             </table>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -32,7 +32,7 @@
   <div class="row">
     <h2>Long term support and interim releases</h2>
     <p>LTS or ‘Long Term Support’ releases are published every two years in April. LTS releases are the ‘enterprise grade’ releases of Ubuntu and are utilised the most. An estimated 95% of all Ubuntu installations are LTS releases, with more than 60% of large-scale production clouds running on the most popular OS images - Ubuntu 18.04, 16.04 and 14.04 LTS.</p>
-    <p>Every six months between LTS versions, Canonical publishes an interim release of Ubuntu, with18.10 being the latest example. These are production-quality releases and are supported for their lifespan, with sufficient time provided for users to update, but these releases do not receive the long-term commitment of LTS releases.</p>
+    <p>Every six months between LTS versions, Canonical publishes an interim release of Ubuntu, with 19.04 being the latest example. These are production-quality releases and are supported for their lifespan, with sufficient time provided for users to update, but these releases do not receive the long-term commitment of LTS releases.</p>
   </div>
   <div class="row">
     <div class="col-10" style="overflow: auto;">
@@ -87,12 +87,6 @@
             <td>Ubuntu 19.04</td>
             <td>April 2019</td>
             <td>January 2020</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>Ubuntu 18.10</td>
-            <td>October 2018</td>
-            <td>July 2019</td>
             <td></td>
           </tr>
           <tr>
@@ -273,27 +267,21 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 18.04.3 LTS</strong></td>
+            <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
             <td>August 2019</td>
             <td>February 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>Ubuntu 19.04</td>
+            <td>Ubuntu 19.04 (v5.0)</td>
             <td>April 2019</td>
             <td>January 2020</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 18.04.2 LTS</strong></td>
+            <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
             <td>February 2019</td>
             <td>August 2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 18.10</td>
-            <td>October 2018</td>
-            <td>July 2019</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
@@ -413,7 +401,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td>OpenStack T</td>
+            <td>OpenStack Train</td>
             <td>August 2019</td>
             <td>February 2021</td>
             <td>&nbsp;</td>


### PR DESCRIPTION
## Done

- Update the /about/release-cycle
    - added kernel version numbers that were missing
    - removed 18.10
    - expired some k8s versions
- Fixed up the [sheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1712489059) that drives it.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it matches the dates in the sheet


## Issue / Card

Fixes [#1541](https://github.com/canonical-web-and-design/web-squad/issues/1541)

