### PR TITLE
Add devices pricing page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -719,6 +719,8 @@ pricing:
       path: /pricing/infra
     - title: Consulting
       path: /pricing/consulting
+    - title: Devices
+      path: /pricing/devices
       
 documentation:
   title: Docs

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -646,4 +646,11 @@
 </section>
 
 {% with colour="dark" %}{% include "shared/_call-sales.html" %}{% endwith %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+<script src="{{ versioned_static('js/build/dynamic-contact-form.min.js') }}"></script>
+
 {% endblock %}

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -14,12 +14,12 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="u-fixed-width">
+  <div class="u-fixed-width" style="padding-bottom: 2rem;">
     <h2>Get to market quickly with SMART START</h2>
     <p>Canonical and partners offer full-service enablement, customisation and development to get your first device to market. App store and security updates guaranteed.</p>
   </div>
 
-  <div class="row">
+  <div class="row u-vertically-center" style="padding-bottom: 2rem;">
     <div class="col-5 p-card">
       <h3 class="p-heading--four">SMART START</h3>
       <p class="p-heading--three">$30,000 - 2 week delivery</p>
@@ -287,7 +287,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Dedicated App Store</h2>
-    <h3>Curate your own app collection with custom pricing and unique applications.</h3>
+    <h3 class="p-heading--four">Curate your own app collection with custom pricing and unique applications.</h3>
     <p>Optional managed app store includes role-based access controls, complete control of application versions, updates and controlled rollouts for $15,000 per year. We enable integrators and VARs to operate app stores on behalf of their clients. Access to the full Ubuntu app ecosystem requires device certification.</p>
   </div>
 </section>
@@ -295,7 +295,7 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2>Enterprise App Store</h2>
-    <h3>Control snap distribution inside your firewall, and cache snap traffic for network efficiency.</h3>
+    <h3 class="p-heading--four">Control snap distribution inside your firewall, and cache snap traffic for network efficiency.</h3>
     <p>The enterprise snap store enables your administrators to control snap updates and upgrades. Ensure that all device traffic goes through an audited communications channel and determine the precise versions of snaps used inside the business.</p>
   </div>
 </section>
@@ -303,12 +303,12 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Workshops, training and consulting</h2>
-    <h3>Make the most of Ubuntu for devices with our executive workshops on digital strategy and connected devices. Take control of your own roadmap by empowering your developers to deliver apps and upgrades to your global fleet of devices.</h3>
+    <p>Make the most of Ubuntu for devices with our executive workshops on digital strategy and connected devices. Take control of your own roadmap by empowering your developers to deliver apps and upgrades to your global fleet of devices.</p>
   </div>
 
   <div class="row">
     <div class="col-4 p-card">
-      <h4 class="p-card__title">Smart device strategy</h4>
+      <h3 class="p-heading--four">Smart device strategy</h3>
       <p class="p-heading--three">$6,000 on site</p>
       <hr class="u-sv1" />
       <p>A two-day workshop for executives that covers devices, edge clusters and cloud operations and strategy.</p>
@@ -319,7 +319,7 @@
     </div>
 
     <div class="col-4 p-card">
-      <h4 class="p-card__title">Ubuntu Core intro</h4>
+      <h3 class="p-heading--four">Ubuntu Core intro</h3>
       <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
@@ -330,7 +330,7 @@
     </div>
 
     <div class="col-4 p-card">
-      <h4 class="p-card__title">Snapcraft 101</h4>
+      <h3 class="p-heading--four">Snapcraft 101</h3>
       <p class="p-heading--three">$6,000 on site</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
@@ -341,7 +341,7 @@
     </div>
 
     <div class="col-4 p-card">
-      <h4 class="p-card__title">Consulting</h4>
+      <h3 class="p-heading--four">Consulting</h3>
       <p class="p-heading--three">$2,000 per day</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
@@ -352,7 +352,7 @@
     </div>
 
     <div class="col-4 p-card">
-      <h4 class="p-card__title">App Store operations</h4>
+      <h3 class="p-heading--four">App Store operations</h3>
       <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
@@ -363,7 +363,7 @@
     </div>
 
     <div class="col-4 p-card">
-      <h4 class="p-card__title">Enterprise Management</h4>
+      <h3 class="p-heading--four">Enterprise Management</h3>
       <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
@@ -375,20 +375,20 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <h2>SoC, board and device enablement</h2>
-      <p>Give your SoC, board or device a custom kernel that’s proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</p>
-    </div>
+  <div class="u-fixed-width">
+    <h2>SoC, board and device enablement</h2>
+    <p class="p-heading--four">Give your SoC, board or device a custom kernel that’s proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</h4>
+  </div>
 
-    <div class="col-4">
-      BEYOND BSPs
-    </div>
-
-    <div class="col-8">
-      <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>
+  <div class="row p-divider" style="padding-top: 1.9rem;">
+    <div class="col-6 p-divider__block">
+      <h3 class="p-heading--five">Beyond BSPs</h3>
       
-      <h3>Ongoing testing and security updates</h3>
+      <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>
+    </div>
+
+    <div class="col-6 p-divider__block">
+      <h3 class="p-heading--five">Ongoing testing and security updates</h3>
       
       <p>For an annual charge of $25k, Canonical will perform continuous security maintenance and testing on your board. When a security issue is fixed in Ubuntu, the fix will be tested on your board. These security updates will be published to the snap store for use on your device. Update Control can be used to require additional testing and validation by your team before these updates are automatically applied to your devices. Testing will cover kernel and base system debs and snaps, along with any board-specific and app-specific tests you specify.</p>
     </div>
@@ -396,26 +396,23 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="u-fixed-width">
-    <h2>Certification of boards and devices</h2>
-    <p>Guarantee long-term security, application compatibility, support and operational consistency with the Ubuntu Certified logo for enterprise-grade devices.</p>
-  </div>
-
-  <div class="row">
+  <div class="row u-vertically-center">
     <div class="col-8">
+      <h2>Certification of boards and devices</h2>
+      <p class="p-heading--four">Guarantee long-term security, application compatibility, support and operational consistency with the Ubuntu Certified logo for enterprise-grade devices.</p>
       <p>Long-term automated Canonical testing of every update and security patch ensures devices perform reliably over the full lifetime of the certified Ubuntu LTS release. Certified devices must run a Canonical kernel. We require four units of every certified board or device for continuous testing. In the case of devices built with existing certified boards, running their standard certified kernel, we reduce this requirement to two devices.</p>
 
       <p>Certification for devices that include pre-installed snaps can include validation of the integrity of those snaps.</p>
     </div>
 
-    <div class="col-4">UBUNTU CERTIFIED LOGO</div>
+    <div class="col-3 col-start-large-10"><img src="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg" alt="Ubuntu Certified"></div>
   </div>
 </section>
 
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2>Device support for manufacturers</h2>
-    <h3>Access to Canonical engineering for device engineering and development teams.</h3>
+    <h3 class="p-heading--four">Access to Canonical engineering for device engineering and development teams.</h3>
     <p>Level 4 (L4) support for device manufacturers enables access to Canonical engineering and techops teams to help troubleshoot and resolve issues in Ubuntu and Ubuntu Core. Covers kernel, device integration, base OS, snap security and update mechanisms, networking, communications and graphics.</p>
 
     <div style="overflow-x: auto;">
@@ -500,14 +497,14 @@
       </table>
     </div>
 
-    <p><small>MicroK8s and MicroStack are the supported Kubernetes and OpenStack solutions for single-node and small edge cluster environments.</small></p>
+    <p class="p-heading--six"><em>MicroK8s and MicroStack are the supported Kubernetes and OpenStack solutions for single-node and small edge cluster environments.</em></p>
   </div>
 </section>
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Ubuntu device support for enterprises</h2>
-    <h3>Treat every device on your network as a first-class server-grade managed asset, with monitoring, security, role-based access controls, and application lifecycle management.</h3>
+    <h3 class="p-heading--four">Treat every device on your network as a first-class server-grade managed asset, with monitoring, security, role-based access controls, and application lifecycle management.</h3>
     <p>Level 1 (L1) support for end-user customers operating certified Ubuntu devices, whether function-specific or open to third party applications. Covers enterprise management software, enterprise off-line app store, update frequency and timing, and the ability to publish private apps to open devices inside the enterprise.</p>
 
     <div style="overflow-x: auto;">

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -1,0 +1,655 @@
+{% extends "pricing/base_pricing.html" %}
+
+{% block title %}Ubuntu IoT and Devices | plans and pricing{% endblock %}
+{% block meta_description %}Canonical enables sophisticated devices to be designed, delivered and operated at scale with Ubuntu and Ubuntu Core, the all-snap solution to IoT software delivery and security.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip is-bordered">
+  <div class="u-fixed-width">
+    <h1>Ubuntu IoT and device services</h1>
+    <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge. Get ten years of security coverage and dedicated app stores for your smart connected devices.</p>
+    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Get to market quickly with SMART START</h2>
+    <p>Canonical and partners offer full-service enablement, customisation and development to get your first device to market. App store and security updates guaranteed.</p>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <div class="p-card">
+        <div class="row p-divider">
+          <div class="col-4 p-divider__block">
+            <ul class="p-list u-no-margin--bottom">
+              <li class="p-list__item is-ticked">X86 or ARM</li>
+              <li class="p-list__item is-ticked">Ubuntu Server or Core</li>
+              <li class="p-list__item is-ticked">Dedicated app store</li>
+              <li class="p-list__item is-ticked">1,000 devices included</li>
+              <li class="p-list__item is-ticked">3 snaps produced for you</li>
+              <li class="p-list__item is-ticked">3 days consulting</li>
+              <li class="p-list__item is-ticked">Monthly security updates</li>
+            </ul>
+          </div>
+
+          <div class="col-8 p-divider__block">
+            <p>Time to market is crucial when establishing an IoT strategy. Canonical will validate your hardware, package your apps and prepare your device image. Free your team to focus on your solution, industrial design and business operations.</p>
+      
+            <p>Choose from our extensive list of <a href="https://certification.ubuntu.com/iot" class="p-link--external">certified boards</a> and boxes with long-term security commitments.</p>
+              
+            <p>Add-ons cover enablement and certification of alternative boards and additional chipsets. For the first year, app store and device security updates are included.</p> 
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <h3>Add-ons to SMART START</h3>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="p-card col-4">
+      <h4 class="p-card__title">Full Disk Encryption<br />$30k</h4>
+      <hr class="u-sv1">
+      <p class="p-card__content">Enable full disk encryption with hardware key management and optional key escrow. Choice of ciphers and hardware acceleration for minimal performance impact. Essential for devices with personal information in regulated industries.</p>
+    </div>
+    <div class="p-card col-4">
+      <h4 class="p-card__title">Secure Boot<br />$30k</h4>
+      <hr class="u-sv1">
+      <p class="p-card__content">Enable secure boot, ensuring that the device will only run its certified workload. Hardware key management devices such as the TPM are used to validate each stage of the boot process, for enhanced assurance of integrity of the running OS.</p>
+    </div>
+    <div class="p-card col-4">
+      <h4 class="p-card__title">Device Enablement<br />$25k - $200k</h4>
+      <hr class="u-sv1">
+      <p class="p-card__content">If Canonical’s certified hardware list doesn’t include what you need, we may be willing to enable your preferred board. Pricing varies depending on the similarity between your board and existing certified boards.</p>
+    </div>
+    <div class="p-card col-4">
+      <h4 class="p-card__title">FIPS Certification<br />$45k</h4>
+      <hr class="u-sv1">
+      <p class="p-card__content">Meet Federal information processing requirements with a FIPS-certified kernel and cryptographic libraries. FIPS certification takes place every six months - fully compliant devices must restrict updates to certified versions. Note that this is available on x86 only.</p>
+    </div>
+    <div class="p-card col-4">
+      <h4 class="p-card__title">Kernel Livepatch<br />$60k</h4>
+      <hr class="u-sv1">
+      <p class="p-card__content">Reduce the number of reboots significantly by live patching your running kernel. Requires specific certified kernel on an Ubuntu LTS release. Requires x86 architecture.</p>
+    </div>
+    <div class="p-card col-4">
+      <h4 class="p-card__title">High Availability Kubernetes<br />$15k</h4>
+      <hr class="u-sv1">
+      <p class="p-card__content">With Canonical MicroK8s you gain a fully CNCF conformant cloud-native Kubernetes for device application operations, including clustering for high availability, service mesh support and automatic security updates.</p>
+    </div>
+  </div>
+  
+  <div class="u-fixed-width">
+    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Security updates and app store services</h2>
+    <p>Annual device fee covers app store services and security updates, with 10 year extended security maintenance for kernel, Ubuntu OS and your pre-installed applications.</p>
+  </div>
+
+  <div class="u-fixed-width">
+    <div style="overflow-x: auto;">
+      <table class="p-table" style="min-width: 100%; width: auto;">
+        <thead>
+          <tr>
+            <th>To</th>
+            <th class="u-align--center">Unscheduled</th>
+            <th class="u-align--center">1 year</th>
+            <th class="u-align--center">6 months</th>
+            <th class="u-align--center">3 months</th>
+            <th class="u-align--center">1 month</th>
+            <th class="u-align--center">1 week</th>
+            <th class="u-align--center">48 hours</th>
+            <th class="u-align--center">24 hours</th>
+            <th class="u-align--center">6 hours</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>1,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$3.03</td>
+            <td class="u-align--center">$4.66</td>
+            <td class="u-align--center">$7.25</td>
+            <td class="u-align--center">$11.40</td>
+            <td class="u-align--center">$18.04</td>
+            <td class="u-align--center">$289.67</td>
+            <td class="u-align--center">$45.66</td>
+            <td class="u-align--center">$72.86</td>
+          </tr>
+
+          <tr>
+            <td>2,500</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$2.08</td>
+            <td class="u-align--center">$3.12</td>
+            <td class="u-align--center">$4.80</td>
+            <td class="u-align--center">$7.47</td>
+            <td class="u-align--center">$11.76</td>
+            <td class="u-align--center">$18.61</td>
+            <td class="u-align--center">$29.58</td>
+            <td class="u-align--center">$47.13</td>
+          </tr>
+
+          <tr>
+            <td>2,500</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$2.08</td>
+            <td class="u-align--center">$3.12</td>
+            <td class="u-align--center">$4.80</td>
+            <td class="u-align--center">$7.47</td>
+            <td class="u-align--center">$11.76</td>
+            <td class="u-align--center">$18.61</td>
+            <td class="u-align--center">$29.58</td>
+            <td class="u-align--center">$47.13</td>
+          </tr>
+
+          <tr>
+            <td>6,500</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$1.46</td>
+            <td class="u-align--center">$2.13</td>
+            <td class="u-align--center">$3.21</td>
+            <td class="u-align--center">$4.94</td>
+            <td class="u-align--center">$7.70</td>
+            <td class="u-align--center">$12.13</td>
+            <td class="u-align--center">$19.20</td>
+            <td class="u-align--center">$30.52</td>
+          </tr>
+
+          <tr>
+            <td>15,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$1.06</td>
+            <td class="u-align--center">$1.49</td>
+            <td class="u-align--center">$2.19</td>
+            <td class="u-align--center">$3.30</td>
+            <td class="u-align--center">$5.09</td>
+            <td class="u-align--center">$7.94</td>
+            <td class="u-align--center">$12.51</td>
+            <td class="u-align--center">$19.81</td>
+          </tr>
+
+          <tr>
+            <td>40,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.80</td>
+            <td class="u-align--center">$1.08</td>
+            <td class="u-align--center">$1.53</td>
+            <td class="u-align--center">$2.25</td>
+            <td class="u-align--center">$3.40</td>
+            <td class="u-align--center">$5.24</td>
+            <td class="u-align--center">$8.19</td>
+            <td class="u-align--center">$12.90</td>
+          </tr>
+
+          <tr>
+            <td>95,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.63</td>
+            <td class="u-align--center">$0.82</td>
+            <td class="u-align--center">$1.11</td>
+            <td class="u-align--center">$1.57</td>
+            <td class="u-align--center">$2.31</td>
+            <td class="u-align--center">$3.50</td>
+            <td class="u-align--center">$5.40</td>
+            <td class="u-align--center">$8.44</td>
+          </tr>
+
+          <tr>
+            <td>250,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.53</td>
+            <td class="u-align--center">$0.64</td>
+            <td class="u-align--center">$0.83</td>
+            <td class="u-align--center">$1.13</td>
+            <td class="u-align--center">$1.61</td>
+            <td class="u-align--center">$2.38</td>
+            <td class="u-align--center">$3.60</td>
+            <td class="u-align--center">$5.56</td>
+          </tr>
+
+          <tr>
+            <td>615,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.46</td>
+            <td class="u-align--center">$0.53</td>
+            <td class="u-align--center">$0.65</td>
+            <td class="u-align--center">$0.85</td>
+            <td class="u-align--center">$1.16</td>
+            <td class="u-align--center">$1.65</td>
+            <td class="u-align--center">$2.44</td>
+            <td class="u-align--center">$3.71</td>
+          </tr>
+
+          <tr>
+            <td>1,500,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.41</td>
+            <td class="u-align--center">$0.46</td>
+            <td class="u-align--center">$0.54</td>
+            <td class="u-align--center">$0.66</td>
+            <td class="u-align--center">$0.86</td>
+            <td class="u-align--center">$1.18</td>
+            <td class="u-align--center">$1.69</td>
+            <td class="u-align--center">$2.51</td>
+          </tr>
+          
+          <tr>
+            <td>4,000,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.38</td>
+            <td class="u-align--center">$0.42</td>
+            <td class="u-align--center">$0.47</td>
+            <td class="u-align--center">$0.55</td>
+            <td class="u-align--center">$0.68</td>
+            <td class="u-align--center">$0.88</td>
+            <td class="u-align--center">$1.21</td>
+            <td class="u-align--center">$1.74</td>
+          </tr>
+
+          <tr>
+            <td>9,500,000</td>
+            <td class="u-align--center">$0.00</td>
+            <td class="u-align--center">$0.37</td>
+            <td class="u-align--center">$0.39</td>
+            <td class="u-align--center">$0.42</td>
+            <td class="u-align--center">$0.47</td>
+            <td class="u-align--center">$0.55</td>
+            <td class="u-align--center">$0.69</td>
+            <td class="u-align--center">$0.90</td>
+            <td class="u-align--center">$1.24</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p><small>Annual price based on device volume and update period</small></p>
+
+      <p>Emergency updates are always available, regardless of the contracted update frequency. The free tier enables you to ship Ubuntu Core free of charge and receive updates when bandwidth allows, or on-demand for emergencies.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Dedicated App Store</h2>
+    <h3>Curate your own app collection with custom pricing and unique applications.</h3>
+    <p>Optional managed app store includes role-based access controls, complete control of application versions, updates and controlled rollouts for $15,000 per year. We enable integrators and VARs to operate app stores on behalf of their clients. Access to the full Ubuntu app ecosystem requires device certification.</p>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Enterprise App Store</h2>
+    <h3>Control snap distribution inside your firewall, and cache snap traffic for network efficiency.</h3>
+    <p>The enterprise snap store enables your administrators to control snap updates and upgrades. Ensure that all device traffic goes through an audited communications channel and determine the precise versions of snaps used inside the business.</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Workshops, training and consulting</h2>
+    <h3>Make the most of Ubuntu for devices with our executive workshops on digital strategy and connected devices. Take control of your own roadmap by empowering your developers to deliver apps and upgrades to your global fleet of devices.</h3>
+  </div>
+
+  <div class="row">
+    <div class="col-4 p-card">
+      <h3>Smart device strategy</h3>
+      <hr class="u-sv1" />
+      <p>A two-day workshop for executives that covers devices, edge clusters and cloud operations and strategy.</p>
+      
+      <p>The architecture of IoT spans appliances, gateways and smart, connected devices, edge clouds and clusters, and the public cloud.</p>
+      
+      <p>Learn how to operate at high speed and precision for your all-digital business models. Two days for up to 10 people.</p>
+
+      $6,000 on site
+    </div>
+
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Ubuntu Core intro</h3>
+      <hr class="u-sv1" />
+      <div class="p-card__content">
+        <p>The all-snap Ubuntu Core guarantees high-reliability transactional updates of every application and the base operating system itself.</p>
+        
+        <p>Learn about the Ubuntu Core architecture, partitioning scheme, update mechanisms, secure boot, full disk encryption, device recovery and registration methods. One day full time for up to 20 people.</p>
+
+        $4,000 online
+      </div>
+    </div>
+
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Snapcraft 101</h3>
+      <hr class="u-sv1" />
+      <div class="p-card__content">
+        <p>Deliver your applications as snaps for high-reliability updates, global content distribution, canary rollouts, bandwidth efficiency and strict security confinement.</p>
+        
+        <p>Learn about snap design and security, and how to package your existing apps as snaps. Setup continuous integration, testing and delivery pipelines to your fleet. Two days full time for up to 20 people.</p>
+
+        $6,000 on site
+      </div>
+    </div>
+
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Consulting</h3>
+      <hr class="u-sv1" />
+      <div class="p-card__content">
+        <p>On-site or remote engagement with Canonical experts in board and SoC enablement, snap development or Ubuntu management.</p>
+      
+        <p>For pre-launch integration we recommend our SMART START package for fixed pricing and delivery schedule commitments. Price per day on site or remote.</p>
+
+        $2,000 per day
+      </div>
+    </div>
+
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">App Store operations</h3>
+      <hr class="u-sv1" />
+      <div class="p-card__content">
+        <p>Get the most from your app store with our two-day in-depth training program.</p>
+        
+        <p>Understand the relationship between devices, app stores, enterprise stores, and master offline operations. Learn how to manage your app portfolio per model, with full control of updates. Two days full time for up to 20 people.</p>
+
+        $4,000 online
+      </div>
+    </div>
+
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">Enterprise Management</h3>
+      <hr class="u-sv1" />
+      <div class="p-card__content">
+        <p>Take control of snaps in the enterprise and on public cloud. Ensure you have full visibility of snap versions, updates and security status across the estate.</p>
+        
+        <p>Ubuntu and Ubuntu Core raise the bar for device management and security, enabling whole-enterprise policy for devices from a wide range of brands. Two days full time for up to 20 people.</p>
+
+        $4,000 online
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2>SoC, board and device enablement</h2>
+      <p>Give your SoC, board or device a custom kernel that’s proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</p>
+    </div>
+
+    <div class="col-4">
+      BEYOND BSPs
+    </div>
+
+    <div class="col-8">
+      <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>
+      
+      <h4>Ongoing testing and security updates</h4>
+      
+      <p>For an annual charge of $25k, Canonical will perform continuous security maintenance and testing on your board. When a security issue is fixed in Ubuntu, the fix will be tested on your board. These security updates will be published to the snap store for use on your device. Update Control can be used to require additional testing and validation by your team before these updates are automatically applied to your devices. Testing will cover kernel and base system debs and snaps, along with any board-specific and app-specific tests you specify.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Certification of boards and devices</h2>
+    <p>Guarantee long-term security, application compatibility, support and operational consistency with the Ubuntu Certified logo for enterprise-grade devices.</p>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <p>Long-term automated Canonical testing of every update and security patch ensures devices perform reliably over the full lifetime of the certified Ubuntu LTS release. Certified devices must run a Canonical kernel. We require four units of every certified board or device for continuous testing. In the case of devices built with existing certified boards, running their standard certified kernel, we reduce this requirement to two devices.</p>
+
+      <p>Certification for devices that include pre-installed snaps can include validation of the integrity of those snaps.</p>
+    </div>
+
+    <div class="col-4">UBUNTU CERTIFIED LOGO</div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Device support for manufacturers</h2>
+    <h3>Access to Canonical engineering for device engineering and development teams.</h3>
+    <p>Level 4 (L4) support for device manufacturers enables access to Canonical engineering and techops teams to help troubleshoot and resolve issues in Ubuntu and Ubuntu Core. Covers kernel, device integration, base OS, snap security and update mechanisms, networking, communications and graphics.</p>
+
+    <div style="overflow-x: auto;">
+      <table class="p-table">
+        <thead>
+          <th>Embedded Ubuntu Support for Manufacturers</th>
+          <th class="u-align--center">Standard</th>
+          <th class="u-align--center">Advanced</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Physical server</td>
+            <td class="u-align--center">$750</td>
+            <td class="u-align--center">$1,500</td>
+          </tr>
+          <tr>
+            <td>Phone and ticket support</td>
+            <td class="u-align--center">Monday - Friday</td>
+            <td class="u-align--center">24/7</td>
+          </tr>
+          <tr>
+            <td>Response time SLA - Sev 1</td>
+            <td class="u-align--center">4 hours</td>
+            <td class="u-align--center">1 hour</td>
+          </tr>
+          <tr>
+            <td>Response time SLA - Sev 2</td>
+            <td class="u-align--center">8 hours</td>
+            <td class="u-align--center">2 hours</td>
+          </tr>
+          <tr>
+            <td>Response time SLA - Sev 3</td>
+            <td class="u-align--center">12 hours</td>
+            <td class="u-align--center">6 hours</td>
+          </tr>
+          <tr>
+            <td>Response time SLA - Sev 4</td>
+            <td class="u-align--center">24 hours</td>
+            <td class="u-align--center">12 hours</td>
+          </tr>
+          <tr>
+            <td>Application packaging and update management</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>Security and integration of software components</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>App store operations</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>Knowledge base access</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>OpenStack</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>Kubernetes</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>KVM/LXD</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+          <tr>
+            <td>Legal assurance program</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p><small>MicroK8s and MicroStack are the supported Kubernetes and OpenStack solutions for single-node and small edge cluster environments.</small></p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Ubuntu device support for enterprises</h2>
+    <h3>Treat every device on your network as a first-class server-grade managed asset, with monitoring, security, role-based access controls, and application lifecycle management.</h3>
+    <p>Level 1 (L1) support for end-user customers operating certified Ubuntu devices, whether function-specific or open to third party applications. Covers enterprise management software, enterprise off-line app store, update frequency and timing, and the ability to publish private apps to open devices inside the enterprise.</p>
+
+    <div style="overflow-x: auto;">
+      <table class="p-table u-sv3">
+        <thead>
+          <th>Ubuntu Advantage for Infrastructure</th>
+          <th class="u-align--center">Essential</th>
+          <th class="u-align--center">Standard</th>
+          <th class="u-align--center">Advanced</th>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td></td>
+            <td class="u-align--center"><em>Bits only</em></td>
+            <td class="u-align--center"><em>Support</em></td>
+            <td class="u-align--center"><em>Support</em></td>
+          </tr>
+
+          <tr>
+            <td>Certified Ubuntu Devices</td>
+            <td class="u-align--center">$225</td>
+            <td class="u-align--center">$750</td>
+            <td class="u-align--center">$1,500</td>
+          </tr>
+
+          <tr style="background-color: #e5e5e5">
+            <td>Phone and ticket support</td>
+            <td class="u-align--center">-</td>
+            <td class="u-align--center">Monday - Friday</td>
+            <td class="u-align--center">24/7</td>
+          </tr>
+
+          <tr style="background-color: #e5e5e5">
+            <td>Response time SLA - Sev 1</td>
+            <td class="u-align--center">-</td>
+            <td class="u-align--center">4 hours</td>
+            <td class="u-align--center">1 hour</td>
+          </tr>
+
+          <tr style="background-color: #e5e5e5">
+            <td>Response time SLA - Sev 2</td>
+            <td class="u-align--center">-</td>
+            <td class="u-align--center">8 hours</td>
+            <td class="u-align--center">2 hours</td>
+          </tr>
+
+          <tr style="background-color: #e5e5e5">
+            <td>Response time SLA - Sev 3</td>
+            <td class="u-align--center">-</td>
+            <td class="u-align--center">12 hours</td>
+            <td class="u-align--center">6 hours</td>
+          </tr>
+
+          <tr style="background-color: #e5e5e5">
+            <td>Response time SLA - Sev 4</td>
+            <td class="u-align--center">-</td>
+            <td class="u-align--center">24 hours</td>
+            <td class="u-align--center">12 hours</td>
+          </tr>
+
+          <tr>
+            <td><a href="/esm">Extended Security Maintenance</a> (ESM)</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+
+          <tr>
+            <td><a href="/livepatch">Kernel Livepatch</a> service to avoid reboots</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+
+          <tr>
+            <td><a href="https://landscape.canonical.com" class="p-link--external">Landscape</a> on-prem systems management</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+
+          <tr>
+            <td>On-premise snap store cache</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+
+          <tr>
+            <td>Private enterprise snap store</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+
+          <tr>
+            <td>Knowledge base access</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+
+          <tr>
+            <td>OpenStack - MicroStack</td>
+            <td class="u-align--center">Security updates</td>
+            <td class="u-align--center">Updates + Support</td>
+            <td class="u-align--center">Updates + Support</td>
+          </tr>
+
+          <tr>
+            <td>Kubernetes  - MicroK8s</td>
+            <td class="u-align--center">Security updates</td>
+            <td class="u-align--center">Updates + Support</td>
+            <td class="u-align--center">Updates + Support</td>
+          </tr>
+
+          <tr>
+            <td>KVM/LXD</td>
+            <td class="u-align--center">Security updates</td>
+            <td class="u-align--center">Updates + Support</td>
+            <td class="u-align--center">Updates + Support</td>
+          </tr>
+
+          <tr>
+            <td>Legal assurance program</td>
+            <td class="u-align--center">-</td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+            <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  
+  <div class="u-fixed-width">
+    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+  </div>
+</section>
+
+{% with colour="dark" %}{% include "shared/_call-sales.html" %}{% endwith %}
+{% endblock %}

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -106,173 +106,173 @@
         <thead>
           <tr>
             <th>To</th>
-            <th class="u-align--center">Unscheduled</th>
-            <th class="u-align--center">1 year</th>
-            <th class="u-align--center">6 months</th>
-            <th class="u-align--center">3 months</th>
-            <th class="u-align--center">1 month</th>
-            <th class="u-align--center">1 week</th>
-            <th class="u-align--center">48 hours</th>
-            <th class="u-align--center">24 hours</th>
-            <th class="u-align--center">6 hours</th>
+            <th class="u-align--right">Unscheduled</th>
+            <th class="u-align--right">1 year</th>
+            <th class="u-align--right">6 months</th>
+            <th class="u-align--right">3 months</th>
+            <th class="u-align--right">1 month</th>
+            <th class="u-align--right">1 week</th>
+            <th class="u-align--right">48 hours</th>
+            <th class="u-align--right">24 hours</th>
+            <th class="u-align--right">6 hours</th>
           </tr>
         </thead>
 
         <tbody>
           <tr>
             <td>1,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$3.03</td>
-            <td class="u-align--center">$4.66</td>
-            <td class="u-align--center">$7.25</td>
-            <td class="u-align--center">$11.40</td>
-            <td class="u-align--center">$18.04</td>
-            <td class="u-align--center">$289.67</td>
-            <td class="u-align--center">$45.66</td>
-            <td class="u-align--center">$72.86</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$3.03</td>
+            <td class="u-align--right">$4.66</td>
+            <td class="u-align--right">$7.25</td>
+            <td class="u-align--right">$11.40</td>
+            <td class="u-align--right">$18.04</td>
+            <td class="u-align--right">$289.67</td>
+            <td class="u-align--right">$45.66</td>
+            <td class="u-align--right">$72.86</td>
           </tr>
 
           <tr>
             <td>2,500</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$2.08</td>
-            <td class="u-align--center">$3.12</td>
-            <td class="u-align--center">$4.80</td>
-            <td class="u-align--center">$7.47</td>
-            <td class="u-align--center">$11.76</td>
-            <td class="u-align--center">$18.61</td>
-            <td class="u-align--center">$29.58</td>
-            <td class="u-align--center">$47.13</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$2.08</td>
+            <td class="u-align--right">$3.12</td>
+            <td class="u-align--right">$4.80</td>
+            <td class="u-align--right">$7.47</td>
+            <td class="u-align--right">$11.76</td>
+            <td class="u-align--right">$18.61</td>
+            <td class="u-align--right">$29.58</td>
+            <td class="u-align--right">$47.13</td>
           </tr>
 
           <tr>
             <td>2,500</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$2.08</td>
-            <td class="u-align--center">$3.12</td>
-            <td class="u-align--center">$4.80</td>
-            <td class="u-align--center">$7.47</td>
-            <td class="u-align--center">$11.76</td>
-            <td class="u-align--center">$18.61</td>
-            <td class="u-align--center">$29.58</td>
-            <td class="u-align--center">$47.13</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$2.08</td>
+            <td class="u-align--right">$3.12</td>
+            <td class="u-align--right">$4.80</td>
+            <td class="u-align--right">$7.47</td>
+            <td class="u-align--right">$11.76</td>
+            <td class="u-align--right">$18.61</td>
+            <td class="u-align--right">$29.58</td>
+            <td class="u-align--right">$47.13</td>
           </tr>
 
           <tr>
             <td>6,500</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$1.46</td>
-            <td class="u-align--center">$2.13</td>
-            <td class="u-align--center">$3.21</td>
-            <td class="u-align--center">$4.94</td>
-            <td class="u-align--center">$7.70</td>
-            <td class="u-align--center">$12.13</td>
-            <td class="u-align--center">$19.20</td>
-            <td class="u-align--center">$30.52</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$1.46</td>
+            <td class="u-align--right">$2.13</td>
+            <td class="u-align--right">$3.21</td>
+            <td class="u-align--right">$4.94</td>
+            <td class="u-align--right">$7.70</td>
+            <td class="u-align--right">$12.13</td>
+            <td class="u-align--right">$19.20</td>
+            <td class="u-align--right">$30.52</td>
           </tr>
 
           <tr>
             <td>15,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$1.06</td>
-            <td class="u-align--center">$1.49</td>
-            <td class="u-align--center">$2.19</td>
-            <td class="u-align--center">$3.30</td>
-            <td class="u-align--center">$5.09</td>
-            <td class="u-align--center">$7.94</td>
-            <td class="u-align--center">$12.51</td>
-            <td class="u-align--center">$19.81</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$1.06</td>
+            <td class="u-align--right">$1.49</td>
+            <td class="u-align--right">$2.19</td>
+            <td class="u-align--right">$3.30</td>
+            <td class="u-align--right">$5.09</td>
+            <td class="u-align--right">$7.94</td>
+            <td class="u-align--right">$12.51</td>
+            <td class="u-align--right">$19.81</td>
           </tr>
 
           <tr>
             <td>40,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.80</td>
-            <td class="u-align--center">$1.08</td>
-            <td class="u-align--center">$1.53</td>
-            <td class="u-align--center">$2.25</td>
-            <td class="u-align--center">$3.40</td>
-            <td class="u-align--center">$5.24</td>
-            <td class="u-align--center">$8.19</td>
-            <td class="u-align--center">$12.90</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.80</td>
+            <td class="u-align--right">$1.08</td>
+            <td class="u-align--right">$1.53</td>
+            <td class="u-align--right">$2.25</td>
+            <td class="u-align--right">$3.40</td>
+            <td class="u-align--right">$5.24</td>
+            <td class="u-align--right">$8.19</td>
+            <td class="u-align--right">$12.90</td>
           </tr>
 
           <tr>
             <td>95,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.63</td>
-            <td class="u-align--center">$0.82</td>
-            <td class="u-align--center">$1.11</td>
-            <td class="u-align--center">$1.57</td>
-            <td class="u-align--center">$2.31</td>
-            <td class="u-align--center">$3.50</td>
-            <td class="u-align--center">$5.40</td>
-            <td class="u-align--center">$8.44</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.63</td>
+            <td class="u-align--right">$0.82</td>
+            <td class="u-align--right">$1.11</td>
+            <td class="u-align--right">$1.57</td>
+            <td class="u-align--right">$2.31</td>
+            <td class="u-align--right">$3.50</td>
+            <td class="u-align--right">$5.40</td>
+            <td class="u-align--right">$8.44</td>
           </tr>
 
           <tr>
             <td>250,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.53</td>
-            <td class="u-align--center">$0.64</td>
-            <td class="u-align--center">$0.83</td>
-            <td class="u-align--center">$1.13</td>
-            <td class="u-align--center">$1.61</td>
-            <td class="u-align--center">$2.38</td>
-            <td class="u-align--center">$3.60</td>
-            <td class="u-align--center">$5.56</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.53</td>
+            <td class="u-align--right">$0.64</td>
+            <td class="u-align--right">$0.83</td>
+            <td class="u-align--right">$1.13</td>
+            <td class="u-align--right">$1.61</td>
+            <td class="u-align--right">$2.38</td>
+            <td class="u-align--right">$3.60</td>
+            <td class="u-align--right">$5.56</td>
           </tr>
 
           <tr>
             <td>615,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.46</td>
-            <td class="u-align--center">$0.53</td>
-            <td class="u-align--center">$0.65</td>
-            <td class="u-align--center">$0.85</td>
-            <td class="u-align--center">$1.16</td>
-            <td class="u-align--center">$1.65</td>
-            <td class="u-align--center">$2.44</td>
-            <td class="u-align--center">$3.71</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.46</td>
+            <td class="u-align--right">$0.53</td>
+            <td class="u-align--right">$0.65</td>
+            <td class="u-align--right">$0.85</td>
+            <td class="u-align--right">$1.16</td>
+            <td class="u-align--right">$1.65</td>
+            <td class="u-align--right">$2.44</td>
+            <td class="u-align--right">$3.71</td>
           </tr>
 
           <tr>
             <td>1,500,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.41</td>
-            <td class="u-align--center">$0.46</td>
-            <td class="u-align--center">$0.54</td>
-            <td class="u-align--center">$0.66</td>
-            <td class="u-align--center">$0.86</td>
-            <td class="u-align--center">$1.18</td>
-            <td class="u-align--center">$1.69</td>
-            <td class="u-align--center">$2.51</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.41</td>
+            <td class="u-align--right">$0.46</td>
+            <td class="u-align--right">$0.54</td>
+            <td class="u-align--right">$0.66</td>
+            <td class="u-align--right">$0.86</td>
+            <td class="u-align--right">$1.18</td>
+            <td class="u-align--right">$1.69</td>
+            <td class="u-align--right">$2.51</td>
           </tr>
           
           <tr>
             <td>4,000,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.38</td>
-            <td class="u-align--center">$0.42</td>
-            <td class="u-align--center">$0.47</td>
-            <td class="u-align--center">$0.55</td>
-            <td class="u-align--center">$0.68</td>
-            <td class="u-align--center">$0.88</td>
-            <td class="u-align--center">$1.21</td>
-            <td class="u-align--center">$1.74</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.38</td>
+            <td class="u-align--right">$0.42</td>
+            <td class="u-align--right">$0.47</td>
+            <td class="u-align--right">$0.55</td>
+            <td class="u-align--right">$0.68</td>
+            <td class="u-align--right">$0.88</td>
+            <td class="u-align--right">$1.21</td>
+            <td class="u-align--right">$1.74</td>
           </tr>
 
           <tr>
             <td>9,500,000</td>
-            <td class="u-align--center">$0.00</td>
-            <td class="u-align--center">$0.37</td>
-            <td class="u-align--center">$0.39</td>
-            <td class="u-align--center">$0.42</td>
-            <td class="u-align--center">$0.47</td>
-            <td class="u-align--center">$0.55</td>
-            <td class="u-align--center">$0.69</td>
-            <td class="u-align--center">$0.90</td>
-            <td class="u-align--center">$1.24</td>
+            <td class="u-align--right">$0.00</td>
+            <td class="u-align--right">$0.37</td>
+            <td class="u-align--right">$0.39</td>
+            <td class="u-align--right">$0.42</td>
+            <td class="u-align--right">$0.47</td>
+            <td class="u-align--right">$0.55</td>
+            <td class="u-align--right">$0.69</td>
+            <td class="u-align--right">$0.90</td>
+            <td class="u-align--right">$1.24</td>
           </tr>
         </tbody>
       </table>
@@ -405,7 +405,7 @@
       <p>Certification for devices that include pre-installed snaps can include validation of the integrity of those snaps.</p>
     </div>
 
-    <div class="col-3 col-start-large-10"><img src="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg" alt="Ubuntu Certified"></div>
+    <div class="col-2 col-start-large-10"><img src="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg" alt="Ubuntu Certified"></div>
   </div>
 </section>
 

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -120,7 +120,7 @@
 
         <tbody>
           <tr>
-            <td>1,000</td>
+            <td class="u-align--right">1,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$3.03</td>
             <td class="u-align--right">$4.66</td>
@@ -133,7 +133,7 @@
           </tr>
 
           <tr>
-            <td>2,500</td>
+            <td class="u-align--right">2,500</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$2.08</td>
             <td class="u-align--right">$3.12</td>
@@ -146,7 +146,7 @@
           </tr>
 
           <tr>
-            <td>2,500</td>
+            <td class="u-align--right">2,500</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$2.08</td>
             <td class="u-align--right">$3.12</td>
@@ -159,7 +159,7 @@
           </tr>
 
           <tr>
-            <td>6,500</td>
+            <td class="u-align--right">6,500</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$1.46</td>
             <td class="u-align--right">$2.13</td>
@@ -172,7 +172,7 @@
           </tr>
 
           <tr>
-            <td>15,000</td>
+            <td class="u-align--right">15,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$1.06</td>
             <td class="u-align--right">$1.49</td>
@@ -185,7 +185,7 @@
           </tr>
 
           <tr>
-            <td>40,000</td>
+            <td class="u-align--right">40,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.80</td>
             <td class="u-align--right">$1.08</td>
@@ -198,7 +198,7 @@
           </tr>
 
           <tr>
-            <td>95,000</td>
+            <td class="u-align--right">95,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.63</td>
             <td class="u-align--right">$0.82</td>
@@ -211,7 +211,7 @@
           </tr>
 
           <tr>
-            <td>250,000</td>
+            <td class="u-align--right">250,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.53</td>
             <td class="u-align--right">$0.64</td>
@@ -224,7 +224,7 @@
           </tr>
 
           <tr>
-            <td>615,000</td>
+            <td class="u-align--right">615,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.46</td>
             <td class="u-align--right">$0.53</td>
@@ -237,7 +237,7 @@
           </tr>
 
           <tr>
-            <td>1,500,000</td>
+            <td class="u-align--right">1,500,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.41</td>
             <td class="u-align--right">$0.46</td>
@@ -250,7 +250,7 @@
           </tr>
           
           <tr>
-            <td>4,000,000</td>
+            <td class="u-align--right">4,000,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.38</td>
             <td class="u-align--right">$0.42</td>
@@ -263,7 +263,7 @@
           </tr>
 
           <tr>
-            <td>9,500,000</td>
+            <td class="u-align--right">9,500,000</td>
             <td class="u-align--right">$0.00</td>
             <td class="u-align--right">$0.37</td>
             <td class="u-align--right">$0.39</td>
@@ -430,7 +430,7 @@
           </tr>
           <tr style="background-color: #e5e5e5">
             <td>Phone and ticket support</td>
-            <td class="u-align--center">Monday - Friday</td>
+            <td class="u-align--center">24/5</td>
             <td class="u-align--center">24/7</td>
           </tr>
           <tr style="background-color: #e5e5e5">
@@ -534,7 +534,7 @@
           <tr style="background-color: #e5e5e5">
             <td>Phone and ticket support</td>
             <td class="u-align--center">-</td>
-            <td class="u-align--center">Monday - Friday</td>
+            <td class="u-align--center">24/5</td>
             <td class="u-align--center">24/7</td>
           </tr>
 

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -106,173 +106,173 @@
         <thead>
           <tr>
             <th>To</th>
-            <th class="u-align--right">Unscheduled</th>
-            <th class="u-align--right">1 year</th>
-            <th class="u-align--right">6 months</th>
-            <th class="u-align--right">3 months</th>
-            <th class="u-align--right">1 month</th>
-            <th class="u-align--right">1 week</th>
-            <th class="u-align--right">48 hours</th>
-            <th class="u-align--right">24 hours</th>
-            <th class="u-align--right">6 hours</th>
+            <th class="u-align--right" style="padding-left: 1rem;">Unscheduled</th>
+            <th class="u-align--right" style="padding-left: 1rem;">1 year</th>
+            <th class="u-align--right" style="padding-left: 1rem;">6 months</th>
+            <th class="u-align--right" style="padding-left: 1rem;">3 months</th>
+            <th class="u-align--right" style="padding-left: 1rem;">1 month</th>
+            <th class="u-align--right" style="padding-left: 1rem;">1 week</th>
+            <th class="u-align--right" style="padding-left: 1rem;">48 hours</th>
+            <th class="u-align--right" style="padding-left: 1rem;">24 hours</th>
+            <th class="u-align--right" style="padding-left: 1rem;">6 hours</th>
           </tr>
         </thead>
 
         <tbody>
           <tr>
-            <td class="u-align--right">1,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$3.03</td>
-            <td class="u-align--right">$4.66</td>
-            <td class="u-align--right">$7.25</td>
-            <td class="u-align--right">$11.40</td>
-            <td class="u-align--right">$18.04</td>
-            <td class="u-align--right">$289.67</td>
-            <td class="u-align--right">$45.66</td>
-            <td class="u-align--right">$72.86</td>
+            <td class="u-align--right" style="padding-left: 1rem;">1,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.03</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$4.66</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$7.25</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$11.40</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$18.04</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$289.67</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$45.66</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$72.86</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">2,500</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$2.08</td>
-            <td class="u-align--right">$3.12</td>
-            <td class="u-align--right">$4.80</td>
-            <td class="u-align--right">$7.47</td>
-            <td class="u-align--right">$11.76</td>
-            <td class="u-align--right">$18.61</td>
-            <td class="u-align--right">$29.58</td>
-            <td class="u-align--right">$47.13</td>
+            <td class="u-align--right" style="padding-left: 1rem;">2,500</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.08</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.12</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$4.80</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$7.47</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$11.76</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$18.61</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$29.58</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$47.13</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">2,500</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$2.08</td>
-            <td class="u-align--right">$3.12</td>
-            <td class="u-align--right">$4.80</td>
-            <td class="u-align--right">$7.47</td>
-            <td class="u-align--right">$11.76</td>
-            <td class="u-align--right">$18.61</td>
-            <td class="u-align--right">$29.58</td>
-            <td class="u-align--right">$47.13</td>
+            <td class="u-align--right" style="padding-left: 1rem;">2,500</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.08</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.12</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$4.80</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$7.47</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$11.76</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$18.61</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$29.58</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$47.13</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">6,500</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$1.46</td>
-            <td class="u-align--right">$2.13</td>
-            <td class="u-align--right">$3.21</td>
-            <td class="u-align--right">$4.94</td>
-            <td class="u-align--right">$7.70</td>
-            <td class="u-align--right">$12.13</td>
-            <td class="u-align--right">$19.20</td>
-            <td class="u-align--right">$30.52</td>
+            <td class="u-align--right" style="padding-left: 1rem;">6,500</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.46</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.13</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.21</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$4.94</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$7.70</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$12.13</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$19.20</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$30.52</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">15,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$1.06</td>
-            <td class="u-align--right">$1.49</td>
-            <td class="u-align--right">$2.19</td>
-            <td class="u-align--right">$3.30</td>
-            <td class="u-align--right">$5.09</td>
-            <td class="u-align--right">$7.94</td>
-            <td class="u-align--right">$12.51</td>
-            <td class="u-align--right">$19.81</td>
+            <td class="u-align--right" style="padding-left: 1rem;">15,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.06</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.49</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.19</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.30</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$5.09</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$7.94</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$12.51</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$19.81</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">40,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.80</td>
-            <td class="u-align--right">$1.08</td>
-            <td class="u-align--right">$1.53</td>
-            <td class="u-align--right">$2.25</td>
-            <td class="u-align--right">$3.40</td>
-            <td class="u-align--right">$5.24</td>
-            <td class="u-align--right">$8.19</td>
-            <td class="u-align--right">$12.90</td>
+            <td class="u-align--right" style="padding-left: 1rem;">40,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.80</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.08</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.53</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.25</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.40</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$5.24</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$8.19</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$12.90</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">95,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.63</td>
-            <td class="u-align--right">$0.82</td>
-            <td class="u-align--right">$1.11</td>
-            <td class="u-align--right">$1.57</td>
-            <td class="u-align--right">$2.31</td>
-            <td class="u-align--right">$3.50</td>
-            <td class="u-align--right">$5.40</td>
-            <td class="u-align--right">$8.44</td>
+            <td class="u-align--right" style="padding-left: 1rem;">95,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.63</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.82</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.11</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.57</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.31</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.50</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$5.40</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$8.44</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">250,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.53</td>
-            <td class="u-align--right">$0.64</td>
-            <td class="u-align--right">$0.83</td>
-            <td class="u-align--right">$1.13</td>
-            <td class="u-align--right">$1.61</td>
-            <td class="u-align--right">$2.38</td>
-            <td class="u-align--right">$3.60</td>
-            <td class="u-align--right">$5.56</td>
+            <td class="u-align--right" style="padding-left: 1rem;">250,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.53</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.64</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.83</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.13</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.61</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.38</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.60</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$5.56</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">615,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.46</td>
-            <td class="u-align--right">$0.53</td>
-            <td class="u-align--right">$0.65</td>
-            <td class="u-align--right">$0.85</td>
-            <td class="u-align--right">$1.16</td>
-            <td class="u-align--right">$1.65</td>
-            <td class="u-align--right">$2.44</td>
-            <td class="u-align--right">$3.71</td>
+            <td class="u-align--right" style="padding-left: 1rem;">615,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.46</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.53</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.65</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.85</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.16</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.65</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.44</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$3.71</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">1,500,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.41</td>
-            <td class="u-align--right">$0.46</td>
-            <td class="u-align--right">$0.54</td>
-            <td class="u-align--right">$0.66</td>
-            <td class="u-align--right">$0.86</td>
-            <td class="u-align--right">$1.18</td>
-            <td class="u-align--right">$1.69</td>
-            <td class="u-align--right">$2.51</td>
+            <td class="u-align--right" style="padding-left: 1rem;">1,500,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.41</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.46</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.54</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.66</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.86</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.18</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.69</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$2.51</td>
           </tr>
           
           <tr>
-            <td class="u-align--right">4,000,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.38</td>
-            <td class="u-align--right">$0.42</td>
-            <td class="u-align--right">$0.47</td>
-            <td class="u-align--right">$0.55</td>
-            <td class="u-align--right">$0.68</td>
-            <td class="u-align--right">$0.88</td>
-            <td class="u-align--right">$1.21</td>
-            <td class="u-align--right">$1.74</td>
+            <td class="u-align--right" style="padding-left: 1rem;">4,000,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.38</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.42</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.47</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.55</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.68</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.88</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.21</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.74</td>
           </tr>
 
           <tr>
-            <td class="u-align--right">9,500,000</td>
-            <td class="u-align--right">$0.00</td>
-            <td class="u-align--right">$0.37</td>
-            <td class="u-align--right">$0.39</td>
-            <td class="u-align--right">$0.42</td>
-            <td class="u-align--right">$0.47</td>
-            <td class="u-align--right">$0.55</td>
-            <td class="u-align--right">$0.69</td>
-            <td class="u-align--right">$0.90</td>
-            <td class="u-align--right">$1.24</td>
+            <td class="u-align--right" style="padding-left: 1rem;">9,500,000</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.00</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.37</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.39</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.42</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.47</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.55</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.69</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$0.90</td>
+            <td class="u-align--right" style="padding-left: 1rem;">$1.24</td>
           </tr>
         </tbody>
       </table>
@@ -405,7 +405,7 @@
       <p>Certification for devices that include pre-installed snaps can include validation of the integrity of those snaps.</p>
     </div>
 
-    <div class="col-2 col-start-large-10"><img src="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg" alt="Ubuntu Certified"></div>
+    <div class="col-2 col-start-large-10 u-hide--small"><img src="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg" alt="Ubuntu Certified"></div>
   </div>
 </section>
 

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -308,74 +308,68 @@
 
   <div class="row">
     <div class="col-4 p-card">
-      <h3>Smart device strategy</h3>
+      <h4 class="p-card__title">Smart device strategy</h4>
+      <p class="p-heading--three">$6,000 on site</p>
       <hr class="u-sv1" />
       <p>A two-day workshop for executives that covers devices, edge clusters and cloud operations and strategy.</p>
       
       <p>The architecture of IoT spans appliances, gateways and smart, connected devices, edge clouds and clusters, and the public cloud.</p>
       
       <p>Learn how to operate at high speed and precision for your all-digital business models. Two days for up to 10 people.</p>
-
-      $6,000 on site
     </div>
 
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu Core intro</h3>
+      <h4 class="p-card__title">Ubuntu Core intro</h4>
+      <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
         <p>The all-snap Ubuntu Core guarantees high-reliability transactional updates of every application and the base operating system itself.</p>
         
-        <p>Learn about the Ubuntu Core architecture, partitioning scheme, update mechanisms, secure boot, full disk encryption, device recovery and registration methods. One day full time for up to 20 people.</p>
-
-        $4,000 online
+        <p>Learn about the Ubuntu Core architecture, partitioning scheme, update mechanisms, secure boot, full disk encryption, device recovery and registration methods. One day full time for up to 20 people.</p>        
       </div>
     </div>
 
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Snapcraft 101</h3>
+      <h4 class="p-card__title">Snapcraft 101</h4>
+      <p class="p-heading--three">$6,000 on site</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
         <p>Deliver your applications as snaps for high-reliability updates, global content distribution, canary rollouts, bandwidth efficiency and strict security confinement.</p>
         
         <p>Learn about snap design and security, and how to package your existing apps as snaps. Setup continuous integration, testing and delivery pipelines to your fleet. Two days full time for up to 20 people.</p>
-
-        $6,000 on site
       </div>
     </div>
 
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Consulting</h3>
+      <h4 class="p-card__title">Consulting</h4>
+      <p class="p-heading--three">$2,000 per day</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
         <p>On-site or remote engagement with Canonical experts in board and SoC enablement, snap development or Ubuntu management.</p>
       
         <p>For pre-launch integration we recommend our SMART START package for fixed pricing and delivery schedule commitments. Price per day on site or remote.</p>
-
-        $2,000 per day
       </div>
     </div>
 
     <div class="col-4 p-card">
-      <h3 class="p-card__title">App Store operations</h3>
+      <h4 class="p-card__title">App Store operations</h4>
+      <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
         <p>Get the most from your app store with our two-day in-depth training program.</p>
         
         <p>Understand the relationship between devices, app stores, enterprise stores, and master offline operations. Learn how to manage your app portfolio per model, with full control of updates. Two days full time for up to 20 people.</p>
-
-        $4,000 online
       </div>
     </div>
 
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Enterprise Management</h3>
+      <h4 class="p-card__title">Enterprise Management</h4>
+      <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
         <p>Take control of snaps in the enterprise and on public cloud. Ensure you have full visibility of snap versions, updates and security status across the estate.</p>
         
         <p>Ubuntu and Ubuntu Core raise the bar for device management and security, enabling whole-enterprise policy for devices from a wide range of brands. Two days full time for up to 20 people.</p>
-
-        $4,000 online
     </div>
   </div>
 </section>
@@ -394,7 +388,7 @@
     <div class="col-8">
       <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>
       
-      <h4>Ongoing testing and security updates</h4>
+      <h3>Ongoing testing and security updates</h3>
       
       <p>For an annual charge of $25k, Canonical will perform continuous security maintenance and testing on your board. When a security issue is fixed in Ubuntu, the fix will be tested on your board. These security updates will be published to the snap store for use on your device. Update Control can be used to require additional testing and validation by your team before these updates are automatically applied to your devices. Testing will cover kernel and base system debs and snaps, along with any board-specific and app-specific tests you specify.</p>
     </div>
@@ -437,27 +431,27 @@
             <td class="u-align--center">$750</td>
             <td class="u-align--center">$1,500</td>
           </tr>
-          <tr>
+          <tr style="background-color: #e5e5e5">
             <td>Phone and ticket support</td>
             <td class="u-align--center">Monday - Friday</td>
             <td class="u-align--center">24/7</td>
           </tr>
-          <tr>
+          <tr style="background-color: #e5e5e5">
             <td>Response time SLA - Sev 1</td>
             <td class="u-align--center">4 hours</td>
             <td class="u-align--center">1 hour</td>
           </tr>
-          <tr>
+          <tr style="background-color: #e5e5e5">
             <td>Response time SLA - Sev 2</td>
             <td class="u-align--center">8 hours</td>
             <td class="u-align--center">2 hours</td>
           </tr>
-          <tr>
+          <tr style="background-color: #e5e5e5">
             <td>Response time SLA - Sev 3</td>
             <td class="u-align--center">12 hours</td>
             <td class="u-align--center">6 hours</td>
           </tr>
-          <tr>
+          <tr style="background-color: #e5e5e5">
             <td>Response time SLA - Sev 4</td>
             <td class="u-align--center">24 hours</td>
             <td class="u-align--center">12 hours</td>

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -20,30 +20,27 @@
   </div>
 
   <div class="row">
-    <div class="col-12">
-      <div class="p-card">
-        <div class="row p-divider">
-          <div class="col-4 p-divider__block">
-            <ul class="p-list u-no-margin--bottom">
-              <li class="p-list__item is-ticked">X86 or ARM</li>
-              <li class="p-list__item is-ticked">Ubuntu Server or Core</li>
-              <li class="p-list__item is-ticked">Dedicated app store</li>
-              <li class="p-list__item is-ticked">1,000 devices included</li>
-              <li class="p-list__item is-ticked">3 snaps produced for you</li>
-              <li class="p-list__item is-ticked">3 days consulting</li>
-              <li class="p-list__item is-ticked">Monthly security updates</li>
-            </ul>
-          </div>
+    <div class="col-5 p-card">
+      <h3 class="p-heading--four">SMART START</h3>
+      <p class="p-heading--three">$30,000 - 2 week delivery</p>
+      <hr class="u-sv3" />
+      <ul class="p-list u-no-margin--bottom">
+        <li class="p-list__item is-ticked">X86 or ARM</li>
+        <li class="p-list__item is-ticked">Ubuntu Server or Core</li>
+        <li class="p-list__item is-ticked">Dedicated app store</li>
+        <li class="p-list__item is-ticked">1,000 devices included</li>
+        <li class="p-list__item is-ticked">3 snaps produced for you</li>
+        <li class="p-list__item is-ticked">3 days consulting</li>
+        <li class="p-list__item is-ticked">Monthly security updates</li>
+      </ul>
+    </div>
 
-          <div class="col-8 p-divider__block">
-            <p>Time to market is crucial when establishing an IoT strategy. Canonical will validate your hardware, package your apps and prepare your device image. Free your team to focus on your solution, industrial design and business operations.</p>
-      
-            <p>Choose from our extensive list of <a href="https://certification.ubuntu.com/iot" class="p-link--external">certified boards</a> and boxes with long-term security commitments.</p>
-              
-            <p>Add-ons cover enablement and certification of alternative boards and additional chipsets. For the first year, app store and device security updates are included.</p> 
-          </div>
-        </div>
-      </div>
+    <div class="col-7">
+      <p>Time to market is crucial when establishing an IoT strategy. Canonical will validate your hardware, package your apps and prepare your device image. Free your team to focus on your solution, industrial design and business operations.</p>
+
+      <p>Choose from our extensive list of <a href="https://certification.ubuntu.com/iot" class="p-link--external">certified boards</a> and boxes with long-term security commitments.</p>
+        
+      <p>Add-ons cover enablement and certification of alternative boards and additional chipsets. For the first year, app store and device security updates are included.</p> 
     </div>
   </div>
 
@@ -55,32 +52,38 @@
 
   <div class="row u-equal-height">
     <div class="p-card col-4">
-      <h4 class="p-card__title">Full Disk Encryption<br />$30k</h4>
+      <h4>Full Disk Encryption</h4>
+      <p class="p-heading--three">$30,000</p>
       <hr class="u-sv1">
       <p class="p-card__content">Enable full disk encryption with hardware key management and optional key escrow. Choice of ciphers and hardware acceleration for minimal performance impact. Essential for devices with personal information in regulated industries.</p>
     </div>
     <div class="p-card col-4">
-      <h4 class="p-card__title">Secure Boot<br />$30k</h4>
+      <h4 class="p-card__title">Secure Boot</h4>
+      <p class="p-heading--three">$30,000</p>
       <hr class="u-sv1">
       <p class="p-card__content">Enable secure boot, ensuring that the device will only run its certified workload. Hardware key management devices such as the TPM are used to validate each stage of the boot process, for enhanced assurance of integrity of the running OS.</p>
     </div>
     <div class="p-card col-4">
-      <h4 class="p-card__title">Device Enablement<br />$25k - $200k</h4>
+      <h4 class="p-card__title">Device Enablement</h4>
+      <p class="p-heading--three">$25,000 - $200,000</p>
       <hr class="u-sv1">
       <p class="p-card__content">If Canonical’s certified hardware list doesn’t include what you need, we may be willing to enable your preferred board. Pricing varies depending on the similarity between your board and existing certified boards.</p>
     </div>
     <div class="p-card col-4">
-      <h4 class="p-card__title">FIPS Certification<br />$45k</h4>
+      <h4 class="p-card__title">FIPS Certification</h4>
+      <p class="p-heading--three">$45,000</p>
       <hr class="u-sv1">
       <p class="p-card__content">Meet Federal information processing requirements with a FIPS-certified kernel and cryptographic libraries. FIPS certification takes place every six months - fully compliant devices must restrict updates to certified versions. Note that this is available on x86 only.</p>
     </div>
     <div class="p-card col-4">
-      <h4 class="p-card__title">Kernel Livepatch<br />$60k</h4>
+      <h4 class="p-card__title">Kernel Livepatch</h4>
+      <p class="p-heading--three">$60,000</p>
       <hr class="u-sv1">
       <p class="p-card__content">Reduce the number of reboots significantly by live patching your running kernel. Requires specific certified kernel on an Ubuntu LTS release. Requires x86 architecture.</p>
     </div>
     <div class="p-card col-4">
-      <h4 class="p-card__title">High Availability Kubernetes<br />$15k</h4>
+      <h4 class="p-card__title">High Availability Kubernetes</h4>
+      <p class="p-heading--three">$15,000</p>
       <hr class="u-sv1">
       <p class="p-card__content">With Canonical MicroK8s you gain a fully CNCF conformant cloud-native Kubernetes for device application operations, including clustering for high availability, service mesh support and automatic security updates.</p>
     </div>
@@ -274,7 +277,7 @@
         </tbody>
       </table>
 
-      <p><small>Annual price based on device volume and update period</small></p>
+      <p class="p-heading--six"><em>Annual price based on device volume and update period</em></p>
 
       <p>Emergency updates are always available, regardless of the contracted update frequency. The free tier enables you to ship Ubuntu Core free of charge and receive updates when bandwidth allows, or on-demand for emergencies.</p>
     </div>

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -30,6 +30,23 @@
         <p><a class="p-button--neutral is-wide" href="/pricing/infra">See our services</a></p>
         <p><a class="p-button--positive is-wide" href="https://buy.ubuntu.com/"><span class="p-link--external">Purchase from the store</span></a>
       </div>
+
+      <div class="col-4 p-card">
+        <h2 class="p-heading--three">IoT and device services</h2>
+        <hr class="u-sv1" />
+        <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge.</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Hardware enablement</li>
+          <li class="p-list__item is-ticked">White-label app stores for IoT</li>devices
+          <li class="p-list__item is-ticked">Long-term OTA software updates</li>
+          <li class="p-list__item is-ticked">24/7 maintenance and support</li>
+          <li class="p-list__item is-ticked">Consulting services</li>
+        </ul>
+        <p><a class="p-button--neutral is-wide" href="/pricing/consulting">Get SMART with Canonical</a></p>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
       <div class="col-4 p-card">
         <h2 class="p-heading--three">Fully managed infrastructure</h2>
         <hr class="u-sv1" />

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -42,7 +42,7 @@
           <li class="p-list__item is-ticked">24/7 maintenance and support</li>
           <li class="p-list__item is-ticked">Consulting services</li>
         </ul>
-        <p><a class="p-button--neutral is-wide" href="/pricing/consulting">Get SMART with Canonical</a></p>
+        <p><a class="p-button--neutral is-wide" href="/pricing/devices">Get SMART with Canonical</a></p>
       </div>
     </div>
 


### PR DESCRIPTION
## Done

- Added a new page at /pricing/devices, based on this [copy doc](https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit#heading=h.l83dv5879ajz)
- Added a card for the page to /pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Visit: http://0.0.0.0:8001/pricing/devices
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the [copy doc](https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit#heading=h.l83dv5879ajz), and is laid out correctly.

## Issue / Card

Fixes #5865 