### PR TITLE
Update iot installation media mac gunzip command

### DIFF
--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -202,7 +202,7 @@ Unlocked Encrypted
         <p class="p-stepped-list__title">
           You can now copy the image to the SD card:
         </p>
-        <pre><code>sudo sh -c 'gunzip ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
+        <pre><code>sudo sh -c 'gunzip -c ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
         <p>When finished you will see this message:</p>
         <pre><code>3719+1 records in
 3719+1 records out


### PR DESCRIPTION
## Done

- Updated the mac gunzip command to use the `-c` flag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot/installation-media
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the command reads `sudo sh -c 'gunzip -c ~/Downloads/< image file > | sudo dd of=< drive address > bs=32m'`


## Issue / Card

Fixes #5803

