### PR TITLE
Update lubuntu logo on /download/flavours

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -30,7 +30,7 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/600c73c4-Lubuntu.svg" width="48" alt="Lubuntu icon">
+          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/2b6fde81-lubuntu-logo.png?w=48" width="48" alt="Lubuntu icon">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="http://lubuntu.me/">Lubuntu</a></h3>
             <p class="p-matrix__desc">Lubuntu is a light, fast, and modern Ubuntu flavor using LXQt as its default desktop environment. Lubuntu used to use LXDE as its default desktop environment.</p>


### PR DESCRIPTION
## Done

Update lubuntu logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/flavours
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is a new lubuntu logo


## Issue / Card

Fixes #3161

## Screenshots

![image](https://user-images.githubusercontent.com/441217/67073307-ba94d480-f17e-11e9-8377-ff7687513141.png)
