### PR TITLE
Add microk8s to server download thankyou page

### DIFF
--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -53,7 +53,7 @@
           Made for developers, great for IoT and AI on the edge.
         </p>
         <p>
-          <a class="" href="https://microk8s.io/">
+          <a href="https://microk8s.io/">
             <span class="p-link--external">Try Microk8s</span>
           </a>
         </p>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -37,29 +37,28 @@
   </section>
 
   <section class="p-strip--light is-shallow">
-    <div class="row">
-      <div class="col-6 p-card u-no-margin--bottom">
+    <div class="row u-vertically-center">
+      <div class="col-2 u-align--left u-hide--small">
+        <a href="https://microk8s.io/">
+          <img src="{{ ASSET_SERVER_URL }}9309d097-MicroK8s_SnapStore_icon.svg" width="100" alt="">
+        </a>
+      </div>
+       <div class="col-10 u-no-margin--left">
         <h4>
           Lightweight, reliable Kubernetes
         </h4>
-        <div class="row">
-          <div class="col-4">
-            <p>
-              Need a fast, reliable, single-node K8s up and running under 60 seconds?  Made for developers, great for IoT and AI on the edge.
-            </p>
-            <p>
-              <a class="p-button is-wide u-no-margin--bottom" href="https://microk8s.io/">
-                <span class="p-link--external">Try Microk8s</span>
-              </a>
-            </p>
-          </div>
-          <div class="col-2 u-align--center u-hide--small">
-            <a href="https://microk8s.io/">
-              <img src="{{ ASSET_SERVER_URL }}9309d097-MicroK8s_SnapStore_icon.svg" width="100" alt="">
-            </a>
-          </div>
-        </div>
+        <p>
+          Need a fast, reliable, single-node K8s up and running under 60 seconds?
+          <br />
+          Made for developers, great for IoT and AI on the edge.
+        </p>
+        <p>
+          <a class="" href="https://microk8s.io/">
+            <span class="p-link--external">Try Microk8s</span>
+          </a>
+        </p>
       </div>
+
     </div>
   </section>
 

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -36,6 +36,33 @@
     </div>
   </section>
 
+  <section class="p-strip--light is-shallow u-no-">
+    <div class="row">
+      <div class="col-6 p-card u-no-margin--bottom">
+        <h4>
+          Lightweight, reliable Kubernetes
+        </h4>
+        <div class="row">
+          <div class="col-4">
+            <p>
+              Need a fast, reliable, single-node K8s up and running under 60 seconds?  Made for developers, great for IoT and AI on the edge.
+            </p>
+            <p>
+              <a class="p-button is-wide" href="https://microk8s.io/">
+                <span class="p-link--external">Try Microk8s</span>
+              </a>
+            </p>
+          </div>
+          <div class="col-2 u-align--center u-hide--small">
+            <a href="https://microk8s.io/">
+              <img src="{{ ASSET_SERVER_URL }}9309d097-MicroK8s_SnapStore_icon.svg" width="100" alt="">
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   {% include "download/shared/_get_ebook_maas.html" with return_url="https://www.ubuntu.com/download/server/thank-you#instructions" %}
 
   <div class="p-strip is-shallow">

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -36,7 +36,7 @@
     </div>
   </section>
 
-  <section class="p-strip--light is-shallow u-no-">
+  <section class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-6 p-card u-no-margin--bottom">
         <h4>
@@ -48,7 +48,7 @@
               Need a fast, reliable, single-node K8s up and running under 60 seconds?  Made for developers, great for IoT and AI on the edge.
             </p>
             <p>
-              <a class="p-button is-wide" href="https://microk8s.io/">
+              <a class="p-button is-wide u-no-margin--bottom" href="https://microk8s.io/">
                 <span class="p-link--external">Try Microk8s</span>
               </a>
             </p>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -58,8 +58,8 @@
               <label class="mktoLabel mktoHasWidth" for="1-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
             </li>
 
-            <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+            <li class="p-list__item" >
+              <div class="g-recaptcha" style="margin-bottom: 2rem;" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
             </li>
 
             <li class="mktField p-list__item">


### PR DESCRIPTION
## Done

- Added a card for microk8s on the /download/server/thank-you page
- Added some bottom margin to the recaptcha box

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc]()

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1542

## Screenshots

![image](https://user-images.githubusercontent.com/441217/63501489-a193de00-c4c3-11e9-8516-7e116b37a075.png)

