### PR TITLE
Add context for passing markdown variables to base.html

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -1,11 +1,12 @@
 {% extends "templates/base.html" %}
 
-
 {% block title %}{{ title }}{% endblock title %}
 
-{% block meta_description %}{{ description }}{% endblock meta_description %}
+{% block meta_description %}{{ meta_description }}{% endblock meta_description %}
 
-{% block meta_copydoc %}{{ copydoc }}{% endblock meta_copydoc %}
+{% block meta_copydoc %}{{ meta_copydoc }}{% endblock meta_copydoc %}
+
+{% block meta_image %}{{ meta_image }}{% endblock meta_image %}
 
 {% block outer_content %}
 {% block content %}

--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -3,6 +3,8 @@ wrapper_template: "legal/ubuntu-advantage-service-description/_base_legal_markdo
 context:
      title: "Ubuntu Advantage service description"
      description: How to get Ceph deployed and related to Kubernetes in order to have a default storage class. This allows for easy storage allocation.
+markdown_includes:
+     pricing_table: "shared/pricing/_ua-for-infrastructure.html"
 ---
 
 # Ubuntu Advantage service description
@@ -11,7 +13,7 @@ Capitalised terms shall have meanings as defined in the [Definitions section](#
 
 <h2 id="uasd-ua-infrastructure">Ubuntu Advantage for Infrastructure (UA-I)</h2>
 
-{% include "shared/pricing/_ua-for-infrastructure.html" %}
+{{ pricing_table | safe }}
 
 <div class="p-top"><a href="#" class="p-top__link">Back to top</a></div>
 
@@ -148,9 +150,9 @@ As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infra
   4. that the [Minimum Size Requirement](#term-min-size) for the [Cloud](#term-cloud) or [Cluster](#term-cluster) is maintained at all times.
 7. Uptime Service Level
   1. The Managed Service includes the following uptime service levels:<br />
-||Data plane for customer workloads which are distributed across two regions|Data plane for customer workloads which are in a single region|Control plane (OpenStack/Kubernetes API, Web UI and CLI)|
-|----|----:|----:|----:|
-|Uptime|99.9%|99.5%|99%|
+|        | Data plane for customer workloads which are distributed across two regions | Data plane for customer workloads which are in a single region | Control plane (OpenStack/Kubernetes API, Web UI and CLI) |
+| ------ | --------------------------------------------------------------------------:| --------------------------------------------------------------:| --------------------------------------------------------:|
+| Uptime |                                                                      99.9% |                                                          99.5% |                                                      99% |
   2. Data plane includes:
     1. Virtualisation (for workloads which are architected to not depend on a single compute node).
     2. Storage (Block & Object).
@@ -324,12 +326,12 @@ Add-Ons constitute additional support services available separately on a per-Nod
   |**Severity Level 4**<br />Non-urgent request|Level 4 requests include cosmetic issues, informational requests, feature requests, and similar matters. Canonical does not provide a timeline or guarantee for inclusion of any feature requests. Canonical will review each level 4 case and determine whether it is a product enhancement to be considered for a future release, an issue to be fixed in the current release or an issue to be fixed in a future release. Canonical will review and respond to information requests with a reasonable level of effort during coverage hours. Canonical may close cases representing level 4 issues after responding if Canonical believes it is appropriate to do so.|
 4. Response times. Canonical will use reasonable efforts to respond to support requests made by the customer within the response times set forth below, based on the applicable service and severity level.
   1. Table of response times
-|                    |Standard         |Advanced|
-|--------------------|-----------------|--------|
-|**Severity Level 1**|4 hours, excluding weekends and holidays |1 hour  |
-|**Severity Level 2**|8 business hours |2 hours |
-|**Severity Level 3**|12 business hours|6 hours |
-|**Severity Level 4**|24 business hours|12 hours|
+|                      | Standard                                 | Advanced |
+| -------------------- | ---------------------------------------- | -------- |
+| **Severity Level 1** | 4 hours, excluding weekends and holidays | 1 hour   |
+| **Severity Level 2** | 8 business hours                         | 2 hours  |
+| **Severity Level 3** | 12 business hours                        | 6 hours  |
+| **Severity Level 4** | 24 business hours                        | 12 hours |
   2. Resolution. Canonical will use reasonable efforts to resolve support cases, but Canonical does not guarantee a work-around, resolution or resolution time.
 5. Hotfixes. To temporarily resolve critical support cases, Canonical may provide a version of the affected software (e.g. package) that applies a patch. Such versions are referred to as “hotfixes”. Hotfixes provided by Canonical are supported for 90 days after the corresponding patch has been incorporated into a release of the software in the Ubuntu Archives. However, if a patch is rejected by the applicable upstream project, the hotfix will no longer be supported and the case will remain open.
 6. Languages. Canonical will provide support in English. Other languages may be available at certain times.

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -17,36 +17,36 @@
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-    <meta charset="UTF-8" />
-    <meta name="description" content="{% block meta_description %}{{ meta_description or "Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things."}}{% endblock %}" />
-    <meta name="author" content="Canonical" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="UTF-8">
+    <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
+    <meta name="author" content="Canonical">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta name="theme-color" content="#E95420" />
-    <meta name="twitter:account_id" content="4503599627481511" />
+    <meta name="theme-color" content="#E95420">
+    <meta name="twitter:account_id" content="4503599627481511">
     <meta name="twitter:site" content="@ubuntu">
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://ubuntu.com{{ request.get_full_path }}" />
-    <meta property="og:site_name" content="Ubuntu" />
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://ubuntu.com{{ request.get_full_path }}">
+    <meta property="og:site_name" content="Ubuntu">
 
     {% if self.title() %}
         <meta name="twitter:title" content="{{ self.title() }} | Ubuntu">
-        <meta property="og:title" content="{{ self.title() }} | Ubuntu" />
+        <meta property="og:title" content="{{ self.title() }} | Ubuntu">
     {% endif %}
     {% if self.meta_description() %}
         <meta name="twitter:description" content="{{ self.meta_description() }}">
-        <meta property="og:description" content="{{ self.meta_description() }}" />
+        <meta property="og:description" content="{{ self.meta_description() }}">
     {% endif %}
 
     <!-- Mate image: {% block meta_image %}{% endblock %} -->
 
     {% if self.meta_image() %}
-        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:image" content="{% if "http" not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
-        <meta property="og:image" content="{% if "http" not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}" />
+        <meta property="og:image" content="{% if "http" not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     {% endif %}
 
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}">
 
     <link rel="preconnect" href="https://www.google-analytics.com">
     <link rel="preconnect" href="https://assets.ubuntu.com">
@@ -56,20 +56,20 @@
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
-    <link rel="canonical" href="{% block canonical_url %}https://ubuntu.com{{ request.get_full_path }}{% endblock %}" />
+    <link rel="canonical" href="{% block canonical_url %}https://ubuntu.com{{ request.get_full_path }}{% endblock %}">
 
-    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />
-    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32">
 
-    <link rel="apple-touch-icon" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
-    <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/c39e0fed-apple-touch-icon.png" />
-    <link type="text/plain" rel="author" href="{{ versioned_static('files/humans.txt') }}" />
+    <link rel="apple-touch-icon" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png">
+    <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/c39e0fed-apple-touch-icon.png">
+    <link type="text/plain" rel="author" href="{{ versioned_static('files/humans.txt') }}">
 
     <!-- stylesheets -->
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static('css/print.css') }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
+    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static('css/print.css') }}">
 
     <script>
       var html = document.documentElement
@@ -80,7 +80,7 @@
 
     {% block crazy_egg %}{% endblock crazy_egg %}
     <!-- google webmaster tools verification -->
-    <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
+    <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M">
   </head>
 
   <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/developing-android-on-ubuntu
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that twitter cards have titles, images and descriptions

## Screenshots

![image](https://user-images.githubusercontent.com/441217/64154617-20283e00-ce29-11e9-8443-ec6555cb558c.png)
