### PR TITLE
Removing regional takeovers for release week

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,13 +25,6 @@
 #}
 
 {% block takeover_content %}
-  {# GERMAN #}
-  {% include "takeovers/_german_ai_webinar.html" %}
-  {% include "takeovers/_german-compliance-webinar.html" %}
-  {% include "takeovers/_german_openstack_security_takeover.html" %}
-  {# FRENCH #}
-  {% include "takeovers/_french_takeover_openstack_made_easy.html" %}
-  {% include "takeovers/_french_14-04-esm.html" %}
   {# ALL #}
   {% include "takeovers/_1910_takeover.html" %}
 {% endblock takeover_content %}


### PR DESCRIPTION
## Done

* Removed regional takeovers to give full exposure to 19.10 in FR and DE

## QA

- Switch your browser to FR or DE, ensure you see the 19.10 takeover on each homepage refresh
