### PR TITLE
Add pricing section to the footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -11,6 +11,9 @@
           {% with section=nav_sections.openstack %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
+          {% with section=nav_sections.pricing %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">


### PR DESCRIPTION
## Done

Add pricing section to the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a pricing section in the footer


## Issue / Card

Fixes #5973

## Screenshots

![image](https://user-images.githubusercontent.com/441217/67190279-97209280-f3e7-11e9-823c-121cc0b7415d.png)
