### PR TITLE
Update links to new juju docs

### DIFF
--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -205,7 +205,7 @@
             <li>Manual</li>
           </ul>
           <p id="fn1"><sup>*</sup> Denotes clouds that are known to Juju by default. For example, Juju knows how to reach AWS, but not an OpenStack cluster that has been created.</p>
-          <p><a class="p-link--external" href="https://docs.jujucharms.com/clouds">Find out more about Clouds in Juju</a></p>
+          <p><a class="p-link--external" href="https://jaas.ai/docs/clouds">Find out more about Clouds in Juju</a></p>
         </div>
       </li>
 
@@ -274,8 +274,8 @@ $ kubectl cluster-info</code></pre>
           <p><strong>Useful Links:</strong> Find out more about Charmed Kubernetes.</p>
           <ul style="list-style-type: disc;">
             <li><a href="/kubernetes/docs/install-manual">Manual Install&nbsp;&rsaquo;</a></li>
-            <li><a class="p-link--external" href="https://docs.jujucharms.com/maas-cloud">Find out more about MAAS as a Cloud in Juju</a></li>
-            <li><a class="p-link--external" href="https://docs.jujucharms.com/">Full Juju documentation</a></li>
+            <li><a class="p-link--external" href="https://jaas.ai/docs/maas-cloud">Find out more about MAAS as a Cloud in Juju</a></li>
+            <li><a class="p-link--external" href="https://jaas.ai/docs">Full Juju documentation</a></li>
             <li><a href="/kubernetes/docs">Full Kubernetes documentation&nbsp;&rsaquo;</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

- Updated links to new juju docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link to docs.juju... has been updated and in the [copy doc](https://docs.google.com/document/d/1oiD6UUomf2daZitS3UOosujYBXPbiOMzPtXVZBq-ph0/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1710

