### PR TITLE
Use single apple-touch-icon

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -24,13 +24,9 @@
 
   <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}">
 
-  <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16">
-  <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" sizes="32x32">
+  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" type="image/x-icon">
+  <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/17b68252-apple-touch-icon-180x180-precomposed-ubuntu.png">
 
-  <link rel="apple-touch-icon" sizes="144x144" href="https://assets.ubuntu.com/v1/3361409d-apple-touch-icon-144x144-precomposed.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="https://assets.ubuntu.com/v1/5fe4d3c8-apple-touch-icon-114x114-precomposed.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png">
-  <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/c39e0fed-apple-touch-icon.png">
   <link type="text/plain" rel="author" href="{{ versioned_static('files/humans.txt') }}">
 
   {% block head_extra %}{% endblock %}


### PR DESCRIPTION
## Done

- Use single apple-touch-icon
- Use single favicon

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the icons are simplier.

