### PR TITLE
remove .html extension from data-form-location values

### DIFF
--- a/templates/about/base_about.html
+++ b/templates/about/base_about.html
@@ -8,7 +8,7 @@
   {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below -->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -203,7 +203,7 @@
     </script>
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
     <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/community/_base_community.html
+++ b/templates/community/_base_community.html
@@ -8,7 +8,7 @@
   {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below -->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -80,7 +80,7 @@
   </div>
 </section>
 
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/containers/base_containers.html
+++ b/templates/containers/base_containers.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1964" data-lp-id="3828" data-return-url="https://www.ubuntu.com/containers/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1964" data-lp-id="3828" data-return-url="https://www.ubuntu.com/containers/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -571,7 +571,7 @@ store for access to all the standard apps, or curate your own collection.</p>
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/desktop/base_desktop.html
+++ b/templates/desktop/base_desktop.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1253" data-lp-id="1409" data-return-url="https://www.ubuntu.com/desktop/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1253" data-lp-id="1409" data-return-url="https://www.ubuntu.com/desktop/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
     <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/download/_base_download.html
+++ b/templates/download/_base_download.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
     <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -676,7 +676,7 @@
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/esm/base_esm.html
+++ b/templates/esm/base_esm.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -230,7 +230,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -248,7 +248,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="2639" data-lp-id="5811" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=appstore" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="2639" data-lp-id="5811" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=appstore" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -202,7 +202,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1422" data-lp-id="2166" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1422" data-lp-id="2166" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -319,7 +319,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below -->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=gateways" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=gateways" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -229,7 +229,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded.html" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -281,7 +281,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_robotics.html" data-form-id="1650" data-lp-id="2838" data-return-url="http://ubuntu.com/internet-of-things/thank-you?product=robotics" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_robotics" data-form-id="1650" data-lp-id="2838" data-return-url="http://ubuntu.com/internet-of-things/thank-you?product=robotics" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -246,7 +246,7 @@
 {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubeflow/features.html
+++ b/templates/kubeflow/features.html
@@ -178,7 +178,7 @@
 {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -221,7 +221,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -230,7 +230,7 @@
   {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow.html" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -181,7 +181,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -314,7 +314,7 @@
   {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -314,7 +314,7 @@ $ kubectl cluster-info</code></pre>
   {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -396,7 +396,7 @@
   {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -68,7 +68,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/livepatch/base_livepatch.html
+++ b/templates/livepatch/base_livepatch.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -234,7 +234,7 @@
   {% with first_item="_cloud_bootstack", second_item="_cloud_rfp", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -340,7 +340,7 @@
 {% with first_item="_cloud_bootstack", second_item="_cloud_rfp", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -322,7 +322,7 @@
 {% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -391,7 +391,7 @@ Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]:</
 {% with first_item="_cloud_bootstack", second_item="_download_cloud_buy_landscape", third_item="_download_documentation" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -529,7 +529,7 @@
 {% with first_item="_cloud_bootstack", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_bootstack.html" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/storage.html
+++ b/templates/openstack/storage.html
@@ -88,7 +88,7 @@
 {% with first_item="_cloud_bootstack", second_item="_cloud_rfp", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_storage.html" data-form-id="1233" data-lp-id="2001" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" data-lp-url="https://www.ubuntu.com/openstack/contact-us?product=ubuntu-advantage-storage">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_storage" data-form-id="1233" data-lp-id="2001" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" data-lp-url="https://www.ubuntu.com/openstack/contact-us?product=ubuntu-advantage-storage">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -113,7 +113,7 @@
 {% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -24,7 +24,7 @@
       {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
     </div>
     <div class="u-fixed-width">
-      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">Get in touch</a>
+      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">Get in touch</a>
     </div>
   </section>
 
@@ -45,7 +45,7 @@
   {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
   
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -58,7 +58,7 @@
   </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -79,7 +79,7 @@
 
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_pricing-infra.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_pricing-infra" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/public-cloud/_base_public-cloud.html
+++ b/templates/public-cloud/_base_public-cloud.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
     <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/rfp/_base_rfp.html
+++ b/templates/rfp/_base_rfp.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
     <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -118,7 +118,7 @@
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -293,7 +293,7 @@
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -191,7 +191,7 @@
 {% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -293,7 +293,7 @@
 {% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -43,7 +43,7 @@
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -225,7 +225,7 @@
     {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support.html" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
     <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -229,7 +229,7 @@
 {% with first_item="_cloud_bootstack", second_item="_cloud_newsletter", third_item="_telco_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general.html" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -46,7 +46,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -67,7 +67,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -97,7 +97,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -123,7 +123,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="u-fixed-width">
@@ -146,7 +146,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -179,7 +179,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -201,7 +201,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/_kubernetes.html" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -211,7 +211,7 @@
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack.html" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/9b170f06-picto-help-orange.svg" width="135" alt="" />
@@ -220,7 +220,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below -->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack.html" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you" data-lp-url="https://www.ubuntu.com/training/thank-you">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you" data-lp-url="https://www.ubuntu.com/training/thank-you">
 </div>
 
 <script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>


### PR DESCRIPTION
## Done

Removed `.html` from `data-form-location` attribute on contact forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit the homepage, click "Contact us" in the footer of the page, and see that the contact form modal appears. Click around the site, and do the same thing on many pages.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5735
