### PR TITLE
fix contact modal launcher in footer of /contact-us

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -80,4 +80,9 @@
   </div>
 </section>
 
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>
+
 {% endblock content %}


### PR DESCRIPTION
## Done

Added contact form modal js to /contact-us
- previously, clicking the "Contact Us" CTA in the footer of the page would just bring the user back to the same page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit /contact-us, click "Contact us" in the footer, see that a modal with a contact form appears and can be successfully completed


## Issue / Card

Fixes #5732 

## Screenshots

[if relevant, include a screenshot]
