### PR TITLE
Add rss icon to the footer

### DIFF
--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -14,6 +14,7 @@
   $color-google:    #dc4e41;
   $color-linkedin:  #0274b3;
   $color-facebook:  #3b5898;
+  $color-rss:       #ea781a;
 
   %list-link {
     display: block;
@@ -60,6 +61,14 @@
 
         &:hover .linkedin-icon {
           fill: $color-linkedin;
+        }
+      }
+
+      &--rss {
+        @extend %list-link;
+
+        &:hover .rss-icon {
+          fill: $color-rss;
         }
       }
     }

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -9,41 +9,41 @@
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% with section=nav_sections.openstack %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% with section=nav_sections.kubernetes %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% with section=nav_sections.desktop %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
           {% with section=nav_sections.server %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% with section=nav_sections.iot %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
           {% with section=nav_sections.support %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
           {% with section=nav_sections.download %}
-            {% include 'templates/_footer_item.html' %}
+          {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
@@ -64,16 +64,16 @@
           </li>
           <ul class="second-level-nav second-level-nav-small">
             {% with section=nav_sections.security %}
-              {% include 'templates/_footer_item.html' %}
+            {% include 'templates/_footer_item.html' %}
             {% endwith %}
             {% with section=nav_sections.publiccloud %}
-              {% include 'templates/_footer_item.html' %}
+            {% include 'templates/_footer_item.html' %}
             {% endwith %}
             {% with section=nav_sections.containers %}
-              {% include 'templates/_footer_item.html' %}
+            {% include 'templates/_footer_item.html' %}
             {% endwith %}
             {% with section=nav_sections.core %}
-              {% include 'templates/_footer_item.html' %}
+            {% include 'templates/_footer_item.html' %}
             {% endwith %}
           </ul>
         </ul>
@@ -119,15 +119,15 @@
             </li>
             <li class="p-inline-list__item">
               <a class="p-link--soft" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" id="report-a-bug"><small>Report
-                  a bug on this site</small></a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-      <div class="p-footer__nav-col col-5">
-        <ul class="p-inline-list-icons">
-          <li class="p-inline-list__item">
-            <a class="p-inline-list__link--twitter" title="Follow Ubuntu on Twitter" href="https://twitter.com/ubuntu"><svg
+                a bug on this site</small></a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+        <div class="p-footer__nav-col col-5">
+          <ul class="p-inline-list-icons">
+            <li class="p-inline-list__item">
+              <a class="p-inline-list__link--twitter" title="Follow Ubuntu on Twitter" href="https://twitter.com/ubuntu"><svg
                 class="p-inline-list_icon" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 44 44">
                 <defs>
                   <style>
@@ -145,9 +145,9 @@
                 </g>
                 <path class="cls-2" d="M25.18 10.95c-2.06.636-4.04 3.464-3.42 6.664-6.834-.42-9.852-4.144-11.667-5.926-1.85 3.32.048 6.55 1.704 7.594-.874.05-1.932-.335-2.457-.67-.2 3.064 2.255 5.188 4.344 5.738-.668.203-1.297.23-2.373.067.917 3.082 3.378 3.907 5.21 4.042-2.36 2.082-5.192 2.536-8.274 2.383 7.99 4.97 16.056 1.912 19.983-1.99 3.296-3.275 4.77-8.18 4.82-12.57.756-.623 2.282-1.945 2.696-2.98-.6.236-1.792.796-3.034.846 1.023-.683 2.195-2.05 2.318-3.117-1.133.627-2.444 1.17-3.567 1.344-2.117-2.078-4.178-2.076-6.284-1.426z" />
               </svg></a>
-          </li>
-          <li class="p-inline-list__item">
-            <a class="p-inline-list__link--facebook" title="Follow Ubuntu on Facebook" href="https://www.facebook.com/ubuntulinux/"><svg
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-inline-list__link--facebook" title="Follow Ubuntu on Facebook" href="https://www.facebook.com/ubuntulinux/"><svg
                 xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32">
                 <defs>
                   <style>
@@ -165,9 +165,9 @@
                 </g>
                 <path class="cls-2" d="M18.632 5.102c-2.91 0-4.904 1.776-4.904 5.04v2.55h-3.293v3.814h3.293V26.87c1.353-.18 2.678-.53 3.942-1.045v-9.31h3.285l.492-3.812h-3.784v-2.18c0-1.104.357-2.238 1.894-1.855h2.02V5.252c-.978-.103-1.96-.154-2.943-.15h-.002z" />
               </svg></a>
-          </li>
-          <li class="p-inline-list__item">
-            <a class="p-inline-list__link--linkedin" title="Find Canonical on LinkedIn" href="https://www.linkedin.com/company/ubuntu/"><svg
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-inline-list__link--linkedin" title="Find Canonical on LinkedIn" href="https://www.linkedin.com/company/ubuntu/"><svg
                 xmlns="http://www.w3.org/2000/svg" viewbox="0 0 33 33">
                 <defs>
                   <style>
@@ -185,6 +185,30 @@
                 </g>
                 <path class="cls-2" d="M7 8.512v16.38c0 .758.63 1.37 1.404 1.37h16.192c.775 0 1.404-.612 1.404-1.37V8.512c0-.755-.63-1.37-1.404-1.37H8.404C7.63 7.143 7 7.757 7 8.513zm5.76 14.636H9.89v-8.634h2.87v8.634zm-1.435-9.812h-.02c-.962 0-1.585-.663-1.585-1.492 0-.847.642-1.492 1.624-1.492s1.586.645 1.604 1.492c0 .83-.623 1.492-1.623 1.492zm3.022 9.812s.038-7.824 0-8.634h2.87v1.252h-.02c.38-.59 1.058-1.454 2.607-1.454 1.888 0 3.303 1.234 3.303 3.885v4.95h-2.87V18.53c0-1.162-.415-1.953-1.453-1.953-.793 0-1.265.534-1.472 1.05-.076.184-.095.44-.095.7v4.82h-2.87z" />
               </svg></a>
+            </li>
+            <li class="p-inline-list__item">
+              <a class="p-inline-list__link--rss" title="Use the Ubuntu Blog rss feed" href="/blog/feed"><svg width="32px" height="32px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <defs>
+                  <style>
+                    .rss-icon {
+                      fill: #666666;
+                    }
+
+                    .cls-2 {
+                      fill: #E5E5E5;
+                    }
+                  </style>
+                </defs>
+                <g class="rss-icon">
+                  <circle id="Oval" cx="20" cy="20" r="20"></circle>
+                </g>
+                <g class="cls-2" transform="translate(10.000000, 8.000000)">
+                  <circle id="Oval" cx="3" cy="18.875" r="3"></circle>
+                  <path d="M14.5,21.875 L10.25,21.875 C10.25,16.2140813 5.66091869,11.625 3.55271368e-15,11.625 L3.55271368e-15,7.375 C8.00812887,7.375 14.5,13.8668711 14.5,21.875 Z" id="Path"></path>
+                  <path d="M17.5,21.875 C17.5,12.2100169 9.66498312,4.375 7.10542736e-15,4.375 L7.10542736e-15,0 C12.0812289,0 21.875,9.7937711 21.875,21.875 L17.5,21.875 Z" id="Path"></path>
+                </g>
+              </svg>
+            </a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

- Added an RSS social icon to the footer with a hover state

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the icon is there, turns oranage on hover, links to /blog/feed

## Issue / Card

Fixes #5799

## Screenshots

![image](https://user-images.githubusercontent.com/441217/65630415-504ca200-dfcd-11e9-900d-1aeccc099e9e.png)

![image](https://user-images.githubusercontent.com/441217/65630471-69ede980-dfcd-11e9-8252-fb928e114fbc.png)

