### PR TITLE
Corrects links, adds alt=, removes redundant headings

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -26,12 +26,12 @@
   </div>
   <div class="row u-equal-height">
     <div class="p-card col-4">
-      <h4>Google Cloud Platform</h4>
-      <hr class="u-sv1" />
       <div class="p-card__content">
-        <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=211" width="211" alt="" style="align-self: center;max-height: 10rem;">
-        </a>
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
+            <img src="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=211" width="211" alt="Google Cloud Platform" style="align-self: center;max-height: 10rem;">
+          </a>
+        </h4>
         <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
       </div>
       <ul class="p-list">
@@ -40,12 +40,12 @@
       </ul>
     </div>
     <div class="p-card col-4">
-      <h4>Amazon Web Services</h4>
-      <hr class="u-sv1" />
       <div class="p-card__content">
-        <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg" width="160" alt="" style="align-self: center;max-height: 10rem; max-width:10rem;">
-        </a>
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="http://cloud-images.ubuntu.com/locator/ec2/">
+            <img src="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg" width="160" alt="Amazon Web Services" style="align-self: center;max-height: 10rem; max-width:10rem;">
+          </a>
+        </h4>
         <p>Amazon Web Services offers reliable, scalable, and inexpensive cloud computing services.</p>
       </div>
       <ul class="p-list">
@@ -54,12 +54,12 @@
       </ul>
     </div>
     <div class="p-card col-4">
-      <h4>Microsoft Azure</h4>
-      <hr class="u-sv1" />
       <div class="p-card__content">
-        <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="184" alt="" style="align-self: center;max-height: 10rem; max-width:12rem;">
-        </a>
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer">
+            <img src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="184" alt="Microsoft Azure" style="align-self: center;max-height: 10rem; max-width:12rem;">
+          </a>
+        </h4>
         <p>Microsoft Azure is an open, flexible, enterprise-grade cloud computing platform.</p>
       </div>
       <ul class="p-list">
@@ -70,36 +70,36 @@
   </div>
   <div class="row u-equal-height">
     <div class="p-card col-4">
-      <h4>IBM Cloud</h4>
-      <hr class="u-sv1" />
       <div class="p-card__content">
-        <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.ibm.com/cloud/">
-          <img src="https://assets.ubuntu.com/v1/5e91ff73-ibm-cloud-logo.svg" width="192" alt="" style="align-self: center;max-height: 10rem; max-width:12rem;">
-        </a>
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.ibm.com/cloud/">
+            <img src="https://assets.ubuntu.com/v1/5e91ff73-ibm-cloud-logo.svg" width="192" alt="IBM Cloud" style="align-self: center;max-height: 10rem; max-width:12rem;">
+          </a>
+        </h4>
       </div>
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://www.ibm.com/cloud/" class="p-link--external">Get started on IBM Cloud</a></li>
       </ul>
     </div>
     <div class="p-card col-4">
-      <h4>Rackspace</h4>
-      <hr class="u-sv1" />
       <div class="p-card__content">
-        <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.rackspace.com/managed-hosting">
-          <img src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" width="192" alt="" style="align-self: center;max-height: 10rem; max-width:12rem;">
-        </a>
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.rackspace.com/managed-hosting">
+            <img src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" width="192" alt="Rackspace" style="align-self: center;max-height: 10rem; max-width:12rem;">
+          </a>
+        </h4>
       </div>
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://www.rackspace.com/managed-hosting" class="p-link--external">Get started on Rackspace</a></li>
       </ul>
     </div>
     <div class="p-card col-4">
-      <h4>Oracle</h4>
-      <hr class="u-sv1" />
       <div class="p-card__content">
-        <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://docs.oracle.com/en/cloud/get-started/index.html">
-          <img src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" width="192" alt="" style="align-self: center;max-height: 10rem; max-width:12rem;">
-        </a>
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://docs.oracle.com/en/cloud/get-started/index.html">
+            <img src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" width="192" alt="Oracle" style="align-self: center;max-height: 10rem; max-width:12rem;">
+          </a>
+        </h4>
       </div>
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://docs.oracle.com/en/cloud/get-started/index.html" class="p-link--external">Guide to using Oracle Cloud</a></li>


### PR DESCRIPTION
## Done

- Corrects the AWS and Azure image link targets, fixing #5877.
- Provides `alt` text for all the linked images, since a link with no text is an accessibility problem.
- Replaces the heading text with the images, now that they have `alt` text, avoiding repetition and matching the copydoc.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/cloud
- Follow each of the public-cloud logo links and check that they go to a sensible place.

## Issue / Card

Fixes #5877.