### PR TITLE
Remove the login from the global navigation

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -58,7 +58,7 @@ core.mobileNav = function () {
 
 core.supportsSvg();
 core.mobileNav();
-createNav();
+createNav({ showLogins: false });
 
 var options = {
   content:


### PR DESCRIPTION
## Done
Remove the login option from the global navigation.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check there are no JS errors
- See there is no login in the global navigation