### PR TITLE
Fix raw template variable in UASD legal page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ canonicalwebteam.flask_base==0.2.0
 canonicalwebteam.http==1.0.1
 canonicalwebteam.blog==3.0.1
 canonicalwebteam.search==0.2.0
-canonicalwebteam.templatefinder==0.2.1
+canonicalwebteam.templatefinder==0.2.2
 flask==1.0.2
 feedparser==5.2.1


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5767

QA
--

Go to the demo at https://ubuntu-com-canonical-web-and-design-pr-5770.run.demo.haus/legal/ubuntu-advantage-service-description, check there's no ugly variable below the table.