### PR TITLE
update variable check in engage header to prevent broken image

### DIFF
--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -19,7 +19,7 @@
       </p>{% endif %}
       </div>
     </div>
-    {% if image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
+    {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
       <img src="{% if 'http' not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for {{ title }}" >
     </div>{% endif %}
   </div>


### PR DESCRIPTION
## Done

Updated variable check in engage page header template to prevent broken image from rendering alt text.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit [http://0.0.0.0:8001/engage/openstack-security-whitepaper](/engage/openstack-security-whitepaper), see that no alt text is present in the header (compare it to https://ubuntu.com/engage/openstack-security-whitepaper)
