### PR TITLE
Update developer dropdown

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -325,6 +325,12 @@
             <li class="p-inline-list__item">
               <a href="https://snapcraft.io/">Snapcraft</a>
             </li>
+            <li class="p-inline-list__item">
+              <a href="http://linuxcontainers.org/">LXD</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="https://multipass.run/">Multipass</a>
+            </li>
           </ul>
         </div>
       </div>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -20,7 +20,7 @@
             <li class="p-list__item">Architectures and ISAs</li>
             <li class="p-list__item">Kernel selection &amp; lifecycle</li>
             <li class="p-list__item">
-              <a href="https://github.com/CanonicalLtd/multipass">Multipass&nbsp;&rsaquo;</a>
+              <a href="https://multipass.run/">Multipass&nbsp;&rsaquo;</a>
             </li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/desktop/developers">Develop with Ubuntu</a></p>
@@ -74,7 +74,7 @@
               <a href="https://cloud-init.io/">Cloud-init - customise cloud instances&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://jujucharms.com/">Juju for standardised operations&nbsp;&rsaquo;</a>
+              <a href="https://jaas.ai/">Juju for standardised operations&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
               <a href="/kubernetes">Charmed Distribution of Kubernetes&nbsp;&rsaquo;</a>
@@ -86,7 +86,7 @@
               <a href="https://maas.io/">MAAS - fast server provisioning&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://github.com/CanonicalLtd/multipass">Multipass - Ubuntu on MacOS&nbsp;&rsaquo;</a>
+              <a href="https://multipass.run/">Multipass - Ubuntu on MacOS&nbsp;&rsaquo;</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

- Updated links to multipass.run and jaas.ai

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/#developer
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit?ts=5d66a9f7#)


## Issue / Card

Fixes #5725

