### PR TITLE
Add prefix for meta image for LinkedIn

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -38,11 +38,11 @@
         <meta property="og:description" content="{{ self.meta_description() }}">
     {% endif %}
 
-    <!-- Mate image: {% block meta_image %}{% endblock %} -->
+    <!-- Meta image: {% block meta_image %}{% endblock %} -->
     {% if self.meta_image() %}
         <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
-        <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+        <meta prefix="og: http://ogp.me/ns#" property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     {% endif %}
 
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}">


### PR DESCRIPTION
## Done

added a prefix to the og:image meta data - https://stackoverflow.com/questions/29769054/linkedin-not-picking-up-ogimage

## QA

- see that there is no image found on https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fubuntu.com%2Fblog%2Fdesign-and-web-team-summary-17-september-2019
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:http://0.0.0.0:8001/blog/design-and-web-team-summary-17-september-2019
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Look at the code and see the og image meta tag looks like `<meta prefix="og: http://ogp.me/ns#" property="og:image" content="https://admin.insights.ubuntu.com/wp-content/uploads/f680/Design-and-Web-Team-Blog.jpg">`


## Issue / Card

- From Alex email

## Screenshot

*from demo service, see that this works*
![image](https://user-images.githubusercontent.com/441217/65248911-44577080-daf3-11e9-80be-5d1eaa124059.png)


