### PR TITLE
Create takeover and engage page for getting started with ai webinar

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -86,7 +86,7 @@
     linear-gradient(to bottom left, rgba(71, 145, 154, 0.16) 0, rgba(71, 145, 154, 0.16) 49.9%, transparent 50%),
     linear-gradient(to bottom right, rgba(71, 145, 154, 0.16) 0, rgba(71, 145, 154, 0.16) 49.9%, transparent 50%),
     linear-gradient(to top left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49.3%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
-      linear-gradient(246deg, #47919a 0%, #47919a 53%); // order: right, left, white, gradient
+    linear-gradient(246deg, #47919a 0%, #47919a 53%, #2b585d 100%); // order: right, left, white, gradient
       color: $color-x-light;
   }
 }

--- a/templates/engage/get-started-with-ai-part-2.md
+++ b/templates/engage/get-started-with-ai-part-2.md
@@ -1,0 +1,32 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Machine Learning Operations (MLOps): Deploy at scale"
+     meta_description: "This webinar will dive into what success looks like when deploying machine learning models, including training, at scale."
+     meta_image: https://assets.ubuntu.com/v1/dd0f6313-social+embedded.jpg
+     meta_copydoc: "https://docs.google.com/document/d/1KeCbhYudWJuKW2cMuNfsClvQXnyrpz0q2I-ILuwhfcY/edit?ts=5d6de4ad"
+     header_title: "Machine Learning Operations&nbsp;(MLOps)"
+     header_subtitle: "Deploy at scale"
+     header_image: "https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg"
+     header_url: '#register-section'
+     header_cta: Register for the webinar
+     header_class: p-engage-banner--aqua
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 365540, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     form_include:
+     form_id:
+     form_return_url:
+---
+
+Artificial Intelligence and Machine Learning adoption in the enterprise is exploding from Silicon Valley to Wall Street with diverse use cases ranging from the analysis of customer behaviour and purchase cycles to diagnosing medical conditions.
+
+Following on from our webinar ‘Getting started with AI’, this webinar will dive into what success looks like when deploying machine learning models, including training, at scale. The key topics are:
+
+- Automatic Workflow Orchestration
+- ML Pipeline development
+- Kubernetes / Kubeflow Integration
+- On-device Machine Learning, Edge Inference and Model Federation
+- On-prem to cloud, on-demand extensibility
+- Scale-out model serving and inference
+
+This webinar will detail recent advancements in these areas alongside providing actionable insights for viewers to apply to their AI/ML efforts!

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1098,6 +1098,19 @@
           </div>
         </div>
 
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--desktop'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              webinar
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/get-started-with-ai-part-2'>Machine Learning Operations (MLOps)</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>This webinar will dive into what success looks like when deploying machine learning models, including training, at scale.</p>
+          </div>
+        </div>
       </div>
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
   {# ALL #}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_buy-ubuntu-advantage.html" %}
-  {% include "takeovers/_developing-android-on-ubuntu.html" %}
+  {% include "takeovers/_get-started-with-ai-part-2.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_get-started-with-ai-part-2.html
+++ b/templates/takeovers/_get-started-with-ai-part-2.html
@@ -1,0 +1,16 @@
+{% with title="Machine Learning at scale",
+subtitle="What do successful solutions have in common?",
+class="p-takeover--aqua",
+image="https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg",
+image_style="width: 200px;",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/get-started-with-ai-part-2",
+primary_cta="Register for the webinar",
+primary_cta_class="p-button--neutral",
+secondary_url="",
+secondary_cta="",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -82,4 +82,6 @@
 {% include "takeovers/_vmware-to-charmed-openstack.html" %}
 <p>6 Sept 2019</p>
 {% include "takeovers/_buy-ubuntu-advantage.html" %}
+<p>11 Sept 2019</p>
+{% include "takeovers/_get-started-with-ai-part-2.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Create takeover and engage page for getting started with ai webinar part 2 http://0.0.0.0:8001/engage/get-started-with-ai-part-2
- Added the takeover to http://0.0.0.0:8001/takeovers
- Added the engage page to http://0.0.0.0:8001/engage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and http://0.0.0.0:8001/engage/get-started-with-ai-part-2
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1641) and the [brief](https://docs.google.com/spreadsheets/d/1zHx_YF7akq8ypjDZVOOK8vXryqW-FyeIjIv6EsH4b5k/edit#gid=877682240)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1641


