### PR TITLE
Keep takeover text vertically tight

### DIFF
--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -1,26 +1,28 @@
 <section {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
   <div class="row u-equal-height">
     <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %} u-vertically-center">
-      <h1>
-        {{ title }}
-      </h1>
-      {% if subtitle %}<h4>
-        {{ subtitle }}
-      </h4>{% endif %}
-      <div class="u-hide--small">
-        {% if primary_url %}
-        <p>
-          <a href="{{ primary_url }}" class="{% if primary_cta_class %}{{ primary_cta_class }}{% else %}p-button--positive{% endif %} u-no-margin--bottom">{% if 'http' in primary_url %}<span class="p-link--external">{% endif %}{{ primary_cta }}{% if 'http' in primary_url %}</span>{% endif %}
-          </a>
-        </p>
-        {% endif %}
-        {% if secondary_url %}
-        <p>
-          <a href="{{ secondary_url }}" class="{% if 'http' in secondary_url %}p-link--external{% endif %} p-link--inverted">
-            {{ secondary_cta }}{% if 'http' not in secondary_url %}&nbsp;&rsaquo;{% endif %}
-          </a>
-        </p>
-        {% endif %}
+      <div>
+        <h1>
+          {{ title }}
+        </h1>
+        {% if subtitle %}<h4>
+          {{ subtitle }}
+        </h4>{% endif %}
+        <div class="u-hide--small">
+          {% if primary_url %}
+          <p>
+            <a href="{{ primary_url }}" class="{% if primary_cta_class %}{{ primary_cta_class }}{% else %}p-button--positive{% endif %} u-no-margin--bottom">{% if 'http' in primary_url %}<span class="p-link--external">{% endif %}{{ primary_cta }}{% if 'http' in primary_url %}</span>{% endif %}
+            </a>
+          </p>
+          {% endif %}
+          {% if secondary_url %}
+          <p>
+            <a href="{{ secondary_url }}" class="{% if 'http' in secondary_url %}p-link--external{% endif %} p-link--inverted">
+              {{ secondary_cta }}{% if 'http' not in secondary_url %}&nbsp;&rsaquo;{% endif %}
+            </a>
+          </p>
+          {% endif %}
+        </div>
       </div>
     </div>
     {% if header_image %}


### PR DESCRIPTION
## Done

- Add a div around the text to keep it verically tight, but centred

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Find the 'An intro to edge computing' takeover and see it is grouped better

## Issue / Card

Fixes #5884

## Screenshots

original
![image](https://user-images.githubusercontent.com/441217/66490316-df1aed80-eaa8-11e9-862f-9e05f33f047b.png)

new
![image](https://user-images.githubusercontent.com/441217/66490350-ea6e1900-eaa8-11e9-9e82-d2a4699e309c.png)

