### PR TITLE
Switch to production API

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
-ADVANTAGE_API=https://contracts.staging.canonical.com/
+ADVANTAGE_API=https://contracts.canonical.com/

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -120,7 +120,7 @@
             <td id="expanded-row-token-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if loop.index == 1 %}false{% else %}true{% endif %}">
               <div class="row">
                 <div class="col-12 u-align--center">
-                  To attach a machine: <code>sudo ua enable {{ contract['token'] }}</code>
+                  To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code>
                 </div>
               </div>
             </td>
@@ -135,7 +135,7 @@
             <td id="expanded-row-livepatch-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
               <div class="row">
                 <div class="col-12 u-align--center">
-                  To activate Livepatch: <code>sudo ua attach livepatch</code>
+                  To activate Livepatch: <code>sudo ua enable livepatch</code>
                 </div>
               </div>
             </td>


### PR DESCRIPTION
## Done
Switch to prod API and fix some incorrect commands

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /advantage
- Login and see your free token

