### PR TITLE
make CaptchaCallback function available to recaptcha script

### DIFF
--- a/static/js/formValidation.js
+++ b/static/js/formValidation.js
@@ -140,7 +140,7 @@ afterSubmit = function(download_asset_url, return_url, isModal, thankYouMessage)
 }
 
 // recaptcha submitCallback
-var CaptchaCallback = function() {
+CaptchaCallback = function() {
   let recaptchas = document.querySelectorAll("div[class^=g-recaptcha]");
   recaptchas.forEach(function(field){
     recaptchaWidgetId = grecaptcha.render(field, {'sitekey' : '6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if'});


### PR DESCRIPTION
## Done

- made `CaptchaCallback` function available again to recaptcha script tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/the-future-of-mobile-connectivity
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open your browser's dev tools, see that there are no messages related to recaptcha in the console.
- Fill out the newsletter form, see that the recaptcha box is present and working, then submit the form.


## Issue / Card

Fixes #5984 
