### PR TITLE
List feeds from most recent to oldest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 talisker[gunicorn,prometheus,raven,django]==0.14.3
 Django==2.2
-canonicalwebteam.blog==2.4.0
+canonicalwebteam.blog==2.4.1
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.django_views==1.3.4
 canonicalwebteam.get-feeds==0.2.4


### PR DESCRIPTION
# Done
Show most recent entries first in feeds endpoints.

# QA
- `./run`
- Go to feeds endpoints and make sure the most recent entries come first.