### PR TITLE
Adjust lang setting on the new takeover template

### DIFF
--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -1,4 +1,4 @@
-<section lang="{% if lang %}{{ lang }}{% else %}en{% endif %}" data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
+<section {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
   <div class="row u-equal-height">
     <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %}">
       <h1>

--- a/templates/takeovers/_vmware-to-charmed-openstack.html
+++ b/templates/takeovers/_vmware-to-charmed-openstack.html
@@ -10,7 +10,6 @@ primary_cta="Register for the webinar",
 primary_cta_class="",
 secondary_url="",
 secondary_cta="",
-lang="en",
 locale="en_GB" %}
 {% include "takeovers/_template.html" %}
 {% endwith %}


### PR DESCRIPTION
## Done

As documented in index.html, our takeover logic ensures takeovers with a `lang` attribute are only displayed to users who have their browsers explicitly set to a locale starting with \<lang>\. For global takeovers such as this one, there should be no `lang`.

* Removed `lang` attribute from the new vmware takeover
* Removed the `lang="en"` fallback in the template. (Note that ``"lang=""` would simply hide the takeover for everyone)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Try various browser languages, ensure the vmware takeover is always part of the loop. 
