### PR TITLE
/search in Flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 talisker[gunicorn,flask,raven,prometheus]==0.14.3
 canonicalwebteam.flask_base==0.2.0
 canonicalwebteam.http==1.0.1
+canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.1.1
 flask==1.0.2
 feedparser==5.2.1

--- a/templates/search.html
+++ b/templates/search.html
@@ -2,9 +2,10 @@
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
-{% block title %}Search results{% if query %} for "{{query}}"{% endif %} | Ubuntu{% endblock %}
+{% block title %}Search results{% if query %} for "{{ query }}"{% endif %} | Ubuntu{% endblock %}
 
 {% block content %}
+
   <div class="p-strip is-shallow">
     <div class="row">
       <div class="col-12">
@@ -43,9 +44,38 @@
     </div>
   </div>
 
-  {# no results page #}
   {% if results %}
-    {% if estimatedTotal == 0 %}
+    {% if results.entries %}
+      {% for item in results.entries %}
+        <div class="p-strip is-shallow">
+          <div class="row">
+            <div class="col-12">
+              <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
+              <p>
+                {{ item.htmlSnippet | safe }}
+              </p>
+              <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+
+      <div class="p-strip">
+        <div class="row">
+          <div class="col-6 u-align--left">
+            {% if results.queries and results.queries.previousPage %}
+              <a href="/search?q={{ query }}&amp;start={{ results.queries.previousPage[0].startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}">&#8249;&nbsp;Previous</a>
+            {% endif %}
+          </div>
+    
+          <div class="col-6 u-align--right">
+            {% if results.queries and results.queries.nextPage %}
+              <a href="/search?q={{ query }}&amp;start={{ results.queries.nextPage[0].startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}">Next&nbsp;&#8250;</a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% else %}
       <div class="p-strip">
         <div class="row">
           <div class="col-6">
@@ -66,39 +96,7 @@
           </div>
         </div>
       </div>
-    {% else %}
-      {% for item in results['items'] %}
-        <div class="p-strip is-shallow">
-          <div class="row">
-            <div class="col-12">
-              <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
-              <p>
-                {{ item.htmlSnippet | safe }}
-              </p>
-              <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
-            </div>
-          </div>
-        </div>
-      {% endfor %}
     {% endif %}
   {% endif %}
-
-  {# pagination #}
-  <div class="p-strip">
-    <div class="row">
-      <div class="col-6 u-align--left">
-        {% if results.queries.previousPage %}
-          <a href="/search?q={{ query }}&amp;num={{ num }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}">&#8249;&nbsp;Previous</a>
-        {% endif %}
-      </div>
-
-      <div class="col-6 u-align--right">
-        {% if results.queries.nextPage %}
-          <a href="/search?q={{ query }}&amp;num={{ num }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}">Next&nbsp;&#8250;</a>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-
 {% endblock content %}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -8,6 +8,7 @@ import flask
 # Packages
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
+from canonicalwebteam.search import build_search_view
 
 # Local
 from webapp.context import (
@@ -33,6 +34,12 @@ app = FlaskBase(
 template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
+
+
+# Search
+app.add_url_rule(
+    "/search", "search", build_search_view(template_path="search.html")
+)
 
 
 @app.errorhandler(404)


### PR DESCRIPTION
Implement /search in Flask.

**NB:** This currently points to `v0.2.0a6` of the `canonicalwebteam.search` module. Testing this PR will be a QA of https://github.com/canonical-web-and-design/canonicalwebteam.search/pull/2. Please review that PR at the same time - please let me know once that's approved, so I can publish `v0.2.0` and switch this branch to use that version.

QA
--

`./run`, go to:

- [x] http://localhost:8001/search
- [x] http://localhost:8001/search?q=hello
- [x] http://localhost:8001/search?q=hello&domain=docs.ubuntu.com%2Fcore
- [x] http://localhost:8001/search?q=hello&siteSearch=docs.ubuntu.com%2Fcore

Check they all work the same as on live. Check the last two only shows results from docs.ubuntu.com/core, with a note saying so.