### PR TITLE
Advantage design review

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -361,6 +361,12 @@ summary {
     td:nth-child(1) {
       flex: 3;
     }
+
+    &:not(:last-of-type) {
+      .p-table-expanding__panel {
+        border-bottom: 0;
+      }
+    }
   }
 
   code {
@@ -372,6 +378,7 @@ summary {
     @extend %vf-card;
     @extend %vf-is-bordered;
     @extend %vf-has-round-corners;
+    margin-bottom: 0;
   }
 
   .p-table--open {

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -78,14 +78,13 @@
           <td class="u-align--center">$500</td>
         </tr>
         <tr>
-          <td>Desktop *</td>
+          <td>Desktop</td>
           <td class="u-align--center">$25</td>
           <td class="u-align--center">$150</td>
           <td class="u-align--center">$300</td>
         </tr>
       </tbody>
     </table>
-    <p id="ua-i-fn1"><sup>*</sup> <small>Minimums and exclusions apply. Please refer to the <a href="/uasd">service description</a> for full details.</small></p>
   </div>
   <div class="row">
     <div class="col-12">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -11,9 +11,6 @@
   <div class="row">
     <div class="col-6">
       <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-      {% if not enterprise_contracts %}
-      <p>By using Ubuntu Avantage you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</p>
-      {% endif %}
     </div>
 
     <div class="col-5 col-start-large-8">
@@ -251,6 +248,7 @@
            Sign in to access your personal or paid subscriptions.
         </p>
         <p class="u-no-margin--bottom">
+          <span class="u-sv1"><small style="color:#666">By signing in you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</small><br /></span>
           <a href="/login" class="p-button--neutral u-no-margin--bottom"
             onclick="dataLayer.push({
               'event' : 'GAEvent',
@@ -273,11 +271,12 @@
       <h2>Free for personal use</h2>
       <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
       <p class="u-no-margin--bottom">
+        <span class="u-sv1"><small style="color:#666">By regisitering you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</small><br /></span>
         <a href="/login" class="p-button--positive" onclick="dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : 'Advantage',
           'eventAction' : 'Authentication',
-          'eventLabel' : 'Sign in',
+          'eventLabel' : 'Register',
           'eventValue' : undefined
         });">Register</a> to get your free subscription.
       </p>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -16,12 +16,10 @@
       {% endif %}
     </div>
 
-    <div class="col-5 col-start-large-8 u-vertically-center">
-      <div class="p-card">
-        <p class="p-heading--five">
-          You are signed in as {{ openid.fullname }}
-        </p>
-        <p style="color:#666">({{ openid.email }})</p>
+    <div class="col-5 col-start-large-8">
+      <div class="u-no-margin--bottom p-card">
+        <p>You are signed in as {{ openid.fullname }}<br />
+        <small style="color:#666">({{ openid.email }})</small></p>
         <p class="u-no-margin--bottom">
           <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
             'event' : 'GAEvent',
@@ -174,7 +172,7 @@
   </div>
 
   <div class="row">
-    <div class="col-12">
+    <div class="col-12 u-hide--small">
       <table style="width:auto;">
         <tr style="border: 0;">
           <td>To attach a machine:</td>
@@ -206,6 +204,28 @@
         {% endif %}
       </table>
     </div>
+    <div class="col-12 u-hide--medium u-hide--large">
+      <dl>
+        <dt>To attach a machine:</dt>
+        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></dd>
+        {% if personal_account['entitlements']['livepatch'] %}
+        <dt>Livepatch:</dt>
+        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua enable livepatch</pre></code></dd>
+        {% endif %}
+        {% if personal_account['entitlements']['esm'] %}
+        <dt>ESM:</dt>
+        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua enable esm-infra</pre></code></dd>
+        {% endif %}
+        {% if personal_account['entitlements']['fips'] %}
+        <dt>FIPS:</dt>
+        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua enable fips</code></pre></dd>
+        {% endif %}
+        {% if personal_account['entitlements']['cc-eal'] %}
+        <dt>CC-EAL:</dt>
+        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua enable cc-eal</code></pre></dd>
+        {% endif %}
+      </dl>
+    </div>
   </div>
 </section>
 
@@ -225,8 +245,8 @@
       <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
       <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
     </div>
-    <div class="col-5 col-start-large-8 u-vertically-center">
-      <div class="p-card">
+    <div class="col-5 col-start-large-8">
+      <div class="u-no-margin--bottom p-card">
         <p>
            Sign in to access your personal or paid subscriptions.
         </p>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -10,9 +10,9 @@
 {% if openid %}
   <div class="row">
     <div class="col-6">
-      <h1>Ubuntu Advantage for Infrastructure</h1>
+      <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
       {% if not enterprise_contracts %}
-      <p>By using Ubuntu Avantage you agree to our <a href="" class="p-label--in-progress" title="missing link">terms and conditions</a>.</p>
+      <p>By using Ubuntu Avantage you agree to our <a href="/legal/ubuntu-advantage-service-description">Ubuntu Advantage Service Description</a>.</p>
       {% endif %}
     </div>
 
@@ -204,11 +204,6 @@
       </table>
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-        <p>For further options <a href="" class="p-label--in-progress" title="missing link">visit the ua manpage</a>.</p>
-    </div>
-  </div>
 </section>
 
 
@@ -224,21 +219,25 @@
 {% else %}
   <div class="row">
     <div class="col-6">
-      <h1>Ubuntu Advantage for Infrastructure</h1>
+      <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
       <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
     </div>
-    <div class="col-6">
+    <div class="col-5 col-start-large-8 u-vertically-center">
       <div class="p-card">
-        <h2 class="p-heading--four">Sign in or register</h2>
+        <p>
+           Sign in to access your personal or paid subscriptions.
+        </p>
         <p class="u-no-margin--bottom">
-          <a href="/login" class="p-button--positive" style="width: 6rem;"
+          <a href="/login" class="p-button--neutral u-no-margin--bottom"
             onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage',
               'eventAction' : 'Authentication',
               'eventLabel' : 'Sign in',
               'eventValue' : undefined
-            });">Sign in</a> to access your personal or paid subscriptions.
+            });">
+            Sign in
+          </a>
         </p>
       </div>
     </div>
@@ -251,7 +250,7 @@
       <h2>Free for personal use</h2>
       <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
       <p class="u-no-margin--bottom">
-        <a href="/login" class="p-button--neutral" onclick="dataLayer.push({
+        <a href="/login" class="p-button--positive" onclick="dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : 'Advantage',
           'eventAction' : 'Authentication',

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -12,23 +12,26 @@
     <div class="col-6">
       <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
       {% if not enterprise_contracts %}
-      <p>By using Ubuntu Avantage you agree to our <a href="/legal/ubuntu-advantage-service-description">Ubuntu Advantage Service Description</a>.</p>
+      <p>By using Ubuntu Avantage you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</p>
       {% endif %}
     </div>
 
-    <div class="col-6 p-card">
-      <p>
-        You are signed in as {{ openid.fullname }} ({{ openid.email }})
-      </p>
-      <p>
-        <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
-          'event' : 'GAEvent',
-          'eventCategory' : 'Advantage',
-          'eventAction' : 'Authentication',
-          'eventLabel' : 'Sign out',
-          'eventValue' : undefined
-        });">Sign out</a>
-      </p>
+    <div class="col-5 col-start-large-8 u-vertically-center">
+      <div class="p-card">
+        <p class="p-heading--five">
+          You are signed in as {{ openid.fullname }}
+        </p>
+        <p style="color:#666">({{ openid.email }})</p>
+        <p class="u-no-margin--bottom">
+          <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'Advantage',
+            'eventAction' : 'Authentication',
+            'eventLabel' : 'Sign out',
+            'eventValue' : undefined
+          });">Sign out</a>
+        </p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/shared/contextual_footers/_ua_further_reading.html
+++ b/templates/shared/contextual_footers/_ua_further_reading.html
@@ -20,7 +20,7 @@
         articlesContainerSelector: "#latest-articles",
         articleTemplateSelector: "#article-template",
         tagId: "1486",
-        limit: "5"
+        limit: "3"
       }
     )
   </script>

--- a/templates/shared/contextual_footers/_ua_legal.html
+++ b/templates/shared/contextual_footers/_ua_legal.html
@@ -1,7 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Legal info</h3>
   <ul class="p-list">
-    <li class="p-list__item"><a href="" class="p-label--in-progress" title="missing link">Terms and conditions</a></li>
     <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description">Ubuntu Advantage Service Description</a></li>
   </ul>
 </div>


### PR DESCRIPTION
## Done
- Set the further reading contextual footer limit to 3
- Remove the margin from the expanding table panels

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Login
- Scroll to the footer and see only 3 further reading articles are loaded
- If you have paid accounts then open the expanding panels and see there is no margin-bottom

## Screenshots
![Screenshot_2019-10-09 Ubuntu Advantage for Infrastructure Ubuntu](https://user-images.githubusercontent.com/1413534/66481362-ae32bc80-ea98-11e9-8177-964d18097cb5.png)

