### PR TITLE
Add a terms and conditions link to the token section of the page

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -30,6 +30,7 @@
   <div class="row">
     <div class="col-6 u-sv3">
       <h2>Your free personal subscription</h2>
+      <p>By using Ubuntu Avantage you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</p>
       <aside class="p-accordion" role="tablist" aria-multiselect="true" style="border: 1px solid #cdcdcd;">
         <ul class="p-accordion__list" style="margin-bottom: 0;">
           <li class="p-accordion__group">


### PR DESCRIPTION
## Done
Add a terms and conditions link to the token section of the page

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- See the terms and condition sentence looks beautiful

## Issue / Card
Fixes https://github.com/canonical-web-and-design/base-squad/issues/705

## Screenshots
![Screenshot_2019-09-11 Ubuntu Advantage for Infrastructure Ubuntu](https://user-images.githubusercontent.com/1413534/64694063-b2b38780-d490-11e9-90f2-ad2b27dafcb5.png)

