### PR TITLE
fix broken /search form layout in Chrome, implement vanilla search box pattern

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -24,20 +24,14 @@
 
   {# search form #}
   <div class="p-strip--light is-shallow">
-    <div class="u-fixed-width u-vertically-center">
-      <form action="/search">
-        <fieldset class="row u-no-margin--bottom" style="border: 0; padding: 0;">
-          <div class="col-10">
-            <label for="search-input" class="u-off-screen">Search</label>
-            <input name="q" id="search-input" type="search" {% if query %}value="{{ query }}"{% endif %} placeholder="e.g. juju" style="margin: 0;"/>
-            {% if siteSearch %}
-              <input name="siteSearch" type="hidden" value="{{ siteSearch }}" />
-            {% endif %}
-          </div>
-          <div class="col-2" style="height: 48px;">
-            <button type="submit" alt="search" class="p-button--neutral u-align--left">Search</button>
-          </div>
-        </fieldset>
+    <div class="u-fixed-width">
+      <form class="p-search-box" action="/search">
+        <label for="search-input" class="u-off-screen">Search</label>
+        <input class="p-search-box__input" name="q" id="search-input" type="search" {% if query %}value="{{ query }}"{% endif %} placeholder="e.g. juju" />
+        {% if siteSearch %}
+          <input name="siteSearch" type="hidden" value="{{ siteSearch }}" />
+        {% endif %}
+        <button type="submit" alt="search" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Fixed broken search input layout by implementing Vanilla's search box pattern

## QA

- Check out this feature branch
- Run the site using the command `./run --env SEARCH_API_KEY=[insert your search api key]`
- View the site locally in your web browser at: http://0.0.0.0:8001/search?q=vanilla
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- In Chrome, see that the layout of the search input bar is not broken, and that the search form works


## Issue / Card

Fixes #5898 

## Screenshots
Old:
![Screenshot 2019-10-17 at 16 22 08](https://user-images.githubusercontent.com/2376968/67023231-60eac680-f0fa-11e9-91e4-4f41803b6aa9.png)

New:
![Screenshot 2019-10-17 at 16 22 00](https://user-images.githubusercontent.com/2376968/67023253-6b0cc500-f0fa-11e9-87a7-1e930c610be5.png)
