### PR TITLE
Remove trailing slashes from local links

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -9,7 +9,7 @@
       <div class="col-6">
         <h1>Ubuntu Desktop for&nbsp;developers</h1>
         <p>Whether you&rsquo;re a mobile app developer, an engineering manager, a music or video editor or a financial analyst with large-scale models to run &mdash; in fact, anyone in need of a powerful machine for your work &mdash; Ubuntu is the ideal platform.</p>
-        <p><a href="/download/desktop/" class="p-button--positive">Get Ubuntu now</a></p>
+        <p><a href="/download/desktop" class="p-button--positive">Get Ubuntu now</a></p>
       </div>
       <div class="col-6 u-vertically-center u-align--center u-hide--small">
         {{
@@ -213,7 +213,7 @@
           <p class="p-pull-quote__quote">Ubuntu has been the perfect OS given its popularity with developers and its cloud capabilities. That&rsquo;s why it&rsquo;s preloaded on the 4th generation of our XPS 13 laptop and our new Precision M3800 Mobile Workstation.</p>
           <cite class="p-pull-quote__citation">Barton George, Director of developer programs at Dell services</cite>
         </blockquote>
-        <p><a href="/blog/designed-for-developers-dell-launches-two-new-ubuntu-based-systems/" class="p-link--external">Learn more about Dell&rsquo;s developer edition line</a></p>
+        <p><a href="/blog/designed-for-developers-dell-launches-two-new-ubuntu-based-systems" class="p-link--external">Learn more about Dell&rsquo;s developer edition line</a></p>
       </div>
     </div>
   </section>
@@ -237,7 +237,7 @@
       <div class="col-6">
         <h2>Support tailored to developers&rsquo; needs</h2>
         <p>With Ubuntu Advantage and Landscape, you can standardise your developer workstations. It helps you manage updates, security patches, and reporting, while minimising downtime. Give your developers the freedom they want while retaining the control you need.</p>
-        <p><a href="/support/">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+        <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 col-start-large-8 u-hide--small">
         <img src="https://assets.ubuntu.com/v1/4125e046-landscape_activity.png?w=413" width="413" alt="" />

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -38,21 +38,21 @@
         <p class="p-pull-quote__quote">We are happy about this partnership as our customers in India will have access to Ubuntu preloaded Thinkpad L450 laptop series.</p>
         <cite class="p-pull-quote__citation">Rahul Agarwal, Managing Director at Lenovo India</cite>
       </blockquote>
-      <p><a href="/blog/ubuntu-to-ship-on-lenovo-laptops-in-india/" class="p-link--external">Read the full article <span class="u-off-screen"> 'Ubuntu to ship on Lenovo laptops in India'</span></a></p>
+      <p><a href="/blog/ubuntu-to-ship-on-lenovo-laptops-in-india" class="p-link--external">Read the full article <span class="u-off-screen"> 'Ubuntu to ship on Lenovo laptops in India'</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <blockquote class="p-pull-quote">
         <p class="p-pull-quote__quote">Ubuntu has been the perfect OS from the start given its popularity with developers and its cloud capabilities.</p>
         <cite class="p-pull-quote__citation">Barton George, Director of developer programs at Dell services</cite>
       </blockquote>
-      <p><a href="/blog/designed-for-developers-dell-launches-two-new-ubuntu-based-systems/" class="p-link--external">Read the full article<span class="u-off-screen"> 'Designed for developers &mdash; Dell launches two new Ubuntu-based systems'</span></a></p>
+      <p><a href="/blog/designed-for-developers-dell-launches-two-new-ubuntu-based-systems" class="p-link--external">Read the full article<span class="u-off-screen"> 'Designed for developers &mdash; Dell launches two new Ubuntu-based systems'</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <blockquote class="p-pull-quote">
         <p class="p-pull-quote__quote">This is another milestone in our productive partnership with Canonical with the introduction of the the Intel<sup>&reg;</sup> Compute Stick with Ubuntu.</p>
         <cite class="p-pull-quote__citation">Joel Christensen, General Manager of Intel NUC and Intel Compute Stick Products</cite>
       </blockquote>
-      <p><a href="/blog/intel-compute-stick-now-comes-with-ubuntu/" class="p-link--external">Read the full article<span class="u-off-screen"> 'Intel Compute Stick now comes with Ubuntu'</span></a></p>
+      <p><a href="/blog/intel-compute-stick-now-comes-with-ubuntu" class="p-link--external">Read the full article<span class="u-off-screen"> 'Intel Compute Stick now comes with Ubuntu'</span></a></p>
     </div>
   </div>
 </section>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -27,7 +27,7 @@
           {% else %}
           <p>
             You didn&rsquo;t pick a version or architecture, please
-            <a href="/download/server/">select again</a>.
+            <a href="/download/server">select again</a>.
           </p>
           {% endif %}
         </div>

--- a/templates/engage/14-04-esm.html
+++ b/templates/engage/14-04-esm.html
@@ -83,8 +83,8 @@
       <div class="col-4 p-divider__block">
         <h3 class="p-heading--four">Further reading</h3>
         <ul class="p-list">
-          <li class="p-list__item"><a href="/blog/ubuntu-14-04-trusty-tahr/">Ubuntu 14.04 Trusty Tahr ESM&nbsp;&rsaquo;</a></li>
-          <li class="p-list__item"><a href="/blog/ubuntu-security-compliance/">Ubuntu, security & compliance&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="/blog/ubuntu-14-04-trusty-tahr">Ubuntu 14.04 Trusty Tahr ESM&nbsp;&rsaquo;</a></li>
+          <li class="p-list__item"><a href="/blog/ubuntu-security-compliance">Ubuntu, security & compliance&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="/blog/legacy-applications-secure-extended-security-maintenance">Keep legacy applications secure with Extended Security Maintenance&nbsp;&rsaquo;</a></li>
           <li class="p-list__item"><a href="/blog/extended-security-maintenance-ubuntu-14-04-trusty-tahr">Announcing Extended Security Maintenance for Ubuntu 14.04 LTS – “Trusty Tahr”&nbsp;&rsaquo;</a></li>
         </ul>

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -103,7 +103,7 @@
         </div>
         <h3>Streamline business with containers for legacy apps</h3>
         <p>Discover how Linux container technologies offer control and flexible provisioning while driving greater density, efficiency and manageability, without additional hardware or infrastructure investment. Different approaches work for next-generation apps and legacy apps. Ubuntu has them all.</p>
-        <p><a href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Accelerate your business with containers', 'eventValue' : undefined });">Download whitepaper&nbsp;&rsaquo;</a></p>
+        <p><a href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Accelerate your business with containers', 'eventValue' : undefined });">Download whitepaper&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center">
         <img src="https://assets.ubuntu.com/v1/a9aff224-Containers-illustration.svg" width="234" alt="" />

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -93,7 +93,7 @@
       <p>
         Enterprise support for Kubernetes on Ubuntu is provided by Canonical as part of an <a href="/pricing/infra">Ubuntu Advantage for Infrastructure</a> (<abbr title="Ubuntu Advantage for Infrastructure">UA-I</abbr>) support subscription on a large range of substrates. UA-I also includes long-term security maintenance, kernel live patching and mission-critical infrastructure support for the full stack, from kernel to container. Canonical supports K8s on Ubuntu on public clouds, VMware, OpenStack and bare metal.
       </p>
-      <p><a href="/pricing/infra/">Learn more about UA-I&nbsp;&rsaquo;</a></p>
+      <p><a href="/pricing/infra">Learn more about UA-I&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 col-start-large-9 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/ca4cff60-pictogram_support01b.svg" alt="" width="200" />
@@ -288,7 +288,7 @@
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a class="p-link--external" href="/blog/webinar-how-to-get-started-with-your-kubernetes-strategy/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'How to get started with your Kubernetes strategy', 'eventValue' : undefined });">How to get started with your Kubernetes strategy</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="/blog/webinar-how-to-get-started-with-your-kubernetes-strategy" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'How to get started with your Kubernetes strategy', 'eventValue' : undefined });">How to get started with your Kubernetes strategy</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
@@ -297,7 +297,7 @@
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a class="p-link--external" href="/blog/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="/blog/kubernetes-for-the-enterprise-1-2-3-go" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
@@ -306,7 +306,7 @@
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a class="p-link--external" href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Kubernetes resource', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -73,7 +73,7 @@
               <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg" width="32" alt="" />
               <h4 class="p-heading-icon__title">Webinar</h4>
             </div>
-            <h3 class="p-heading--four"><a class="p-link--external" href="/blog/kubernetes-for-the-enterprise-1-2-3-go/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
+            <h3 class="p-heading--four"><a class="p-link--external" href="/blog/kubernetes-for-the-enterprise-1-2-3-go" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
           </div>
         </div>
         <div class="col-4 p-divider__block">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -170,7 +170,7 @@
       <li class="p-list__item is-ticked">Ubuntu Advantage for infrastructure &mdash; predictable per-node support and security</li>
       <li class="p-list__item is-ticked">Managed services available for both OpenStack and Kubernetes</li>
     </ul>
-    <p><a href="/openstack/features/" class="p-button--positive">Learn about Canonical OpenStack features</a></p>
+    <p><a href="/openstack/features" class="p-button--positive">Learn about Canonical OpenStack features</a></p>
   </div>
 </section>
 

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -27,7 +27,7 @@
           <li class="p-list__item is-ticked">SDN</li>
           <li class="p-list__item is-ticked">Storage</li>
         </ul>
-        <p><a class="p-button--neutral is-wide" href="/pricing/infra/">See our services</a></p>
+        <p><a class="p-button--neutral is-wide" href="/pricing/infra">See our services</a></p>
         <p><a class="p-button--positive is-wide" href="https://buy.ubuntu.com/"><span class="p-link--external">Purchase from the store</span></a>
       </div>
       <div class="col-4 p-card">
@@ -52,7 +52,7 @@
           <li class="p-list__item is-ticked">Kubernetes</li>
           <li class="p-list__item is-ticked">Kubeflow</li>
         </ul>
-        <p><a class="p-button--neutral is-wide" href="/pricing/consulting/">Dive in with Canonical</a></p>
+        <p><a class="p-button--neutral is-wide" href="/pricing/consulting">Dive in with Canonical</a></p>
       </div>
     </div>
   </section>

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -50,7 +50,7 @@
       <hr class="u-sv1" />
       <div class="p-card__content u-no-margin--top">
         <h3 class="p-heading--four">
-          <a href="/blog/certified-ubuntu-cloud-guest-the-best-of-ubuntu-on-the-best-clouds/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Ubuntu cloud guest', 'eventLabel' : 'from ubuntu.com/public-cloud', 'eventValue' : undefined });">
+          <a href="/blog/certified-ubuntu-cloud-guest-the-best-of-ubuntu-on-the-best-clouds" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Ubuntu cloud guest', 'eventLabel' : 'from ubuntu.com/public-cloud', 'eventValue' : undefined });">
             Ubuntu cloud guest
           </a>
         </h3>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -167,7 +167,7 @@
       <h2>Find out why the UK Government puts Ubuntu in first place for security</h2>
       <p><abbr title="Communications-Electronics Security Group">CESG</abbr>, the security arm of the UK government rated Ubuntu as the most secure operating system of the 11 they tested.</p>
       <p>For the first time, both a <abbr title="Defence Industry Security Association">DISA</abbr> approved <abbr title="Security Technical Implementation Guide">STIG</abbr> and a <abbr title="Center for Internet Security">CIS</abbr> Benchmark are available for Ubuntu 16.04 LTS. This is in addition to the CIS Benchmark already available for 14.04 LTS.</p>
-      <a class="p-button--neutral" href="/blog/ubuntu-scores-highest-in-uk-gov-security-assessment/"><span class="p-link--external">Read the <span class="u-off-screen">UK Gov Report Summary </span>case study</span></a>
+      <a class="p-button--neutral" href="/blog/ubuntu-scores-highest-in-uk-gov-security-assessment"><span class="p-link--external">Read the <span class="u-off-screen">UK Gov Report Summary </span>case study</span></a>
     </div>
     <div class="col-5 u-align--center">
       <img class="u-image-position--top u-hide--small u-hide--medium u-no-margin--top" alt="" src="https://assets.ubuntu.com/v1/4107dc1c-image-ubuntu-medal.png" width="160" />

--- a/templates/shared/contextual_footers/_maas-faq.html
+++ b/templates/shared/contextual_footers/_maas-faq.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">MAAS FAQ</h3>
   <p>Top 10 questions about MAAS. Your guide to MAAS, bare metal provisioning, and more.</p>
-  <p><a href="/blog/top-10-questions-about-maas/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Download MAAS datasheet', 'eventValue' : undefined });" class="p-link--external">Download MAAS datasheet</a></p>
+  <p><a href="/blog/top-10-questions-about-maas" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'MAAS page', 'eventLabel' : 'Download MAAS datasheet', 'eventValue' : undefined });" class="p-link--external">Download MAAS datasheet</a></p>
 </div>

--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -58,7 +58,7 @@
           <h4 class="p-heading--four is-dense u-hide--small">Governance</h4>
           <h4 class="p-muted-heading u-hide--medium u-hide--large">Governance</h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/community/governance/">Project Governance</a></li>
+            <li class="p-list__item"><a href="/community/governance">Project Governance</a></li>
             <li class="p-list__item"><a href="https://community.ubuntu.com/t/what-is-the-ubuntu-community-council/706">Community Council</a></li>
             <li class="p-list__item"><a href="/community/diversity">Diversity policy</a></li>
           </ul>


### PR DESCRIPTION
'Cos trailing slashes mean redirects. Bad for performance.

I used this magic incantation:

``` bash
find templates -name '*.html' -exec sed -i -E 's|href="([^:]+)/"|href="\1"|g' {} \;
```

QA
--

Either with `./run` or on the demo - go to some pages where I changed links, check the links still work.