### PR TITLE
Fix 410 template syntax error

### DIFF
--- a/templates/410.html
+++ b/templates/410.html
@@ -11,7 +11,7 @@
     <div class="col-6 u-vertically-center">
       <div>
         <h1>410: Page deleted</h1>
-        <p class="p-heading--four">{{ message | default:"This page has been removed" }}</p>
+        <p class="p-heading--four">{{ message or "This page has been removed" }}</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
See how https://ubuntu.com/gomobile shows 500? This should fix that.

The error is here in sentry: https://sentry.is.canonical.com/canonical/ubuntu-com/issues/3748/?query=is%3Aunresolved

QA
--

Go to `/gomobile`, see a 410 page (rather than a 500).