### PR TITLE
Fix footer and rapsberry-pi menu

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -403,8 +403,8 @@ download:
         - title: Intel IEI TANK 870
           path: /download/iot/intel-iei-tank-870
           hidden: True
-        - title: Raspberry Pi 2 or 3
-          path: /download/iot/raspberry-pi-2-3
+        - title: Raspberry Pi 2, 3 or 4
+          path: /download/iot/raspberry-pi
           hidden: True
         - title: Raspberry Pi 2 or 3 Core
           path: /download/iot/raspberry-pi-2-3-core
@@ -721,7 +721,7 @@ pricing:
       path: /pricing/consulting
     - title: Devices
       path: /pricing/devices
-      
+
 documentation:
   title: Docs
   path: /_docs

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -1,4 +1,4 @@
-{% if section.children|length < 3 %}
+{% if (section.children|length < 3) and (section.path != "/security") %}
 <li class="p-footer-list--margin p-footer-list-single-child">
   <a class="p-link--soft" href="{{ section.path }}"><small>{{ section.title }}</small></a>
 {% else %}

--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -30,8 +30,8 @@
           <h4 class="p-heading-four is-dense"><a href="/download/iot">Ubuntu for IoT&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Are you a developer who wants to try snappy Ubuntu Core or classic Ubuntu on an IoT board?</p>
           <ul class='p-text-list--small is-bordered'>
-            <li class='p-list__item'><a class='p-link' href='/download/iot/raspberry-pi-2-3'>
-              Raspberry Pi 2 or 3
+            <li class='p-list__item'><a class='p-link' href='/download/iot/raspberry-pi'>
+              Raspberry Pi 2, 3 or 4
             </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/iot/raspberry-pi-compute-module-3'>
               Raspberry Pi Compute Module 3

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -18,6 +18,9 @@
           {% with section=nav_sections.kubernetes %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
+          {% with section=nav_sections.security %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
@@ -56,16 +59,9 @@
             <ul class="second-level-nav">
               <li class="p-footer-list--margin"><a href="/telecommunications">Telco</a></li>
               <li class="p-footer-list--margin"><a href="/financial-services">Finance</a></li>
-              <li class="p-footer-list--margin"><a href="/internet-of-things/digital-signage">Signage</a></li>
-              <li class="p-footer-list--margin"><a href="/internet-of-things/robotics">Robotics</a></li>
-              <li class="p-footer-list--margin"><a href="/internet-of-things/gateways">Gateways</a></li>
-              <li class="p-footer-list--margin"><a href="/desktop/organisations">Organisations</a></li>
             </ul>
           </li>
           <ul class="second-level-nav second-level-nav-small">
-            {% with section=nav_sections.security %}
-            {% include 'templates/_footer_item.html' %}
-            {% endwith %}
             {% with section=nav_sections.publiccloud %}
             {% include 'templates/_footer_item.html' %}
             {% endwith %}


### PR DESCRIPTION
## Done

- Removed some dup-sectors in the footer
- Expanded security in the footer
- Fixed the text and link for the raspberry pi 2,3 and 4 in the download mega menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the footer and the download menu

## Issue / Card

Partially Fixes #5935

