### PR TITLE
K8sdocs-Fix release notes for 1.16

### DIFF
--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -16,7 +16,7 @@ toc: False
 
 # 1.16
 
-### September 23, 2019 -  [charmed-kubernetes-252](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml)
+### September 27, 2019 -  [charmed-kubernetes-252](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml)
 
 Before upgrading, please read the [upgrade notes](/kubernetes/docs/upgrade-notes).
 
@@ -66,7 +66,8 @@ for more information.
 - Docker Registry with Containerd
 
 The Docker registry charm can now be related directly to the Containerd runtime charm.
-Refer to the [documentation][docker-registry] for instructions on how to deploy the charm.
+Refer to the [documentation](/kubernetes/docs/docker-registry) for instructions
+on how to deploy the charm.
 
 ## Fixes
 


### PR DESCRIPTION
## Done

Corrcted the date and inserted a new link into the release notes.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)