### PR TITLE
Add Yahoo Japan case study

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1139,6 +1139,19 @@
             <p class='u-no-padding--bottom u-hide--small'>Join us for a month of webinars on edge computing.  Learn how edge computing provides enterprises with real-time data processing, cost-effective security and scalability.</p>
           </div>
         </div>
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--cloud-and-server'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              case study
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/yahoo-japan-case-study'>Yahoo! Japan builds their IaaS environment with Canonical</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>Using Ubuntu and a wide range of Canonical’s management tools, Yahoo! Japan has been able to reduce both CAPEX and OPEX costs while successfully building and operating a large scale IaaS environment.</p>
+          </div>
+        </div><!-- 3rd -->
       </div>
     </section>
     {% endblock content %}

--- a/templates/engage/yahoo-japan-case-study.md
+++ b/templates/engage/yahoo-japan-case-study.md
@@ -1,0 +1,36 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Yahoo! Japan builds their IaaS environment with Canonical"
+     meta_description: "Yahoo! Japan builds large-scale IaaS environment with Canonical’s OpenStack and management tools."
+     meta_image: https://assets.ubuntu.com/v1/bb29b611-yahoo-japan-case-study-social.jpg
+     meta_copydoc: https://docs.google.com/document/d/1WHnbQO6m6B4puJr8Vc3WxPC9BBJ0E7pvkTXSJUKvCM0/edit
+     header_title: "Yahoo! Japan builds their IaaS environment with Canonical"
+     header_subtitle:
+     header_image: "https://assets.ubuntu.com/v1/5d403409-2018-logo-yahoo-japan.svg"
+     header_url: '#register-section'
+     header_cta: Download case study
+     header_class: p-engage-banner--dark
+     header_lang: en
+     webinar_code:
+     form_include: en
+     form_id: 3426
+     form_return_url: "https://pages.ubuntu.com/CStudy_Yahoo_TY.html"
+---
+
+Yahoo! Japan, originally formed as a joint venture between Yahoo! and SoftBank, is one of the most popular internet advertising, search engines and e-commerce sites in the country and employs over 6000 people.
+
+Due to having such scale and volume of users, Yahoo! Japan required outside help to build their IaaS (infrastructure as a service) solution and OSS distributed storage solution. In 2013, Yahoo! Japan turned to Canonical and the two companies have grown the relationship ever since.
+
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">During unexpected incidents, the cause needs to be tracked down to the OS layer and being able to ask a professional is a big advantage. I think Canonical is the only company capable of offering this robust support,</p>
+  <cite class="p-pull-quote__citation">Mr. Sakata, Cloud Development Leader, Yahoo! Japan</cite>
+</blockquote>
+
+Using Ubuntu and a wide range of Canonical’s management tools, Yahoo! Japan has been able to reduce both CAPEX and OPEX costs while successfully building and operating a large scale IaaS environment.
+
+In this case study, learn how Yahoo! Japan:
+
+- Deployed an [OpenStack](/openstack) private cloud with 1PB of Ceph storage across three regions using <a class="p-link--external" href="https://maas.io">MaaS</a> and <a class="p-link--external" href="https://jaas.ai">Juju</a>.
+- Benefited from the reassurance and expertise of Canonical engineers through <a class="p-link--external" href="https://buy.ubuntu.com/">Ubuntu Advantage</a> to ensure unexpected incidents are kept to a minimum.
+- Have future-proofed themselves by taking advantage of ESM (Extended Security Maintenance) for security patches until April 2028.

--- a/templates/engage/yahoo-japan-case-study.md
+++ b/templates/engage/yahoo-japan-case-study.md
@@ -31,6 +31,6 @@ Using Ubuntu and a wide range of Canonical’s management tools, Yahoo! Japan ha
 
 In this case study, learn how Yahoo! Japan:
 
-- Deployed an [OpenStack](/openstack) private cloud with 1PB of Ceph storage across three regions using <a class="p-link--external" href="https://maas.io">MaaS</a> and <a class="p-link--external" href="https://jaas.ai">Juju</a>.
+- Deployed an [OpenStack](/openstack) private cloud with 1PB of Ceph storage across three regions using <a class="p-link--external" href="https://maas.io">MAAS</a> and <a class="p-link--external" href="https://jaas.ai">Juju</a>.
 - Benefited from the reassurance and expertise of Canonical engineers through <a class="p-link--external" href="https://buy.ubuntu.com/">Ubuntu Advantage</a> to ensure unexpected incidents are kept to a minimum.
-- Have future-proofed themselves by taking advantage of ESM (Extended Security Maintenance) for security patches until April 2028.
+- Have future-proofed themselves by taking advantage of [ESM (Extended Security Maintenance)](/esm) for security patches until April 2028.

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -20,7 +20,7 @@
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32">
 
   <link rel="apple-touch-icon" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-ouch-icon-114x114-precomposed.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png">
   <link rel="apple-touch-icon" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png">
   <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/c39e0fed-apple-touch-icon.png">
   <link type="text/plain" rel="author" href="{{ versioned_static('files/humans.txt') }}">


### PR DESCRIPTION
## Done

- New Yahoo! Japan case study engage page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/yahoo-japan-case-study and http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare it to the [brief](https://docs.google.com/spreadsheets/d/1txCEDcgszYy43FEnxEc2lV3EG6vcYpJSnO878T-s5VU/edit#gid=1595677042) and the [copy doc](https://docs.google.com/document/d/1WHnbQO6m6B4puJr8Vc3WxPC9BBJ0E7pvkTXSJUKvCM0/edit)
- Test the form

## Issue / Card

Fixes #5807

