### PR TITLE
Parse markdown files with template parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ canonicalwebteam.flask_base==0.2.0
 canonicalwebteam.http==1.0.1
 canonicalwebteam.blog==3.0.1
 canonicalwebteam.search==0.2.0
-canonicalwebteam.templatefinder==0.2.0
+canonicalwebteam.templatefinder==0.2.1
 flask==1.0.2
 feedparser==5.2.1


### PR DESCRIPTION
Update to the latest version of
[templatefinder](https://pypi.org/project/canonicalwebteam.templatefinder/)
so that template statements inside Markdown files will be resolved.

This fixes e.g. https://ubuntu.com/legal/ubuntu-advantage-service-description

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5743

QA
--

Go to https://ubuntu-com-canonical-web-and-design-pr-5750.run.demo.haus/legal/ubuntu-advantage-service-description, see a table.