### PR TITLE
Update "What's new in 19.10" section on /server

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -65,8 +65,8 @@
     </h2>
     <ul class="p-list is-split">
       <li class="p-list__item is-ticked">Supported by Canonical for 9 months</li>
-      <li class="p-list__item is-ticked">Linux 5.0 kernel</li>
-      <li class="p-list__item is-ticked">Updates to LXD (v3.12), qemu (v3.1), dpdk (v18.11) and more</li>
+      <li class="p-list__item is-ticked">Linux 5.3 kernel</li>
+      <li class="p-list__item is-ticked">Updates to qemu (v4.0), libvirt (v5.4), mysql (v8.0), postgresql (v11) and more</li>
       <li class="p-list__item is-ticked">Fresh set of fixes and refreshes to the Ubuntu Server installer</li>
       <li class="p-list__item is-ticked">New Ubuntu Advantage experience</li>
     </ul>


### PR DESCRIPTION
## Done

- Update "What's new in 19.10" section on /server

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#) - *note, it will say 19.04 because the variable PR still hasn't been merged!*

## Issue / Card

Fixes #5924

## Screenshots

![image](https://user-images.githubusercontent.com/441217/66630358-fe765f80-ebfb-11e9-959a-e7bd5a4fdd2a.png)
