### PR TITLE
Bump the version of lodash to resolve its critical severity alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "vanilla-framework": "1.8.1"
   },
   "resolutions": {
-    "lodash": "4.17.11",
+    "lodash": "4.17.13",
     "minimatch": "3.0.2",
     "merge": "1.2.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4135,10 +4135,10 @@ lodash.some@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
   integrity sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=
 
-lodash@4.17.11, lodash@^3.5.0, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.3.0, lodash@~1.0.1, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@4.17.13, lodash@^3.5.0, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.3.0, lodash@~1.0.1, lodash@~4.17.10:
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
+  integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Done
Bump the version of lodash to resolve its critical severity alert

## QA
- Check out this feature branch
- Run `./run clean`
- Run `./run build` and see there are no errors
- Run `./run server` and check the site looks ok