### PR TITLE
Fix typo on iot/gateways

### DIFF
--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -198,7 +198,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h4>Docker</h4>
-      <p>ocker containers complement snap packages to deliver full flexibility in the development and deployment of applications at the edge.</p>
+      <p>Docker containers complement snap packages to deliver full flexibility in the development and deployment of applications at the edge.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h4>Kubernetes</h4>


### PR DESCRIPTION
## Done

Fix typo on iot/gateways - 'ocker' to 'Docker'

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/gateways
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the typo if fixed


## Issue / Card

Fixes #5721

