### PR TITLE
Add feedback links to K8s docs

### DIFF
--- a/templates/kubernetes/docs/audit-logging.md
+++ b/templates/kubernetes/docs/audit-logging.md
@@ -163,3 +163,13 @@ information about the audit webhook config format and related options.
 [k8s-audit-policy]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#policy
 [k8s-audit-log]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend
 [k8s-audit-backend]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#webhook-backend
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/audit-logging.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/auth.md
+++ b/templates/kubernetes/docs/auth.md
@@ -169,3 +169,13 @@ AWS IAM credentials can be used for authentication and authorisation on your Cha
 [docs-ldap]: /kubernetes/docs/ldap
 [roles]: #rbac
 [aws-iam]: /kubernetes/docs/aws-iam-auth
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/auth.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/aws-iam-auth.md
+++ b/templates/kubernetes/docs/aws-iam-auth.md
@@ -293,3 +293,13 @@ between calls.
 [aws-iam-role-creation]: https://github.com/kubernetes-sigs/aws-iam-authenticator#1-create-an-iam-role
 [aws-iam-authenticator-releases]: https://github.com/kubernetes-sigs/aws-iam-authenticator/releases
 [aws-iam-page]: https://console.aws.amazon.com/iam/home
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/aws-iam-auth.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -291,3 +291,13 @@ If you are an AWS user, you may also be interested in how to
 [aws-integrator-readme]: https://jujucharms.com/u/containers/aws-integrator/
 [aws-iam]: /kubernetes/docs/aws-iam-auth
 [install]: /kubernetes/docs/install-manual
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/aws-integration.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -136,3 +136,13 @@ unit-new-etcd-0:
     started: 2018-10-26 15:16:33 +0000 UTC
   unit: new-etcd/0
 ```
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/backups.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/ceph.md
+++ b/templates/kubernetes/docs/ceph.md
@@ -149,3 +149,13 @@ data-calling-wombat-mariadb-0   Bound     pvc-b1df7ac9a4bd11e8   8Gi        RWO 
 
 Now you have a **Ceph** cluster talking to your **Kubernetes** cluster. From
 here you can install any of the things that require storage out of the box.
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/ceph.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/certs-and-trust.md
+++ b/templates/kubernetes/docs/certs-and-trust.md
@@ -153,3 +153,13 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 [hacluster]: https://jujucharms.com/stable/en/hacluster
 [vault-bug-ttl]: https://bugs.launchpad.net/vault-charm/+bug/1788945
 [vault-cdk]: /kubernetes/docs/using-vault
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/certs-and-trust.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -376,3 +376,13 @@ For additional troubleshooting pointers, please see the [dedicated troubleshooti
 [bgp-multiple-subnets-bird-example]: https://gist.github.com/Cynerva/46712dd1e9b75d42cb38fb966abfa932
 [route reflection]: https://tools.ietf.org/html/rfc4456
 [AS Per Rack model]: https://docs.projectcalico.org/v3.6/networking/design/l3-interconnect-fabric#the-as-per-rack-model
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/cni-calico.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/cni-canal.md
+++ b/templates/kubernetes/docs/cni-canal.md
@@ -77,3 +77,13 @@ For additional troubleshooting pointers, please see the
 
 [canal]: https://docs.projectcalico.org/v3.7/getting-started/kubernetes/installation/flannel
 [troubleshooting]: /kubernetes/docs/troubleshooting
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/cni-canal.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/cni-flannel.md
+++ b/templates/kubernetes/docs/cni-flannel.md
@@ -74,3 +74,13 @@ For additional troubleshooting pointers, please see the [dedicated troubleshooti
 [install-manual]:  /kubernetes/docs/install-manual
 [Calico]: /kubernetes/docs/cni-calico
 [Canal]: /kubernetes/docs/cni-canal
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/cni-flannel.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/cni-overview.md
+++ b/templates/kubernetes/docs/cni-overview.md
@@ -51,3 +51,13 @@ Kubernetes, such a migration should be manageable with no downtime.
 [tigera]: /kubernetes/docs/tigera-secure-ee
 [install]: /kubernetes/docs/install-manual
 [federation]: https://github.com/kubernetes-sigs/kubefed
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/cni-overview.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/container-runtime.md
+++ b/templates/kubernetes/docs/container-runtime.md
@@ -78,3 +78,13 @@ juju relate docker kubernetes-worker-docker
 <!-- LINKS -->
 
 [docker2containerd]: /kubernetes/docs/upgrade-notes#1.15
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/container-runtime.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/custom-loadbalancer.md
+++ b/templates/kubernetes/docs/custom-loadbalancer.md
@@ -59,3 +59,13 @@ juju config kubernetes-master loadbalancer-ips="192.168.1.1 192.168.2.1"
 ```
 
 Multiple IP addresses should be given as a space-separated list.
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/custom-loadbalancer.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/decommissioning.md
+++ b/templates/kubernetes/docs/decommissioning.md
@@ -125,3 +125,13 @@ users:
     password: sZVKhY7bZK8oG7vLkkOssNhTzKZlBmcG
     username: admin
 ```
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/decommissioning.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -207,3 +207,13 @@ juju config kubernetes-master addons-registry=$REGISTRY
 [registry-charm]: http://jujucharms.com/u/containers/docker-registry
 [upstream-registry]: https://docs.docker.com/registry/
 [quickstart]: /kubernetes/docs/quickstart
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/docker-registry.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/encryption-at-rest.md
+++ b/templates/kubernetes/docs/encryption-at-rest.md
@@ -74,3 +74,13 @@ storage pool, or even full-disk-encryption on the host machine.
 [VaultLocker]: https://github.com/openstack-charmers/vaultlocker
 [Vault charm]: https://jujucharms.com/u/openstack-charmers-next/vault/
 [unseal]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-vault.html#initialize-and-unseal-vault
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/encryption-at-rest.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/gcp-integration.md
+++ b/templates/kubernetes/docs/gcp-integration.md
@@ -325,3 +325,13 @@ juju debug-log --replay --include gcp-integrator/0
 [gcp-integrator-readme]: https://jujucharms.com/u/containers/gcp-integrator/
 [target-pool]: https://cloud.google.com/load-balancing/docs/target-pools
 [install]: /kubernetes/docs/install-manual
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/gcp-integration.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/get-in-touch.md
+++ b/templates/kubernetes/docs/get-in-touch.md
@@ -53,3 +53,13 @@ Canonical can also provide [managed solutions][managed] for Kubernetes.
 [managed]: /kubernetes/managed
 [slack]: http://slack.kubernetes.io/
 [source]: https://github.com/charmed-kubernetes
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/get-in-touch.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/gpu-workers.md
+++ b/templates/kubernetes/docs/gpu-workers.md
@@ -163,3 +163,13 @@ find the hardware report.
 [quickstart]: /kubernetes/docs/quickstart
 [aws-instance]: https://aws.amazon.com/ec2/instance-types/
 [azure-instance]: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/gpu-workers.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/hacluster.md
+++ b/templates/kubernetes/docs/hacluster.md
@@ -65,3 +65,13 @@ juju scp kubernetes-master/0:config ~/.kube/config
 
 [keepalived]: /kubernetes/docs/keepalived
 [maas]: https://maas.io
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/hacluster.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/high-availability.md
+++ b/templates/kubernetes/docs/high-availability.md
@@ -112,3 +112,13 @@ software to enable HA
 [hacluster]: /kubernetes/docs/hacluster
 [metallb]: /kubernetes/docs/metallb
 [customlb]: /kubernetes/docs/custom-loadbalancer
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/high-availability.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -179,3 +179,13 @@ newgrp lxd
 [snap]: https://snapcraft.io/docs/installing-snapd
 [install]: /kubernetes/docs/install-manual
 [operations]: /kubernetes/docs/operations
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/install-local.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -452,3 +452,13 @@ Now you have a cluster up and running, check out the
 [gcp-docs]: /kubernetes/docs/gcp-integration
 [operations]: /kubernetes/docs/operations
 [localhost]: /kubernetes/docs/install-local
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/install-manual.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/kata.md
+++ b/templates/kubernetes/docs/kata.md
@@ -124,3 +124,13 @@ spec:
 
 [containerd]: /kubernetes/docs/container-runtime
 [kata]: https://katacontainers.io
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/kata.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/keepalived.md
+++ b/templates/kubernetes/docs/keepalived.md
@@ -85,3 +85,13 @@ balancer.
 [SAN]: https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name
 [logging-doc]: /kubernetes/docs/logging
 [subordinate-charm]: https://docs.jujucharms.com/stable/en/authors-subordinate-applications
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/keepalived.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -287,3 +287,13 @@ configuring Keystone/LDAP.
 [keystone-bundle]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/keystone.yaml
 [docs-ldap-keystone]: https://jujucharms.com/keystone-ldap
 [trouble]: /kubernetes/docs/troubleshooting/#troubleshooting-keystoneldap-issues
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/ldap.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/logging.md
+++ b/templates/kubernetes/docs/logging.md
@@ -160,3 +160,13 @@ the following:
 
 [juju-logging]: https://docs.jujucharms.com/stable/en/troubleshooting-logs
 [k8-logs]: https://kubernetes.io/docs/concepts/cluster-administration/logging/
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/logging.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -58,3 +58,13 @@ Further configuration can be performed by using a [MetalLB configmap][configmap]
 [bgp]: https://tools.ietf.org/html/rfc1105
 [helm]: /kubernetes/docs/helm
 [configmap]: https://metallb.universe.tf/configuration/
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/metallb.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -219,3 +219,13 @@ juju status kibana --format yaml| grep public-address
 [nagios]: https://www.nagios.org/
 [elastic]: https://www.elastic.co/
 [external-nagios]: https://jujucharms.com/nrpe/
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/monitoring.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/openstack-integration.md
+++ b/templates/kubernetes/docs/openstack-integration.md
@@ -264,3 +264,13 @@ juju debug-log --replay --include openstack-integrator/0
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [openstack-integrator-readme]: https://jujucharms.com/u/containers/openstack-integrator/
 [install]: /kubernetes/docs/install-manual
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/openstack-integration.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/operations.md
+++ b/templates/kubernetes/docs/operations.md
@@ -298,3 +298,13 @@ things you may wish to try:
 [decommission]: /kubernetes/docs/decommissioning
 [get-in-touch]:  /kubernetes/docs/get-in-touch
 [bundle-source]: https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-3/archive/bundle.yaml?channel=stable
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/operations.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -62,3 +62,13 @@ additional configuration or hassle.
 [maas]: https://maas.io
 [cdk]: /kubernetes
 [juju]: https://jujucharms.com
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/overview.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -166,3 +166,13 @@ Google. You can see which ones are ready to use by running this command:
 [cloud-azure]: https://azure.microsoft.com/
 [cloud-joyent]: https://www.joyent.com/
 [storage]: /kubernetes/docs/storage
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/quickstart.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/release-notes-historic.md
+++ b/templates/kubernetes/docs/release-notes-historic.md
@@ -184,3 +184,13 @@ For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy` J
 [docs-ear]: /kubernetes/docs/encryption-at-rest
 [docs-keepalived]: /kubernetes/docs/keepalived
 [docs-registry]: /kubernetes/docs/docker-registry
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/release-notes-historic.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -66,8 +66,7 @@ for more information.
 - Docker Registry with Containerd
 
 The Docker registry charm can now be related directly to the Containerd runtime charm.
-Refer to the [documentation](/kubernetes/docs/docker-registry) for instructions
-on how to deploy the charm.
+Refer to the [documentation](/kubernetes/docs/docker-registry) for instructions on how to deploy the charm.
 
 ## Fixes
 
@@ -99,17 +98,17 @@ A list of bug fixes and other minor feature updates in this release can be found
 
 - Containerd support
 
-Although Docker is still supported, [containerd](https://containerd.io/) is now
+Although Docker is still supported, [containerd](https://containerd.io/) is now 
 the default container runtime in Charmed Kubernetes. Containerd brings significant
 [peformance improvements](https://kubernetes.io/blog/2018/05/24/kubernetes-containerd-integration-goes-ga/)
 and prepares the way for Charmed Kubernetes integration with
 [Kata](https://katacontainers.io/) in the future.
 
 Container runtime code has been moved out of the kubernetes-worker charm, and
-into subordinate charms (one for Docker and one for containerd). This allows
+into subordinate charms (one for Docker and one for containerd). This allows 
 the operator to swap the container runtime as desired, and even mix
 container runtimes within a cluster. It also allows for additional container
-runtimes to be supported in the future. Because this is a significant change, you
+runtimes to be supported in the future. Because this is a significant change, you 
 are advised to read the [upgrade notes](/kubernetes/docs/upgrade-notes) before
 upgrading from a previous version.
 
@@ -357,3 +356,13 @@ Please see [this page][historic] for release notes of earlier versions.
 [cni-calico]: /kubernetes/docs/cni-calico
 [containerd]: /kubernetes/docs/containerd
 [container-runtime]: /kubernetes/docs/container-runtime
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/release-notes.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/scaling.md
+++ b/templates/kubernetes/docs/scaling.md
@@ -173,3 +173,13 @@ For a more detailed guide, please refer to the [Juju high availability documenta
 
 [juju-ha]: https://docs.jujucharms.com/stable/en/controllers-ha
 [juju-constraints]: https://docs.jujucharms.com/stable/en/reference-constraints
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/scaling.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/snap-refresh.md
+++ b/templates/kubernetes/docs/snap-refresh.md
@@ -102,3 +102,13 @@ juju run --unit kubernetes-master/0 'snap refresh cdk-addons'
 
 [layer-snap]: https://git.launchpad.net/layer-snap
 [system-snap-opts]: https://forum.snapcraft.io/t/system-options/87
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/snap-refresh.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -176,7 +176,7 @@ juju add-storage ceph-osd/2 --storage osd-devices=32G,2
 
 ### Using a separate Juju model
 
-In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kuberentes**.
+In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kubernetes**.
 
 For more information on how to achieve this, please see the [Juju documentation][juju-cmr] on cross-model relations.
 
@@ -240,9 +240,9 @@ There is no requirement that these additional units should have the same amount 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/storage.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/storage.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -176,7 +176,7 @@ juju add-storage ceph-osd/2 --storage osd-devices=32G,2
 
 ### Using a separate Juju model
 
-In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kubernetes**.
+In some circumstances it can be useful to locate the persistent storage in a different **Juju** model, for example to have one set of storage used by different clusters. The only change required is in adding relations between **Ceph** and **Charmed Kuberentes**.
 
 For more information on how to achieve this, please see the [Juju documentation][juju-cmr] on cross-model relations.
 
@@ -236,3 +236,13 @@ There is no requirement that these additional units should have the same amount 
 [ceph-charm]: https://jujucharms.com/ceph-osd/
 [juju-storage]: https://docs.jujucharms.com/stable/en/charms-storage
 [juju-cmr]: https://docs.jujucharms.com/stable/en/models-cmr
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/storage.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/tigera-secure-ee.md
+++ b/templates/kubernetes/docs/tigera-secure-ee.md
@@ -227,3 +227,13 @@ juju config tigera-secure-ee registry=$REGISTRY
 [tigera byo-elasticsearch]: https://docs.tigera.io/v2.2/getting-started/kubernetes/installation/byo-elasticsearch
 [storage]: /kubernetes/docs/storage
 [private docker registry]: /kubernetes/docs/docker-registry
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/tigera-secure-ee.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/troubleshooting.md
+++ b/templates/kubernetes/docs/troubleshooting.md
@@ -103,13 +103,15 @@ This will automatically ssh you to the easyrsa unit.
 
 ## Collecting debug information
 
-Sometimes it is useful to collect all the information from a cluster to share with a developer to identify problems. This is best accomplished with
-[CDK Field Agent](https://github.com/charmed-kubernetes/cdk-field-agent).
+To collect comprehensive debug output from your Charmed Kubernetes cluster, install and run
+[juju-crashdump](https://github.com/juju/juju-crashdump) on a computer that has the Juju client installed, with the current controller and model pointing at your Charmed Kubernetes deployment.
 
-Download and execute the collect.py script from
-[CDK Field Agent](https://github.com/charmed-kubernetes/cdk-field-agent) on a box that has a Juju client configured with the current controller and model pointing at the Charmed Kubernetes deployment of interest.
+```bash
+sudo snap install juju-crashdump --classic --channel edge
+juju-crashdump -a debug-layer -a config
+```
 
-Running the script will generate a tarball of system information and includes basic information such as systemctl status, Juju logs, charm unit data, etc. Additional application-specific information may be included as well.
+Running the `juju-crashdump` script will generate a tarball of debug information that includes systemd unit status and logs, Juju logs, charm unit data, and Kubernetes cluster information. It is recommended that you include this tarball when [filing a bug](https://bugs.launchpad.net/charmed-kubernetes). 
 
 ## Common Problems
 
@@ -401,3 +403,13 @@ such as timeouts or errors with the webhook.
 ```bash
 juju run --unit kubernetes-master/0 -- journalctl -u snap.kube-apiserver.daemon.service
 ```
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/troubleshooting.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -295,3 +295,13 @@ You can now proceed with the rest of the upgrade.
 [script]: https://raw.githubusercontent.com/juju-solutions/cdk-etcd-2to3/master/migrate
 [dns-provider-config]: https://github.com/juju-solutions/kubernetes/blob/5f4868af82705a0636680a38d7f3ea760d35dadb/cluster/juju/layers/kubernetes-master/config.yaml#L58-L67
 [docker-page]: https://jaas.ai/u/containers/docker#configuration
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/upgrade-notes.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -414,3 +414,13 @@ kube-system                       monitoring-influxdb-grafana-v4-65cc9bb8c8-mwvc
 [snap-channels]: https://docs.snapcraft.io/reference/channels
 [blue-green]: https://martinfowler.com/bliki/BlueGreenDeployment.html
 [validation]: /kubernetes/docs/validation
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/upgrading.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/using-vault.md
+++ b/templates/kubernetes/docs/using-vault.md
@@ -233,3 +233,13 @@ relations:
 [csr]: https://en.wikipedia.org/wiki/Certificate_signing_request
 [leadership]: https://docs.jujucharms.com/stable/en/authors-charm-leadership
 [cdk-bundle]: https://jujucharms.com/charmed-kubernetes
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/using-vault.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/validation.md
+++ b/templates/kubernetes/docs/validation.md
@@ -174,3 +174,13 @@ juju upgrade-charm kubernetes-e2e
 <!--LINKS -->
 
 [e2e-upstream]: https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md#kinds-of-tests
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/validation.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>


### PR DESCRIPTION
## Done

- Add a feedback link to the bottom of every page
- update crash-reporting section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

Feedback section should look something like this:

![image](https://user-images.githubusercontent.com/115290/66039609-436c0900-e50d-11e9-8882-3a78e4ecba8f.png)


