### PR TITLE
Add vmware takeover and engage page

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -80,3 +80,47 @@
       color: $color-x-light;
   }
 }
+
+
+/// engage banners takeovers
+
+@mixin p-engage-banner($name) {
+  .p-engage-banner--#{$name} {
+    background-blend-mode: normal;
+    @content;
+    background-position: left top;
+    background-repeat: no-repeat;
+    background-size: 100% 99.8%;
+  }
+}
+
+@mixin ubuntu-p-engage-banner {
+
+  @include p-engage-banner('grad') {
+    background-color: #772953;
+    background-image:
+      linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+      color: $color-x-light;
+  }
+
+  @include p-engage-banner('k8s') {
+    background-color: #326de6;
+    background-image:
+      linear-gradient(74deg, #173d8b 0%, #326de6 92%);
+      color: $color-x-light;
+  }
+
+  @include p-engage-banner('dark') {
+    background-color: #111;
+    background-image:
+      linear-gradient(201deg, #4e4e4e 0%, #333 46%, #111 90%);
+      color: $color-x-light;
+  }
+
+  @include p-engage-banner('snapcraft') {
+    background-color: #83bfa1;
+    background-image:
+      linear-gradient(134deg, #2d6162 0%, #83bfa1 100%);
+      color: $color-x-light;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -73,6 +73,7 @@
 @include ubuntu-p-tables;
 @include ubuntu-p-takeunders;
 @include ubuntu-p-takeovers;
+@include ubuntu-p-engage-banner;
 @include ubuntu-p-ubuntu-intro;
 @include p-takeover-financial-services;
 @include u-animations;

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -32,16 +32,17 @@
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if header_image != "http" %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for {{ header_title }}" >
+      <img src="{% if "http" not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for {{ header_title }}" >
     </div>{% endif %}
   </div>
 </section>
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
-    <div class="col-7">
+    <div class="{% if form_id %}col-7{% else %}col-8{% endif %}">
       {{ content | safe }}
     </div>
+    {% if form_id %}
     <div class="col-5" id="register-section">
       <!-- MARKETO FORM -->
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ form_id }}">
@@ -115,8 +116,17 @@
         </fieldset>
       </form>
       <!-- /MARKETO FORM -->
-
     </div>
+    {% else %}
+  </div>
+</section>
+<!-- webinar -->
+<section class="p-strip is-shallow" id="register-section">
+  <div class="row" id="register-section">
+    {{ webinar_code | safe }}
+  </div>
+</section>
+{% endif %}
   </div>
 </section>
 {% endblock %}

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -15,10 +15,10 @@
     <div class="{% if header_image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
       <div>
         <h1 {% if header_subtitle is none and header_date is none %}class="u-no-margin--bottom"{% endif %}>
-          {{ header_title }}
+          {{ header_title | safe }}
         </h1>
         {% if header_subtitle %}<h4>
-          {{ header_subtitle }}
+          {{ header_subtitle | safe }}
         </h4>{% endif %}
         {% if header_date %}<p>
           {{ header_date }}

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -5,7 +5,7 @@ context:
      meta_description: "In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack."
      meta_image: https://assets.ubuntu.com/v1/27fed536-vmware-to-charmed-openstack-social.jpg
      meta_copydoc: https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit
-     header_title: "From VMware to Charmed OpenStack"
+     header_title: "From VMware to Charmed&nbsp;OpenStack"
      header_subtitle:
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
      header_url: '#register-section'

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -1,0 +1,23 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "From VMware to Charmed OpenStack"
+     meta_description: "In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack."
+     meta_image: https://assets.ubuntu.com/v1/27fed536-vmware-to-charmed-openstack-social.jpg
+     meta_copydoc: https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit
+     header_title: "From VMware to Charmed OpenStack"
+     header_subtitle:
+     header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_url: '#register-section'
+     header_cta: Register for the webinar
+     header_class: p-engage-banner--dark
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     form_include:
+     form_id:
+     form_return_url:
+---
+
+Over the last decade, organizations have started virtualizing their IT workloads and migrating from legacy monolithic infrastructure to cloud environments. Many choose VMware as a provider for their virtualised infrastructure. However, because of the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other platforms such as OpenStack.
+
+In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack. In addition, we'll provide a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack. This webinar also provides a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using the Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis.

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,8 +33,8 @@
   {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
   {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
+  {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_enterprise-snap-management.html" %}
-  {% include "takeovers/_maas-hardware-testing_takeover.html" %}
   {% include "takeovers/_developing-android-on-ubuntu.html" %}
 
 {% endblock takeover_content %}

--- a/templates/takeovers/_vmware-to-charmed-openstack.html
+++ b/templates/takeovers/_vmware-to-charmed-openstack.html
@@ -1,0 +1,16 @@
+{% with title="From VMware to Charmed OpenStack",
+subtitle="How migrating to Charmed OpenStack can significantly reduce TCO",
+class="p-takeover--dark",
+image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+image_style="width: 300px;",
+image_hide_small="",
+equal_cols="true",
+primary_url="/engage/vmware-to-charmed-openstack?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_VMwaretoOpenstack",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="en",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- created a takeover
- created the engage page
- extended the engage template for webinars
- extended new takeover banners for engage pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and http://0.0.0.0:8001/engage/vmware-to-charmed-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [brief](https://docs.google.com/spreadsheets/d/1-wWL1DZZ1i1czQVuqrKDCXsqiUQi7dIh9gxPB3aBos8/edit#gid=877682240)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1571

## Screenshots
### takeover
![image](https://user-images.githubusercontent.com/441217/64267801-e7728c80-cf2e-11e9-8485-8bd98db188c2.png)
