### PR TITLE
Update CK release notes

### DIFF
--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,14 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.16+ck1 Bugfix release
+
+### October 4, 2019 - [charmed-kubernetes-268](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-268/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.16+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.16+ck1).
 
 # 1.16
 
@@ -67,6 +75,13 @@ for more information.
 
 The Docker registry charm can now be related directly to the Containerd runtime charm.
 Refer to the [documentation](/kubernetes/docs/docker-registry) for instructions on how to deploy the charm.
+
+- Renamed default container registry
+
+The Canonical container image registry has a new, firewall-friendly name:
+`image-registry.canonical.com:5000` is now `rocks.canonical.com`. The old URL
+is an alias for `rocks` and will continue to work. However, the default
+configuration for current charms has changed to the new URL.
 
 ## Fixes
 


### PR DESCRIPTION
## Done

Update the release notes for 1.16-ck1 release

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
