### PR TITLE
Improve logout

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -21,7 +21,7 @@
     <div class="col-10">
       <h3>You are signed in</h3>
       <p>{{ openid.fullname }} ({{ openid.email }})</p>
-      <a href="/logout" class="p-button--neutral u-no-margin--bottom">Sign out</a>
+      <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom">Sign out</a>
     </div>
   </div>
 

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -56,6 +56,8 @@ def after_login(resp):
 
 
 def logout():
+    return_to = flask.request.args.get("return_to", flask.request.host_url)
+
     if "openid" in flask.session:
         flask.session.pop("macaroon_root", None)
         flask.session.pop("macaroon_discharge", None)
@@ -64,5 +66,5 @@ def logout():
 
     return flask.redirect(
         "https://login.ubuntu.com/+logout"
-        f"?return_to={flask.request.url_root}/advantage&return_now=True"
+        f"?return_to={return_to}&return_now=True"
     )

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -1,3 +1,6 @@
+# Standard library
+from urllib.parse import quote, unquote
+
 # Packages
 import flask
 import flask_openid
@@ -56,7 +59,12 @@ def after_login(resp):
 
 
 def logout():
-    return_to = flask.request.args.get("return_to", flask.request.host_url)
+    return_to = flask.request.args.get("return_to") or flask.request.url_root
+
+    # Make sure return_to is URL encoded
+    if return_to == unquote(return_to):
+        # Not encoded
+        return_to = quote(return_to, safe="")
 
     if "openid" in flask.session:
         flask.session.pop("macaroon_root", None)


### PR DESCRIPTION
Logout doesn't redirect back to the site properly.

Here I've changed the logic of the `/logout` view, so it also can accept a `return_to` paramter, and so the "Sign out" link on `/advantage` now passes a `return_to` parameter to bring you back to `/advantage`.

This is because in general I don't think it's sensible for `/logout` to send you back to the page you came from. In many cases the page you came from would only be available with authentication, and so you'd end up in a redirect loop.

If you want the user to come back to the existing page, you should explicitly set `return_to`, otherwise the user will be sent to the homepage, which I think is sensible.

QA
--

Don't QA this yet.