### PR TITLE
Make advantage API overrideable, and set to staging in local development

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
+ADVANTAGE_API=https://contracts.staging.canonical.com/

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,6 +2,9 @@
 A Flask application for ubuntu.com
 """
 
+# Standard library
+import os
+
 # Packages
 import flask
 from canonicalwebteam.flask_base.app import FlaskBase
@@ -40,6 +43,9 @@ app = FlaskBase(
     "ubuntu.com",
     template_folder="../templates",
     static_folder="../static",
+)
+app.config["ADVANTAGE_API"] = os.getenv(
+    "ADVANTAGE_API", "https://contracts.canonical.com/"
 )
 
 # Error pages

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -1,4 +1,5 @@
 # Standard library
+import os
 from urllib.parse import quote, unquote
 
 # Packages
@@ -22,7 +23,10 @@ def login_handler():
         return flask.redirect(open_id.get_next_url())
 
     root = requests.get(
-        "https://contracts.staging.canonical.com/v1/canonical-sso-macaroon"
+        os.path.join(
+            flask.current_app.config["ADVANTAGE_API"],
+            "v1/canonical-sso-macaroon",
+        )
     ).json()["macaroon"]
 
     for caveat in Macaroon.deserialize(root).third_party_caveats():


### PR DESCRIPTION
This defaults the API URL to https://contracts.canonical.com/, but makes it overrideable with the ADVANTAGE_API environment variable.

I then set `ADVANTAGE_API=https://contracts.staging.canonical.com/` in `.env`, so that local development (and demos) will use the staging API, but when released to production it will use the production API.

**NB: This local development state is intended to be *temporary*, so we should undo it as soon as we are able to**

QA
--

`./run`, check it's using the staging API.

`docker build -t ubuntu-com . && docker run -ti -p 8001:80 ubuntu-com`, check it's using the production API.