### PR TITLE
Deep tech webinar takeover & engage

### DIFF
--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -1,0 +1,23 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Accelerating deep tech with Ubuntu"
+     meta_description: ""
+     meta_image: https://assets.ubuntu.com/v1/e93f66b3-deeptech.jpg
+     meta_copydoc: "https://docs.google.com/document/d/1guBMZs8ymlZ2sk5R84hYFLhQBIDhKKll9lsg9rHS854/edit"
+     header_title: "Accelerating deep tech with Ubuntu"
+     header_subtitle: ""
+     header_image: "https://assets.ubuntu.com/v1/3f8c22da-Deep+tech+ubuntu+-+light.svg"
+     header_url: '#register-section'
+     header_cta: Register for the webinar
+     header_class: p-engage-banner--aqua
+     header_lang: en
+     webinar_code: ''
+     form_include:
+     form_id:
+     form_return_url:
+---
+
+Deep tech can be characterised as risky, challenging, innovative technologies that solve real world problems. Whilst the term is not yet ubiquitous, emerging areas of deep tech today include autonomous vehicles, Internet of Things, robots, deep learning and virtual reality as well as some underlying enabling technologies. Three attributes in particular characterise deep tech: the potential impact they can have on society, the long development time they need to reach market-readiness and the significant amount of capital required to develop and scale.
+
+Ubuntu was created on the premise that future innovation would be primarily software-driven and that to foster innovation, it is necessary to empower innovators with free open source software. In this webinar, we will discuss how innovators can leverage Ubuntu as a platform to realise the potential of their technology endeavours and share examples of exciting deep tech innovations that are being delivered on Ubuntu.

--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -5,7 +5,7 @@ context:
      meta_description: ""
      meta_image: https://assets.ubuntu.com/v1/e93f66b3-deeptech.jpg
      meta_copydoc: "https://docs.google.com/document/d/1guBMZs8ymlZ2sk5R84hYFLhQBIDhKKll9lsg9rHS854/edit"
-     header_title: "Accelerating deep tech with Ubuntu"
+     header_title: "Accelerating deep tech <br class='u-hide--small' />with Ubuntu"
      header_subtitle: ""
      header_image: "https://assets.ubuntu.com/v1/3f8c22da-Deep+tech+ubuntu+-+light.svg"
      header_url: '#register-section'

--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -12,10 +12,7 @@ context:
      header_cta: Register for the webinar
      header_class: p-engage-banner--aqua
      header_lang: en
-     webinar_code: ''
-     form_include:
-     form_id:
-     form_return_url:
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 365534, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---
 
 Deep tech can be characterised as risky, challenging, innovative technologies that solve real world problems. Whilst the term is not yet ubiquitous, emerging areas of deep tech today include autonomous vehicles, Internet of Things, robots, deep learning and virtual reality as well as some underlying enabling technologies. Three attributes in particular characterise deep tech: the potential impact they can have on society, the long development time they need to reach market-readiness and the significant amount of capital required to develop and scale.

--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -2,7 +2,7 @@
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "Accelerating deep tech with Ubuntu"
-     meta_description: ""
+     meta_description: "How innovators are leveraging open source to create life-changing tech."
      meta_image: https://assets.ubuntu.com/v1/e93f66b3-deeptech.jpg
      meta_copydoc: "https://docs.google.com/document/d/1guBMZs8ymlZ2sk5R84hYFLhQBIDhKKll9lsg9rHS854/edit"
      header_title: "Accelerating deep tech <br class='u-hide--small' />with Ubuntu"

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1111,8 +1111,20 @@
             <p class='u-no-padding--bottom u-hide--small'>This webinar will dive into what success looks like when deploying machine learning models, including training, at scale.</p>
           </div>
         </div>
+
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--desktop'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              webinar
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/deeptech'>Accelerating deep tech with Ubuntu</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>How innovators are leveraging open source to create life-changing tech.</p>
+          </div>
+        </div>
       </div>
-
-
     </section>
     {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
   {# ALL #}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_buy-ubuntu-advantage.html" %}
-  {% include "takeovers/_get-started-with-ai-part-2.html" %}
+  {% include "takeovers/_deep-tech-webinar-takeover.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_deep-tech-webinar-takeover.html
+++ b/templates/takeovers/_deep-tech-webinar-takeover.html
@@ -1,0 +1,15 @@
+{% with title="Accelerating deep tech with Ubuntu",
+subtitle="How innovators are leveraging open source to create life-changing tech",
+class="p-takeover--aqua",
+header_image="https://assets.ubuntu.com/v1/3f8c22da-Deep+tech+ubuntu+-+light.svg",
+image_style="",
+image_hide_small=true,
+equal_cols="true",
+primary_url="/engage/deeptech?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Ubuntu Core_WBN_Deeptech",
+primary_cta="Register for the webinar",
+primary_cta_class="p-button--neutral",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+  {% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -26,6 +26,7 @@
 {% include "takeovers/_core18-security_takeover.html" %}
 {% include "takeovers/_desktop-developer-takeover.html" %}
 {% include "takeovers/_de-vmware-to-os.html" %}
+{% include "takeovers/_deep-tech-webinar-takeover.html" %}
 {% include "takeovers/_devops-iot-webinar_takeover.html" %}
 {% include "takeovers/_edge-month_takeover.html" %}
 {% include "takeovers/_financial-services.html" %}


### PR DESCRIPTION
## Done

- added Deep Tech takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see a takeover with the title "Accelerating deep tech with Ubuntu"
  - See that the takeover matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1751#issuecomment-537438531) and the [brief](https://docs.google.com/spreadsheets/d/1z7Dojp0ZXFgLFz9oPwNopvNPdMifTPRUoI-WtckGE84/edit#gid=2113339190)
- Follow the link on the takeover to the engage page
    - See that the page matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1751#issuecomment-537438531) and the [copy doc](https://docs.google.com/document/d/1guBMZs8ymlZ2sk5R84hYFLhQBIDhKKll9lsg9rHS854/edit?usp=sharing)
- Test the engage page on https://cards-dev.twitter.com/validator and see that Twitter card preview includes a title, image and description.


## Issue / Card

Fixes #5868
