### PR TITLE
Swap homepage takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,10 +33,10 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
-  {% include "takeovers/_developing-android-on-ubuntu.html" %}
+  {% include "takeovers/_enterprise-snap-management.html" %}
   {% include "takeovers/_maas-hardware-testing_takeover.html" %}
-  {% include "takeovers/_data-pipelines-kubeflow.html" %}
-  {# include "takeovers/_enterprise-snap-management.html" #}
+  {% include "takeovers/_developing-android-on-ubuntu.html" %}
+
 {% endblock takeover_content %}
 
 


### PR DESCRIPTION
## Done

- Replace AI data pipelines takeover with Enterprise Snaps

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that enterprise snap management replaces data pipelines


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1568

## Screenshots

![image](https://user-images.githubusercontent.com/441217/63858281-22a81500-c99d-11e9-84d9-84d0cae69ccb.png)
