### PR TITLE
Use new version of canonicalwebteam.templatefinder to fix Markdown pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ talisker[gunicorn,flask,raven,prometheus]==0.14.3
 canonicalwebteam.flask_base==0.2.0
 canonicalwebteam.http==1.0.1
 canonicalwebteam.search==0.2.0
-canonicalwebteam.templatefinder==0.1.1
+canonicalwebteam.templatefinder==0.2.0
 flask==1.0.2
 feedparser==5.2.1

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -39,7 +39,7 @@
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
     <div class="col-7">
-      {{ html_content | safe }}
+      {{ content | safe }}
     </div>
     <div class="col-5" id="register-section">
       <!-- MARKETO FORM -->

--- a/templates/engage/developing-android-on-ubuntu.md
+++ b/templates/engage/developing-android-on-ubuntu.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "_base_engage_markdown.html"
+wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "A guide to developing Android apps on Ubuntu"
      meta_description: Android is the most popular mobile operating system and is continuing to grow its market share.  IDC expects that Android will have 85.5% of the market by 2022, demonstrating that app development on Android will continue to be an in-demand skill.

--- a/templates/engage/enterprise-snap-management.md
+++ b/templates/engage/enterprise-snap-management.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "_base_engage_markdown.html"
+wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "Management of snaps in a controlled, enterprise environment"
      meta_description: "How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies"

--- a/templates/kubernetes/docs/audit-logging.md
+++ b/templates/kubernetes/docs/audit-logging.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Audit logging"
   description: Accessing and configuring the Kubernetes audit logs with CDK

--- a/templates/kubernetes/docs/auth.md
+++ b/templates/kubernetes/docs/auth.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Configuring authorisation and authentication"
   description: Controlling access with RBAC and other authorisation modes.

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CDK on AWS"
   description: Running CDK on AWS using the aws-integrator.

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Backups"
   description: How to backup and restore the state of your Kubernetes cluster in the etcd datastore.

--- a/templates/kubernetes/docs/base_docs.html
+++ b/templates/kubernetes/docs/base_docs.html
@@ -50,7 +50,7 @@
       </div>
       {% endif %}
       <div class="p-strip is-shallow">
-        {{ html_content | safe }}
+        {{ content | safe }}
       </div>
     </div>
   </div>

--- a/templates/kubernetes/docs/ceph.md
+++ b/templates/kubernetes/docs/ceph.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Ceph storage"
   description: How to get Ceph deployed and related to Kubernetes in order to have a default storage class. This allows for easy storage allocation.

--- a/templates/kubernetes/docs/certs-and-trust.md
+++ b/templates/kubernetes/docs/certs-and-trust.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Certificates and Trust Management"
   description: How CDK manages PKI certificates and trust

--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CNI with Calico"
   description: How to manage and deploy Kubernetes with Calico

--- a/templates/kubernetes/docs/cni-canal.md
+++ b/templates/kubernetes/docs/cni-canal.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CNI with canal"
   description: How to manage and deploy Kubernetes with Canal

--- a/templates/kubernetes/docs/cni-flannel.md
+++ b/templates/kubernetes/docs/cni-flannel.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CNI with flannel"
   description: How to manage and deploy Kubernetes with flannel

--- a/templates/kubernetes/docs/cni-overview.md
+++ b/templates/kubernetes/docs/cni-overview.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CNI overview"
   description: How to manage and deploy Kubernetes with flannel, calico, canal or Tigera Secure EE

--- a/templates/kubernetes/docs/container-runtime.md
+++ b/templates/kubernetes/docs/container-runtime.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Container runtimes"
   description: Configure and use containerd or docker as the container runtime

--- a/templates/kubernetes/docs/custom-loadbalancer.md
+++ b/templates/kubernetes/docs/custom-loadbalancer.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Custom load balancers"
   description: How to configure your Kubernetes cluster to use a custom load balancer.

--- a/templates/kubernetes/docs/decommissioning.md
+++ b/templates/kubernetes/docs/decommissioning.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Decommissioning"
   description: Decommissioning a cluster requires only a few commands, but beware that it will irretrievably destroy the cluster.

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Private Docker Registry"
   description: How to use a private Docker registry to serve Docker images to your Kubernetes cluster components.

--- a/templates/kubernetes/docs/encryption-at-rest.md
+++ b/templates/kubernetes/docs/encryption-at-rest.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Encryption at rest"
   description: How to enable encryption-at-rest using Vault

--- a/templates/kubernetes/docs/gcp-integration.md
+++ b/templates/kubernetes/docs/gcp-integration.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CDK on GCP"
   description: Running CDK on Google Cloud Platform using the gcp-integrator.

--- a/templates/kubernetes/docs/get-in-touch.md
+++ b/templates/kubernetes/docs/get-in-touch.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Get in Touch"
   description: How to contact the CDK team

--- a/templates/kubernetes/docs/gpu-workers.md
+++ b/templates/kubernetes/docs/gpu-workers.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Using GPU workers"
   description: How to run workloads with GPU support.

--- a/templates/kubernetes/docs/hacluster.md
+++ b/templates/kubernetes/docs/hacluster.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "HAcluster"
   description: How to configure your Kubernetes cluster to use HAcluster.

--- a/templates/kubernetes/docs/high-availability.md
+++ b/templates/kubernetes/docs/high-availability.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "High Availability"
   description: How to configure your Kubernetes cluster for high availability.

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Kubernetes documentation"
   description: Documentation for Charmed Kubernetes.

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Installing to a local machine"
   description: How to install the Charmed Distribution of Kubernetes on a single machine for easy testing and development.

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Installing CDK"
   description: How to install and customise Charmed Kubernetes using Juju bundles.

--- a/templates/kubernetes/docs/keepalived.md
+++ b/templates/kubernetes/docs/keepalived.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "HA for kubeapi-load-balancer"
   description: Using keepalived to provide failover for the kube-api-loadbalancer .

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Authentication with LDAP and Keystone"
   description: Using LDAP authentication via Keystone

--- a/templates/kubernetes/docs/logging.md
+++ b/templates/kubernetes/docs/logging.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Logging"
   description: Learn about the tools and techniques to examine cluster logs as described in the Kubernetes documentation.

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "MetalLB"
   description: How to configure your Kubernetes cluster to use MetalLB.

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Monitoring"
   description: How to create monitoring solution that runs whether the cluster itself is running or not. It may also be useful to integrate monitoring into existing setups.

--- a/templates/kubernetes/docs/openstack-integration.md
+++ b/templates/kubernetes/docs/openstack-integration.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "CDK on OpenStack"
   description: Running CDK on OpenStack using the openstack-integrator.

--- a/templates/kubernetes/docs/operations.md
+++ b/templates/kubernetes/docs/operations.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Basic operations"
   description: How to operate your CDK cluster.

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Overview"
   description: Understand how the Charmed Distribution of Kubernetes works.

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Quick start"
   description: With this quick start guide and some tools from Canonical, you'll have a Kubernetes cluster running on the cloud of your choice in minutes!

--- a/templates/kubernetes/docs/release-notes-historic.md
+++ b/templates/kubernetes/docs/release-notes-historic.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Release notes"
   description: Release notes for CDK

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Release notes"
   description: Release notes for CDK

--- a/templates/kubernetes/docs/scaling.md
+++ b/templates/kubernetes/docs/scaling.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Scaling"
   description: Learn how various components of CDK can be horizontally scaled to meet demand or increase reliability.

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Storage"
   description: How to add and configure different types of persistent storage for your Kubernetes cluster.

--- a/templates/kubernetes/docs/tigera-secure-ee.md
+++ b/templates/kubernetes/docs/tigera-secure-ee.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Using Tigera Secure EE"
   description: Using Tigera Secure EE with CDK

--- a/templates/kubernetes/docs/troubleshooting.md
+++ b/templates/kubernetes/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Troubleshooting"
   description: How to troubleshoot the deployment of a Kubernetes cluster.

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Upgrade notes"
   description: How to deal with specific, special circumstances you may encounter when upgrading between versions of Kubernetes.

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Upgrading"
   description: How to upgrade your version of CDK.

--- a/templates/kubernetes/docs/using-vault.md
+++ b/templates/kubernetes/docs/using-vault.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Using Vault as a CA"
   description: How to replace EasyRSA with Vault for increased security

--- a/templates/kubernetes/docs/validation.md
+++ b/templates/kubernetes/docs/validation.md
@@ -1,7 +1,7 @@
 ---
-wrapper_template: "base_docs.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Validation"
   description: How to run end-to-end (e2e) tests for Kubernetes.

--- a/templates/legal/_base_legal_markdown.html
+++ b/templates/legal/_base_legal_markdown.html
@@ -18,7 +18,7 @@
 {% endif %}
       <div class="row" id="service-description">
         <div class="col-8 l-legal-pages">
-{{ html_content | safe }}
+{{ content | safe }}
         </div>
         <div class="col-4">
         </div>

--- a/templates/legal/data-privacy/contact.md
+++ b/templates/legal/data-privacy/contact.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Contact us and enquiries"
   description: "This privacy notice tells you about the information we collect from you when you submit your information to us via an enquiry or contact us form on our website."

--- a/templates/legal/data-privacy/esxi.md
+++ b/templates/legal/data-privacy/esxi.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy Notice – ESXi"
   description: This privacy notice tells you about the information collected from you when you register to download the ESXi packer-template.

--- a/templates/legal/data-privacy/newsletter.md
+++ b/templates/legal/data-privacy/newsletter.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice | Newsletter signup"
   description: "This privacy notice tells you about the information we collect from you when you sign up to receive our regular newsletter via our website."

--- a/templates/legal/data-privacy/online-purchase.md
+++ b/templates/legal/data-privacy/online-purchase.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Online purchase"
   description: "This privacy notice tells you about the information we collect from you when you purchase one or more of our products via our website."

--- a/templates/legal/data-privacy/partner-portal.md
+++ b/templates/legal/data-privacy/partner-portal.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Partner Portal"
   description: This privacy notice tells you about the information we collect from you when you access the Canonical Partner Portal.

--- a/templates/legal/data-privacy/snap-store.md
+++ b/templates/legal/data-privacy/snap-store.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Snap store"
   description: "This privacy notice tells you about the information we collect from you when you download and install and purchase snaps and software on Ubuntu Core and any compatible supported systems."

--- a/templates/legal/data-privacy/snapcraft-nps.md
+++ b/templates/legal/data-privacy/snapcraft-nps.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Snapcraft NPS Survey"
   description: This Privacy notice tells you about the information collected from you when you participate in the Snapcraft Net Promoter Score (NPS) survey.

--- a/templates/legal/data-privacy/sso.md
+++ b/templates/legal/data-privacy/sso.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Single Sign On (SSO)"
   description: "This privacy notice tells you about the information collected from you when you register for a Single Sign On (SSO) account."

--- a/templates/legal/data-privacy/user-survey.md
+++ b/templates/legal/data-privacy/user-survey.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – User Survey"
   description: "This privacy notice tells you about the information collected from you when you take part in a user survey on a Canonical webpage, hosted by Usabilla."

--- a/templates/legal/data-privacy/webinar.md
+++ b/templates/legal/data-privacy/webinar.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice - Webinar sign-up"
   description: "This privacy notice tells you about the information collected from you when you sign up to watch one of our webinars via the BrightTALK website."

--- a/templates/legal/partner-portal-terms.md
+++ b/templates/legal/partner-portal-terms.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "./_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Partner Portal terms and conditions"
   description: "This privacy notice tells you about the information we collect from you when you submit your information to us via an enquiry or contact us form on our website."

--- a/templates/legal/trademarks/index.md
+++ b/templates/legal/trademarks/index.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "../_base_legal_markdown.html"
+wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Trademarks"
   description: "Canonical’s trademarks registered in word and logo form."

--- a/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
+++ b/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
@@ -10,7 +10,7 @@
     <div class="p-strip is-deep">
       <div class="row" id="service-description">
         <div class="col-8 l-legal-pages">
-{{ html_content | safe }}
+{{ content | safe }}
         </div>
         <div class="col-4">
           <nav class="u-hide--small p-card">

--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "_base_legal_markdown.html"
+wrapper_template: "legal/ubuntu-advantage-service-description/_base_legal_markdown.html"
 context:
      title: "Ubuntu Advantage service description"
      description: How to get Ceph deployed and related to Kubernetes in order to have a default storage class. This allows for easy storage allocation.

--- a/templates/legal/ubuntu-advantage-service-description/ja/_base_legal_markdown_ja.html
+++ b/templates/legal/ubuntu-advantage-service-description/ja/_base_legal_markdown_ja.html
@@ -10,7 +10,7 @@
     <div class="p-strip is-deep">
       <div class="row" id="service-description">
         <div class="col-8 l-legal-pages">
-         {{ html_content | safe }}
+         {{ content | safe }}
         </div>
         <div class="col-4">
           <nav class="u-hide--small p-card">

--- a/templates/legal/ubuntu-advantage-service-description/ja/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/ja/index.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "_base_legal_markdown_ja.html"
+wrapper_template: "legal/ubuntu-advantage-service-description/ja/_base_legal_markdown_ja.html"
 context:
      title: "Ubuntu Advantage サービス範囲"
      description: How to get Ceph deployed and related to Kubernetes in order to have a default storage class. This allows for easy storage allocation.

--- a/templates/legal/ubuntu-advantage-service-terms/_base_uast_markdown.html
+++ b/templates/legal/ubuntu-advantage-service-terms/_base_uast_markdown.html
@@ -10,7 +10,7 @@
     <div class="p-strip is-deep">
       <div class="row" id="service-description">
         <div class="col-8 l-legal-pages">
-{{ html_content | safe }}
+{{ content | safe }}
         </div>
         <nav class="col-4 p-card">
           <h3>Older versions</h3>

--- a/templates/legal/ubuntu-advantage-service-terms/index.md
+++ b/templates/legal/ubuntu-advantage-service-terms/index.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "./_base_uast_markdown.html"
+wrapper_template: "legal/ubuntu-advantage-service-terms/_base_uast_markdown.html"
 context:
   title: "Short form services agreement"
   description: "Ubuntu and Canonical Legal - Short form services agreement"


### PR DESCRIPTION
This is currently pointing at [this branch](https://github.com/nottrobin/canonicalwebteam.templatefinder/tree/0.2.0-ubuntu-support), and initially reviewing this can be considered a QA for that branch - so please go and +1 [this PR](https://github.com/canonical-web-and-design/canonicalwebteam.templatefinder/pull/5) as the first thing.

Once that's merged, I'll publish `v0.2.0` and then update this PR to use that version.

Fixes https://github.com/canonical-web-and-design/base-squad/issues/688

QA
--

`./run clean && ./run`

Browse around `/kubernetes/docs`, `/engage` and `/legel` to check all the markdown pages look the same as on live.