### PR TITLE
Google Analytics: Increase site speed sampling

### DIFF
--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -3,7 +3,7 @@
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true});
+        ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true, 'siteSpeedSampleRate': 10});
         ga('require', 'GTM-N2MDH37');
         ga('require', 'linker');
         ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',


### PR DESCRIPTION
## Done
Increase site speed sampling on Google Analytics

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Look for console errors

