### PR TITLE
Small QA issues for 19.10

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -309,3 +309,10 @@ summary {
     }
   }
 }
+
+.u-pull-up--large {
+  @media only screen and (min-width: $breakpoint-large) {
+    position: relative;
+    top: -2rem;
+  }
+}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -63,7 +63,7 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <ul class="p-list--divided is-split">
+      <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Linux 4.15 kernel</li>
         <li class="p-list__item is-ticked">Core applications packaged as snaps</li>
         <li class="p-list__item is-ticked">Apps available in store including Spotify, Skype and VLC</li>
@@ -86,12 +86,12 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <ul class="p-list--divided is-split">
+      <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Thousands of updated snaps and packages such as Spotify, VLC, Skype, Slack, Discord, Visual Studio Code and Telegram</li>
         <li class="p-list__item is-ticked">The fastest and most responsive GNOME Desktop, featuring improved settings for wifi, wallpaper and application groups in the Activities overview</li>
         <li class="p-list__item is-ticked">Plugging in a USB drive now automatically display the device on the launcher giving you instant access to your files</li>
         <li class="p-list__item is-ticked">Nvidia hardware is now supported out of the box. Now you can be up and running with your Nvidia graphics card from the moment you install</li>
-        <li class="p-list__item is-ticked">Support for ZFS as your root filesystem. When coupled with the new zsys package you get access to modern features such as file system snapshotting, rolling backwards and forwards between snapshots and automated snapshots. <br /><div class="p-label--in-progress">Experimental feature</div></li>
+        <li class="p-list__item is-ticked">Support for ZFS as your root filesystem. When coupled with the new zsys package you get access to modern features such as file system snapshotting, rolling backwards and forwards between snapshots and automated snapshots. <div class="p-label--in-progress">Experimental feature</div></li>
       </ul>
       <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Read the full release notes</a></p>
     </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -91,7 +91,7 @@
         <li class="p-list__item is-ticked">The fastest and most responsive GNOME Desktop, featuring improved settings for wifi, wallpaper and application groups in the Activities overview</li>
         <li class="p-list__item is-ticked">Plugging in a USB drive now automatically display the device on the launcher giving you instant access to your files</li>
         <li class="p-list__item is-ticked">Nvidia hardware is now supported out of the box. Now you can be up and running with your Nvidia graphics card from the moment you install</li>
-        <li class="p-list__item is-ticked">Support for ZFS as your root filesystem.  When coupled with the new zsys package you get access to modern features such as file system snapshotting, rolling backwards and forwards between snapshots and automated snapshots. Note, this is an experimental feature.</li>
+        <li class="p-list__item is-ticked">Support for ZFS as your root filesystem. When coupled with the new zsys package you get access to modern features such as file system snapshotting, rolling backwards and forwards between snapshots and automated snapshots. <br /><div class="p-label--in-progress">Experimental feature</div></li>
       </ul>
       <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">Read the full release notes</a></p>
     </div>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -15,7 +15,7 @@
       <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
       <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
         <div class="col-8 p-divider__block">
-          <p>Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
+          <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
           <p><a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
           <p>Recommended system requirements:</p>
           <ul class="p-list">
@@ -41,7 +41,7 @@
       <h2>Ubuntu {{ releases.latest.full_version }}</h2>
       <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
         <div class="col-8 p-divider__block">
-          <p>The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
+          <p class="u-no-padding--top">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
           <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</p>
           <p><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
         </div>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -15,7 +15,7 @@
 </section>
 
 <section class="p-strip--light u-no-padding--top">
-  <div class="row u-vertically-center" style="position: relative; top: -2rem;" >
+  <div class="row u-vertically-center u-pull-up--large">
     <div class="col-6">
       <h2>
         <a href="/download/desktop">

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -35,9 +35,9 @@
   </div>
 </section>
 
-<section class="p-strip u-no-padding--bottom">
+<section class="p-strip">
   <div class="row">
-    <div class="col-6">
+    <div class="col-6 u-sv3">
       <h2>
         <a href="/download/server">
           Ubuntu Server&nbsp;&rsaquo;
@@ -47,7 +47,7 @@
         Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.
       </p>
     </div>
-    <div class="col-6">
+    <div class="col-6 u-sv3">
       <h2>
         <a href="/download/cloud">
           Ubuntu Cloud&nbsp;&rsaquo;
@@ -58,11 +58,8 @@
       </p>
     </div>
   </div>
-</section>
-
-<section class="p-strip">
   <div class="row">
-    <div class="col-6">
+    <div class="col-6 u-sv3">
       <h2>
         <a href="/download/ubuntu-flavours">
           Ubuntu flavours&nbsp;&rsaquo;
@@ -72,7 +69,7 @@
         Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.
       </p>
     </div>
-    <div class="col-6">
+    <div class="col-6 u-sv3">
       <h2>
         <a href="/download/core">
           Ubuntu for IoT&nbsp;&rsaquo;

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -73,7 +73,7 @@
           Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.
         </p>
         <p>
-          <a class="p-button--neutral is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a><br class="u-hide--large u-hide--medium" /><a href="/download/iot/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
+          <a class="p-button--neutral is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core</a><br class="u-hide--large u-hide--medium" /><a href="/download/iot/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-4 u-vertically-center u-align--center u-hide--small">

--- a/templates/download/iot/raspberry-pi.html
+++ b/templates/download/iot/raspberry-pi.html
@@ -4,7 +4,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h1>Install Ubuntu Server on a Raspberry Pi 2, 3 or 4</h1>
@@ -13,6 +13,9 @@
       <img src="https://assets.ubuntu.com/v1/31bd2627-logo-raspberry-pi.svg" width="100" alt="Raspberry Pi">
     </div>
   </div>
+</section>
+
+<section class="p-strip is-bordered u-no-padding--top">
   <div class="row">
     <div class="col-12 p-card">
       <div class="u-equal-height row p-divider">
@@ -46,10 +49,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <p>
-            Download the Ubuntu Server image for your board:
-          </p>
-          <p>
-            <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-armhf+raspi3.img.xz">Ubuntu Server image for Raspberry Pi 2, 3 and 4</a>
+            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/bionic/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-armhf+raspi3.img.xz">Download Ubuntu Server image for Raspberry Pi 2, 3 and 4</a>
           </p>
           <p>
             You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -4,7 +4,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
       <div>
@@ -14,6 +14,9 @@
       </div>
     </div>
   </div>
+</section>
+
+<section class="p-strip is-bordered">
   <div class="row u-equal-height">
     <div class="col-6 p-card--highlighted is-divided">
       <h3 class="p-card__title">Ubuntu Server</h3>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -16,7 +16,7 @@
       <h2>Ubuntu Server {{ releases.lts.full_version }} LTS</h2>
       <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
         <div class="col-8 p-divider__block">
-          <p>
+          <p class="u-no-padding--top">
             The long-term support version of Ubuntu Server, including the {{ releases.openstack_lts.slug }} release of OpenStack and support guaranteed until {{ releases.lts.eol }} &mdash; 64-bit only.
           </p>
           <p>
@@ -42,7 +42,7 @@
       <h2>Ubuntu Server {{ releases.latest.full_version }}</h2>
       <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
         <div class="col-8 p-divider__block">
-          <p>
+          <p class="u-no-padding--top">
             The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{ releases.latest.eol }}.
           </p>
           <p>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1e-vav_b54KlKsi92w3rDu9J14O0gpp8yAanEAIImlE8/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-10">
       <div>
@@ -14,6 +14,9 @@
       </div>
     </div>
   </div>
+</section>
+
+<section class="p-strip is-bordered">
   <div class="row u-equal-height">
     <div class="col-6 p-card--highlighted" >
       <h3 class="p-card__title">Ubuntu Server</h3>

--- a/templates/engage/19-10-webinar.md
+++ b/templates/engage/19-10-webinar.md
@@ -27,10 +27,3 @@ In this webinar you will learn about:
 - Desktop performance improvements with GNOME 3.34, delivering a more responsive, smooth and organised experience
 
 Join the Ubuntu team to learn about the full capabilities of the latest Ubuntu release, and see what updates and features will improve developer and infrastructure efficiency, from cloud to the edge.
-
-Have any questions about this release and its use for organisational development and containerization? Contact us with any upgrade, capability or infrastructure questions you may have and our team will be happy to chat with you.
-
-<a class="p-button--neutral js-invoke-modal" href="/contact-us">Get in touch</a>
-
-{% include "shared/forms/_form-validation.html" %}
-{% include "shared/forms/_form-validation.html" %}


### PR DESCRIPTION
## Done
- Use label pattern for experimental in feature list on /desktop/developer
- Add `u-no-padding--top` to the first p in each download box to align with the Download button on `/download/desktop` and `/download/server`
- Replace the inline styles with class on the /download page as does not look good on small screens
- /download/iot the Ubuntu Core button removed the chevron
- Spliting the Install Ubuntu Server box into its own strip on download/iot/raspberry-pi to add some space

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check done comments look ok
