### PR TITLE
Add a font-display:optional override

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -10,9 +10,23 @@
 // import cookie policy
 @import "cookie-policy/build/css/cookie-policy";
 
+// Font display Vanilla override
+//sass-lint:disable no-url-protocols
+//sass-lint:disable no-url-domains
+@font-face {
+  font-display: optional;
+  font-family: 'UbtuOverride';
+  font-style: normal;
+  font-weight: 300;
+  src: url('https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2') format('woff2'), url('https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff') format('woff');
+}
+
 // import vanilla-framework
 @import "vanilla-framework/scss/build";
 @import "vanilla-placeholders";
+
+// Vanilla framework overrides
+$font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
 
 // import site specific patterns and overrides
 @import 'pattern_blog-featured';
@@ -304,3 +318,7 @@ summary {
   visibility: hidden;
   width: 0;
 }
+
+
+
+


### PR DESCRIPTION
## Done

Add a `font-display:optional` override

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Throttle your connection and test for font fallback

