### PR TITLE
Fix notices styling

### DIFF
--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -1,8 +1,10 @@
 <section class="p-strip--light is-shallow notice u-hide" lang="{{lang}}">
   <div class="u-fixed-width">
-    <p class="u-no-max-width p-heading--four u-no-margin--bottom u-vertically-center">
-      {% if icon %}<img src="{{icon}}" alt="{{text}}" style="width:25px;"/>&nbsp;&nbsp;{% endif %}
-      <a href="{{url}}" class="p-link--external">{{text}}</a>
-    </p>
+    <div class="p-heading-icon">
+      <div class="p-heading-icon__header">
+        {% if icon %}<img src="{{icon}}" alt="{{text}}" class="p-heading-icon__img" />{% endif %}
+        <h4 class="p-heading-icon__title"><a href="{{url}}" class="p-link--external">{{text}}</a></h3>
+      </div>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
Since the recent Vanilla update, notices using u-vertical-center have been rendering incorrectly (switch your browser to jp and head to the homepage to test). This fixes it by using the p-heading-icon class instead.

## Done

* Switch notices to use p-heading-icon class

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Switch your browser to japanese and ensure the homepage notice is on a single line.

## Screenshots

### Broken notice

![Screenshot from 2019-09-03 11-43-43](https://user-images.githubusercontent.com/18480003/64162709-1f4ed680-ce40-11e9-9aff-8c14cf36ce59.png)

### Fix

![Screenshot from 2019-09-03 11-44-34](https://user-images.githubusercontent.com/18480003/64162761-3ab9e180-ce40-11e9-8158-ee3ba55fe754.png)


