### PR TITLE
Remove meta_image string rendered in base template

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -53,7 +53,7 @@
   {% endif %}
 
   {# Define the required meta_image block #}
-  {% block meta_image %}{% endblock %}
+  <!-- Meta image: {% block meta_image %}{% endblock %} -->
   {% if self.meta_image() %}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">


### PR DESCRIPTION
## Done

Remove `meta_image` string rendered in base template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/openstack-made-easy
- Verify the `meta_image` string no longer renders in the template


## Issue / Card

Fixes #5904