### PR TITLE
Removes ineffective and redundant hidden text

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -478,7 +478,7 @@ store for access to all the standard apps, or curate your own collection.</p>
           <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/CS_IMS_Evolve.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - left', 'eventLabel' : 'Case study - IMS Evolve ', 'eventValue' : '1' });'><span hidden>Read the case study </span>IMS Evolve adopts Ubuntu Core to provide IoT business intelligence</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/CS_IMS_Evolve.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - left', 'eventLabel' : 'Case study - IMS Evolve ', 'eventValue' : '1' });'>IMS Evolve adopts Ubuntu Core to provide IoT business intelligence</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-core_center">
@@ -489,7 +489,7 @@ store for access to all the standard apps, or curate your own collection.</p>
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='engage/ubuntu-core-and-kura' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - center', 'eventLabel' : 'Whitepaper - Ubuntu Core and Kura - a framework for IoT gateways', 'eventValue' : '1' });'><span hidden>Read the whitepaper </span>Ubuntu Core and Kura &mdash; a framework for IoT gateways&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='engage/ubuntu-core-and-kura' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - center', 'eventLabel' : 'Whitepaper - Ubuntu Core and Kura - a framework for IoT gateways', 'eventValue' : '1' });'>Ubuntu Core and Kura &mdash; a framework for IoT gateways&nbsp;&rsaquo;</a></h3>
       <!-- rtp section center end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_iot-robotics_right">
@@ -500,7 +500,7 @@ store for access to all the standard apps, or curate your own collection.</p>
           <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/fingbox-case-study' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - right', 'eventLabel' : 'Case study - Fing snaps up 30,000 customers', 'eventValue' : '1' });'><span hidden>Read the case study </span>Fing snaps up 30,000 customers with a secure, future-proof device&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/fingbox-case-study' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - right', 'eventLabel' : 'Case study - Fing snaps up 30,000 customers', 'eventValue' : '1' });'>Fing snaps up 30,000 customers with a secure, future-proof device&nbsp;&rsaquo;</a></h3>
       <!-- rtp section right end -->
     </div>
   </div>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -120,7 +120,7 @@
         </div>
       </div>
       <h2 class='p-heading--four'>
-        <a class='p-link--external' href='/engage/iot-business-model' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - left', 'eventLabel' : 'White paper - Establishing a software defined IoT business model', 'eventValue' : '1' });'><span hidden>Read the white paper </span>Establishing a software defined IoT business model</a>
+        <a class='p-link--external' href='/engage/iot-business-model' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - left', 'eventLabel' : 'White paper - Establishing a software defined IoT business model', 'eventValue' : '1' });'>Establishing a software defined IoT business model</a>
       </h2>
       <!-- rtp section end -->
     </div>
@@ -133,7 +133,7 @@
         </div>
       </div>
       <h2 class='p-heading--four'>
-        <a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/290087' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - center', 'eventLabel' : 'Webinar - IoT App Stores: The Path to Post-Sale Revenue', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>IoT App Stores: The Path to Post-Sale Revenue</a>
+        <a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/290087' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - center', 'eventLabel' : 'Webinar - IoT App Stores: The Path to Post-Sale Revenue', 'eventValue' : '1' });'>IoT App Stores: The Path to Post-Sale Revenue</a>
       </h2>
       <!-- rtp section end -->
     </div>
@@ -146,7 +146,7 @@
         </div>
       </div>
       <h2 class='p-heading--four'>
-        <a class='p-link--external' href='/blog/building-a-future-proofed-iot-consumer-device-with-brand-stores' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - right', 'eventLabel' : 'Case study - Fing builds a future-proofed IoT consumer device', 'eventValue' : '1' });'><span hidden>Read the case study </span>Fing builds a future-proofed IoT consumer device</a>
+        <a class='p-link--external' href='/blog/building-a-future-proofed-iot-consumer-device-with-brand-stores' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'appstore - right', 'eventLabel' : 'Case study - Fing builds a future-proofed IoT consumer device', 'eventValue' : '1' });'>Fing builds a future-proofed IoT consumer device</a>
       </h2>
       <!-- rtp section end -->
     </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -40,7 +40,7 @@
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Building success with a Raspberry Pi!</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/206421?utm_campaign=channel-feed&utm_content=&amp;utm_source=brighttalk-portal&amp;utm_medium=web&amp;utm_term=' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - left', 'eventLabel' : 'Webinar - Building success with a Raspberry Pi!', 'eventValue' : '1' });'>Building success with a Raspberry Pi!</a></h3>
       <!-- rtp section end -->
     </div>
 
@@ -52,7 +52,7 @@
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/226883/why-the-world-s-largest-digital-signage-networks-use-linux' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Why the world’s largest digital signage networks use Linux', 'eventValue' : '1' });'><span hidden>Watch the webinar </span>Why the world’s largest digital signage networks use Linux</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://www.brighttalk.com/webcast/6793/226883/why-the-world-s-largest-digital-signage-networks-use-linux' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - center', 'eventLabel' : 'Webinar - Why the world’s largest digital signage networks use Linux', 'eventValue' : '1' });'>Why the world’s largest digital signage networks use Linux</a></h3>
       <!-- rtp section end -->
     </div>
 
@@ -64,7 +64,7 @@
           <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='/blog/cinergy-makes-significant-digital-signage-savings-using-ubuntu-core' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Find out how Cinergy saves on digital Signage', 'eventValue' : '1' });'><span hidden>Read the case study </span>Find out how Cinergy saves on digital Signage</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='/blog/cinergy-makes-significant-digital-signage-savings-using-ubuntu-core' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'digital signage - right', 'eventLabel' : 'Case study - Find out how Cinergy saves on digital Signage', 'eventValue' : '1' });'>Find out how Cinergy saves on digital Signage</a></h3>
       <!-- rtp section end -->
     </div>
   </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -188,7 +188,7 @@
           <h4 class='p-heading-icon__title'>White paper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='https://assets.ubuntu.com/v1/66fcd858-canonical-ubuntu-core-security-2018-11-13.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - left', 'eventLabel' : 'White paper - Read Ubuntu Core Security Whitepaper', 'eventValue' : '1' });'><span hidden>Read the white paper </span>Ubuntu Core Security Whitepaper</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://assets.ubuntu.com/v1/66fcd858-canonical-ubuntu-core-security-2018-11-13.pdf' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - left', 'eventLabel' : 'White paper - Read Ubuntu Core Security Whitepaper', 'eventValue' : '1' });'>Ubuntu Core Security Whitepaper</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_security_center">
@@ -199,7 +199,7 @@
           <h4 class='p-heading-icon__title'>White paper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/IoT-Security-whitepaper.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - center', 'eventLabel' : 'White paper - Read IoT Security Whitepaper', 'eventValue' : '1' });'><span hidden>Read the white paper </span>IoT Security Whitepaper</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='https://pages.ubuntu.com/IoT-Security-whitepaper.html' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External link', 'eventAction' : 'Security - center', 'eventLabel' : 'White paper - Read IoT Security Whitepaper', 'eventValue' : '1' });'>IoT Security Whitepaper</a></h3>
       <!-- rtp section end -->
     </div>
     <div class="col-4 p-divider__block" id="ubuntu-com_security_right">
@@ -210,7 +210,7 @@
           <h4 class='p-heading-icon__title'>FAQ</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class='p-link--external' href='/blog/faqs-ensuring-the-ongoing-security-compliance-of-ubuntu/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'FAQ - Ensuring the ongoing security compliance of Ubuntu', 'eventValue' : '1' });'><span hidden>Read FAQ </span>Ensuring the ongoing security compliance of Ubuntu</a></h3>
+      <h3 class='p-heading--four'><a class='p-link--external' href='/blog/faqs-ensuring-the-ongoing-security-compliance-of-ubuntu/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'gateways - right', 'eventLabel' : 'FAQ - Ensuring the ongoing security compliance of Ubuntu', 'eventValue' : '1' });'>Ensuring the ongoing security compliance of Ubuntu</a></h3>
       <!-- rtp section end -->
     </div>
   </div>


### PR DESCRIPTION
## Done

Removes `<span hidden>` text from ubuntu.com pages.

This text was reportedly intended “for screen readers to get more context”. This was mistaken, because [`hidden` text is is deliberately ignored by screen readers](http://stevefaulkner.github.io/HTML5accessibility/tests/hidden-2016.html), just as it is by browsers.

If the text would have been useful for screenreaders, the appropriate fix would have been to change `hidden` to [`class="u-off-screen"`](https://docs.vanillaframework.io/utilities/off-screen/).

However, in all these cases the text would not be useful for screenreaders, because it’s immediately preceded by a heading that provides the same context: `<h4 class="p-heading-icon__title">White paper</h4>`, `<h4 class="p-heading-icon__title">Case study</h4>`, and so on. So the better solution is just to remove the dead code.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Point a browser or screen reader at: http://0.0.0.0:8001/security
- Notice that the page looks, and sounds, exactly as it did before