### PR TITLE
Update renamed Vanilla patterns

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -14,9 +14,9 @@ core.footerMobileNav = function() {
 // Adds click eventlistener to the copy-to-clipboard buttons. Selects the input
 // and tries to copy the value to the clipboard.
 core.commandLine = function () {
-  document.querySelectorAll('.p-code-snippet').forEach(function(node) {
-    var copyButton = node.querySelector('.p-code-snippet__action');
-    var commandInput = node.querySelector('.p-code-snippet__input');
+  document.querySelectorAll('.p-code-copyable').forEach(function(node) {
+    var copyButton = node.querySelector('.p-code-copyable__action');
+    var commandInput = node.querySelector('.p-code-copyable__input');
     if (copyButton && commandInput) {
       copyButton.addEventListener('click', function(e) {
         commandInput.select();

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -3,7 +3,7 @@
   @include ubuntu-p-is-trisected;
   @include ubuntu-p-nested-counter-lists;
   @include ubuntu-p-inline-definition-list;
-  @include ubuntu-p-list-step;
+  @include ubuntu-p-stepped-list;
   @include ubuntu-p-ordered-legal-list;
   @include ubuntu-p-inline-list-middot;
   @include ubuntu-p-list-small;
@@ -136,13 +136,29 @@
   }
 }
 
-// XXX Ant - 11 July 2018
-// This block can be removed when the following issue is resolved:
-// https://github.com/vanilla-framework/vanilla-framework/issues/1917
-@mixin ubuntu-p-list-step {
-  .p-stepped-list--detailed .p-list-step {
+@mixin ubuntu-p-stepped-list {
+  // XXX Ant - 11 July 2018
+  // This block can be removed when the following issue is resolved:
+  // https://github.com/vanilla-framework/vanilla-framework/issues/1917
+  .p-stepped-list--detailed .p-stepped-list {
     &__item {
       margin-top: 1rem;
+    }
+  }
+
+  // XXX Scott - 19 August 2019
+  // This block can be removed when the following issue is resolved:
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/2489
+  p.p-stepped-list__title { //sass-lint:disable-line no-qualifying-elements
+    display: inline-block;
+    padding-left: 2rem;
+    position: relative;
+
+    &::before {
+      display: inline-block;
+      left: 0;
+      position: absolute;
+      width: 1.5rem;
     }
   }
 }

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -222,9 +222,9 @@
     <div class="col-8">
       <p>Ubuntu LTS releases transition into Extended Security Maintenance (ESM) phase as the standard, five-year public support window comes to a close. It is recommended for users and organisations to upgrade to the latest LTS release or <a href="/esm">subscribe to ESM</a> for continued security coverage.</p>
       <p>This command will print the exact status of your system:</p>
-      <div class="p-code-snippet" style="margin-top: .5rem;">
-        <input class="p-code-snippet__input" value="ubuntu-support-status" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable" style="margin-top: .5rem;">
+        <input class="p-code-copyable__input" value="ubuntu-support-status" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
       <p>The <a class="p-link--external" href="https://wiki.ubuntu.com/Releases">Ubuntu Releases wiki</a> has current information on previous and upcoming versions.</p>
     </div>

--- a/templates/download/iot/_first-boot-setup.html
+++ b/templates/download/iot/_first-boot-setup.html
@@ -1,9 +1,8 @@
-<li class="p-list-step__item">
-  <h3 class="p-list-step__title">
-    <span class="p-list-step__bullet">{{ number|default:1 }}</span>
+<li class="p-stepped-list__item">
+  <h3 class="p-stepped-list__title">
     First boot setup
   </h3>
-  <div class="p-list-step__content">
+  <div class="p-stepped-list__content">
     <ol class="u-no-margin--left">
       <li>The system will boot then become ready to configure.</li>
       <li>The device will display the prompt “Press enter to configure”.</li>

--- a/templates/download/iot/_flash-image.html
+++ b/templates/download/iot/_flash-image.html
@@ -1,8 +1,8 @@
-<li class="p-list-step__item">
-  <h3 class="p-list-step__title">
+<li class="p-stepped-list__item">
+  <h3 class="p-stepped-list__title">
     Flash the {{ card|default:"card" }}
   </h3>
-  <div class="p-list-step__content">
+  <div class="p-stepped-list__content">
     <p>Copy the Ubuntu image on the {{ card|default:"card" }} by following the <a class="p-link" href="/download/iot/installation-media">installation media instructions</a>.</p>
   </div>
 </li>

--- a/templates/download/iot/_login.html
+++ b/templates/download/iot/_login.html
@@ -1,9 +1,8 @@
-<li class="p-list-step__item">
-  <h3 class="p-list-step__title">
-    <span class="p-list-step__bullet">{{ number|default:1 }}</span>
+<li class="p-stepped-list__item">
+  <h3 class="p-stepped-list__title">
     Login
   </h3>
-  <div class="p-list-step__content">
+  <div class="p-stepped-list__content">
     <p>Once setup is done, you can login with SSH into Ubuntu Core, from a machine on the same network, using the following command:</p>
     <pre><code>ssh &lt;Ubuntu SSO user name&gt;@&lt;device IP address&gt;</code></pre>
     <p>Your user name is your Ubuntu SSO user name, it has been reminded to you at the end of the account configuration step.</p>

--- a/templates/download/iot/_setup-ubuntu-sso.html
+++ b/templates/download/iot/_setup-ubuntu-sso.html
@@ -1,8 +1,8 @@
-<li class="p-list-step__item ">
-  <h3 class="p-list-step__title">
+<li class="p-stepped-list__item ">
+  <h3 class="p-stepped-list__title">
     Setup an Ubuntu SSO account
   </h3>
-  <div class="p-list-step__content">
+  <div class="p-stepped-list__content">
     <p>An Ubuntu SSO account is required to create the first user on an Ubuntu Core installation.</p>
     <ol class="u-no-margin--left">
       <li>Start by creating an <a class="p-link--external" href="https://login.ubuntu.com/">Ubuntu SSO account</a>.</li>

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -22,216 +22,203 @@
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="row" id="ubuntu">
-    <div class="col-12">
-      <h2>On Ubuntu</h2>
-      <ol class="p-list-step">
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+  <div class="u-fixed-width" id="ubuntu">
+    <h2>On Ubuntu</h2>
+    <ol class="p-stepped-list">
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Insert your SD card or USB flash drive
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Insert your SD card or USB flash drive
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Identify its address by opening the "Disks" application and look for the "Device" line. If the line is in the <code>/dev/mmcblk0p1</code> format, then your drive address is: <code>/dev/mmcblk0</code>. If it is in the <code>/dev/sdb1</code> format, then the address is <code>/dev/sdb</code>
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Unmount it by right-clicking its icon in the launcher bar, the eject icon in a file manager or the square icon in the "Disks" application
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Open a terminal (<code>Ctrl+Alt+T</code>) to copy the image to your removable drive
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
-          </p>
-          <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
+        </p>
+        <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Else, run:
-          </p>
-          <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Else, run:
+        </p>
+        <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Then, run the <code>sync</code> command to finalize the process
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Then, run the <code>sync</code> command to finalize the process
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-          </p>
-        </li>
-      </ol>
-    </div>
+          You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+        </p>
+      </li>
+    </ol>
   </div>
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="row" id="windows">
-    <div class="col-12">
-      <h2>On Windows</h2>
-      <ol class="p-list-step">
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+  <div class="u-fixed-width" id="windows">
+    <h2>On Windows</h2>
+    <ol class="p-stepped-list">
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Download the Ubuntu image for your device in your <strong>`Downloads`</strong> folder
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          If the Ubuntu image file you have downloaded ends with an .xz file extension, you will need to extract it first. To do so, you might have to install an archive extractor software, like <a class="p-link--external" href="http://www.7-zip.org/">7-zip</a>
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Insert your SD card or USB flash drive
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Insert your SD card or USB flash drive
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Download and install <a class="p-link--external" href="http://sourceforge.net/projects/win32diskimager/files/latest/download">Win32DiskImager</a>, then launch it
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
-          </p>
-          <p>
-            <img alt="" src="http://i.imgur.com/QXLkLsa.png?w=138" width="138" />
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          Find out where your removable drive is mounted by opening a File Explorer window to check which mount point the drive is listed under. Here is an example of an SD card listed under <strong>E:</strong>
+        </p>
+        <p>
+          <img alt="" src="http://i.imgur.com/QXLkLsa.png?w=138" width="138" />
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
-          </p>
-          <ol>
-            <li>an <strong>Image File</strong>: navigate to your <code>Downloads</code> folder and select the image you have just extracted</li>
-            <li>a <strong>Device</strong>: the location of your SD card. Select the drive on which your SD card is mounted</li>
-            <p><img alt="" src="http://i.imgur.com/ebeQHKT.png?w=421" width="421" /></p>
-          </ol>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          In order to flash your card with the Ubuntu image, Win32DiskImager will need 2 elements:
+        </p>
+        <ol>
+          <li>an <strong>Image File</strong>: navigate to your <code>Downloads</code> folder and select the image you have just extracted</li>
+          <li>a <strong>Device</strong>: the location of your SD card. Select the drive on which your SD card is mounted</li>
+          <p><img alt="" src="http://i.imgur.com/ebeQHKT.png?w=421" width="421" /></p>
+        </ol>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            When ready click on <strong>Write</strong> and wait for the process to complete.
-          </p>
-        </li>
-        <li class="p-list-step__item col-8">
-          <p class="p-list-step__title">
+          When ready click on <strong>Write</strong> and wait for the process to complete.
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-            You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-          </p>
-        </li>
-      </ol>
-    </section>
+          You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+        </p>
+      </li>
+    </ol>
+  </div>
+</section>
 
-    <section class="p-strip--light is-bordered">
-      <div class="row" id="macos">
-        <div class="col-12">
-          <h2>On macOS</h2>
-          <ol class="p-list-step">
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+<section class="p-strip--light is-bordered">
+  <div class="u-fixed-width" id="macos">
+    <h2>On macOS</h2>
+    <ol class="p-stepped-list">
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-                Download the Ubuntu image for your device in your <strong>Downloads</strong> folder
-              </p>
-            </li>
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+          Download the Ubuntu image for your device in your <strong>Downloads</strong> folder
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-                Insert your SD card or USB flash drive
-              </p>
-            </li>
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+          Insert your SD card or USB flash drive
+        </p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-                Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run this command:
-              </p>
-              <p><pre><code>diskutil list</code></pre></p>
-            </li>
-            <li class="p-list-step__item col-8">
-              <p class="p-list-step__title">
+          Open a terminal window (Go to <strong>Application</strong> » <strong>Utilities</strong>, you will find the Terminal app there), then run this command:
+        </p>
+        <p><pre><code>diskutil list</code></pre></p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">In the results, identify your removable drive device address, it will probably look like an entry like the ones below:</p>
+        <pre><code>/dev/disk0
+#:                       TYPE NAME                    SIZE       IDENTIFIER
+0:      GUID_partition_scheme                        *500.3 GB   disk0
+/dev/disk2
+#:                       TYPE NAME                    SIZE       IDENTIFIER
+0:                  Apple_HFS Macintosh HD           *428.8 GB   disk1
+Logical Volume on disk0s2
+E2E7C215-99E4-486D-B3CC-DAB8DF9E9C67
+Unlocked Encrypted
+/dev/disk3
+#:                       TYPE NAME                    SIZE       IDENTIFIER
+0:     FDisk_partition_scheme                        *7.9 GB     disk3
+1:                 DOS_FAT_32 NO NAME                 7.9 GB     disk3s1</code></pre>
+        <p>Your removable drive must be <code>DOS_FAT_32</code> formatted. In this example, <code>/dev/disk3</code> is the drive address of an 8GB SD card.</p>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">Unmount your SD card with this command:</p>
+        <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
 
-                In the results, identify your removable drive device address, it will probably look like an entry like the ones below:
-              </p>
-              <pre>
-                <code>/dev/disk0
-                  #:                       TYPE NAME                    SIZE       IDENTIFIER
-                  0:      GUID_partition_scheme                        *500.3 GB   disk0
-                  /dev/disk2
-                  #:                       TYPE NAME                    SIZE       IDENTIFIER
-                  0:                  Apple_HFS Macintosh HD           *428.8 GB   disk1
-                  Logical Volume on disk0s2
-                  E2E7C215-99E4-486D-B3CC-DAB8DF9E9C67
-                  Unlocked Encrypted
-                  /dev/disk3
-                  #:                       TYPE NAME                    SIZE       IDENTIFIER
-                  0:     FDisk_partition_scheme                        *7.9 GB     disk3
-                  1:                 DOS_FAT_32 NO NAME                 7.9 GB     disk3s1
-                </code></pre>
-                <p>Your removable drive must be <code>DOS_FAT_32</code> formatted. In this example, <code>/dev/disk3</code> is the drive address of an 8GB SD card.</p>
-              </li>
-              <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
+          When successful, you should see a message similar to this:
+        </p>
+        <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
+          You can now copy the image to the SD card:
+        </p>
+        <pre><code>sudo sh -c 'gunzip ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
+        <p>When finished you will see this message:</p>
+        <pre><code>3719+1 records in
+3719+1 records out
+3899999744 bytes transferred in 642.512167 secs (6069924 bytes/sec)</code></pre>
+      </li>
+      <li class="p-stepped-list__item col-8">
+        <p class="p-stepped-list__title">
+          You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
+        </p>
+      </li>
+    </ol>
+  </div>
+</section>
 
-                  Unmount your SD card with this command:
-                </p>
-                <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
-              </li>
-              <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
 
-                  When successful, you should see a message similar to this:
-                </p>
-                <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
-              </li>
-              <li class="p-list-step__item col-8">
-                <p class="p-list-step__title">
-
-                  You can now copy the image to the SD card:
-                </p>
-                <pre><code>sudo sh -c 'gunzip ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
-                <p>When finished you will see this message:</p>
-                <pre>
-                  <code>3719+1 records in
-                    3719+1 records out
-                    3899999744 bytes transferred in 642.512167 secs (6069924 bytes/sec)
-                  </code></pre>
-                </li>
-                <li class="p-list-step__item col-8">
-                  <p class="p-list-step__title">
-
-                    You can now eject your removable drive. You are ready to <a href="/download/iot">install Ubuntu on your device ›</a>
-                  </p>
-                </li>
-              </section>
-
-              {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_core_learn_more" second_item="_core_contribute" third_item="_iot_further_reading" %}
-
-              {% endblock content %}
+{% endblock content %}

--- a/templates/download/iot/intel-iei-tank-870.html
+++ b/templates/download/iot/intel-iei-tank-870.html
@@ -35,68 +35,66 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64+kassel.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
-            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/MD5SUMS">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64+kassel.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
+          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/MD5SUMS">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Prepare the two USB flash drives
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Download and flash an <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a>.</li>
-              <li>Copy the Ubuntu Core image file to the second USB flash drive.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Prepare the two USB flash drives
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Download and flash an <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a>.</li>
+            <li>Copy the Ubuntu Core image file to the second USB flash drive.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Boot the live Ubuntu Desktop image
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Connect the keyboard and monitor to the Intel IEI TANK 870.</li>
-              <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
-              <li>Start the device and press F7 to enter the boot menu.</li>
-              <li>Select the USB flash drive as a boot option.</li>
-              <li>Select "Try Ubuntu without installing”.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Boot the live Ubuntu Desktop image
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Connect the keyboard and monitor to the Intel IEI TANK 870.</li>
+            <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
+            <li>Start the device and press F7 to enter the boot menu.</li>
+            <li>Select the USB flash drive as a boot option.</li>
+            <li>Select "Try Ubuntu without installing”.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Flash Ubuntu Core to the internal memory
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
-              <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
-              <pre><code>sudo fdisk -l</code></pre></li>
-              <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
-              <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/&lt;name of the image&gt;.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
-              <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=6 %}
-        {% include "./_login.html" with number=7 %}
-      </ol>
-    </div>
+          Flash Ubuntu Core to the internal memory
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
+            <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
+            <pre><code>sudo fdisk -l</code></pre></li>
+            <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
+            <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/&lt;name of the image&gt;.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
+            <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=6 %}
+      {% include "./_login.html" with number=7 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-joule-desktop.html
+++ b/templates/download/iot/intel-joule-desktop.html
@@ -38,70 +38,68 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Desktop image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/tuchuck/desktop-final/tuchuck-xenial-desktop-iso-20170317-0.iso">Intel Joule - Ubuntu Desktop 16.04 LTS image</a></li>
-              <li>MD5SUM: 07e4895b2921117288ff611c6f5fea28</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Flash the USB drive with Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download and copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
-            <ol class="u-no-margin--left">
-              <li>Boot the system from the USB flash drive.</li>
-              <li>The system will automatically execute the first stage of installation, including eMMC storage partitioning and image installation. After installation is complete, a prompt dialog will be shown and you will need to restart the system.</li>
-              <li>Boot the system on the eMMC storage and finish the install configuration.</li>
-              <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
-              <li>Pick a hostname, user account and password.</li>
-              <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system.</li>
-              <li>Ubuntu is installed. Use your account and password to log in.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Change the default audio output
-          </h3>
-          <div class="p-list-step__content">
-            <p>In the current release, the analog audio port on mezzanine board is chosen as the default audio output. To use HDMI audio, you need to modify the Joule sound configuration file: <code>/etc/modprobe.d/joule-snd.conf</code></p>
-            <h4>Edit configuration</h4>
-            <ol class="u-no-margin--left">
-              <li>
-                <p>Open an editor to modify the configuration file:</p>
-                <pre><code>sudo nano /etc/modprobe.d/joule-snd.conf</pre></code>
-              </li>
-              <li>To use HDMI audio, uncomment the line <code>#blacklist snd_sock_skl</code> and comment the line <code>softdep snd_hda_intel pre: snd_sock_skl</code>. You can revert these changes if you want to change your sound output back to defaults.</li>
-              <li>Reboot the system to apply the new setting.</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Download Ubuntu Desktop
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Desktop image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/tuchuck/desktop-final/tuchuck-xenial-desktop-iso-20170317-0.iso">Intel Joule - Ubuntu Desktop 16.04 LTS image</a></li>
+            <li>MD5SUM: 07e4895b2921117288ff611c6f5fea28</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Flash the USB drive with Ubuntu Desktop
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Download and copy the image on an USB flash drive by following the <a class="p-link--external" href="https://developer.ubuntu.com/core/get-started/installation-medias">installation media instructions</a>.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install Ubuntu Desktop
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
+          <ol class="u-no-margin--left">
+            <li>Boot the system from the USB flash drive.</li>
+            <li>The system will automatically execute the first stage of installation, including eMMC storage partitioning and image installation. After installation is complete, a prompt dialog will be shown and you will need to restart the system.</li>
+            <li>Boot the system on the eMMC storage and finish the install configuration.</li>
+            <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
+            <li>Pick a hostname, user account and password.</li>
+            <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system.</li>
+            <li>Ubuntu is installed. Use your account and password to log in.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Change the default audio output
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>In the current release, the analog audio port on mezzanine board is chosen as the default audio output. To use HDMI audio, you need to modify the Joule sound configuration file: <code>/etc/modprobe.d/joule-snd.conf</code></p>
+          <h4>Edit configuration</h4>
+          <ol class="u-no-margin--left">
+            <li>
+              <p>Open an editor to modify the configuration file:</p>
+              <pre><code>sudo nano /etc/modprobe.d/joule-snd.conf</pre></code>
+            </li>
+            <li>To use HDMI audio, uncomment the line <code>#blacklist snd_sock_skl</code> and comment the line <code>softdep snd_hda_intel pre: snd_sock_skl</code>. You can revert these changes if you want to change your sound output back to defaults.</li>
+            <li>Reboot the system to apply the new setting.</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-joule.html
+++ b/templates/download/iot/intel-joule.html
@@ -41,59 +41,57 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/ubuntu-core-16-joule.img.xz">Ubuntu Core 16 image for Intel Joule</a></li>
-              <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/ubuntu-core-16-joule.img.xz">Ubuntu Core 16 image for Intel Joule</a></li>
+            <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/16/stable/20170323/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Flash the USB drives
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
-              <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Flash the USB drives
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+            <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
-              <li>Insert the first USB flash drive, containing Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
-              <li>Power-up the Joule board, boot-up the device from USB and select “Try Ubuntu without installing” in the first boot menu.</li>
-              <li>Once the system is ready, insert the second USB flash drive.</li>
-              <li>
-                <p>Open a terminal and run the following command, where &lt;disk label&gt; is the name of the second USB flash drive:</p>
-                <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/ubuntu-core-16-joule.img.xz | sudo dd of=/dev/mmcblk0 bs=32M status=progress; sync</code></pre>
-              </li>
-              <li>Remove all USB flash drives and reboot the system, it will reboot from the internal memory now containing Ubuntu Core.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=4 %}
-        {% include "./_login.html" with number=5 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
+            <li>Insert the first USB flash drive, containing Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
+            <li>Power-up the Joule board, boot-up the device from USB and select “Try Ubuntu without installing” in the first boot menu.</li>
+            <li>Once the system is ready, insert the second USB flash drive.</li>
+            <li>
+              <p>Open a terminal and run the following command, where &lt;disk label&gt; is the name of the second USB flash drive:</p>
+              <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/ubuntu-core-16-joule.img.xz | sudo dd of=/dev/mmcblk0 bs=32M status=progress; sync</code></pre>
+            </li>
+            <li>Remove all USB flash drives and reboot the system, it will reboot from the internal memory now containing Ubuntu Core.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=4 %}
+      {% include "./_login.html" with number=5 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-nuc-desktop.html
+++ b/templates/download/iot/intel-nuc-desktop.html
@@ -37,53 +37,51 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download the correct Ubuntu image for your device:</p>
-            <ul class="u-no-margin--left u-no-margin--top">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
-              <br>Certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE, NUC7i3DNBE and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Flash the USB drive
-          </h3>
-          <div class="p-list-step__content">
-            <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions</a>.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Desktop
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the system from the USB flash drive will start the Ubuntu installer.</p>
-            <ol class="u-no-margin--left">
-              <li>Insert the USB flash drive in the NUC.</li>
-              <li>Start the NUC and push F10 to enter the boot menu.</li>
-              <li>Select the USB flash drive as a boot option.</li>
-              <li>The system will automatically execute the first stage of installation and prompt for an acknowledgement of a complete system recovery.</li>
-              <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
-              <li>Pick a hostname, user account and password.</li>
-              <li>Wait for the configuration to finish. If you are connected to an active network, it will take several minutes to download and apply additional updates.</li>
-              <li>Ubuntu is installed. Use your account and password to log in.</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Download Ubuntu Desktop
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Download the correct Ubuntu image for your device:</p>
+          <ul class="u-no-margin--left u-no-margin--top">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
+            <br>Certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE, NUC7i3DNBE and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Flash the USB drive
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions</a>.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install Ubuntu Desktop
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Booting the system from the USB flash drive will start the Ubuntu installer.</p>
+          <ol class="u-no-margin--left">
+            <li>Insert the USB flash drive in the NUC.</li>
+            <li>Start the NUC and push F10 to enter the boot menu.</li>
+            <li>Select the USB flash drive as a boot option.</li>
+            <li>The system will automatically execute the first stage of installation and prompt for an acknowledgement of a complete system recovery.</li>
+            <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout.</li>
+            <li>Pick a hostname, user account and password.</li>
+            <li>Wait for the configuration to finish. If you are connected to an active network, it will take several minutes to download and apply additional updates.</li>
+            <li>Ubuntu is installed. Use your account and password to log in.</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/intel-nuc.html
+++ b/templates/download/iot/intel-nuc.html
@@ -42,81 +42,79 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Download the <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz">Ubuntu Core 18 image for Intel Dawson Canyon and June Canyon NUC</a></p>
-            <p>This image is certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE, NUC7i3DNHE, NUC7i3DNKE, and NUC7i3DNBE, and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH</p>
-            <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Download the <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz">Ubuntu Core 18 image for Intel Dawson Canyon and June Canyon NUC</a></p>
+          <p>This image is certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE, NUC7i3DNHE, NUC7i3DNKE, and NUC7i3DNBE, and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH</p>
+          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://people.canonical.com/~platform/images/nuc/intel_dawson/dawson-uc18-m7-20190122-10.img.xz.md5sum">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Flash the USB drives
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
-              <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Flash the USB drives
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+            <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
-              <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
-              <li>Connect the USB hub, keyboard, mouse and the monitor to the NUC.</li>
-              <li>Insert the Live USB Ubuntu Desktop flash drive in the NUC.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Install Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Connect your USB hub, keyboard, mouse, monitor to the Joule.</li>
+            <li>Insert the first USB flash drive, containing Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</li>
+            <li>Connect the USB hub, keyboard, mouse and the monitor to the NUC.</li>
+            <li>Insert the Live USB Ubuntu Desktop flash drive in the NUC.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Boot from the Live USB flash drive
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Start the NUC and push F10 to enter the boot menu.</li>
-              <li>Select the USB flash drive as a boot option.</li>
-              <li>Select "Try Ubuntu without installing”.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Boot from the Live USB flash drive
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Start the NUC and push F10 to enter the boot menu.</li>
+            <li>Select the USB flash drive as a boot option.</li>
+            <li>Select "Try Ubuntu without installing”.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Flash Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
-              <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
-              <pre><code>sudo fdisk -l</code></pre></li>
-              <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
-              <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/dawson-uc18-m7-20190122-10.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
-              <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=7 %}
-        {% include "./_login.html" with number=8 %}
-      </ol>
-    </div>
+          Flash Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Once the Ubuntu session has started, insert the second USB flash drive containing the Ubuntu Core image file.</li>
+            <li><p>Open a terminal and use the following command to find out the target disk device to install the Ubuntu Core image to:</p>
+            <pre><code>sudo fdisk -l</code></pre></li>
+            <li><p>Run the following command, where <code>&lt;disk label&gt;</code> is the label of the second USB flash drive:</p>
+            <pre><code>xzcat /media/ubuntu/&lt;disk label&gt;/dawson-uc18-m7-20190122-10.img.xz | sudo dd of=/dev/&lt;target disk device&gt; bs=32M status=progress; sync</code></pre></li>
+            <li>Reboot the system and remove the flash drives when prompted. It will then boot from the internal memory where Ubuntu Core has been flashed.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=7 %}
+      {% include "./_login.html" with number=8 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/kvm.html
+++ b/templates/download/iot/kvm.html
@@ -32,89 +32,87 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ul class="u-no-margin--left">
-              <li>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-              <li>
-                <p>Uncompress the image with the following command:</p>
-                <pre><code>unxz ubuntu-core-18-amd64.img.xz</code></pre>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-
-            Install KVM
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>
-                <p>Install the qemu-kvm package with the following command:</p>
-                <pre><code>sudo apt install qemu-kvm</code></pre>
-              </li>
-              <li>
-                <p>Then, run the kvm-ok command to check KVM status and your hardware:</p>
-                <pre><code>kvm-ok</code></pre>
-              </li>
-              <li>
-                <p>The message should say:</p>
-                <pre><code>INFO: /dev/kvm exists
-KVM acceleration can be used</code></pre>
-                <p>This is the best outcome — it means that Ubuntu Core will run fast on your system, taking advantage of hardware acceleration in your CPU.</p>
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ul class="u-no-margin--left">
+            <li>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+            <li>
+              <p>Uncompress the image with the following command:</p>
+              <pre><code>unxz ubuntu-core-18-amd64.img.xz</code></pre>
             </li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Launch KVM
-          </h3>
-          <div class="p-list-step__content">
-            <p>You can now launch a virtual machine with KVM, using the following command:</p>
-            <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-18-amd64.img,format=raw</code></pre>
-            <p>
-              Note: this command sets up port redirections:
-              <ul>
-                <li><code>localhost:8022</code> is redirecting to port <code>22</code> of the virtual machine for accessing it through SSH</li>
-                <li><code>localhost:8090</code> is redirecting to its port <code>80</code></li>
-              </ul>
-            </p>
-            <p>
-              Note: this command is required for graphics such as mir-kiosk:
-              <ul>
-                <li><code>-vga qxl</code> sets the paravirtual graphics driver qxl</li>
-              </ul>
-            </p>
-            <p>You should now see a window, with your Ubuntu Core virtual machine booting inside it.</p>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Install KVM
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>
+              <p>Install the qemu-kvm package with the following command:</p>
+              <pre><code>sudo apt install qemu-kvm</code></pre>
+            </li>
+            <li>
+              <p>Then, run the kvm-ok command to check KVM status and your hardware:</p>
+              <pre><code>kvm-ok</code></pre>
+            </li>
+            <li>
+              <p>The message should say:</p>
+              <pre><code>INFO: /dev/kvm exists
+KVM acceleration can be used</code></pre>
+              <p>This is the best outcome — it means that Ubuntu Core will run fast on your system, taking advantage of hardware acceleration in your CPU.</p>
+          </li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Login
-          </h3>
-          <div class="p-list-step__content">
-            <p>Once setup is done, you can login with SSH into Ubuntu Core, using the following command:</p>
-            <pre><code>ssh -p 8022 &lt;Ubuntu SSO user name&gt;@localhost</code></pre>
-            <p>Your user name is your Ubuntu SSO user name, it has been reminded to you at the end of the account configuration step.</p>
-          </div>
-        </li>
-      </ol>
-    </div>
+          Launch KVM
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>You can now launch a virtual machine with KVM, using the following command:</p>
+          <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-18-amd64.img,format=raw</code></pre>
+          <p>
+            Note: this command sets up port redirections:
+            <ul>
+              <li><code>localhost:8022</code> is redirecting to port <code>22</code> of the virtual machine for accessing it through SSH</li>
+              <li><code>localhost:8090</code> is redirecting to its port <code>80</code></li>
+            </ul>
+          </p>
+          <p>
+            Note: this command is required for graphics such as mir-kiosk:
+            <ul>
+              <li><code>-vga qxl</code> sets the paravirtual graphics driver qxl</li>
+            </ul>
+          </p>
+          <p>You should now see a window, with your Ubuntu Core virtual machine booting inside it.</p>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+
+          Login
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Once setup is done, you can login with SSH into Ubuntu Core, using the following command:</p>
+          <pre><code>ssh -p 8022 &lt;Ubuntu SSO user name&gt;@localhost</code></pre>
+          <p>Your user name is your Ubuntu SSO user name, it has been reminded to you at the end of the account configuration step.</p>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/orange-pi-zero.html
+++ b/templates/download/iot/orange-pi-zero.html
@@ -37,49 +37,47 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://www.orangepi.org/downloadresources/orangepizero/2017-08-18/orangepizero_97899291e57c7a56ec9073f.html">Ubuntu Core 16 for Orange Pi Zero</a></li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://www.orangepi.org/downloadresources/orangepizero/2017-08-18/orangepizero_97899291e57c7a56ec9073f.html">Ubuntu Core 16 for Orange Pi Zero</a></li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Insert the SD card into the board.</li>
-              <li>Connect the Ethernet cable to the board and to the network.</li>
-              <li>Connect the TTL end of the TTL to USB cable, to the three pins next to the Ethernet port. On this diagram, they are identified by the label "Debug serial port". The pin layout is, from the outside to the inside:
-                <ul>
-                  <li><code>GND</code> (black wire)</li>
-                  <li><code>RX</code> (white wire)</li>
-                  <li><code>TX</code> (green wire)</li>
-                </ul>
-              </li>
-              <li>Connect the USB end of the cable into your host computer, open a terminal and run <code>sudo screen /dev/ttyUSB0 115200</code> to open a listening connection to the board.</li>
-              <li>Power on the board. The terminal on your host computer should display the boot sequence. If not, please ensure the TTL to USB cable is correctly connected.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Insert the SD card into the board.</li>
+            <li>Connect the Ethernet cable to the board and to the network.</li>
+            <li>Connect the TTL end of the TTL to USB cable, to the three pins next to the Ethernet port. On this diagram, they are identified by the label "Debug serial port". The pin layout is, from the outside to the inside:
+              <ul>
+                <li><code>GND</code> (black wire)</li>
+                <li><code>RX</code> (white wire)</li>
+                <li><code>TX</code> (green wire)</li>
+              </ul>
+            </li>
+            <li>Connect the USB end of the cable into your host computer, open a terminal and run <code>sudo screen /dev/ttyUSB0 115200</code> to open a listening connection to the board.</li>
+            <li>Power on the board. The terminal on your host computer should display the boot sequence. If not, please ensure the TTL to USB cable is correctly connected.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/qualcomm-dragonboard-410c.html
+++ b/templates/download/iot/qualcomm-dragonboard-410c.html
@@ -38,43 +38,41 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz">Ubuntu Core 18 image for DragonBoard 410c</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz">Ubuntu Core 18 image for DragonBoard 410c</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Make sure the DragonBoard is unplugged from power.</li>
-              <li>Set the S6 switch to 0-1-0-0, where 1 is the "SD boot" option.</li>
-              <li>Attach the monitor and keyboard to the board.</li>
-              <li>Insert the SD card and plug the power adaptor into the board.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Make sure the DragonBoard is unplugged from power.</li>
+            <li>Set the S6 switch to 0-1-0-0, where 1 is the "SD boot" option.</li>
+            <li>Attach the monitor and keyboard to the board.</li>
+            <li>Insert the SD card and plug the power adaptor into the board.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/raspberry-pi-2-3-core.html
+++ b/templates/download/iot/raspberry-pi-2-3-core.html
@@ -36,44 +36,42 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
-              </li>
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
-              </li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi2.img.xz">Ubuntu Core 18 image for Raspberry Pi 2.</a>
+            </li>
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi3.img.xz">Ubuntu Core 18 image for Raspberry Pi 3.</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+            </li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
-              <li>Insert the microSD card and plug the power adaptor into the board.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+          Install Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+            <li>Insert the microSD card and plug the power adaptor into the board.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -39,50 +39,48 @@
 </section>
 
 <section class="p-strip--light is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Server image for your board:</p>
-            <ul class="u-no-margin--left" style="list-style-type: disc;">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-armhf+raspi2.img.xz">Ubuntu Server image for Raspberry Pi 2.</a>
-              </li>
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-arm64+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 3</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
-              </li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="microSD card" %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Server
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Server image for your board:</p>
+          <ul class="u-no-margin--left" style="list-style-type: disc;">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-armhf+raspi2.img.xz">Ubuntu Server image for Raspberry Pi 2.</a>
+            </li>
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.lts.full_version }}-preinstalled-server-arm64+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 3</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+            </li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="microSD card" %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Install Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
-              <li>Insert the microSD card and plug the power adaptor into the board.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Install Ubuntu Server
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+            <li>Insert the microSD card and plug the power adaptor into the board.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Login
-          </h3>
-          <div class="p-list-step__content">
-            <p>When prompted to log in, use "ubuntu" for the username and the password. You will be asked to change this default password after you log in.</p>
-          </div>
-        </li>
-      </ol>
-    </div>
+          Login
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>When prompted to log in, use "ubuntu" for the username and the password. You will be asked to change this default password after you log in.</p>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/raspberry-pi-2-3.html
+++ b/templates/download/iot/raspberry-pi-2-3.html
@@ -91,17 +91,17 @@
     <div class="col-8">
       <h3>First boot tips</h3>
       <p>You can install a desktop if you like, here are some popular ones:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="sudo apt-get install xubuntu-desktop" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="sudo apt-get install lubuntu-desktop" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="sudo apt-get install kubuntu-desktop" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
       <p>For more details about Raspberry Pi specific packages included with this image and further customisations, such as accelerated video drivers and optional package repositories, you can refer to the <a class="p-link--external" href="https://wiki.ubuntu.com/ARM/RaspberryPi#Packages">RaspberryPi wiki</a>.</p>
     </div>

--- a/templates/download/iot/raspberry-pi-compute-module-3.html
+++ b/templates/download/iot/raspberry-pi-compute-module-3.html
@@ -40,98 +40,96 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" %}
-        <li class="p-list-step__item" id="step2">
-          <h3 class="p-list-step__title">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" %}
+      <li class="p-stepped-list__item" id="step2">
+        <h3 class="p-stepped-list__title">
 
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+cm3.img.xz">Ubuntu Core 18 image for Compute Module 3</a></li>
-              <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+cm3.img.xz">Ubuntu Core 18 image for Compute Module 3</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Setup USBboot on your host system
-          </h3>
-          <div class="p-list-step__content">
-            <p>On the host system: Ubuntu Desktop 16.04 or above:</p>
-            <ol>
-              <li>
-                <p>In a terminal, download the USBboot tool you will use to setup the board, and install its build dependencies:</p>
-                <pre><code>git clone --depth=1 https://github.com/raspberrypi/usbboot.git
+          Setup USBboot on your host system
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>On the host system: Ubuntu Desktop 16.04 or above:</p>
+          <ol>
+            <li>
+              <p>In a terminal, download the USBboot tool you will use to setup the board, and install its build dependencies:</p>
+              <pre><code>git clone --depth=1 https://github.com/raspberrypi/usbboot.git
 sudo apt install libusb-1.0-0-dev</code></pre>
-              </li>
-              <li>
-                <p>Then <code>cd</code into the USBboot directory, build with <code>make</code> and start the resulting binary as root:</p>
-                <pre><code>cd usbboot
+            </li>
+            <li>
+              <p>Then <code>cd</code into the USBboot directory, build with <code>make</code> and start the resulting binary as root:</p>
+              <pre><code>cd usbboot
 make
 sudo ./rpiboot</code></pre>
-              </li>
-              <li>Once started, it will wait for the Compute Module to be attached to the machine.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+            </li>
+            <li>Once started, it will wait for the Compute Module to be attached to the machine.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Setup the Compute Module IO board
-          </h3>
-          <div class="p-list-step__content">
-            <p>On the Compute Module IO board:</p>
-            <ol>
-              <li>Position the Compute Module on the IO board.</li>
-              <li>Attach the USB hub, RJ45 adaptor, keyboard and monitor (HDMI) to the board.</li>
-              <li>
-                <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
-                <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"></p>
-              </li>
-              <li>
-                <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
-                <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"></p>
-              </li>
-              <li>With the second micro USB to USB cable, power on the IO board.</li>
-            </ol>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+          Setup the Compute Module IO board
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>On the Compute Module IO board:</p>
+          <ol>
+            <li>Position the Compute Module on the IO board.</li>
+            <li>Attach the USB hub, RJ45 adaptor, keyboard and monitor (HDMI) to the board.</li>
+            <li>
+              <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
+              <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"></p>
+            </li>
+            <li>
+              <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
+              <p><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"></p>
+            </li>
+            <li>With the second micro USB to USB cable, power on the IO board.</li>
+          </ol>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
 
-            Flash the board from your host system
-          </h3>
-          <div class="p-list-step__content">
-            <p>On your host system:</p>
-            <ol>
-              <li>The USBboot tool should have recognized the attached Compute Module and mounted the EMMC partition as a new device.</li>
-              <li>Identify the device by opening the "Disks" application:
-                <ul>
-                  <li>Locate the EMMC partition of the Compute Module in the left pane.</li>
-                  <li>Note down its "Device" address on the right pane.</li>
-                  <li>If the partition is mounted, unmount it by clicking the square icon below the partition diagram or the eject icon in a file manager</li>
-                </ul>
-              </li>
-              <li>Download the <a href="#step2">Ubuntu Core image</a>. When this is done you should have an <code>ubuntu-core-18-armhf+cm3.img.xz</code> file in your <code>~/Downloads</code> directory</li>
-              <li>
-                <p>Flash Ubuntu Core on the EMMC partition with:</p>
-                <pre><code>xzcat ~/Downloads/&lt;image file .xz&gt; | sudo dd of=&lt;device address&gt; bs=32M; sync</code></pre>
-              </li>
-              <li>This process will take some time. After completion, you can reboot your Compute Module IO board and follow the first boot process with the display, keyboard and RJ45/WiFI dongle attached to it.</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=6 %}
-        {% include "./_login.html" with number=7 %}
-      </ol>
-    </div>
+          Flash the board from your host system
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>On your host system:</p>
+          <ol>
+            <li>The USBboot tool should have recognized the attached Compute Module and mounted the EMMC partition as a new device.</li>
+            <li>Identify the device by opening the "Disks" application:
+              <ul>
+                <li>Locate the EMMC partition of the Compute Module in the left pane.</li>
+                <li>Note down its "Device" address on the right pane.</li>
+                <li>If the partition is mounted, unmount it by clicking the square icon below the partition diagram or the eject icon in a file manager</li>
+              </ul>
+            </li>
+            <li>Download the <a href="#step2">Ubuntu Core image</a>. When this is done you should have an <code>ubuntu-core-18-armhf+cm3.img.xz</code> file in your <code>~/Downloads</code> directory</li>
+            <li>
+              <p>Flash Ubuntu Core on the EMMC partition with:</p>
+              <pre><code>xzcat ~/Downloads/&lt;image file .xz&gt; | sudo dd of=&lt;device address&gt; bs=32M; sync</code></pre>
+            </li>
+            <li>This process will take some time. After completion, you can reboot your Compute Module IO board and follow the first boot process with the display, keyboard and RJ45/WiFI dongle attached to it.</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=6 %}
+      {% include "./_login.html" with number=7 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/samsung-artik-5-10-server.html
+++ b/templates/download/iot/samsung-artik-5-10-server.html
@@ -35,54 +35,52 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik5-ubuntu-server.img.tar.xz">ARTIK 5 - Ubuntu Server 16.04 LTS image</a></li>
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik10-ubuntu-server.img.tar.xz">ARTIK 10 - Ubuntu Server 16.04 LTS image</a></li>
-              <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Set your board to boot from the SD card
-          </h3>
-          <div class="p-list-step__content">
-            <p>Before installing Ubuntu, you need to set your Artik to boot from the SD card, to do so, set the "SW2" switches to <code>1:on</code> and <code>2:on</code>.</p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the board from the SD Card will start the Ubuntu installer:</p>
-            <ol class="u-no-margin--left">
-              <li>Insert the SD card in your Samsung ARTIK</li>
-              <li>Connect the 5V power supply to the board, then use the power button on the board to switch on your Samsung ARTIK</li>
-              <li>The system will automatically execute the first stage of installation</li>
-              <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout</li>
-              <li>Pick a hostname, user account and password</li>
-              <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system</li>
-              <li>Ubuntu is installed. Use your account and password to log in</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" with number=1 %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik5-ubuntu-server.img.tar.xz">ARTIK 5 - Ubuntu Server 16.04 LTS image</a></li>
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/archive/artik10-ubuntu-server.img.tar.xz">ARTIK 10 - Ubuntu Server 16.04 LTS image</a></li>
+            <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Set your board to boot from the SD card
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Before installing Ubuntu, you need to set your Artik to boot from the SD card, to do so, set the "SW2" switches to <code>1:on</code> and <code>2:on</code>.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install Ubuntu Server
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Booting the board from the SD Card will start the Ubuntu installer:</p>
+          <ol class="u-no-margin--left">
+            <li>Insert the SD card in your Samsung ARTIK</li>
+            <li>Connect the 5V power supply to the board, then use the power button on the board to switch on your Samsung ARTIK</li>
+            <li>The system will automatically execute the first stage of installation</li>
+            <li>Follow the instructions and enter appropriate options for language, WiFi, location (timezone), and keyboard layout</li>
+            <li>Pick a hostname, user account and password</li>
+            <li>Wait for the configuration to finish. If you connected to a WiFi network at step 4, it will take several minutes to download and apply additional updates. You can now reboot the system</li>
+            <li>Ubuntu is installed. Use your account and password to log in</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/samsung-artik-5-10.html
+++ b/templates/download/iot/samsung-artik-5-10.html
@@ -35,43 +35,41 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        {% include "./_setup-ubuntu-sso.html" with number=1 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Core image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik5.img.xz">Ubuntu Core 16 image for Samsung Artik 5</a></li>
-              <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik10.img.xz">Ubuntu Core 16 image for Samsung Artik 10</a></li>
-              <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
-            </ul>
-          </div>
-        </li>
-        {% include "./_flash-image.html" with card="SD card" number=3 %}
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Core
-          </h3>
-          <div class="p-list-step__content">
-            <ol class="u-no-margin--left">
-              <li>Prepare your Artik to boot from the SD card, by setting the "SW2" switches to <code>1:on</code> and <code>2:on</code></li>
-              <li>Insert the SD card</li>
-              <li>Connect the 5V power supply to the board, then use the power button on the board to switch it on</li>
-            </ol>
-          </div>
-        </li>
-        {% include "./_first-boot-setup.html" with number=5 %}
-        {% include "./_login.html" with number=6 %}
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      {% include "./_setup-ubuntu-sso.html" with number=1 %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Download Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Core image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik5.img.xz">Ubuntu Core 16 image for Samsung Artik 5</a></li>
+            <li><a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/artik10.img.xz">Ubuntu Core 16 image for Samsung Artik 10</a></li>
+            <li>You can verify the integrity of the file using the <a class="p-link--external" href="http://people.canonical.com/~platform/snappy/artik/uc-series16-final-image/md5sum">MD5sum</a> file.</li>
+          </ul>
+        </div>
+      </li>
+      {% include "./_flash-image.html" with card="SD card" number=3 %}
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install Ubuntu Core
+        </h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Prepare your Artik to boot from the SD card, by setting the "SW2" switches to <code>1:on</code> and <code>2:on</code></li>
+            <li>Insert the SD card</li>
+            <li>Connect the 5V power supply to the board, then use the power button on the board to switch it on</li>
+          </ol>
+        </div>
+      </li>
+      {% include "./_first-boot-setup.html" with number=5 %}
+      {% include "./_login.html" with number=6 %}
+    </ol>
   </div>
 </section>
 

--- a/templates/download/iot/up-squared-iot-grove-server.html
+++ b/templates/download/iot/up-squared-iot-grove-server.html
@@ -33,39 +33,37 @@
 </section>
 
 <section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h2>Installation instructions</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Download Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Get the correct Ubuntu Server image for your board:</p>
-            <ul class="u-no-margin--left">
-              <li>Intel provides a modified Ubuntu Server 16.04.3 LTS image shipped with a custom 4.10 kernel and the Intel IoT Developer Kit.</li>
-              <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
-            </ul>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Server
-          </h3>
-          <div class="p-list-step__content">
-            <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
-            <ol class="u-no-margin--left">
-              <li>Insert the USB flash drive in the Up<sup>2</sup> board.</li>
-              <li>Power on the board.</li>
-              <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
-            </ol>
-          </div>
-        </li>
-      </ol>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Download Ubuntu Server
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Get the correct Ubuntu Server image for your board:</p>
+          <ul class="u-no-margin--left">
+            <li>Intel provides a modified Ubuntu Server 16.04.3 LTS image shipped with a custom 4.10 kernel and the Intel IoT Developer Kit.</li>
+            <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">Mac OS X</a></li>
+          </ul>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install Ubuntu Server
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Booting the board from the USB flash drive will start the Ubuntu installer.</p>
+          <ol class="u-no-margin--left">
+            <li>Insert the USB flash drive in the Up<sup>2</sup> board.</li>
+            <li>Power on the board.</li>
+            <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
+          </ol>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -34,110 +34,108 @@
 </section>
 
 <section class="p-strip is-deep is-bordered" id="instructions">
-  <div class="row">
-    <div class="col-12">
-      <h2>Install MAAS in 7 easy steps</h2>
-      <ol class="p-stepped-list--detailed">
-        <li class="p-list-step__item ">
-          <h3 class="p-list-step__title">
-            
-            Setup your hardware
-          </h3>
-          <p class="p-list-step__content">You need one small server for MAAS and at least one server which can be managed with a <abbr title="Baseboard Management Controller">BMC</abbr>. It is recommended to have the MAAS server provide <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> and <abbr title="Domain Name Service">DNS</abbr> on a network the managed machines are connected to.</p>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install Ubuntu Server
-          </h3>
-          <p class="p-list-step__content"><a aria-label="External link to download Ubuntu Server {{ releases.lts.short_version }} LTS" href="/download/server">Download Ubuntu Server {{ releases.lts.short_version }} LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Install MAAS
-          </h3>
-          <div class="p-list-step__content">
-            <div class="p-code-copyable">
-              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo apt update" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-            <div class="p-code-copyable">
-              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo apt install maas" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
+  <div class="u-fixed-width">
+    <h2>Install MAAS in 7 easy steps</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item ">
+        <h3 class="p-stepped-list__title">
+          
+          Setup your hardware
+        </h3>
+        <p class="p-stepped-list__content">You need one small server for MAAS and at least one server which can be managed with a <abbr title="Baseboard Management Controller">BMC</abbr>. It is recommended to have the MAAS server provide <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> and <abbr title="Domain Name Service">DNS</abbr> on a network the managed machines are connected to.</p>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install Ubuntu Server
+        </h3>
+        <p class="p-stepped-list__content"><a aria-label="External link to download Ubuntu Server {{ releases.lts.short_version }} LTS" href="/download/server">Download Ubuntu Server {{ releases.lts.short_version }} LTS</a> and follow the step-by-step installation instructions on your MAAS server.</p>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Install MAAS
+        </h3>
+        <div class="p-stepped-list__content">
+          <div class="p-code-copyable">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo apt update" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Create admin user
-          </h3>
-          <div class="p-list-step__content">
-            <p>Create your admin credentials by typing.</p>
-            <div class="p-code-copyable">
-              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo maas init" readonly="readonly">
-              <button class="p-code-copyable__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
-            </div>
-            <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
+          <div class="p-code-copyable">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo apt install maas" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Complete the first user configuration journey
-          </h3>
-          <div class="p-list-step__content">
-            <p>Follow the instructions on screen to complete the first installation of MAAS. We recommend using the default values unless your installation has different requirements.</p>
-            <p>By the end of the journey you should have the following configured;</p>
-            <ul>
-              <li>Region name (MAAS name)</li>
-              <li>Ubuntu archive, Ubuntu extra architectures</li>
-              <li>Ubuntu images</li>
-              <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
-            </ul>
-            <p><a href="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png?w=552" width="552" alt="First user journey screenshot"></a></p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Create admin user
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Create your admin credentials by typing.</p>
+          <div class="p-code-copyable">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo maas init" readonly="readonly">
+            <button class="p-code-copyable__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
           </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Turn on DHCP
-          </h3>
-          <div class="p-list-step__content">
-            <p>Go to the &ldquo;Subnets&rdquo; tab, and select the <abbr title="Virtual Local Area Network">VLAN</abbr> for which you want to enable DHCP. From the &ldquo;Take action&rdquo; button select &ldquo;Provide DHCP&rdquo;.</p>
-            <ol>
-              <li>Set the Rack controller that will manage DHCP.</li>
-              <li>Select the subnet where to create the DHCP Dynamic range on.</li>
-              <li>Fill in the details for the dynamic range.</li>
-            </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png" title="VLAN details page in an active MAAS">
-              <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png?w=552" width="552" class="image--shadow" alt="VLAN details">
-            </a></p>
-          </div>
-        </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
-            
-            Enlist and commission servers
-          </h3>
-          <div class="p-list-step__content">
-            <p>Now MAAS is ready to enlist and commission machines.</p>
-            <ol>
-              <li>Set all the servers to <abbr title="Preboot Execution Environment">PXE</abbr> boot</li>
-              <li>Boot each machine once. You should see these machines appear in MAAS</li>
-              <li>If your machines do not have a <abbr title="Intelligent Platform Management Interface">IPMI</abbr> based BMC, proceed to edit them and enter their BMC details</li>
-              <li>Select all the machines and &ldquo;Commission&rdquo; them using the &ldquo;Take action&rdquo; button</li>
-              <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
-            </ol>
-            <p><a href="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png" title="The node listing page in MAAS">
-              <img src="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png?w=552" width="552" class="p-image--bordered" alt="MAAS node listing">
-            </a></p>
-            <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
-          </div>
-        </li>
-      </ol>
-    </div>
+          <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Complete the first user configuration journey
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Follow the instructions on screen to complete the first installation of MAAS. We recommend using the default values unless your installation has different requirements.</p>
+          <p>By the end of the journey you should have the following configured;</p>
+          <ul>
+            <li>Region name (MAAS name)</li>
+            <li>Ubuntu archive, Ubuntu extra architectures</li>
+            <li>Ubuntu images</li>
+            <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
+          </ul>
+          <p><a href="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png" title="Initial screen of the first use journey"><img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}e0915052-initial_setup.png?w=552" width="552" alt="First user journey screenshot"></a></p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Turn on DHCP
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Go to the &ldquo;Subnets&rdquo; tab, and select the <abbr title="Virtual Local Area Network">VLAN</abbr> for which you want to enable DHCP. From the &ldquo;Take action&rdquo; button select &ldquo;Provide DHCP&rdquo;.</p>
+          <ol>
+            <li>Set the Rack controller that will manage DHCP.</li>
+            <li>Select the subnet where to create the DHCP Dynamic range on.</li>
+            <li>Fill in the details for the dynamic range.</li>
+          </ol>
+          <p><a href="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png" title="VLAN details page in an active MAAS">
+            <img class="p-image--bordered" src="{{ ASSET_SERVER_URL }}65c03778-provide_DHCP.png?w=552" width="552" class="image--shadow" alt="VLAN details">
+          </a></p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          
+          Enlist and commission servers
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>Now MAAS is ready to enlist and commission machines.</p>
+          <ol>
+            <li>Set all the servers to <abbr title="Preboot Execution Environment">PXE</abbr> boot</li>
+            <li>Boot each machine once. You should see these machines appear in MAAS</li>
+            <li>If your machines do not have a <abbr title="Intelligent Platform Management Interface">IPMI</abbr> based BMC, proceed to edit them and enter their BMC details</li>
+            <li>Select all the machines and &ldquo;Commission&rdquo; them using the &ldquo;Take action&rdquo; button</li>
+            <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
+          </ol>
+          <p><a href="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png" title="The node listing page in MAAS">
+            <img src="{{ ASSET_SERVER_URL }}94f90490-machine_listing.png?w=552" width="552" class="p-image--bordered" alt="MAAS node listing">
+          </a></p>
+          <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
+        </div>
+      </li>
+    </ol>
   </div>
 </section>
 

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -58,13 +58,13 @@
             Install MAAS
           </h3>
           <div class="p-list-step__content">
-            <div class="p-code-snippet">
-              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo apt update" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
-            <div class="p-code-snippet">
-              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo apt install maas" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </div>
         </li>
@@ -75,9 +75,9 @@
           </h3>
           <div class="p-list-step__content">
             <p>Create your admin credentials by typing.</p>
-            <div class="p-code-snippet">
-              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo maas init" readonly="readonly">
-              <button class="p-code-snippet__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo maas init" readonly="readonly">
+              <button class="p-code-copyable__action" onClick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Completion', 'eventAction' : 'Click', 'eventLabel' : 'Install' });">Copy to clipboard</button>
             </div>
             <p>Login to the MAAS <abbr title="User interface">UI</abbr> at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
           </div>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -5,9 +5,9 @@
       <section class="p-accordion__panel" id="tab1-section" role="tabpanel" aria-hidden="true" aria-labelledby="tab1-section" style="margin-bottom: 1.5rem; border: 0; background: 0;">
         <p style="margin-right: 2rem;"><small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small></p>
         <div style="margin-right: 2rem;">
-          <div class="p-code-snippet">
-            <textarea class="p-code-snippet__input" style="background-position: 0 0.25rem; color: rebeccapurple; padding-right: 1.5rem;" readonly="readonly">echo "{{ releases.checksums | keyvalue:system | keyvalue:version }}" | shasum -a 256 --check</textarea>
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <textarea class="p-code-copyable__input" style="background-position: 0 0.25rem; color: rebeccapurple; padding-right: 1.5rem;" readonly="readonly">echo "{{ releases.checksums | keyvalue:system | keyvalue:version }}" | shasum -a 256 --check</textarea>
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
         <p><small>You should get the following output:</small></p>

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -25,17 +25,19 @@
 </section>
 
 <nav class="p-tabs p-sticky-nav">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#developers">Developers</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#apps">Apps</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#hardware">Hardware</a>
-    </li>
-  </ul>
+  <div class="u-fixed-width">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#developers">Developers</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#apps">Apps</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#hardware">Hardware</a>
+      </li>
+    </ul>
+  </div>
 </nav>
 
 <section class="p-strip u-no-padding--bottom">
@@ -389,14 +391,14 @@
       <h4>Docker</h4>
       <p>Bring your cloud containers and CI/CD tooling to the edge.</p>
       <p>Using apt and debs:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="apt install docker.io" readonly="readonly" aria-label="">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="apt install docker.io" readonly="readonly" aria-label="">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
       <p>Using snaps:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="snap install docker" readonly="readonly" aria-label="">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="snap install docker" readonly="readonly" aria-label="">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
     </div>
   </div>

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -24,20 +24,22 @@
 </section>
 
 <nav class="p-tabs p-sticky-nav">
-  <ul class="p-tabs__list" role="tablist">
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#benefits">Security and compliance</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#enable-esm">Enable ESM</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#get-esm">Get ESM</a>
-    </li>
-    <li class="p-tabs__item" role="presentation">
-      <a class="p-tabs__link js-sticky-tab" href="#faq">FAQ</a>
-    </li>
-  </ul>
+  <div class="u-fixed-width">
+    <ul class="p-tabs__list" role="tablist">
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#benefits">Security and compliance</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#enable-esm">Enable ESM</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#get-esm">Get ESM</a>
+      </li>
+      <li class="p-tabs__item" role="presentation">
+        <a class="p-tabs__link js-sticky-tab" href="#faq">FAQ</a>
+      </li>
+    </ul>
+  </div>
 </nav>
 
 <section class="p-strip is-deep is-bordered" id="benefits">
@@ -59,13 +61,13 @@
       <h2>How to enable ESM on your system</h2>
       <p>To enable ESM on your Ubuntu LTS systems, you will need a token which is issued when you purchase ESM coverage. Once you have the token, follow this guide.</p>
       <p>From the command line type the following commands and follow the step-by-step instructions:</p>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo ubuntu-advantage enable-esm [ENTER TOKEN]" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="sudo ubuntu-advantage enable-esm [ENTER TOKEN]" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
-      <div class="p-code-snippet">
-        <input class="p-code-snippet__input" value="sudo apt-get update" readonly="readonly">
-        <button class="p-code-snippet__action">Copy to clipboard</button>
+      <div class="p-code-copyable">
+        <input class="p-code-copyable__input" value="sudo apt-get update" readonly="readonly">
+        <button class="p-code-copyable__action">Copy to clipboard</button>
       </div>
     </div>
     <p>ESM patches will now be offered as part of the standard APT upgrade procedure.</p>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -227,41 +227,39 @@
     <p class="p-heading--two">Bootstrap for production-grade robots</p>
     <p>This is how you can get started today:</p>
   </div>
-</section>
-
-<section class="p-strip--light is-deep is-bordered">
+  
   <div class="u-fixed-width">
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
           Pick your development board
         </h3>
-        <div class="p-list-step__content">
+        <div class="p-stepped-list__content">
           <p>Ubuntu is supported by popular development boards and the majority of high performance SoCs. Other boards can be enabled to work with Ubuntu: we provide full options for device enablement when needed.</p>
           <a class="p-link--external" href="https://docs.ubuntu.com/core/en/guides/build-device/board-enablement">Read the board enablement overview&nbsp;›</a>
         </div>
       </li>
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
           Set up your development environment
         </h3>
-        <div class="p-list-step__content">
+        <div class="p-stepped-list__content">
           <p>Set up your development toolchain with Ubuntu Server via Multipass or on your Ubuntu Desktop. Install Snapcraft to build a bespoke application stack for your target use case. Benefit from the wealth of tools and libraries available on Ubuntu, and take advantage of the strong community support.</p>
         </div>
       </li>
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
           Create your production stack on Ubuntu Core
         </h3>
-        <div class="p-list-step__content">
+        <div class="p-stepped-list__content">
           <p>Snaps allow you to package and sandbox your application stack. With Ubuntu Core and snaps, you will be able to create lean production images streamlined for the purposes of your application. Test your production image in KVM before flashing it to your board.</p>
         </div>
       </li>
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
           Setup your service infrastructure
         </h3>
-        <div class="p-list-step__content">
+        <div class="p-stepped-list__content">
           <p>Before going to production, get in touch with us to setup the infrastructure for the successful launch, maintenance and long term support of your product.</p>
         </div>
       </li>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -20,73 +20,71 @@
 </section>
 
 <div class="p-strip is-deep is-bordered" id="instructions">
-  <div class="row">
-    <div class="col-12">
-      <h2>How to deploy Kubeflow</h2>
-      <p>
-        If you already have Ubuntu or another Linux, the following instructions are all you need. However, if you are on Windows or Mac, consider using <a class="p-link--external" href="https://github.com/CanonicalLtd/multipass">Multipass</a> to easily create an Ubuntu VM to work with.
-      </p>
-      <p>
-        Kubeflow runs on top of Kubernetes. Visit our <a href="/kubernetes/install">Kubernetes install</a> page and follow the instructions to install the Kubernetes as you want.
-      </p>
-      <p>
-        The following step assumes you want to install <a class="p-link--external" href="https://microk8s.io/">MicroK8s</a> as your Kubernetes cluster.
-      </p>
-      <ol class="p-stepped-list--detailed">
+  <div class="u-fixed-width">
+    <h2>How to deploy Kubeflow</h2>
+    <p>
+      If you already have Ubuntu or another Linux, the following instructions are all you need. However, if you are on Windows or Mac, consider using <a class="p-link--external" href="https://github.com/CanonicalLtd/multipass">Multipass</a> to easily create an Ubuntu VM to work with.
+    </p>
+    <p>
+      Kubeflow runs on top of Kubernetes. Visit our <a href="/kubernetes/install">Kubernetes install</a> page and follow the instructions to install the Kubernetes as you want.
+    </p>
+    <p>
+      The following step assumes you want to install <a class="p-link--external" href="https://microk8s.io/">MicroK8s</a> as your Kubernetes cluster.
+    </p>
+    <ol class="p-stepped-list--detailed">
 
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title">Install MicroK8s</h3>
-          <div class="p-list-step__content">
-            <p>
-              MicroK8s can be installed with one command. However, to get the most out of the installation, there are a few extra steps that need to be done, particularly if executing these steps in a virtual machine. The <code>setup-microk8s.sh</code> script will automate these steps for you.
-            </p>
-            <p>Clone the kubernetes-tools project</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="git clone https://github.com/canonical-labs/kubernetes-tools" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
-            </div>
-            <p>Run the script as root</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo kubernetes-tools/setup-microk8s.sh" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
-            </div>
-            <p>If you have a GPU, run</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="microk8s.enable gpu" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
-            </div>
+      <li class="p-list-step__item col-12">
+        <h3 class="p-list-step__title">Install MicroK8s</h3>
+        <div class="p-list-step__content">
+          <p>
+            MicroK8s can be installed with one command. However, to get the most out of the installation, there are a few extra steps that need to be done, particularly if executing these steps in a virtual machine. The <code>setup-microk8s.sh</code> script will automate these steps for you.
+          </p>
+          <p>Clone the kubernetes-tools project</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="git clone https://github.com/canonical-labs/kubernetes-tools" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
+          <p>Run the script as root</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo kubernetes-tools/setup-microk8s.sh" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
+          </div>
+          <p>If you have a GPU, run</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="microk8s.enable gpu" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
+          </div>
+        </div>
+      </li>
 
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title">Install Kubeflow</h3>
-          <div class="p-list-step__content">
-            <p>Clone the kubeflow-tools project</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="git clone https://github.com/canonical-labs/kubeflow-tools" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
-            </div>
-            <p>Run the Kubeflow Install script</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="kubeflow-tools/install-kubeflow.sh" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
-            </div>
+      <li class="p-list-step__item col-12">
+        <h3 class="p-list-step__title">Install Kubeflow</h3>
+        <div class="p-list-step__content">
+          <p>Clone the kubeflow-tools project</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="git clone https://github.com/canonical-labs/kubeflow-tools" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
+          <p>Run the Kubeflow Install script</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="kubeflow-tools/install-kubeflow.sh" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
+          </div>
+        </div>
+      </li>
 
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title">Access Kubeflow</h3>
-          <div class="p-list-step__content">
-            <p>If you installed Microk8s on your local host, then you can use localhost as the IP address in your browser. Otherwise, if you used Multipass as per the instructions above, you can get the IP address of the VM with either <code>multipass list</code> or <code>multipass info kubeflow</code>.</p>
-            <p>Point browser to either:</p>
-            <ul>
-              <li class="p-list__item"><code>http://&lt;kubeflow VM IP&gt;:&lt;Ambassador PORT&gt;</code></li>
-              <li class="p-list__item"><code>http://localhost:&lt;Ambassador PORT&gt;</code></li>
-            </ul>
-          </div>
-        </li>
-      </ol>
-    </div>
+      <li class="p-list-step__item col-12">
+        <h3 class="p-list-step__title">Access Kubeflow</h3>
+        <div class="p-list-step__content">
+          <p>If you installed Microk8s on your local host, then you can use localhost as the IP address in your browser. Otherwise, if you used Multipass as per the instructions above, you can get the IP address of the VM with either <code>multipass list</code> or <code>multipass info kubeflow</code>.</p>
+          <p>Point browser to either:</p>
+          <ul>
+            <li class="p-list__item"><code>http://&lt;kubeflow VM IP&gt;:&lt;Ambassador PORT&gt;</code></li>
+            <li class="p-list__item"><code>http://localhost:&lt;Ambassador PORT&gt;</code></li>
+          </ul>
+        </div>
+      </li>
+    </ol>
   </div>
 </div>
 

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -32,10 +32,9 @@
       The following step assumes you want to install <a class="p-link--external" href="https://microk8s.io/">MicroK8s</a> as your Kubernetes cluster.
     </p>
     <ol class="p-stepped-list--detailed">
-
-      <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title">Install MicroK8s</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install MicroK8s</h3>
+        <div class="p-stepped-list__content">
           <p>
             MicroK8s can be installed with one command. However, to get the most out of the installation, there are a few extra steps that need to be done, particularly if executing these steps in a virtual machine. The <code>setup-microk8s.sh</code> script will automate these steps for you.
           </p>
@@ -57,9 +56,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title">Install Kubeflow</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install Kubeflow</h3>
+        <div class="p-stepped-list__content">
           <p>Clone the kubeflow-tools project</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="git clone https://github.com/canonical-labs/kubeflow-tools" readonly="readonly">
@@ -73,9 +72,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
-        <h3 class="p-list-step__title">Access Kubeflow</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Access Kubeflow</h3>
+        <div class="p-stepped-list__content">
           <p>If you installed Microk8s on your local host, then you can use localhost as the IP address in your browser. Otherwise, if you used Multipass as per the instructions above, you can get the IP address of the VM with either <code>multipass list</code> or <code>multipass info kubeflow</code>.</p>
           <p>Point browser to either:</p>
           <ul>

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -47,9 +47,9 @@ Kubernetes cluster running on the cloud of your choice in minutes!
 deploying, configuring, and operating complex software on public or private
 clouds. It can be installed with a snap:
 
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="sudo snap install juju --classic" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="sudo snap install juju --classic" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <script id="asciicast-254739" src="https://asciinema.org/a/254739.js" async data-autoplay="true" data-rows="4"></script>
           </div>
@@ -62,9 +62,9 @@ clouds. It can be installed with a snap:
 Juju has baked in knowledge of many public clouds such as AWS, Azure and
 Google. You can see which ones are ready to use by running this command:
 
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="juju clouds" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="juju clouds" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <script id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
 
@@ -76,9 +76,9 @@ Google. You can see which ones are ready to use by running this command:
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Add Credentials</h3>
           <div class="p-list-step__content">
 <p>Most clouds require credentials so that the cloud knows which operations are authorised, so you will need to supply these for Juju. If you choose to use AWS, for example, you would run:</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="juju add-credential aws" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="juju add-credential aws" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
 <p>For a different cloud, just substitute in the name from the previous
    list output by Juju. The data you need to supply will vary depending on the cloud. </p>
@@ -91,9 +91,9 @@ Google. You can see which ones are ready to use by running this command:
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Add a Controller</h3>
           <div class="p-list-step__content">
             <p>The Juju controller is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as 'models'.</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="juju bootstrap aws my-controller" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="juju bootstrap aws my-controller" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <script id="asciicast-2FOd2qvaJL0wWqvZqFeVbwUsz" src="https://asciinema.org/a/2FOd2qvaJL0wWqvZqFeVbwUsz.js" async data-rows="18"></script>
           </div>
@@ -103,9 +103,9 @@ Google. You can see which ones are ready to use by running this command:
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Add a Model</h3>
           <div class="p-list-step__content">
             <p>The model holds a specific deployment. It is a good idea to create a new one specifically for each deployment.</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="juju add-model k8s" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="juju add-model k8s" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
                         <p>Remember that you can have multiple models on each controller, so you can deploy multiple Kubernetes clusters, or other applications.</p>
           </div>
@@ -115,9 +115,9 @@ Google. You can see which ones are ready to use by running this command:
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Deploy Kubernetes</h3>
           <div class="p-list-step__content">
             <p>Deploy the Kubernetes bundle to the model. This will add instances to the model and deploy the required applications.</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="juju deploy charmed-kubernetes" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="juju deploy charmed-kubernetes" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
             <script id="asciicast-8YAPb63aB9kfB7j1M9X6COGer" src="https://asciinema.org/a/8YAPb63aB9kfB7j1M9X6COGer.js" async></script>
           </div>
@@ -126,9 +126,9 @@ Google. You can see which ones are ready to use by running this command:
           <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Monitor the deployment</h3>
           <div class="p-list-step__content">
             <p>Juju is now busy creating instances, installing software and connecting the different parts of the cluster together, which can take several minutes. You can monitor what's going on by running:</p>
-            <div class="p-code-snippet">
-              <input class="p-code-snippet__input" value="watch -c juju status --color" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input class="p-code-copyable__input" value="watch -c juju status --color" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
           </div>
         </li>

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -35,117 +35,112 @@ Kubernetes cluster running on the cloud of your choice in minutes!
 
 
 <section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <ol class="p-stepped-list--detailed">
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title col-12"><span class="p-list-step__bullet">1</span>Install Juju</h3>
-          <div class="p-list-step__content">
-
+  <div class="u-fixed-width">
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">1</span>Install Juju</h3>
+        <div class="p-stepped-list__content">
 <a class="p-link--external" href="https://jaas.ai" >Juju</a> is a tool for
 deploying, configuring, and operating complex software on public or private
 clouds. It can be installed with a snap:
-
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="sudo snap install juju --classic" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-            <script id="asciicast-254739" src="https://asciinema.org/a/254739.js" async data-autoplay="true" data-rows="4"></script>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo snap install juju --classic" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
+          <script id="asciicast-254739" src="https://asciinema.org/a/254739.js" async data-autoplay="true" data-rows="4"></script>
+        </div>
+      </li>
 
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">2</span>Find your cloud</h3>
-          <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">2</span>Find your cloud</h3>
+        <div class="p-stepped-list__content">
 
 Juju has baked in knowledge of many public clouds such as AWS, Azure and
 Google. You can see which ones are ready to use by running this command:
 
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="juju clouds" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-            <script id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
-
-            <p><a class="p-link--external" href="https://docs.jujucharms.com/clouds">Find out more about Clouds in Juju</a></p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju clouds" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
+          <script id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
 
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">3</span>Add Credentials</h3>
-          <div class="p-list-step__content">
+          <p><a class="p-link--external" href="https://docs.jujucharms.com/clouds">Find out more about Clouds in Juju</a></p>
+        </div>
+      </li>
+
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">3</span>Add Credentials</h3>
+        <div class="p-stepped-list__content">
 <p>Most clouds require credentials so that the cloud knows which operations are authorised, so you will need to supply these for Juju. If you choose to use AWS, for example, you would run:</p>
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="juju add-credential aws" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju add-credential aws" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
+          </div>
 <p>For a different cloud, just substitute in the name from the previous
-   list output by Juju. The data you need to supply will vary depending on the cloud. </p>
-             <script id="asciicast-Wo12W39et3IJzF15rAyVunbbl" src="https://asciinema.org/a/Wo12W39et3IJzF15rAyVunbbl.js" async data-rows="18" ></script>
+  list output by Juju. The data you need to supply will vary depending on the cloud. </p>
+            <script id="asciicast-Wo12W39et3IJzF15rAyVunbbl" src="https://asciinema.org/a/Wo12W39et3IJzF15rAyVunbbl.js" async data-rows="18" ></script>
+        </div>
+
+      </li>
+
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">4</span>Add a Controller</h3>
+        <div class="p-stepped-list__content">
+          <p>The Juju controller is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as 'models'.</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju bootstrap aws my-controller" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
+          <script id="asciicast-2FOd2qvaJL0wWqvZqFeVbwUsz" src="https://asciinema.org/a/2FOd2qvaJL0wWqvZqFeVbwUsz.js" async data-rows="18"></script>
+        </div>
+      </li>
 
-        </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">4</span>Add a Controller</h3>
-          <div class="p-list-step__content">
-            <p>The Juju controller is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations. One Juju controller can manage multiple projects or workspaces, which in Juju are known as 'models'.</p>
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="juju bootstrap aws my-controller" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-            <script id="asciicast-2FOd2qvaJL0wWqvZqFeVbwUsz" src="https://asciinema.org/a/2FOd2qvaJL0wWqvZqFeVbwUsz.js" async data-rows="18"></script>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">5</span>Add a Model</h3>
+        <div class="p-stepped-list__content">
+          <p>The model holds a specific deployment. It is a good idea to create a new one specifically for each deployment.</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju add-model k8s" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
+                      <p>Remember that you can have multiple models on each controller, so you can deploy multiple Kubernetes clusters, or other applications.</p>
+        </div>
+      </li>
 
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">5</span>Add a Model</h3>
-          <div class="p-list-step__content">
-            <p>The model holds a specific deployment. It is a good idea to create a new one specifically for each deployment.</p>
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="juju add-model k8s" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-                        <p>Remember that you can have multiple models on each controller, so you can deploy multiple Kubernetes clusters, or other applications.</p>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">6</span>Deploy Kubernetes</h3>
+        <div class="p-stepped-list__content">
+          <p>Deploy the Kubernetes bundle to the model. This will add instances to the model and deploy the required applications.</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju deploy charmed-kubernetes" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
-
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Deploy Kubernetes</h3>
-          <div class="p-list-step__content">
-            <p>Deploy the Kubernetes bundle to the model. This will add instances to the model and deploy the required applications.</p>
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="juju deploy charmed-kubernetes" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-            <script id="asciicast-8YAPb63aB9kfB7j1M9X6COGer" src="https://asciinema.org/a/8YAPb63aB9kfB7j1M9X6COGer.js" async></script>
+          <script id="asciicast-8YAPb63aB9kfB7j1M9X6COGer" src="https://asciinema.org/a/8YAPb63aB9kfB7j1M9X6COGer.js" async></script>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">6</span>Monitor the deployment</h3>
+        <div class="p-stepped-list__content">
+          <p>Juju is now busy creating instances, installing software and connecting the different parts of the cluster together, which can take several minutes. You can monitor what's going on by running:</p>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="watch -c juju status --color" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-        </li>
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Monitor the deployment</h3>
-          <div class="p-list-step__content">
-            <p>Juju is now busy creating instances, installing software and connecting the different parts of the cluster together, which can take several minutes. You can monitor what's going on by running:</p>
-            <div class="p-code-copyable">
-              <input class="p-code-copyable__input" value="watch -c juju status --color" readonly="readonly">
-              <button class="p-code-copyable__action">Copy to clipboard</button>
-            </div>
-          </div>
-        </li>
-        <li class="p-list-step__item col-12">
-          <h3 class="p-list-step__title"><span class="p-list-step__bullet">6</span>Start using your cluster!</h3>
-          <div class="p-list-step__content">
-            <p>Congratulations! You have a Kubernetes cluster up and running - now let's use it! The link below takes you to the operations guide, detailing some of the common things you'll want to do next: </p>
-            <p>
-            <a href="/kubernetes/docs/operations">Get started with your new cluster&nbsp;›</a>
-            </p>
-          </div>
-        </li>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">6</span>Start using your cluster!</h3>
+        <div class="p-stepped-list__content">
+          <p>Congratulations! You have a Kubernetes cluster up and running - now let's use it! The link below takes you to the operations guide, detailing some of the common things you'll want to do next: </p>
+          <p>
+          <a href="/kubernetes/docs/operations">Get started with your new cluster&nbsp;›</a>
+          </p>
+        </div>
+      </li>
 
 
-        </ol>
+      </ol>
 
-      </div>
     </div>
   </section>
 

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -85,9 +85,9 @@
 <section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Install latest MicroK8s</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install latest MicroK8s</h3>
+        <div class="p-stepped-list__content">
           <p>MicroK8s is packaged as a snap which requires snapd to be installed. The latest Ubuntu release comes with this already built in. For other Linux systems install snapd first. Use this command to get the latest version of MicroK8s:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo snap install microk8s --classic" readonly="readonly">
@@ -96,9 +96,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Install specific versions of MicroK8s</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install specific versions of MicroK8s</h3>
+        <div class="p-stepped-list__content">
           <p><strong>List specific Kubernetes versions</strong></p>
           <p>The following command will list all versions of MicroK8s that can be installed:</p>
           <div class="p-code-copyable">
@@ -114,9 +114,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Useful tips</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Useful tips</h3>
+        <div class="p-stepped-list__content">
           <p>This command will install a the stable 1.14 version of MicroK8s:</p>
           <p>After installing MicroK8s, you should verify it is ready. Use this command:</p>
           <div class="p-code-copyable">
@@ -174,9 +174,9 @@
 <section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Install Juju</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install Juju</h3>
+        <div class="p-stepped-list__content">
           <p>Juju simplifies how you configure, scale and operate today’s complex software. Juju deploys everywhere: to public or private clouds. It is packaged as a snap which requires snapd to be installed. The latest Ubuntu release comes with this already built in. For other Linux systems install snapd first:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo snap install juju --classic" readonly="readonly">
@@ -185,9 +185,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Add your cloud - optional</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Add your cloud - optional</h3>
+        <div class="p-stepped-list__content">
           <p>This interactive step allows you to register a cloud that isn’t known to Juju by default. In the summary instructions above, since AWS is used, this step isn’t necessary - AWS and other public clouds have well-known IP addresses. For private clouds you need to give some details to juju. An example is a MAAS cloud, which operates your bare metal infrastructure.</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="juju add-cloud" readonly="readonly">
@@ -212,9 +212,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Add Credentials</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Add Credentials</h3>
+        <div class="p-stepped-list__content">
           <p>Most clouds require credentials so that the cloud knows which operations are authorised and on which account. If you choose to use AWS, for example, you would run <code>juju add-credential aws</code></p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="juju add-credential aws" readonly="readonly">
@@ -223,9 +223,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Add Controller</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Add Controller</h3>
+        <div class="p-stepped-list__content">
           <p>The Juju controller is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations.</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="juju bootstrap aws my-cloud-controller" readonly="readonly">
@@ -234,9 +234,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Add Model</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Add Model</h3>
+        <div class="p-stepped-list__content">
           <p>The model holds a specific deployment, like Kubernetes, which includes all necessary applications and the number of instances of each one. This is where the number of Kubernetes worker nodes are scaled up or down.</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="juju add-model k8s-test" readonly="readonly">
@@ -245,9 +245,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Deploy Kubernetes</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Deploy Kubernetes</h3>
+        <div class="p-stepped-list__content">
           <p>Add the Kubernetes bundle to the model and deploy the components, including the default number of components, like worker nodes.</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="juju deploy charmed-kubernetes" readonly="readonly">
@@ -256,9 +256,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">&#9734;</span>Useful tips</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">&#9734;</span>Useful tips</h3>
+        <div class="p-stepped-list__content">
           <p><strong>Observe installation progress:</strong> Watch the deployment process in real-time:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="watch -c juju status --color" readonly="readonly">

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -85,62 +85,62 @@
 <section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Install latest MicroK8s</h3>
         <div class="p-list-step__content">
           <p>MicroK8s is packaged as a snap which requires snapd to be installed. The latest Ubuntu release comes with this already built in. For other Linux systems install snapd first. Use this command to get the latest version of MicroK8s:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo snap install microk8s --classic" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo snap install microk8s --classic" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Install specific versions of MicroK8s</h3>
         <div class="p-list-step__content">
           <p><strong>List specific Kubernetes versions</strong></p>
           <p>The following command will list all versions of MicroK8s that can be installed:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="snap info microk8s" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="snap info microk8s" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p><strong>Install specific Kubernetes version</strong></p>
           <p>This command will install a the stable 1.14 version of MicroK8s:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo snap install microk8s --classic --channel=1.14/stable" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo snap install microk8s --classic --channel=1.14/stable" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Useful tips</h3>
         <div class="p-list-step__content">
           <p>This command will install a the stable 1.14 version of MicroK8s:</p>
           <p>After installing MicroK8s, you should verify it is ready. Use this command:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="microk8s.status" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="microk8s.status" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>To block until MicroK8s is ready, use the following command:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="microk8s.status --wait-ready" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="microk8s.status --wait-ready" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p><strong>Accessing Kubernetes:</strong> MicroK8s embeds a kubectl and a .kubeconfig file required for accessing the installed MicroK8s. This avoids  colliding with any local versions  that might be already installed. Here is an example of how to use this:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="microk8s.kubectl" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="microk8s.kubectl" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>If you would like to use the MicroK8s kubectl and .kubeconfig file locally, you can do the following:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="snap alias microk8s.kubectl kubectl" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="snap alias microk8s.kubectl kubectl" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="microk8s.kubectl config view --raw > $HOME/.kube/config" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="microk8s.kubectl config view --raw > $HOME/.kube/config" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
@@ -174,24 +174,24 @@
 <section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Install Juju</h3>
         <div class="p-list-step__content">
           <p>Juju simplifies how you configure, scale and operate today’s complex software. Juju deploys everywhere: to public or private clouds. It is packaged as a snap which requires snapd to be installed. The latest Ubuntu release comes with this already built in. For other Linux systems install snapd first:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo snap install juju --classic" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo snap install juju --classic" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Add your cloud - optional</h3>
         <div class="p-list-step__content">
           <p>This interactive step allows you to register a cloud that isn’t known to Juju by default. In the summary instructions above, since AWS is used, this step isn’t necessary - AWS and other public clouds have well-known IP addresses. For private clouds you need to give some details to juju. An example is a MAAS cloud, which operates your bare metal infrastructure.</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="juju add-cloud" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju add-cloud" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>What clouds can you deploy to?</p>
           <ul style="list-style-type: disc;">
@@ -212,62 +212,62 @@
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Add Credentials</h3>
         <div class="p-list-step__content">
           <p>Most clouds require credentials so that the cloud knows which operations are authorised and on which account. If you choose to use AWS, for example, you would run <code>juju add-credential aws</code></p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="juju add-credential aws" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju add-credential aws" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Add Controller</h3>
         <div class="p-list-step__content">
           <p>The Juju controller is used to manage the software deployed through Juju, from deployment to upgrades to day-two operations.</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="juju bootstrap aws my-cloud-controller" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju bootstrap aws my-cloud-controller" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Add Model</h3>
         <div class="p-list-step__content">
           <p>The model holds a specific deployment, like Kubernetes, which includes all necessary applications and the number of instances of each one. This is where the number of Kubernetes worker nodes are scaled up or down.</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="juju add-model k8s-test" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju add-model k8s-test" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title">Deploy Kubernetes</h3>
         <div class="p-list-step__content">
           <p>Add the Kubernetes bundle to the model and deploy the components, including the default number of components, like worker nodes.</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="juju deploy charmed-kubernetes" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju deploy charmed-kubernetes" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </div>
       </li>
 
-      <li class="p-list-step__item col-12">
+      <li class="p-list-step__item">
         <h3 class="p-list-step__title"><span class="p-list-step__bullet">&#9734;</span>Useful tips</h3>
         <div class="p-list-step__content">
           <p><strong>Observe installation progress:</strong> Watch the deployment process in real-time:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="watch -c juju status --color" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="watch -c juju status --color" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p><strong>Observe log messages:</strong> To  view the last twenty log messages for the “k8s-test” model:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="juju debug-log -m k8s-test -n 20" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="juju debug-log -m k8s-test -n 20" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p><strong>Accessing Kubernetes:</strong> Juju creates a .kubeconfig file that is required  for accessing the Kubernetes cluster it created. Follow these instructions to install kubectl (if needed) and export the configuration file: (use kubectl to run commands against Kubernetes clusters)</p>
           <pre><code>$ mkdir -p ~/.kube

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -96,13 +96,13 @@
       <p class="u-sv3">The best way to keep costs down and ensure a high-quality cloud is to use a repeatable, standardised methodology for workload analysis, requirements gathering, deployment and operations.</p>
     </div>
     <div class="u-fixed-width">
-      <ol class="p-list-step">
-        <li class="p-list-step__item">
+      <ol class="p-stepped-list">
+        <li class="p-stepped-list__item">
           <div class="row u-equal-height">
             <div class="col-6">
-              <h3 class="p-list-step__title">
+              <h3 class="p-stepped-list__title">
                 
-                Design and <strong>build</strong>
+                Design and&nbsp;<strong>build</strong>
               </h3>
               <p>Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. This happens on your site and in your preferred data centre. We’ll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we’ll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
             </div>
@@ -111,12 +111,12 @@
             </div>
           </div>
         </li>
-        <li class="p-list-step__item">
+        <li class="p-stepped-list__item">
           <div class="row u-equal-height">
             <div class="col-6">
-              <h3 class="p-list-step__title">
+              <h3 class="p-stepped-list__title">
                 
-                We <strong>operate</strong> your Kubernetes
+                We&nbsp;<strong>operate</strong>&nbsp;your Kubernetes
               </h3>
               <p>We take responsibility for the remote management and 24/7 availability of your Kubernetes clusters. Your SLA covers uptime and performance. Your hardware and software are proactively monitored. Scale on demand with additional racks.</p>
               <p>For as long as you want, Canonical will tend to the infrastructure so that you can tend to your business workloads. The most important thing for a new private container initiative is engagement with development and operations teams, to build confidence in your private or multi-cloud strategy. This will prove the business case for on-prem or multi-cloud Kubernetes and ensure high service levels during the critical early stages of your journey.</p>
@@ -126,12 +126,12 @@
             </div>
           </div>
         </li>
-        <li class="p-list-step__item">
+        <li class="p-stepped-list__item">
           <div class="row u-equal-height">
             <div class="col-6">
-              <h3 class="p-list-step__title">
+              <h3 class="p-stepped-list__title">
                 
-                We <strong>transfer</strong> control
+                We&nbsp;<strong>transfer</strong>&nbsp;control
               </h3>
               <p>On request, we’ll give you the keys. We provide training and a handover process with on-site  reliability engineers to ensure a smooth handover.</p>
               <p>Not everyone wants to operate Kubernetes, and for many people, the benefit of the cloud is freedom from the infrastructure layer. Managed Kubernetes offers that in your own data centre. However, if you do want to take control, you have full visibility from the very beginning in every aspect of cloud management, performance tuning, log aggregation and monitoring. There’s no better way to learn Kubernetes than to run a cloud shoulder to shoulder with Canonical.</p>
@@ -141,12 +141,12 @@
             </div>
           </div>
         </li>
-        <li class="p-list-step__item">
+        <li class="p-stepped-list__item">
           <div class="row">
             <div class="col-6">
-              <h3 class="p-list-step__title">
+              <h3 class="p-stepped-list__title">
                 
-                We <strong>support</strong> your operations
+                We&nbsp;<strong>support</strong>&nbsp;your operations
               </h3>
               <p>Once you have control of the cloud, Canonical provides 24/7 enterprise telephone support. Since we know the architecture of your Kubernetes clusters, problems are faster to debug and easier to resolve.</p>
             </div>

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -104,9 +104,9 @@
 
             Install the livepatch daemon
           </h3>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo snap install canonical-livepatch" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo snap install canonical-livepatch" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </li>
         <li class="p-list-step__item">
@@ -114,9 +114,9 @@
 
             Enable it on your system
           </h3>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo canonical-livepatch enable [TOKEN]" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo canonical-livepatch enable [TOKEN]" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </li>
       </ol>

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -91,16 +91,16 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <ol class="p-list-step">
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+      <ol class="p-stepped-list">
+        <li class="p-stepped-list__item">
+          <h3 class="p-stepped-list__title">
 
             Generate your credentials
           </h3>
           <p>Via the <a class="p-link--external" href="https://auth.livepatch.canonical.com/">Canonical Livepatch portal</a>.</p>
         </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+        <li class="p-stepped-list__item">
+          <h3 class="p-stepped-list__title">
 
             Install the livepatch daemon
           </h3>
@@ -109,8 +109,8 @@
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
         </li>
-        <li class="p-list-step__item">
-          <h3 class="p-list-step__title">
+        <li class="p-stepped-list__item">
+          <h3 class="p-stepped-list__title">
 
             Enable it on your system
           </h3>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -98,18 +98,18 @@
         <h3 class="p-list-step__title">Install MAAS</h3>
         <div class="p-list-step__content">
           <p>On your Ubuntu Server 16.04 LTS machine:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo apt update" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo apt update" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo apt install maas" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo apt install maas" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>Create your admin credentials:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo maas init" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo maas init" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>Login to the MAAS UI at <code>http://&lt;serverip&gt;/MAAS/</code></p>
           <p>Complete the setup wizard for MAAS and import images for Ubuntu. Importing images may take a while, but you can &lsquo;continue&rsquo; as soon as it&rsquo;s started and work on other aspects of MAAS setup while the import happens.</p>
@@ -157,13 +157,13 @@
         <h3 class="p-list-step__title">Install and launch conjure-up</h3>
         <div class="p-list-step__content">
           <p>Install conjure-up on the MAAS server:</p>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="sudo snap install conjure-up --classic" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="sudo snap install conjure-up --classic" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
-          <div class="p-code-snippet">
-            <input class="p-code-snippet__input" value="conjure-up" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input class="p-code-copyable__input" value="conjure-up" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>If successful you should see a screen as below:</p>
           <p>
@@ -280,14 +280,14 @@
           <p>
             <a href="https://snapcraft.io/">Snaps</a> are the recommended installation method for LXD, If you need to enable snap packages:
           </p>
-          <div class="p-code-snippet">
-            <input aria-label="code snippet" class="p-code-snippet__input" value="sudo snap install lxd" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install lxd" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>For the best experience, it is recommended to migrate from the <strong>deb</strong> LXD packaging. This will move all container specific data to the snap version and clean up the unused debian packages.  So, if you already had the the lxd package installed, run lxd.migrate. When prompted, uninstall the old LXD version so that only the snap version is available.</p>
-          <div class="p-code-snippet">
-            <input aria-label="code snippet" class="p-code-snippet__input" value="sudo lxd.migrate" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo lxd.migrate" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>Now that lxd has been installed it needs to be initialised to set up, among other things, a network bridge and a storage pool. While mostly default options can be used, check the table below and ensure your answers match.</p>
           <pre><code>$ sudo lxd init
@@ -308,9 +308,9 @@ Would you like LXD to be available over the network? (yes/no) [default=no]:
 Would you like stale cached images to be updated automatically? (yes/no) [default=yes]
 Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</code></pre>
             <p>Then install conjure-up:</p>
-            <div class="p-code-snippet">
-              <input aria-label="code snippet" class="p-code-snippet__input" value="sudo snap install conjure-up --classic" readonly="readonly">
-              <button class="p-code-snippet__action">Copy to clipboard</button>
+            <div class="p-code-copyable">
+              <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install conjure-up --classic" readonly="readonly">
+              <button class="p-code-copyable__action">Copy to clipboard</button>
             </div>
         </div>
       </li>
@@ -318,9 +318,9 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
         <h3 class="p-list-step__title">Deploy OpenStack</h3>
         <div class="p-list-step__content">
           <p>Now you are ready to start the OpenStack deployment process on your workstation.</p>
-          <div class="p-code-snippet">
-            <input aria-label="code snippet" class="p-code-snippet__input" value="conjure-up" readonly="readonly">
-            <button class="p-code-snippet__action">Copy to clipboard</button>
+          <div class="p-code-copyable">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="conjure-up" readonly="readonly">
+            <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p>You will see a menu of 'spells' which are descriptions of distributed software systems that conjure-up can deploy for you. Choose &lsquo;OpenStack with NovaLXD&rsquo;.</p>
           <img src="{{ ASSET_SERVER_URL }}23a02e6d-conjure-up-install-openstack.png?w=444" width="444" alt="screenshot of the conjure-up interface with the 'OpenStack with NovaLXD' option selected" />

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -71,9 +71,9 @@
   </div>
   <div class="u-fixed-width">
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Minimum requirements</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Minimum requirements</h3>
+        <div class="p-stepped-list__content">
           <p>4 x Intel, POWER or ARM servers each with:</p>
           <ul class="p-list">
             <li class="p-list__item">8GB RAM</li>
@@ -85,18 +85,18 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Set up your MAAS hardware</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Set up your MAAS hardware</h3>
+        <div class="p-stepped-list__content">
           <p>Connect the both NICs of the servers to the same network switch.</p>
           <p>Identify the smallest server, if they are not identical. You will use this for <a href="https://maas.io/" class="p-link--external">MAAS</a>, the &lsquo;Metal as a Service&rsquo; provisioning system which will drive automated installation of the OS on the rest of the cluster.</p>
           <p><a href="/download/server" class="p-link--external">Install Ubuntu Server 18.04 LTS</a> on the MAAS server. Give it an IP address on the /24 and static default route to the gateway router, so it can see the Internet. You might want to bond the two NICs for resilience and/or bandwidth aggregation.</p>
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Install MAAS</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install MAAS</h3>
+        <div class="p-stepped-list__content">
           <p>On your Ubuntu Server 16.04 LTS machine:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo apt update" readonly="readonly">
@@ -117,9 +117,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Configure the subnet and&nbsp;DHCP</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Configure the subnet and&nbsp;DHCP</h3>
+        <div class="p-stepped-list__content">
           <p>Go to the &ldquo;Subnets&rdquo; tab and verify that &ldquo;gateway&rdquo; and &ldquo;DNS&rdquo; are correct for your subnet.</p>
           <p>MAAS will provide DHCP and DNS for the /24 network on your isolated LAN switch.</p>
           <p>For the DHCP dynamic range, we recommend at least two IPs per NIC in the cluster (and remember you have at least two NICs per server, so probably 50 IPs in the range if you have 10 servers). Don&rsquo;t use the entire /24 for DHCP though since you will need IP addresses for various OpenStack services and guests.</p>
@@ -127,16 +127,16 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Verify image syncing</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Verify image syncing</h3>
+        <div class="p-stepped-list__content">
           <p>Go to the &ldquo;Images&rdquo; tab and check if the Ubuntu images have all been downloaded and are in a &ldquo;Synced&rdquo; state. Depending on your bandwidth it may take a while for it to finish. You can only proceed with the next steps if the images are synced.</p>
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Register your hardware with<br /> MAAS</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Register your hardware with<br /> MAAS</h3>
+        <div class="p-stepped-list__content">
           <p>For the rest of the machines in the cluster:</p>
           <ul>
             <li>These are your OpenStack hosts</li>
@@ -153,9 +153,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Install and launch conjure-up</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install and launch conjure-up</h3>
+        <div class="p-stepped-list__content">
           <p>Install conjure-up on the MAAS server:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo snap install conjure-up --classic" readonly="readonly">
@@ -174,9 +174,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Select OpenStack hypervisor</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Select OpenStack hypervisor</h3>
+        <div class="p-stepped-list__content">
           <p>conjure-up offers two options with OpenStack:</p>
           <p>1. OpenStack with NovaLXD</p>
           <p>This installs OpenStack configured to use the LXC &lsquo;machine container&rsquo; hypervisor &mdash; containers that behave like ultra-fast VMs. Choose this option to run Linux workloads in LXD containers, for higher density and for evaluation of OpenStack.</p>
@@ -190,9 +190,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Configure a new cloud</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Configure a new cloud</h3>
+        <div class="p-stepped-list__content">
           <p>Once you have selected &lsquo;OpenStack with &lsquo;NovaKVM&rsquo;, you will be prompted to create a new cloud with MAAS.</p>
           <p>
             <a href="{{ ASSET_SERVER_URL }}610f81f8-build-openstack-with-conjure-up-3.png">
@@ -202,9 +202,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">10</span>Add MAAS endpoint and credentials</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">10</span>Add MAAS endpoint and credentials</h3>
+        <div class="p-stepped-list__content">
           <p>The MAAS REST API endpoint will be of the form: <code>http://&lt;maas.ip&gt;/MAAS/</code>.</p>
           <p>The api key is found under the MAAS &lsquo;admin&rsquo; acouunt page as shown below.</p>
           <p>
@@ -226,9 +226,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title"><span class="p-list-step__bullet">11</span>Configure and deploy the OpenStack services</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title"><span class="p-stepped-list__bullet">11</span>Configure and deploy the OpenStack services</h3>
+        <div class="p-stepped-list__content">
           <p>Choose <strong>Configure</strong> to change the default configuration of any component. When all components are configured to your liking, choose <strong>Deploy</strong>.</p>
           <p>
             <a href="{{ ASSET_SERVER_URL }}85a136cd-build-openstack-with-conjure-up-7.png">
@@ -260,9 +260,9 @@
   <div class="u-fixed-width">
     <h2>Installation instructions</h2>
     <ol class="p-stepped-list--detailed">
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Minimum requirements</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Minimum requirements</h3>
+        <div class="p-stepped-list__content">
           <ul class="p-list">
             <li class="p-list__item">Single machine with 16GB RAM running Ubuntu 16.04 LTS or later and at least 40GB of free disk space</li>
             <li class="p-list__item">Approximately one hour to complete the process</li>
@@ -270,9 +270,9 @@
         </div>
       </li>
 
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Install conjure-up</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install conjure-up</h3>
+        <div class="p-stepped-list__content">
           <p><code>conjure-up</code> provides a text-based wizard to walk you through the process of setting up OpenStack. It can be used with full bare metal clusters, or on your workstation with LXD. We&rsquo;ll be using LXD to create a set of container machines for the OpenStack services.</p>
           <p>Follow these step-by-step instructions.</p>
           <p><strong>conjure-up</strong> requires a minimum version of LXD of <strong>3.0.0</strong>. Additionally, LXD should be configured prior to running.</p>
@@ -314,9 +314,9 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
             </div>
         </div>
       </li>
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Deploy OpenStack</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Deploy OpenStack</h3>
+        <div class="p-stepped-list__content">
           <p>Now you are ready to start the OpenStack deployment process on your workstation.</p>
           <div class="p-code-copyable">
             <input aria-label="code snippet" class="p-code-copyable__input" value="conjure-up" readonly="readonly">
@@ -326,9 +326,9 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
           <img src="{{ ASSET_SERVER_URL }}23a02e6d-conjure-up-install-openstack.png?w=444" width="444" alt="screenshot of the conjure-up interface with the 'OpenStack with NovaLXD' option selected" />
         </div>
       </li>
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Follow the on-screen instructions</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Follow the on-screen instructions</h3>
+        <div class="p-stepped-list__content">
           <p>The conjure-up wizard will now prompt you for:</p>
           <ol>
             <li>A selection from a list of recommended spells &mdash; Here we&rsquo;re using &ldquo;OpenStack with Nova-LXD&rdquo;.</li>
@@ -343,9 +343,9 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
           <p>Make sure that "Create New Volume" is set to "no" when creating an instance.</p>
         </div>
       </li>
-      <li class="p-list-step__item">
-        <h3 class="p-list-step__title">Launch an instance</h3>
-        <div class="p-list-step__content">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Launch an instance</h3>
+        <div class="p-stepped-list__content">
           <p>Conjure-up will have created the basic building blocks for launching an instance . To launch an instance on the new cloud using the Openstack Dashboard, Horizon:</p>
           <ol>
             <li>Projects -&gt; Compute -&gt; Instances -&gt; Launch Instance</li>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -397,72 +397,74 @@
     <h2>Build, operate, transfer and support</h2>
     <p>The best way to keep costs down and ensure a high quality cloud is to use a repeatable, standardised methodology for workload analysis, requirements gathering, deployment and operations.</p>
   </div>
-
-  <div class="u-fixed-width">
-    <ol class="p-list-step">
-      <li class="p-list-step__item">
-        <div class="row u-equal-height">
-          <div class="col-6">
-            <h3 class="p-list-step__title">
-              
-              Design and build
-            </h3>
-            <p>Together, we <a href="/openstack/consulting">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system.</p>
-            <p>We’ll guide you through the hardware specification process to maximise the efficiency of your capex, and we’ll tailor the architecture of your cloud to meet your workload, security, regulatory and integration requirements.</p>
-            <p>Then we build your cloud. It takes no more than two weeks. We do this at your office and in your preferred data center.</p>
+  
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      <ol class="p-stepped-list">
+        <li class="p-stepped-list__item">
+          <div class="row u-equal-height">
+            <div class="col-6">
+              <h3 class="p-stepped-list__title">
+                
+                Design and build
+              </h3>
+              <p>Together, we <a href="/openstack/consulting">design your OpenStack cloud</a> based on your hardware, scale, roadmap, applications and monitoring system.</p>
+              <p>We’ll guide you through the hardware specification process to maximise the efficiency of your capex, and we’ll tailor the architecture of your cloud to meet your workload, security, regulatory and integration requirements.</p>
+              <p>Then we build your cloud. It takes no more than two weeks. We do this at your office and in your preferred data center.</p>
+            </div>
+            <div class="col-6 u-align--center u-vertically-center u-hide--small">
+              <img src="{{ ASSET_SERVER_URL }}4287c2b2-transfer.svg" alt="" width="134">
+            </div>
           </div>
-          <div class="col-6 u-align--center u-vertically-center u-hide--small">
-            <img src="{{ ASSET_SERVER_URL }}4287c2b2-transfer.svg" alt="" width="134">
+        </li>
+        <li class="p-stepped-list__item">
+          <div class="row u-equal-height">
+            <div class="col-6">
+              <h3 class="p-stepped-list__title">
+                
+                Operations
+              </h3>
+              <p>We take responsibility for the remote management and 24/7 availability of your OpenStack.</p>
+              <p>Your SLA covers uptime and performance. Your hardware and software are proactively monitored. Scale on demand with additional racks.</p>
+              <p>Canonical will tend to the infrastructure so that you can tend to your business workloads. The most important thing for a new private cloud is engagement with development and operations teams, to build confidence in the private cloud for application hosting.</p>
+              <p>This period will prove the business case for your OpenStack and ensure high service levels during the critical early stages of your journey, so you can evaluate OpenStack without making a large commitment to skills in a complex and unfamiliar technology.</p>
+            </div>
+            <div class="col-6 u-align--center u-vertically-center u-hide--small">
+              <img src="{{ ASSET_SERVER_URL }}43798107-Laptop_4px.svg" alt="" width="134" />
+            </div>
           </div>
-        </div>
-      </li>
-      <li class="p-list-step__item">
-        <div class="row u-equal-height">
-          <div class="col-6">
-            <h3 class="p-list-step__title">
-              
-              Operations
-            </h3>
-            <p>We take responsibility for the remote management and 24/7 availability of your OpenStack.</p>
-            <p>Your SLA covers uptime and performance. Your hardware and software are proactively monitored. Scale on demand with additional racks.</p>
-            <p>Canonical will tend to the infrastructure so that you can tend to your business workloads. The most important thing for a new private cloud is engagement with development and operations teams, to build confidence in the private cloud for application hosting.</p>
-            <p>This period will prove the business case for your OpenStack and ensure high service levels during the critical early stages of your journey, so you can evaluate OpenStack without making a large commitment to skills in a complex and unfamiliar technology.</p>
+        </li>
+        <li class="p-stepped-list__item">
+          <div class="row u-equal-height">
+            <div class="col-6">
+              <h3 class="p-stepped-list__title">
+                
+                We transfer control
+              </h3>
+              <p>On request, we’ll give you the keys. We provide training and a handover process with on-site cloud reliability engineers to ensure a smooth handover.</p>
+              <p>Some customers never want to operate OpenStack. For many people the benefit of the cloud is freedom from the infrastructure layer and BootStack offers that in your own data center.</p>
+              <p>But if you do want to take control, you have full visibility from the very beginning on every aspect of cloud management, performance tuning, log aggregation and monitoring.</p>
+              <p>There’s no better way to learn OpenStack than to run a cloud shoulder to shoulder with Canonical.</p>
+            </div>
+            <div class="col-6 u-align--center u-vertically-center u-hide--small">
+              <img style="margin-left: -2rem;" src="{{ ASSET_SERVER_URL }}e96658e8-transfer_4px.svg" alt="" width="160" />
+            </div>
           </div>
-          <div class="col-6 u-align--center u-vertically-center u-hide--small">
-            <img src="{{ ASSET_SERVER_URL }}43798107-Laptop_4px.svg" alt="" width="134" />
+        </li>
+        <li class="p-stepped-list__item">
+          <div class="row">
+            <div class="col-6">
+              <h3 class="p-stepped-list__title">
+                
+                We support your operations
+              </h3>
+              <p>Once you have control of the cloud, Canonical provides 24/7 enterprise telephone support. Since we know the architecture of your cloud, problems are faster to debug and easier to resolve.</p>
+            </div>
           </div>
-        </div>
-      </li>
-      <li class="p-list-step__item">
-        <div class="row u-equal-height">
-          <div class="col-6">
-            <h3 class="p-list-step__title">
-              
-              We transfer control
-            </h3>
-            <p>On request, we’ll give you the keys. We provide training and a handover process with on-site cloud reliability engineers to ensure a smooth handover.</p>
-            <p>Some customers never want to operate OpenStack. For many people the benefit of the cloud is freedom from the infrastructure layer and BootStack offers that in your own data center.</p>
-            <p>But if you do want to take control, you have full visibility from the very beginning on every aspect of cloud management, performance tuning, log aggregation and monitoring.</p>
-            <p>There’s no better way to learn OpenStack than to run a cloud shoulder to shoulder with Canonical.</p>
-          </div>
-          <div class="col-6 u-align--center u-vertically-center u-hide--small">
-            <img style="margin-left: -2rem;" src="{{ ASSET_SERVER_URL }}e96658e8-transfer_4px.svg" alt="" width="160" />
-          </div>
-        </div>
-      </li>
-      <li class="p-list-step__item">
-        <div class="row">
-          <div class="col-6">
-            <h3 class="p-list-step__title">
-              
-              We support your operations
-            </h3>
-            <p>Once you have control of the cloud, Canonical provides 24/7 enterprise telephone support. Since we know the architecture of your cloud, problems are faster to debug and easier to resolve.</p>
-          </div>
-        </div>
-      </li>
-    </ol>
-    <p><a href="/openstack/contact-us?product=openstack-managed-cloud" class="p-button--positive js-invoke-modal">Free quote and architecture assessment</a></p>
+        </li>
+      </ol>
+      <p><a href="/openstack/contact-us?product=openstack-managed-cloud" class="p-button--positive js-invoke-modal">Free quote and architecture assessment</a></p>
+    </div>
   </div>
 </section>
 

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -9,6 +9,7 @@
 {% block content %}
 
 <section class="p-strip is-deep is-bordered">
+<<<<<<< HEAD
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Software-Defined Storage for OpenStack</h1>
@@ -16,6 +17,14 @@
       <p><a href="/openstack/contact-us?product=ubuntu-advantage-storage" class="js-invoke-modal p-button">Get in touch</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
+=======
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-7">
+      <h1>Software-Defined Storage for OpenStack</h1>
+      <p>The Ubuntu Advantage Storage support package from Canonical embeds proven software-defined storage (SDS) technologies into a 24x7-supported software solution with a fixed or metered pricing model.</p>
+    </div>
+    <div class="col-5 u-align--center u-hide--small">
+>>>>>>> update row/col markup on /openstack pages
       <img class="hero-image" width="100%" src="{{ ASSET_SERVER_URL }}c2d50399-storage.svg" alt="Lots of server pictos in a cloud" />
     </div>
   </div>

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -9,7 +9,6 @@
 {% block content %}
 
 <section class="p-strip is-deep is-bordered">
-<<<<<<< HEAD
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Software-Defined Storage for OpenStack</h1>
@@ -17,14 +16,6 @@
       <p><a href="/openstack/contact-us?product=ubuntu-advantage-storage" class="js-invoke-modal p-button">Get in touch</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
-=======
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-7">
-      <h1>Software-Defined Storage for OpenStack</h1>
-      <p>The Ubuntu Advantage Storage support package from Canonical embeds proven software-defined storage (SDS) technologies into a 24x7-supported software solution with a fixed or metered pricing model.</p>
-    </div>
-    <div class="col-5 u-align--center u-hide--small">
->>>>>>> update row/col markup on /openstack pages
       <img class="hero-image" width="100%" src="{{ ASSET_SERVER_URL }}c2d50399-storage.svg" alt="Lots of server pictos in a cloud" />
     </div>
   </div>


### PR DESCRIPTION
## Done

- renamed `.p-code-snippet` class to `.p-code-copyable`
- renamed `.p-list-step` and related classes to `.p-stepped-list`
  - also introduced a temporary fix for a Vanilla bug that appears when`p` tags have the `.p-stepped-list__title` class, being addressed [here](https://github.com/canonical-web-and-design/vanilla-framework/issues/2489)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- On the following list of pages, ensure that the stepped lists and copyable code elements are not broken:
  - [x] /about/release-cycle
  - [x] /download/iot/installation-media
  - [x] /download/iot/intel-iei-tank-870
  - [x] /download/iot/intel-joule-desktop
  - [x] /download/iot/intel-joule
  - [x] /download/iot/intel-nuc-desktop
  - [x] /download/iot/intel-nuc
  - [x] /download/iot/kvm
  - [x] /download/iot/orange-pi-zero
  - [x] /download/iot/qualcomm-dragonboard-410c
  - [x] /download/iot/raspberry-pi-2-3-core
  - [x] /download/iot/raspberry-pi-2-3
  - [x] /download/iot/raspberry-pi-compute-module-3
  - [x] /download/iot/samsung-artik-5-10
  - [x] /download/iot/up-squared-iot-grove-server
  - [x] /download/server/provisioning
  - [x] /embedded
  - [x] /esm
  - [x] /internet-of-things/robotics
  - [x] /kubeflow/install
  - [x] /kubernetes/docs/quickstart
  - [x] /kubernetes/install
  - [x] /kubernetes/managed
  - [x] /livepatch
  - [x] /openstack/install
  - [x] /openstack/managed


## Issue / Card

Fixes #5646 
