### PR TITLE
Add colour variations of the takeovers

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -1,26 +1,13 @@
 /// homepage takeovers
-//@mixin ubuntu-p-takeovers {
-//@include ubuntu-p-takeover;
-//@include ubuntu-p-takeover-k8s;
-//@include ubuntu-p-takeover-neutral;
-//@include ubuntu-p-takeover-dark;
-//@include ubuntu-p-takeover-snapcraft;/
-//}
 
-@mixin ubuntu-p-takeovers {
-  .p-takeover {
+@mixin p-takeovers($name) {
+  .p-takeover--#{$name} {
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
-    background-color: #772953;
-    background-image:
-      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0, rgba(119, 41, 83, 0.16) 49.9%, transparent 50%),
-      linear-gradient(to bottom right, rgba(228, 228, 228, 0.5) 0, rgba(228, 228, 228, 0.5) 49.9%, transparent 50%),
-      linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
-      linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    @content;
     background-position: top right, top left, right 100%, left top;
     background-repeat: no-repeat;
     background-size: 74% 99.83%, 68% 91%, 103.5% 18.1%, 100% 99.8%;
-    color: $color-x-light;
     margin: 0;
     padding-bottom: 11rem;
     padding-top: 6rem;
@@ -50,3 +37,50 @@
     }
   }
 }
+
+@mixin ubuntu-p-takeovers {
+
+  @include p-takeovers('grad') {
+    background-color: #772953;
+    background-image:
+      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0, rgba(119, 41, 83, 0.16) 49.9%, transparent 50%),
+      linear-gradient(to bottom right, rgba(228, 228, 228, 0.5) 0, rgba(228, 228, 228, 0.5) 49.9%, transparent 50%),
+      linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%); // order: right, left, white, gradient
+      color: $color-x-light;
+  }
+
+  @include p-takeovers('k8s') {
+    background-color: #326de6;
+    background-image:
+      linear-gradient(to bottom left, rgba(21, 58, 138, 0.16) 0, rgba(21, 58, 138, 0.16) 49.9%, transparent 50%),
+      linear-gradient(to bottom right, rgba(50, 109, 230, 0.5) 0, rgba(50, 109, 230, 0.5) 49.9%, transparent 50%),
+      linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(74deg, #173d8b 0%, #326de6 92%); // order: right, left, white, gradient
+      color: $color-x-light;
+  }
+
+  @include p-takeovers('dark') {
+    background-color: #111;
+    background-image:
+      linear-gradient(to bottom left, rgba(216, 216, 216, 0.54) 0, rgba(216, 216, 216, 0.54) 49.9%, transparent 50%),
+      linear-gradient(to bottom right, rgba(228, 228, 228, 0.54) 0, rgba(228, 228, 228, 0.54) 49.9%, transparent 50%),
+      linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(201deg, #4e4e4e 0%, #333 46%, #111 90%); // order: right, left, white, gradient
+      color: $color-x-light;
+  }
+
+  @include p-takeovers('snapcraft') {
+    background-color: #83bfa1;
+    background-image:
+      linear-gradient(to bottom left, rgba(74, 131, 125, 0.16) 0, rgba(74, 131, 125, 0.16) 49.9%, transparent 50%),
+      linear-gradient(to bottom right, rgba(63, 120, 115, 0.08) 0, rgba(63, 120, 115, 0.08) 49.9%, transparent 50%),
+      linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(134deg, #2d6162 0%, #83bfa1 100%); // order: right, left, white, gradient
+      color: $color-x-light;
+  }
+}
+
+//@include ubuntu-p-takeover-neutral;
+//@include ubuntu-p-takeover-dark;
+//@include ubuntu-p-takeover-snapcraft;/

--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -80,7 +80,3 @@
       color: $color-x-light;
   }
 }
-
-//@include ubuntu-p-takeover-neutral;
-//@include ubuntu-p-takeover-dark;
-//@include ubuntu-p-takeover-snapcraft;/

--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -14,10 +14,10 @@
           </a>
         </p>
         {% endif %}
-        {% if seconary_url %}
+        {% if secondary_url %}
         <p>
-          <a href="{{ seconary_url }}" class="{% if 'http' in seconary_url %}p-link--external{% endif %} p-link--inverted">
-            {{ seconary_cta }}{% if 'http' not in seconary_url %}&nbsp;&rsaquo;{% endif %}
+          <a href="{{ secondary_url }}" class="{% if 'http' in secondary_url %}p-link--external{% endif %} p-link--inverted">
+            {{ secondary_cta }}{% if 'http' not in secondary_url %}&nbsp;&rsaquo;{% endif %}
           </a>
         </p>
         {% endif %}
@@ -35,10 +35,10 @@
         </a>
       </p>
       {% endif %}
-      {% if seconary_url %}
+      {% if secondary_url %}
       <p>
-        <a href="{{ seconary_url }}" class="{% if 'http' in seconary_url %}p-link--external{% endif %} p-link--inverted">
-          {{ seconary_cta }}{% if 'http' not in seconary_url %}&nbsp;&rsaquo;{% endif %}
+        <a href="{{ secondary_url }}" class="{% if 'http' in secondary_url %}p-link--external{% endif %} p-link--inverted">
+          {{ secondary_cta }}{% if 'http' not in secondary_url %}&nbsp;&rsaquo;{% endif %}
         </a>
       </p>
       {% endif %}

--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -1,4 +1,4 @@
-<section lang="{% if lang %}{{ lang }}{% else %}en{% endif %}" data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover{% endif %} js-takeover">
+<section lang="{% if lang %}{{ lang }}{% else %}en{% endif %}" data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
   <div class="row u-equal-height">
     <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %}">
       <h1>

--- a/templates/takeovers/templates.html
+++ b/templates/takeovers/templates.html
@@ -55,7 +55,7 @@ locale="" %}
       <h3>Details</h3>
       <ul class="p-list">
         <li class="p-list__item"><strong>title</strong>: the h1 text for the takeover</li>
-        <li class="p-list__item"><strong>subtitle</strong>: the h4 text forthe takeover <em>(optional)</em></li>
+        <li class="p-list__item"><strong>subtitle</strong>: the h4 text for the takeover <em>(optional)</em></li>
         <li class="p-list__item"><strong>class</strong>: the full class name for the takeover - null or p-takeover--grad, p-takeover--k8s, p-takeover--dark, p-takeover--snapcraft <em>(optional)</em></li>
         <li class="p-list__item"><strong>image</strong>: the full path to the image <em>(optional)</em></li>
         <li class="p-list__item"><strong>image_style</strong>: any extra information to add to the image in the 'style' property  <em>(optional)</em></li>

--- a/templates/takeovers/templates.html
+++ b/templates/takeovers/templates.html
@@ -16,8 +16,8 @@ equal_cols="true",
 primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
 primary_cta="Download the whitepaper",
 primary_cta_class="",
-seconary_url="",
-seconary_cta="",
+secondary_url="",
+secondary_cta="",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}
@@ -44,8 +44,8 @@ equal_cols="true",
 primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
 primary_cta="Download the whitepaper",
 primary_cta_class="",
-seconary_url="",
-seconary_cta="",
+secondary_url="",
+secondary_cta="",
 lang="",
 locale="" %}
 &#123;% include "takeovers/_template.html" %}
@@ -64,7 +64,7 @@ locale="" %}
         <li class="p-list__item"><strong>primary_url</strong>: the url for the primary cta, which will be a button and a <code>p-link--external</code> will be added automatically <em>(optional)</em></li>
         <li class="p-list__item"><strong>primary_cta</strong>: The text of the button <em>(optional)</em></li>
         <li class="p-list__item"><strong>primary_cta_class</strong>: the class of the button, defaults to <code>p-button--positive</code> <em>(optional)</em></li>
-        <li class="p-list__item"><strong>seconary_url</strong>: the url for the secondary cta, which will be a text link and a <code>p-link--external</code> will be added automatically <em>(optional)</em></li>
+        <li class="p-list__item"><strong>secondary_url</strong>: the url for the secondary cta, which will be a text link and a <code>p-link--external</code> will be added automatically <em>(optional)</em></li>
         <li class="p-list__item"><strong>lang</strong>: the language of the takeover, default is 'en'   <em>(optional)</em></li>
         <li class="p-list__item"><strong>locale</strong>: the locale of the takeover, default is 'en-GB'  <em>(optional)</em></li>
       </ul>
@@ -81,8 +81,8 @@ equal_cols="true",
 primary_url="https://kubeflow-news.com",
 primary_cta="Download the whitepaper",
 primary_cta_class="",
-seconary_url="",
-seconary_cta="",
+secondary_url="",
+secondary_cta="",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}
@@ -104,8 +104,8 @@ equal_cols="true",
 primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
 primary_cta="Download the whitepaper",
 primary_cta_class="",
-seconary_url="/contact-us#get-in-touch",
-seconary_cta="Contact Canonical",
+secondary_url="/contact-us#get-in-touch",
+secondary_cta="Contact Canonical",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}
@@ -127,8 +127,8 @@ equal_cols="true",
 primary_url="https://snapcraft.io",
 primary_cta="Download the whitepaper",
 primary_cta_class="p-button--neutral",
-seconary_url="",
-seconary_cta="",
+secondary_url="",
+secondary_cta="",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}

--- a/templates/takeovers/templates.html
+++ b/templates/takeovers/templates.html
@@ -2,30 +2,143 @@
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
-{% block title %}Takeover index | Ubuntu{% endblock %}
+{% block title %}Takeover template example | Ubuntu{% endblock %}
 
 {% block content %}
 
 {% with title="A guide to developing Android apps on Ubuntu",
-  subtitle="Learn what makes Ubuntu the perfect platform for Android app development",
-  image="https://assets.ubuntu.com/v1/30f461a5-android-on-ubuntu.svg",
-  image_style="width: 380px; margin: 1.5rem 0;",
-  image_hide_small="true",
-  equal_cols="true",
-  primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
-  primary_cta="Download the whitepaper",
-  primary_cta_class="",
-  seconary_url="",
-  seconary_cta="",
-  lang="",
-  locale="" %}
-  {% include "takeovers/_template.html" %}
+subtitle="Learn what makes Ubuntu the perfect platform for Android app development",
+class="",
+image="https://assets.ubuntu.com/v1/30f461a5-android-on-ubuntu.svg",
+image_style="width: 380px; margin: 1.5rem 0;",
+image_hide_small="true",
+equal_cols="true",
+primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+seconary_url="",
+seconary_cta="",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h1>Takeover templates</h1>
+      <p>Using the suru gradient patterns, you can now easily build homepage takeovers with a simple include, passing in all your variables to build a takeover in minutes.</p>
+      <h2>Default takeover - gradient</h2>
+      <h4><code>p-takeover--grad</code></h4>
+      <p>This is the default takeover style with an aubergine to orange gradient.</p>
+      <p>The following is the jinja2 template code you need for all takeovers, but with the default pattern.</p>
+      <pre>
+        <code>
+&#123;% with title="A guide to developing Android apps on Ubuntu",
+subtitle="Learn what makes Ubuntu the perfect platform for Android app development",
+class="",
+image="https://assets.ubuntu.com/v1/30f461a5-android-on-ubuntu.svg",
+image_style="width: 380px; margin: 1.5rem 0;",
+image_hide_small="true",
+equal_cols="true",
+primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+seconary_url="",
+seconary_cta="",
+lang="",
+locale="" %}
+&#123;% include "takeovers/_template.html" %}
+&#123;% endwith %}
+        </code>
+      </pre>
+      <h3>Details</h3>
+      <ul class="p-list">
+        <li class="p-list__item"><strong>title</strong>: the h1 text for the takeover</li>
+        <li class="p-list__item"><strong>subtitle</strong>: the h4 text forthe takeover <em>(optional)</em></li>
+        <li class="p-list__item"><strong>class</strong>: the full class name for the takeover - null or p-takeover--grad, p-takeover--k8s, p-takeover--dark, p-takeover--snapcraft <em>(optional)</em></li>
+        <li class="p-list__item"><strong>image</strong>: the full path to the image <em>(optional)</em></li>
+        <li class="p-list__item"><strong>image_style</strong>: any extra information to add to the image in the 'style' property  <em>(optional)</em></li>
+        <li class="p-list__item"><strong>image_hide_small</strong>: 'true' if you want to hide the image on small screens  <em>(optional)</em></li>
+        <li class="p-list__item"><strong>equal_cols</strong>: 'true' if you want the takeover to be spilt into two six cols, otherwise the default will be <code>col-7</code>, <code>col-5</code> <em>(optional)</em></li>
+        <li class="p-list__item"><strong>primary_url</strong>: the url for the primary cta, which will be a button and a <code>p-link--external</code> will be added automatically <em>(optional)</em></li>
+        <li class="p-list__item"><strong>primary_cta</strong>: The text of the button <em>(optional)</em></li>
+        <li class="p-list__item"><strong>primary_cta_class</strong>: the class of the button, defaults to <code>p-button--positive</code> <em>(optional)</em></li>
+        <li class="p-list__item"><strong>seconary_url</strong>: the url for the secondary cta, which will be a text link and a <code>p-link--external</code> will be added automatically <em>(optional)</em></li>
+        <li class="p-list__item"><strong>lang</strong>: the language of the takeover, default is 'en'   <em>(optional)</em></li>
+        <li class="p-list__item"><strong>locale</strong>: the locale of the takeover, default is 'en-GB'  <em>(optional)</em></li>
+      </ul>
+    </div>
+  </div>
+</section>
+{% with title="A guide to developing Android apps on Ubuntu",
+subtitle="Learn what makes Ubuntu the perfect platform for Android app development",
+class="p-takeover--k8s",
+image="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg",
+image_style="width: 240px;",
+image_hide_small="true",
+equal_cols="true",
+primary_url="https://kubeflow-news.com",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+seconary_url="",
+seconary_cta="",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
 {% endwith %}
 
 <section class="p-strip is-deep is-bordered">
   {% with gtm_event_label="ubuntu.com homepage" %}
-    {% include "shared/_insights_news_strip.html" %}
+  {% include "shared/_insights_news_strip.html" %}
   {% endwith %}
 </section>
+
+{% with title="A guide to developing Android apps on Ubuntu",
+subtitle="Learn what makes Ubuntu the perfect platform for Android app development",
+class="p-takeover--dark",
+image="https://assets.ubuntu.com/v1/30f461a5-android-on-ubuntu.svg",
+image_style="width: 380px; margin: 1.5rem 0;",
+image_hide_small="true",
+equal_cols="true",
+primary_url="/engage/developing-android-on-ubuntu?utm_source=takeover&utm_campaign=CY19_IOT_Snapstore_Whitepaper_AndroidonUbuntu",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+seconary_url="/contact-us#get-in-touch",
+seconary_cta="Contact Canonical",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}
+
+<section class="p-strip is-deep is-bordered">
+  {% with gtm_event_label="ubuntu.com homepage" %}
+  {% include "shared/_insights_news_strip.html" %}
+  {% endwith %}
+</section>
+
+{% with title="A guide to developing Android apps on Ubuntu",
+subtitle="Learn what makes Ubuntu the perfect platform for Android app development",
+class="p-takeover--snapcraft",
+image="https://assets.ubuntu.com/v1/c3b8a9dd-Snap_Store_shopping_icon.svg",
+image_style="width: 200px;",
+image_hide_small="true",
+equal_cols="true",
+primary_url="https://snapcraft.io",
+primary_cta="Download the whitepaper",
+primary_cta_class="p-button--neutral",
+seconary_url="",
+seconary_cta="",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}
+
+<section class="p-strip is-deep is-bordered">
+  {% with gtm_event_label="ubuntu.com homepage" %}
+  {% include "shared/_insights_news_strip.html" %}
+  {% endwith %}
+</section>
+
 
 {% endblock %}


### PR DESCRIPTION
## Done

- added snapcraft, dark and k8s varients for the takeover templates
- added examples and some help for the new include

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers/templates
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the examples match the designs and the template works as described

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1560
Fixes https://github.com/canonical-web-and-design/web-squad/issues/1558
Fixes https://github.com/canonical-web-and-design/web-squad/issues/1561


