### PR TITLE
Add recaptcha to modals

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -16,6 +16,15 @@
       });
     });
 
+    // recaptcha submitCallback
+    var CaptchaCallback = function() {
+      let recaptchas = document.querySelectorAll("div[class^=g-recaptcha]");
+      recaptchas.forEach(function(field){
+        recaptchaWidgetId = grecaptcha.render(field, {'sitekey' : '6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if'});
+        field.setAttribute("data-widget-id", recaptchaWidgetId);
+      });
+    }
+
     // Fetch, load and initialise form
     function fetchForm(formData, contactButton) {
       fetch(formData.formLocation)
@@ -27,6 +36,7 @@
           formContainer.innerHTML = text.replace(/%% formid %%/g, formData.formId).replace(/%% lpId %%/g, formData.lpId).replace(/%% returnURL %%/g, formData.returnUrl).replace(/%% lpurl %%/g, formData.lpUrl);
           setProductContext(contactButton);
           initialiseForm();
+          CaptchaCallback();
         })
         .catch(function (error) {
           console.log('Request failed', error)


### PR DESCRIPTION
## Done

- Add g-recaptcha to the modals

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to any page that has a modal an make sure the modal has g-recaptcha


## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/65161793-16f5be80-da30-11e9-9f8b-ce18823a3728.png)

