### PR TITLE
Adds UA-I (Personal) Terms of Service page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -596,6 +596,10 @@ legal:
           hidden: True
         - title: Ubuntu Assurance
           path: /legal/ubuntu-advantage-assurance
+        - title: UA Terms
+          path: /legal/ubuntu-advantage/ua-terms
+        - title: UA-I Personal Terms
+          path: /legal/ubuntu-advantage/personal
 
     - title: Contributors
       path: /legal/contributors

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -596,9 +596,9 @@ legal:
           hidden: True
         - title: Ubuntu Assurance
           path: /legal/ubuntu-advantage-assurance
-        - title: UA Terms
+        - title: UA terms
           path: /legal/ubuntu-advantage/ua-terms
-        - title: UA-I Personal Terms
+        - title: UA-I Personal terms
           path: /legal/ubuntu-advantage/personal
 
     - title: Contributors

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -254,7 +254,6 @@
            Sign in to access your personal or paid subscriptions.
         </p>
         <p class="u-no-margin--bottom">
-          <span class="u-sv1"><small>By signing in you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</small><br /></span>
           <a href="/login" class="p-button--neutral u-no-margin--bottom"
             onclick="dataLayer.push({
               'event' : 'GAEvent',
@@ -277,7 +276,7 @@
       <h2>Free for personal use</h2>
       <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
       <p class="u-no-margin--bottom">
-        <span class="u-sv1"><small>By registering you agree to our <a href="/legal/ubuntu-advantage-service-description">terms and conditions</a>.</small><br /></span>
+        <span class="u-sv1"><small>By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
         <a href="/login" class="p-button--positive" onclick="dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : 'Advantage',

--- a/templates/legal/ubuntu-advantage/index.html
+++ b/templates/legal/ubuntu-advantage/index.html
@@ -43,7 +43,7 @@
     <div class="col-6 p-card">
       <h3>UA-I Personal terms</h3>
       <p>The terms of service of our UA-I Essential (Personal) service for Ubuntu 14.04 LTS.</p>
-      <p><a href="/legal/ubuntu-advantage/ua-terms">View the Ubuntu Advantage service terms&nbsp;&rsaquo;</a></p>
+      <p><a href="/legal/ubuntu-advantage/personal">View the Ubuntu Advantage service terms&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/legal/ubuntu-advantage/index.html
+++ b/templates/legal/ubuntu-advantage/index.html
@@ -40,6 +40,11 @@
       <p>This agreement sets out Canonical's standard service terms for Ubuntu Advantage customers.</p>
       <p><a href="/legal/ubuntu-advantage/ua-terms">View the Ubuntu Advantage service terms&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-6 p-card">
+      <h3>UA-I Personal terms</h3>
+      <p>The terms of service of our UA-I Essential (Personal) service for Ubuntu 14.04 LTS.</p>
+      <p><a href="/legal/ubuntu-advantage/ua-terms">View the Ubuntu Advantage service terms&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
 </section>
 

--- a/templates/legal/ubuntu-advantage/personal/_markdown.html
+++ b/templates/legal/ubuntu-advantage/personal/_markdown.html
@@ -1,0 +1,39 @@
+{% extends "templates/base.html" %}
+{% block title %}{{ title }}{% endblock title %}
+{% block meta_description %}{{ description }}{% endblock meta_description %}
+
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block outer_content %}
+
+    {% block content %}
+    <div class="p-strip is-deep">
+      <div class="row" id="service-description">
+        <div class="col-8 l-legal-pages">
+{{ content | safe }}
+        </div>
+        <div class="col-4">
+          <address>
+            <div class="p-card">
+              <h3>Registered office</h3>
+              <div>5th Floor</div>
+              <div>Blue Fin Building</div>
+              <div>110 Southwark Street</div>
+              <div>London SE1 0SU</div>
+              <div>United Kingdom</div>
+            </div>
+            <div class="p-card">
+              <h3>Contact us</h3>
+              <p>
+                Please note Canonical will not provide legal advice.
+                For other queries, please contact us via <a href="mailto:legal@canonical.com">legal@canonical.com</a>
+              </p>
+            </div>
+          </address>
+        </nav>
+      </div>
+    </div>
+
+    {% endblock %}
+
+{% endblock %}

--- a/templates/legal/ubuntu-advantage/personal/index.md
+++ b/templates/legal/ubuntu-advantage/personal/index.md
@@ -1,0 +1,86 @@
+---
+wrapper_template: "legal/ubuntu-advantage/personal/_markdown.html"
+context:
+  title: "UA-I Essential (Personal) Terms of Service"
+  description: "The terms of service of our UA-I Essential (Personal) service which provides users of Ubuntu with a subscription to use UA-I Essential (Personal) on up to three physical or virtual Ubuntu systems for the eligible 14.04 LTS release, and up to 50 machines for official Ubuntu Community members."
+  copydoc: https://docs.google.com/document/d/1b2TSeqGfBsmZMepXGEGkEWyTDo0M5aHmyqaQIzEZfPs/edit
+---
+
+# UA-I Essential (Personal) Terms of Service
+
+## 1. Introduction
+
+These Terms of Service cover the provision of Canonical’s **UA-I Essential (Personal)** Service (the “<dfn>Service</dfn>”) by Canonical Group Limited (“<dfn>Canonical</dfn>”, “<dfn>us</dfn>”, “<dfn>our</dfn>” or “<dfn>we</dfn>”) to you (“<dfn>you</dfn>” or “<dfn>your</dfn>”) subject to and in accordance with these Terms of Service. Please read these Terms of Service carefully before you use the Service. By using the Service, you agree to become bound by these Terms of Service.
+
+If you have an executed agreement with a Canonical group company which includes a licence to the software your use of the software may be governed by that agreement. Otherwise, these Terms of Service will apply.
+
+If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Service through the account, to these Terms of Service. “You” and “your” shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.    
+
+You must be at least 13 years old to use the Service. If you are between age 13 and 18, you confirm that you have your parent’s or legal guardian’s consent to use the Services and that they have read and agreed to these Terms of Service.
+
+Canonical may update these Terms of Service from time to time in its discretion.
+
+## 2. Service
+
+The Service provides users of Ubuntu with a free subscription to use Ubuntu Advantage - Essential services on up to three physical or virtual Ubuntu systems for the eligible Ubuntu LTS versions as designated by Canonical.
+
+Details about the Service can be found here:  https://ubuntu.com/legal/ubuntu-advantage-service-description
+
+For recognised Ubuntu Community Members (as designated by Canonical) the Services can be used on up to fifty physical or virtual Ubuntu systems for the eligible Ubuntu LTS versions as designated by Canonical. 
+
+## 3. Account
+
+You will need a Single Sign On Ubuntu One account to access and use the Service. If you do not have an account you will need to create one. You are responsible for choosing an appropriate password for your accounts and for keeping such password secure. Canonical will not ask you for your password and you should not reveal it to anyone. You are responsible for keeping your account details up to date.
+
+We reserve the right to reject your request for an account or to immediately cancel or suspend your account and your use of the Services at any time if you do not comply with the following requirements. You must not attempt to create an account or use the Service if doing so would violate these Terms of Service. You must not:            
+
+- use the software made available through the Service for more than the entitled number of physical or virtual Ubuntu systems except as otherwise agreed, nor resell or attempt to resell the Services.
+
+- use the Service for illegal or unauthorised purposes (or encourage or permit illegal or unauthorised purposes), in infringement of a third party’s rights or otherwise cause an adverse impact to the Services.
+
+- be located in or use the Services in an OFAC/EAR embargoed or sanctioned country or be on the U.S. Commerce Department’s Denied Persons List, Entity List, or Unverified List.
+
+## 4. End of Service
+
+We look forward to providing you with the Service for so long as you wish to receive it. However, there are some circumstances under which the Service may be suspended or terminated:
+
+- we cease to make the Service (or any part thereof) available.    
+
+- by us at any time as described in Section 3 above.          
+
+We may also cease to offer the services for any other reason, in which case we will provide you with notice on your account page.    
+
+## 5. Intellectual property
+
+You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Services for such time as it is made available by us strictly in accordance with these Terms of Service.
+
+You will not acquire any rights to the Service (or the intellectual property rights contained therein) from your use of the Service, other than as set out in these Terms of Service.  
+
+Use of Canonical intellectual property is subject to [Canonical’s intellectual property rights policy](/legal/intellectual-property-policy).
+
+## 6. Personal data
+
+So that we can provide the Service to you, you will be required to provide information about yourself such as your name and email address. Any such information you provide to Canonical must always be accurate, correct and up to date.    
+
+Our [Single Sign On Privacy Notice](/legal/data-privacy/sso) and [Privacy Policy](/legal/terms-and-policies/privacy-policy) explain how we treat your personal data and protect your privacy when using these Services. In addition, if you use the Service for more than the entitled number of physical or virtual Ubuntu systems Canonical may contact you directly, using the SSO account details provided, to discuss ongoing support requirements.
+
+We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.    
+
+Canonical may disclose any or all personal data and content you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of your personal data is subject to the Privacy Policy.
+
+## 7. Liability
+
+Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis without warranty of any kind.
+
+In the case of the Services provided by Canonical, the Services are provided “as is” and all warranties (whether express, implied, statutory or otherwise) in respect of the software and Service are expressly excluded to the maximum extent permitted by law.   
+
+Canonical will provide the Service with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Service, but makes no guarantee that the Service will be available without interruption or will be error-free.
+
+Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical’s total liability in contract, tort or otherwise for any claims is limited to £10.
+
+Nothing in these Terms of Service will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.
+
+## 8. General
+
+These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.    
+Nothing in these Terms of Service and no action taken by you pursuant to these Terms of Service will be construed as creating a partnership or joint venture of any kind or as constituting either party as the agent of the other party. No party will have the authority to bind the other party or to contract in the name of or create a liability against the other party. Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties’ original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.

--- a/templates/legal/ubuntu-advantage/personal/index.md
+++ b/templates/legal/ubuntu-advantage/personal/index.md
@@ -82,5 +82,6 @@ Nothing in these Terms of Service will exclude or limit Canonical’s liability 
 
 ## 8. General
 
-These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.    
+These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.
+
 Nothing in these Terms of Service and no action taken by you pursuant to these Terms of Service will be construed as creating a partnership or joint venture of any kind or as constituting either party as the agent of the other party. No party will have the authority to bind the other party or to contract in the name of or create a liability against the other party. Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties’ original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.


### PR DESCRIPTION
# Done

- Adds the new Terms of Service page at `/legal/ubuntu-advantage/personal`, fixing #5931.
- Adjusts the links on `/advantage` to match.
- The terms are just for the Personal subscription — for which you must have chosen “Register” at some point — not for UA subscriptions in general. Therefore on `/advantage` the legal text only makes sense above “Register”, not above “Sign in”.
- Adds a card for the UA-Personal terms to `/legal/ubuntu-advantage`.
- Drive-by: Adds the UA customer terms page to the `/legal/ubuntu-advantage` ribbon navigation too.

This is the first time I’ve actually added a page, so I have probably missed something.

# QA

Go to [/legal/ubuntu-advantage](https://ubuntu-com-canonical-web-and-design-pr-5930.run.demo.haus/legal/ubuntu-advantage) and verify:
- ribbon navigation “UA Terms” link
- ribbon navigation “UA-I Personal Terms” link
- “UA-I Personal terms” card
- “UA-I Essential (Personal) Terms of Service” page ([copydoc](https://docs.google.com/document/d/1b2TSeqGfBsmZMepXGEGkEWyTDo0M5aHmyqaQIzEZfPs/edit))