### PR TITLE
kubeflow tutorial: fix broken command

### DIFF
--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -105,7 +105,7 @@
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
               <div class="p-code-copyable">
-                <input class="p-code-copyable__input" value="export VERSION='curl -s https://api.github.com/repos/kubeflow/kubeflow/releases/latest |    grep tag_name | head -1 | cut -d '&#34;' -f 4'" readonly="readonly">
+                <input class="p-code-copyable__input" value="export VERSION=$(curl -s https://api.github.com/repos/kubeflow/kubeflow/releases/latest | grep tag_name | head -n 1| cut -d '"' -f 4)" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
               <div class="p-code-copyable">

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -105,7 +105,7 @@
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
               <div class="p-code-copyable">
-                <input class="p-code-copyable__input" value="export VERSION=$(curl -s https://api.github.com/repos/kubeflow/kubeflow/releases/latest | grep tag_name | head -n 1| cut -d '"' -f 4)" readonly="readonly">
+                <input class="p-code-copyable__input" value="export VERSION=$(curl -s https://api.github.com/repos/kubeflow/kubeflow/releases/latest | grep tag_name | head -n 1| cut -d '&quot' -f 4)" readonly="readonly">
                 <button class="p-code-copyable__action">Copy to clipboard</button>
               </div>
               <div class="p-code-copyable">


### PR DESCRIPTION
## Done

Fixed a broken command in the kubeflow tutorial

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

I tested in my local browser and it works well:
![image](https://user-images.githubusercontent.com/42066843/65721265-55fac400-e06f-11e9-8112-045592009ea6.png)
I tested the copy/paste and the version is obtained correctly.

## Issue / Card
Issue not opened, here's an example of the problematic behavior
![image](https://user-images.githubusercontent.com/42066843/65720757-3fa03880-e06e-11e9-8277-07531263f7a5.png)

Fixes #

## Screenshots
With the updated command
![image](https://user-images.githubusercontent.com/42066843/65720796-55156280-e06e-11e9-86d1-2230bdda7308.png)
