### PR TITLE
update semantic error on lime telco engage page

### DIFF
--- a/templates/engage/ubuntu-lime-telco.html
+++ b/templates/engage/ubuntu-lime-telco.html
@@ -14,7 +14,7 @@
       <div>
         <h1>The future of mobile connectivity</h1>
 
-        <p class="p-heading--four u-sv2">Are mobile operators ready to adopt open source rather than proprietary technology?</p>
+        <p class="p-heading--four u-sv2">Major mobile operators are adopting open source versus proprietary technologies to reduce costs.</p>
         
         <br class="u-hide--medium u-hide--large">
 

--- a/templates/engage/ubuntu-lime-telco.html
+++ b/templates/engage/ubuntu-lime-telco.html
@@ -14,7 +14,7 @@
       <div>
         <h1>The future of mobile connectivity</h1>
 
-        <p class="p-heading--four u-sv2">Are mobile operators ready to adopt open source in favour of proprietary technology?</p>
+        <p class="p-heading--four u-sv2">Are mobile operators ready to adopt open source rather than proprietary technology?</p>
         
         <br class="u-hide--medium u-hide--large">
 


### PR DESCRIPTION
## Done

- Updated the subheading on /engage/ubuntu-lime-telco per @matthewpaulthomas's [suggestion](https://github.com/canonical-web-and-design/ubuntu.com/issues/5332).
  - the takeover mentioned in the issue is no longer in rotation and, in any case, its subheading has been changed since the issue was created.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Visit: http://0.0.0.0:8001/engage/ubuntu-lime-telco
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the subheader makes sense in context (i.e. champions open source, not proprietary technology)


## Issue / Card

Fixes #5332 
