### PR TITLE
Add back campaign params to context

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -104,8 +104,12 @@ def context():
         "month_name": month_name,
         "months_list": months_list,
         "navigation": navigation,
+        "product": flask.request.args.get("product", ""),
         "request": flask.request,
         "releases": releases(),
+        "utm_campaign": flask.request.args.get("utm_campaign", ""),
+        "utm_medium": flask.request.args.get("utm_medium", ""),
+        "utm_source": flask.request.args.get("utm_source", ""),
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5763

QA
--

Go to e.g. `/engage/fr/openstack-made-easy?utm_campaign=mordor` and inspect the source - see that the `utm_campaign` hidden field is populated.