### PR TITLE
Build the ESM page ready for the advantage release

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -63,6 +63,21 @@
       }
     }
   }
+
+  .p-strip--suru-accent {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal, normal;
+    background-image:
+      linear-gradient(to bottom right, rgba(228, 228, 228, .54) 0%, rgba(228, 228, 228, .54) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(216, 216, 216, .54) 0%, rgba(216, 216, 216, .54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
+      linear-gradient(to top right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 1) 49%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 100%),
+      linear-gradient(-89deg, #e95420 0%, #772953 38%, #2C001e 85%);
+    background-position: 0% 0%, top right, right bottom, 0% 0%;
+    background-repeat: no-repeat;
+    background-size: 100% 100%, 50% 100%, 100% 4rem, auto;
+    color: $color-x-light;
+    padding-bottom: 6rem;
+  }
 }
 
 @mixin ubuntu-p-strip-suru-topped {

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -23,18 +23,18 @@
   </div>
 </section>
 
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru-accent is-dark">
   <div class="row">
-    <div class="col-3 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/f96c0ef9-ITstrategen_logo.jpg" alt="">
+    <div class="col-3 p-card u-hide--small u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/3e31f0f5-ITstrategen+logo.svg" alt="">
     </div>
-    <div class="col-9">
+    <div class="col-8 col-start-large-5">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg">
-          <h3 class="p-heading-icon__title" style="font-size: 1rem;">CASE STUDY</h3>
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/3100aa6a-case-study-08.svg">
+          <h4 class="p-heading-icon__title">CASE STUDY</h4>
         </div>
-        <h5>Case study: ITstrategen keeps their applications secure with ESM</h5  >
+        <h5>Case study: ITstrategen keeps their applications secure with ESM</h5>
         <p>The security of customer data is of utmost importance to ITstrategen. That’s why Ubuntu is their server operating system of choice.</p>
         <p><a href="/engage/ITstrategen-case-study" class="p-button--neutral">Read the case study</a></p>
       </div>

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -32,9 +32,9 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/3100aa6a-case-study-08.svg">
-          <h4 class="p-heading-icon__title">CASE STUDY</h4>
+          <p class="p-muted-heading u-sv3" style="color: #fff;">CASE STUDY</p>
         </div>
-        <h5>Case study: ITstrategen keeps their applications secure with ESM</h5>
+        <h4>ITstrategen keeps their applications secure with ESM</h4>
         <p>The security of customer data is of utmost importance to ITstrategen. That’s why Ubuntu is their server operating system of choice.</p>
         <p><a href="/engage/ITstrategen-case-study" class="p-button--neutral">Read the case study</a></p>
       </div>

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -2,84 +2,78 @@
 
 {% block title %}Ubuntu Extended Security Maintenance{% endblock %}
 
-{% block meta_description %}Extended Security Maintenance provides ongoing Linux security fixes for Ubuntu 14.04 LTS releases for the Linux kernel and essential packages beyond the five-year basic maintenance window.{% endblock meta_description %}
+{% block meta_description %}Extended Security Maintenance provides ongoing Linux security fixes for Ubuntu 14.04 LTS, for the Linux kernel and essential packages beyond the five-year basic maintenance window.{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1BK-XXECYJJllG8jIe3WN3X8EMo_3wBBa03nlzYDP8xE/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
-<section class="p-strip--image is-deep is-dark" style="background-image:url('https://assets.ubuntu.com/v1/728c5851-Yakkety_Yak-Wallpaper_8192x4608_aubergine_wider.jpg');">
+<section class="p-strip--suru-topped">
   <div class="row u-equal-height">
     <div class="col-8">
-      <h1>Ubuntu Extended Security Maintenance</h1>
-      <p>Extended Security Maintenance (ESM) ensures the ongoing security and integrity of Ubuntu Long-term support (LTS) systems through Ubuntu Advantage for Infrastructure.</p>
-      <p><a href="https://buy.ubuntu.com/" class="p-button--positive">Buy Ubuntu Advantage</a></p>
-      <p><a href="/support" class="p-link--inverted">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <span class="u-sv3"><h1>Extended Security Maintenance</h1></span>
+      <span class="u-sv3"><p class="p-heading--four">Security updates for 14.04 LTS until 2022</p></span>
+      <p>Continue to receive security updates for the Ubuntu base OS and critical infrastructure components &ndash; Ceph, OpenStack and more &ndash; with ESM in your Ubuntu Advantage subscription.</p>
+      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops. And it’s free for personal use.</p>
+      <p><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Get started with Ubuntu Advantage</span></a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/9e59756d-shield-ESM.svg" width="150" alt="" />
+      <img src="https://assets.ubuntu.com/v1/fa103ed7-1A-shield.svg" width="200" alt="" />
     </div>
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered" id="benefits">
+<section class="p-strip--suru is-dark">
+  <div class="row">
+    <div class="col-3 u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/f96c0ef9-ITstrategen_logo.jpg" alt="">
+    </div>
+    <div class="col-9">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg">
+          <h3 class="p-heading-icon__title" style="font-size: 1rem;">CASE STUDY</h3>
+        </div>
+        <h5>Case study: ITstrategen keeps their applications secure with ESM</h5  >
+        <p>The security of customer data is of utmost importance to ITstrategen. That’s why Ubuntu is their server operating system of choice.</p>
+        <p><a href="/engage/ITstrategen-case-study" class="p-button--neutral">Read the case study</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered" id="get-esm">
   <div class="row">
     <div class="col-8">
-      <h2>Security and compliance</h2>
-      <p>Aligning to organisational needs to build upon rapid release cycles, ESM ensures systems and the Linux kernel remain patched against security vulnerabilities through Ubuntu Advantage.</p>
-      <p>Canonical&rsquo;s Ubuntu security team provide fixes on high and critical CVEs (common vulnerabilities and exposures) for the most commonly used server packages in the Ubuntu main archive. ESM provides the essential continuation of the security updates for 12.04 LTS (Precise Pangolin) and 14.04 LTS (Trusty Tahr) that Ubuntu users have always received via a secure, private archive.</p>
-      <p><a href="/engage/ITstrategen-case-study">Learn how ITstrategen keeps legacy applications secure with ESM&nbsp;&rsaquo;</a></p>
+      <h2>Free for personal use</h2>
+      <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 5 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a> we will gladly increase that to 50 machines. Your personal subscription will also cover <a href="/livepatch">Livepatch</a>, FIPS and CIS hardening tools.</p>
+      <a href="https://buy.ubuntu.com/" class="p-button--positive u-no-margin--bottom"><span class="p-link--external">Get ESM now</a></a>
     </div>
   </div>
-</section>
 
-{% with colour="dark" %}{% include "shared/_call-sales.html" %}{% endwith %}
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
 
-<section class="p-strip--light is-deep is-bordered" id="get-esm">
-  <div class="row">
+  <div class="row" id="benefits">
     <div class="col-10">
-      <h2>Getting started with total estate coverage</h2>
+      <h2>What’s covered?</h2>
+      <p>ESM continues security updates for:</p>
+      <ul class="u-no-margin--bottom">
+        <li>high and critical CVEs (Common Vulnerabilities and Exposures), in</li>
+        <li>the Ubuntu base OS and scale-out infrastructure (Ceph, Openstack, see <a href="https://wiki.ubuntu.com/SecurityTeam/ESM/14.04#A14.04_Infrastructure_ESM_Packages" class="p-link--external">the complete list</a>), on</li>
+        <li>the 64-bit x86 architecture.</li>
+      </ul>
     </div>
   </div>
-  <div class="row p-divider u-equal-height u-vertically-spaced">
-    <div class="col-4 p-divider__block">
-      <h4>Buy direct from the store</h4>
-      <p>Users interested in Ubuntu ESM updates can purchase Ubuntu Advantage from our online store.</p>
-      <p><a href="https://buy.ubuntu.com/" class="p-link--external">Purchase at buy.ubuntu.com</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h4>Buy from the AWS Marketplace</h4>
-      <p>For Amazon AWS users, you can purchase Ubuntu Advantage through the AWS Marketplace.</p>
-      <p>Purchase <a href="https://aws.amazon.com/marketplace/pp/B01MZ1LSBQ?qid=1486382973569&sr=0-1&ref_=srh_res_product_title" class="p-link--external">Standard</a> or <a href="https://aws.amazon.com/marketplace/pp/B01N9JG6EM?qid=1490357851557&sr=0-7&ref_=srh_res_product_title" class="p-link--external">Advanced</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h4>For existing subscribers</h4>
-      <p>If you&rsquo;re already a qualifying Ubuntu Advantage customer, you can request your credentials.</p>
-      <p>Ask on <a href="http://support.canonical.com/" class="p-link--external">support.canonical.com</a></p>
-    </div>
-  </div>
-</section>
 
-<section class="p-strip is-deep u-no-padding--bottom"id="faq">
-  <div class="row u-equal-height">
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
+
+  <div class="row" id="faq">
     <div class="col-8">
-      <h2>Frequently asked questions (FAQ)</h2>
-      <p>If you have any more questions, feel free to get in touch.</p>
-    </div>
-    <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1b45cd30-picto-help-warmgrey.svg" width="140" alt="" />
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h4 class="u-no-max-width">What CVEs (Common Vulnerabilities and Exposures) will receive patches?</h4>
-      <p>Ubuntu  ESM is focused on fixing high and critical CVEs. Low and medium updates typically have a mitigation path.</p>
-
-      <h4 class="u-no-max-width">Which hardware platforms are supported under Ubuntu ESM?</h4>
-      <p>Currently, we are maintaining the Ubuntu Cloud/Server 64-bit AMD/Intel binaries. We will extend support for other platforms in future updates.</p>
+      <h2>Common questions</h2>
 
       <h4 class="u-no-max-width">Do all levels of Ubuntu Advantage for Infrastructure have access to Ubuntu ESM?</h4>
       <p>Yes. Ubuntu ESM is available for UA-I Essential, Standard and Advanced customers. For more information on levels please visit our <a href="/pricing">pricing page</a>. Existing UA customers can request their credentials through the <a class="p-link--external" href="https://support.canonical.com/ua/s/article/obtain-ESM-credentials-and-modify-your-apt-sources-to-get-ESM-updates">Canonical support portal</a>.</p>
@@ -94,31 +88,27 @@
       <p>You can purchase Ubuntu Advantage support at any time. It does not need to be in place in advance, although we strongly recommend you eliminate the gap between when Ubuntu ESM is enabled on your system(s), to avoid exposing your systems to security vulnerabilities. Ubuntu Advantage is priced year-over-year so there is no backdating.</p>
 
       <h4 class="u-no-max-width">We're mirroring the repository on our internal Landscape server. Can we still get Ubuntu ESM if using Landscape?</h4>
-      <p>ESM is just a regular Ubuntu archive, but authenticated and served over HTTPS. Archive mirroring is already available in Landscape and is the only supported mechanism for mirroring the ESM archive.</p>
-
-      <h4 class="u-no-max-width">Will Ubuntu ESM include patching my-favourite-package?</h4>
-      <p>Canonical’s Ubuntu Security Team are committed to providing fixes for high and critical CVEs against the most commonly used server packages in the Ubuntu Main archive. This is essentially a continuation of the same security updates that Ubuntu LTS Server users have always received.</p>
+      <p>ESM is just a regular Ubuntu archive, but authenticated and served over HTTPS. Archive mirroring is already available in Landscape and is a supported mechanism for mirroring the ESM archive.</p>
 
       <h4 class="u-no-max-width">Will source code for Ubuntu ESM patches be made available? If so, will that be publicly available on Launchpad or only through Ubuntu ESM?</h4>
-      <p>Both the binary updates and source code will be available to Ubuntu ESM users. We will honour any and all licenses associated with the open source code in Ubuntu.</p>
+      <p>Both the binary updates and source code will be available to Ubuntu ESM users. We honour all licenses associated with the open-source code in Ubuntu.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-deep">
+<section class="p-strip--light">
   <div class="row u-equal-height">
-    <div class="col-8">
-      <h2>Get ESM for Ubuntu</h2>
-      <p>If you would like to discuss ESM for Ubuntu please <a href="/support/contact-us?product=server-esm" class="js-invoke-modal">get in touch</a>.</p>
-      <p>Or <a href="https://buy.ubuntu.com" class="p-link--external">visit the Ubuntu Advantage store</a></p>
+    <div class="col-5 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/9c7bda7d-contact-us.svg" alt="">
     </div>
-    <div class="col-3 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1f1d581a-picto-quote-orange.svg" width="140" alt="" />
+    <div class="col-7 u-vertically-center">
+      <div>
+        <h2>Secure your Ubuntu estate</h2>
+        <p class="u-no-margin--bottom">If you would like to discuss ESM or Ubuntu Advantage please <a href="/support/contact-us" class="js-invoke-modal">get in touch</a>.</p>
+      </div>
     </div>
   </div>
 </section>
-
-<script src="{{ versioned_static('js/build/stickyNav.min.js') }}"></script>
 
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -29,10 +29,10 @@
       <img src="https://assets.ubuntu.com/v1/3e31f0f5-ITstrategen+logo.svg" alt="">
     </div>
     <div class="col-8 col-start-large-5">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/3100aa6a-case-study-08.svg">
-          <p class="p-muted-heading u-sv3" style="color: #fff;">CASE STUDY</p>
+          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">CASE STUDY</p>
         </div>
         <h4>ITstrategen keeps their applications secure with ESM</h4>
         <p>The security of customer data is of utmost importance to ITstrategen. That’s why Ubuntu is their server operating system of choice.</p>

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -14,7 +14,7 @@
       <span class="u-sv3"><h1>Extended Security Maintenance</h1></span>
       <span class="u-sv3"><p class="p-heading--four">Security updates for 14.04 LTS until 2022</p></span>
       <p>Continue to receive security updates for the Ubuntu base OS and critical infrastructure components &ndash; Ceph, OpenStack and more &ndash; with ESM in your Ubuntu Advantage subscription.</p>
-      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops. And it’s free for personal use.</p>
+      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops.</p>
       <p><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Get started with Ubuntu Advantage</span></a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
@@ -43,18 +43,6 @@
 </section>
 
 <section class="p-strip is-deep is-bordered" id="get-esm">
-  <div class="row">
-    <div class="col-8">
-      <h2>Free for personal use</h2>
-      <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 5 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a> we will gladly increase that to 50 machines. Your personal subscription will also cover <a href="/livepatch">Livepatch</a>, FIPS and CIS hardening tools.</p>
-      <a href="https://buy.ubuntu.com/" class="p-button--positive u-no-margin--bottom"><span class="p-link--external">Get ESM now</a></a>
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator">
-  </div>
-
   <div class="row" id="benefits">
     <div class="col-10">
       <h2>What’s covered?</h2>


### PR DESCRIPTION
## Done
Rebuild the ESM page without links to advantage for now.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/esm
- See that the copy matches [the copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit)
- Check it matches [the design](https://user-images.githubusercontent.com/36884067/64698699-4722e780-d49b-11e9-9dd0-d2af30f81352.jpg)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/base-squad/issues/707

