### PR TITLE
Optimise Disco Dingo SVG pictogram

### DIFF
--- a/templates/_docs/strips.html
+++ b/templates/_docs/strips.html
@@ -70,7 +70,7 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/db6764bc-disco-dingo-grad.svg" width="216" alt="" />
+      <img src="https://assets.ubuntu.com/v1/6c0f3ca0-disco-dingo.svg" width="216" alt="Disco Dingo pictogram" />
     </div>
   </div>
 </section>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -30,7 +30,7 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/db6764bc-disco-dingo-grad.svg" width="216" alt="" />
+      <img src="https://assets.ubuntu.com/v1/6c0f3ca0-disco-dingo.svg" width="216" alt="Disco Dingo pictogram" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Optimise Disco Dingo pictogram as it's on `/download` - most traffic-ed page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/

## Screenshots

<img width="388" alt="Screenshot 2019-10-04 at 10 03 32" src="https://user-images.githubusercontent.com/505570/66195427-7ab5f380-e68e-11e9-9e52-859485b76b0e.png">


