### PR TITLE
Add sha256 checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -16,8 +16,8 @@ previous_lts:
 
 checksums:
   desktop:
-    "19.10": 9846a5b513b50deea86da7ae9d5726d8f0ca9c89c925417d474f3679909b4bac *ubuntu-19.10-beta-desktop-amd64.iso
+    "19.10": 96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso
     "18.04.3": add4614b6fe3bb8e7dddcaab0ea97c476fbd4ffe288f2a4912cb06f1a47dcfa0 *ubuntu-18.04.3-desktop-amd64.iso
   live-server:
-    "19.10": 4579d4f98c4ac9d3a8ae8c75dc471e6a4034f5600ac005bf06552d230ada80c1 *ubuntu-19.10-beta-live-server-amd64.iso
+    "19.10": 3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso
     "18.04.3": b9beac143e36226aa8a0b03fc1cbb5921cff80123866e718aaeba4edb81cfa63 *ubuntu-18.04.3-live-server-amd64.iso

--- a/templates/download/iot/raspberry-pi.html
+++ b/templates/download/iot/raspberry-pi.html
@@ -21,7 +21,7 @@
       <div class="u-equal-height row p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Server</h2>
-          <p>We will walk you through the steps of flashing Ubuntu Server on a Raspberry Pi 2, 3 or 4. At the end of this process, you will have a fully fledged development or production environment..</p>
+          <p>We will walk you through the steps of flashing Ubuntu Server on a Raspberry Pi 2, 3 or 4. At the end of this process, you will have a fully fledged development or production environment.</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>


### PR DESCRIPTION
## Done

- Add sha256 checksums
- Removed a full stop on the pi download page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Confirm the checksums in the releases file are:

> <infinity> 96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso
> 14:41 <infinity> 3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso

you can't really see them yet.

## Issue / Card

Fixes #5907

