### PR TITLE
Add design and build takeover& engage github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUILD_TAKEOVER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUILD_TAKEOVER_ISSUE_TEMPLATE.md
@@ -7,10 +7,10 @@ assignees: ''
 ---
 ## Requirements
 
-- [ ] Please build a takeover and an engage page based on this [brief]() and [design]():
+- Please build a takeover and an engage page based on this [brief]() and [design]():
     - [ ] build takeover
     - [ ] build engage page
     - [ ] add takeover to `/takeovers/index.html`
-    - [ ] add takeover to `/templates/index.html`
+    - [ ] add takeover to `/index.html`
     - [ ] add engage page to `/engage/index.html`
     - [ ] test the engage page on [https://socialdebug.com/](https://socialdebug.com/) or [http://debug.iframely.com/](http://debug.iframely.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)

--- a/.github/ISSUE_TEMPLATE/BUILD_TAKEOVER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUILD_TAKEOVER_ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 name: Takeover build issue
-about: All the requirements for creating a takeover epic
+about: All the requirements for takeover & landing page build
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/BUILD_TAKEOVER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUILD_TAKEOVER_ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+---
+name: Takeover build issue
+about: All the requirements for creating a takeover epic
+title: ''
+labels: ''
+assignees: ''
+---
+## Requirements
+
+- [ ] Please build a takeover and an engage page based on this [brief]() and [design]():
+    - [ ] build takeover
+    - [ ] build engage page
+    - [ ] add takeover to `/takeovers/index.html`
+    - [ ] add takeover to `/templates/index.html`
+    - [ ] add engage page to `/engage/index.html`
+    - [ ] test the engage page on [https://socialdebug.com/](https://socialdebug.com/) or [http://debug.iframely.com/](http://debug.iframely.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)

--- a/.github/ISSUE_TEMPLATE/DESIGN_TAKEOVER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/DESIGN_TAKEOVER_ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 ## Marketing requirements
 
-- [ ] Please design the elements below according to this [brief]():
+- Please design the elements below according to this [brief]():
     - [ ] takeover & landing page
     - [ ] meta image
     - [ ] social media banner (1200px x 630px)

--- a/.github/ISSUE_TEMPLATE/DESIGN_TAKEOVER_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/DESIGN_TAKEOVER_ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+---
+name: Takeover design issue
+about: All the requirements for takeover & landing page design
+title: ''
+labels: ''
+assignees: ''
+---
+## Marketing requirements
+
+- [ ] Please design the elements below according to this [brief]():
+    - [ ] takeover & landing page
+    - [ ] meta image
+    - [ ] social media banner (1200px x 630px)
+    - [ ] save assets 


### PR DESCRIPTION
## Done

- Add design and build GitHub issue template 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
