### PR TITLE
Fix the Hiri case study engage page

### DIFF
--- a/templates/engage/hiri-case-study.html
+++ b/templates/engage/hiri-case-study.html
@@ -55,7 +55,7 @@
       </ul>
     </div>
     <div class="col-5" id="the-form">
-    {% with id="3374", returnURL="https://pages.ubuntu.com/snapcraft_CS_Hiri-TY.html", label=Download the case study %}{% include "engage/shared/_en_engage_form.html" %}{% endwith %}
+    {% with id="3374", returnURL="https://pages.ubuntu.com/snapcraft_CS_Hiri-TY.html", label="Download the case study" %}{% include "engage/shared/_en_engage_form.html" %}{% endwith %}
     </div>
   </div>
   <style>


### PR DESCRIPTION
## Done
Fix the Hiri case study engage page

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- Go to https://ubuntu.com/engage/hiri-case-study and see it 500
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/hiri-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the page loads fine

## Issue / Card
Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/3718/ 
