### PR TITLE
Track requests for API calls on blog

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,6 +9,7 @@ import os
 import re
 
 # Packages
+import talisker.requests
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam.search import build_search_view
@@ -16,6 +17,7 @@ from canonicalwebteam import image_template
 from feedparser import parse
 from canonicalwebteam.blog.flask import build_blueprint
 from canonicalwebteam.blog import BlogViews
+from canonicalwebteam.blog.wordpress_api import api_session
 
 # Local
 from webapp.context import (
@@ -40,6 +42,7 @@ app = FlaskBase(
 
 # Blog
 blog_views = BlogViews(excluded_tags=[3184, 3265, 3408])
+talisker.requests.configure(api_session)
 
 
 @app.route("/blog/topics/<regex('maas|design|juju|robotics|snapcraft'):slug>")


### PR DESCRIPTION
## Done
 
Configure session to log API calls with Talisker. The session configured is the one for Blog

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Make sure that when on pages that make insights api calls a talisker log is added. For example:
  - on /
  - You should have a log similar to this one:

```
2019-10-14 10:44:01.126Z INFO talisker.requests "http request" url=https://admin.insights.ubuntu.com/wp-json/wp/v2/posts? qs="?per_page=<len 1>&page=<len 1>&tags_exclude=<len 14>&exclude=<len 5>&_embed=<len 4>" qs_size=75 method=GET host=admin.insights.ubuntu.com status_code=200 server="Apache/2.4.7 (Ubuntu)" duration_ms=10.65 response_type="application/json; charset=UTF-8" request_id=e987e86d-7851-4b8c-ab4c-550c6c2c0bdc service=ubuntu.com
``` 