### PR TITLE
Fix 404ing groups by upgrading blog to v3.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 talisker[gunicorn,flask,raven,prometheus]==0.14.3
 canonicalwebteam.flask_base==0.2.0
 canonicalwebteam.http==1.0.1
-canonicalwebteam.blog==3.0.0
+canonicalwebteam.blog==3.0.1
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.0
 flask==1.0.2


### PR DESCRIPTION
QA
--

- [x] `./run`
- [x] Go to http://0.0.0.0:8001/blog/archives?group=robotics, see it works
- [x] Go to http://0.0.0.0:8001/blog/archives?group=snappy, see it 404s, unlike https://ubuntu.com/blog/archives?group=robotics