### PR TITLE
hide featured articles on blog when category query param present

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -2,7 +2,12 @@
 {% block title %}Ubuntu Blog{% endblock %}
 {% block content%}
 
-{% if current_page and current_page == 1 and featured_articles %}
+{% 
+  if current_page 
+  and current_page == 1 
+  and featured_articles 
+  and not request.args.category 
+%}
   {% include "blog/featured-articles.html" %}
 {% endif %}
 


### PR DESCRIPTION
## Done

- Hid the featured articles block when the blog index has a category filter applied to it, per the top suggestion [here](https://github.com/canonical-web-and-design/ubuntu.com/issues/5828#issue-497118113).

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Visit http://0.0.0.0:8001/blog
- See that featured articles are visible
- Visit http://0.0.0.0:8001/blog?category=webinars
- See that featured articles are not visible
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #5828