### PR TITLE
Smooth suru

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -104,9 +104,9 @@
     background-blend-mode: multiply, multiply, normal, normal;
     // sass-lint:disable-block no-color-literals
     background-image:
-      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
-      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
-      linear-gradient(to bottom left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%,),
+      linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49.9%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49.9%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%),
+      linear-gradient(to bottom left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49.6%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%,),
       linear-gradient(-89deg, rgba(233, 84, 32, 1) 0%, rgba(119, 41, 83, 1) 38%, rgba(44, 0, 30, 1) 85%);
     background-position: right top, right top, right top, right top;
     background-repeat: no-repeat;

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -7,7 +7,7 @@ Ubuntu 18.04 LTS.{% endblock %}
 
 {% block content %}
 
-<section class="p-strip--suru-image">
+<section class="p-strip--suru-image is-deep">
   <div class="row">
     <div class="col-6">
       <h1 style="font-weight: 100;">Ubuntu user statistics</h1>


### PR DESCRIPTION
## Done

- tweaked `p-strip--suru-image` pattern to smooth out suru lines 
- added `is-deep` class to /desktop/statistics
  - the same suru is applied to the header strips on /desktop/statistics and /internet-of-things/digital-signage, but the former has a lot less content than the latter, which reduced the height of strip and made the suru looked pixellated. Adding `is-deep` remedies that problem.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit [/desktop/statistics](http://0.0.0.0:8001/desktop/statistics) and [/internet-of-things/digital-signage](http://0.0.0.0:8001/internet-of-things/digital-signage), and compare them to https://ubuntu.com/desktop/statistics and https://ubuntu.com/internet-of-things/digital-signage
- See that the suru patterns in the header strips are not blurry or pixellated

## Issue / Card

Fixes #5855 

## Screenshots
### Before fix:
![Screenshot 2019-09-30 at 11 55 25](https://user-images.githubusercontent.com/2376968/65873624-7aaab080-e37b-11e9-890e-87d3b50f955e.png)
![Screenshot 2019-09-30 at 11 55 42](https://user-images.githubusercontent.com/2376968/65873659-931acb00-e37b-11e9-84bf-5f830ec122b1.png)

### After fix:
![Screenshot 2019-09-30 at 11 55 06](https://user-images.githubusercontent.com/2376968/65873646-85fddc00-e37b-11e9-9f18-52cd1269d16a.png)
![Screenshot 2019-09-30 at 11 55 15](https://user-images.githubusercontent.com/2376968/65873667-9910ac00-e37b-11e9-9fc4-5b13bdc58398.png)

