### PR TITLE
Updated pricing table

### DIFF
--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -37,8 +37,8 @@
         <tr style="background-color: #e5e5e5">
           <td><strong>Phone and ticket support</strong></td>
           <td class="u-align--center"><strong>-</strong></td>
-          <td class="u-align--center"><strong>Office hours</strong> <a href="#ua-i-fn1"><sup>*</sup></a></td>
-          <td class="u-align--center"><strong>24/7</strong></td>
+          <td class="u-align--center"><strong>24x5</strong> <a href="#ua-i-fn1"><sup>*</sup></a></td>
+          <td class="u-align--center"><strong>24x7</strong></td>
         </tr>
         <tr style="background-color: #e5e5e5">
           <td>Response time SLA - Sev 1</td>
@@ -125,6 +125,12 @@
           <td class="u-align--center">Updates + support</td>
         </tr>
         <tr>
+          <td>MAAS</td>
+          <td class="u-align--center">Security updates</td>
+          <td class="u-align--center">Updates + support</td>
+          <td class="u-align--center">Updates + support</td>
+        </tr>
+        <tr>
           <td>Legal assurance program</td>
           <td class="u-align--center">-</td>
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
@@ -139,5 +145,5 @@
       </tbody>
     </table>
   </div>
-  <p id="ua-i-fn1"><sup>*</sup> <small>Minimums and exclusions apply.{{ extra|safe }}</small></p>
+  <p id="ua-i-fn1"><sup>*</sup> <small>{{ extra|safe }}</small></p>
 </div>


### PR DESCRIPTION
## Done

- Updated pricing table
    - 24x5 instead of 'office hours'
    - Added MAAS
    - Removed part of a footnote

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/infra
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#) and please reslove the edit suggestions and comments.

## Issue / Card

Fixes #5780