### PR TITLE
Add 64 bit for Raspberry Pi

### DIFF
--- a/templates/download/iot/raspberry-pi.html
+++ b/templates/download/iot/raspberry-pi.html
@@ -48,9 +48,14 @@
           Download Ubuntu Server
         </h3>
         <div class="p-stepped-list__content">
+          <p>Download the Ubuntu Server image:</p>
           <p>
-            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-armhf+raspi3.img.xz">Download Ubuntu Server image for Raspberry Pi 2, 3 and 4</a>
+            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-armhf+raspi3.img.xz">32-bit for Raspberry Pi 2, 3 and 4</a>
           </p>
+          <p>
+            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-arm64+raspi3.img.xz">64-bit for Raspberry Pi 3 and 4</a>
+          </p>
+
           <p>
             You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
           </p>


### PR DESCRIPTION
## Done

Add 64 bit for Raspberry Pi

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

