### PR TITLE
Use native lazy loading if it's available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ canonicalwebteam.http==1.0.1
 canonicalwebteam.blog==3.1.2
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
-canonicalwebteam.image-template==0.3.0
+canonicalwebteam.image-template==1.0.0
 flask==1.0.2
 feedparser==5.2.1

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -309,16 +309,3 @@ summary {
     }
   }
 }
-
-// Hide images that fail to lazy load due to JS failing or other
-.lazyload {
-  height: 0;
-  margin: 0;
-  padding: 0;
-  visibility: hidden;
-  width: 0;
-}
-
-
-
-

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -133,7 +133,7 @@
               height="280",
               width="667",
               hi_def=True,
-              extra_classes="u-hide--small"
+              attrs={"class": "u-hide--small"},
             ) | safe
           }}
         </div>
@@ -151,7 +151,7 @@
               height="374",
               width="667",
               hi_def=True,
-              extra_classes="u-hide--small"
+              attrs={"class": "u-hide--small"},
             ) | safe
           }}
         </div>
@@ -177,7 +177,7 @@
               height="350",
               width="694",
               hi_def=True,
-              extra_classes="u-hide--small"
+              attrs={"class": "u-hide--small"},
             ) | safe
           }}
         </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -19,7 +19,7 @@
             height="191",
             width="380",
             hi_def=True,
-            extra_classes="col-6 u-vertically-center u-align--center u-hide--small"
+            attrs={"class": "col-6 u-vertically-center u-align--center u-hide--small"},
           ) | safe
         }}
       </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -8,6 +8,8 @@
   <title>{% block title %}{% endblock %} | Ubuntu</title>
 
   {% include "templates/_tag_manager.html" %}
+  <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>
+  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   {% block content_experiment %}{% endblock %}
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
@@ -85,8 +87,6 @@
   <!-- form validation -->
   {% include "shared/forms/_form-validation.html" %}
   {% endif %}
-  <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>
-  <script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" async></script>
   {% block footer_extra %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
As per https://github.com/canonical-web-and-design/canonicalwebteam.image-template/pull/34 - reviewing this branch reviews that PR, so please go and approve that branch. Then I'll get it published and update here.

Fixes https://github.com/canonical-web-and-design/canonicalwebteam.image-template/issues/35

QA
--

`./run`

Go to homepage.

Inspect an image lower down the page, check its markup shows the native syntax.