### PR TITLE
Fix the contact us button in the banner

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -37,7 +37,6 @@
     overflow: hidden;
     padding-bottom: 12rem !important;
     position: relative;
-    z-index: -1;
 
     &.is-light {
       color: $color-x-dark;

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -22,7 +22,7 @@
         As an established leader in this area, Canonical has the experience to guide your 5G transformation.
       </p>
       <p>
-        <a href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Telcos - Top CTA' });" class="p-button--neutral js-invoke-modal">Contact us</a>
+        <a href="/openstack/contact-us" class="p-button--neutral js-invoke-modal">Contact us</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

- Fixed the contact us button in the banner by removing the z-index from the suru pattern

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/telecommunications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that a modal contact us opens with the top button

