### PR TITLE
Engage pages in Markdown - removing extraneous bit of title

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 
 
-{% block title %}{{ title }} | Ubuntu and Canonical Legal{% endblock title %}
+{% block title %}{{ title }}{% endblock title %}
 
 {% block meta_description %}{{ description }}{% endblock meta_description %}
 


### PR DESCRIPTION
## Done

* Removing " | Ubuntu and Canonical Legal" from engage page titles when written in md.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure /engage/developing-android-on-ubuntu page title ends with " | Ubuntu" and not " | Ubuntu and Canonical Legal | Ubuntu"

