### PR TITLE
Render the blog titles as HTML

### DIFF
--- a/static/js/latest-news.js
+++ b/static/js/latest-news.js
@@ -59,7 +59,7 @@
     }
 
     if (title) {
-      title.innerText = article.title.rendered;
+      title.innerHTML = article.title.rendered;
     }
 
     return articleFragment
@@ -72,7 +72,7 @@
       var fragment = document.importNode(template.content, true);
     } else {
       var fragment = document.createDocumentFragment();
-      
+
       for (var i = 0; i < template.childNodes.length; i++) {
         fragment.appendChild(template.childNodes[i].cloneNode(true));
       }
@@ -130,7 +130,7 @@
     oReq.send();
   }
 
-  if(typeof(window.fetchLatestNews) == "undefined") {
+  if (typeof(window.fetchLatestNews) == "undefined") {
     window.fetchLatestNews = fetchLatestNews
   }
 })()


### PR DESCRIPTION
## Done
Rendered the blog titles as HTML on the client.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open `base_index.html` line 60 and add limit as an option to the blog feed, as seen below:
```javascript
fetchLatestNews(
  {
    limit: 5,
    articlesContainerSelector: "#latest-articles",
    articleTemplateSelector: "#articles-template",
    spotlightContainerSelector: "#spotlight",
    spotlightTemplateSelector: "#spotlight-template",
    gtmEventLabel: "ubuntu.com homepage"
  }
)
```
- When reload the homepage and see the rendered blog titled "Deploying Kubernetes Locally – MicroK8s"

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5872

## Screenshots
![Screenshot_2019-10-01 The leading operating system for PCs, IoT devices, servers and the cloud Ubuntu](https://user-images.githubusercontent.com/1413534/65999774-fd279300-e495-11e9-9edd-05aa83ee4269.png)

