### PR TITLE
escape html correctly on /pricing/infra

### DIFF
--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -139,5 +139,5 @@
       </tbody>
     </table>
   </div>
-  <p id="ua-i-fn1"><sup>*</sup> <small>Minimums and exclusions apply.{{ extra }}</small></p>
+  <p id="ua-i-fn1"><sup>*</sup> <small>Minimums and exclusions apply.{{ extra|safe }}</small></p>
 </div>


### PR DESCRIPTION
## Done

- added `safe` filter to /pricing/infra template so html elements are correctly escaped

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit /pricing/infra, see that the text: "Minimums and exclusions apply. Please refer to the service description for full details." contains a link.


## Issue / Card

Fixes #5729 

## Screenshots

[if relevant, include a screenshot]
Broken:
![Screenshot 2019-08-30 at 09 26 13](https://user-images.githubusercontent.com/2376968/64005405-43d94480-cb08-11e9-97f3-1a00d842c424.png)

Fixed:
![Screenshot 2019-08-30 at 09 26 22](https://user-images.githubusercontent.com/2376968/64005415-4b005280-cb08-11e9-9708-7745c5c443f5.png)
