### PR TITLE
add acuris case study

### DIFF
--- a/templates/engage/case-study-acuris.md
+++ b/templates/engage/case-study-acuris.md
@@ -1,0 +1,34 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+    title: "TIM ensures system security and client confidence with ESM"
+    meta_description: "TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits (CVEs) to enable them to continue using Ubuntu 14.04 LTS."
+    meta_image: "https://assets.ubuntu.com/v1/9f33421e-acuris-case-study-social-media.jpg"
+    meta_copydoc: "https://docs.google.com/document/d/1rKM8TyZFZipp0NL_QbsIyJ6cn5oPFmN_cD5XDCL003s/edit"
+    header_title: "TIM ensures system security and client confidence with ESM"
+    header_image: "https://assets.ubuntu.com/v1/e7043d2c-TIM_Logo_white.png"
+    header_url: '#register-section'
+    header_cta: Download case study
+    header_class: p-engage-banner--dark
+    header_lang: en
+    form_cta: Download case study
+    form_include: en
+    form_id: 3447
+    form_return_url: https://pages.ubuntu.com/Cstudy_Acuris_TY.html
+---
+
+Security is an essential expectation in the financial services industry. The risk of not taking security seriously can lead to significant reputational damage and loss of client trust. TIM, an Acuris company, who operate the world’s largest trade ideas network are well aware of the need to maintain and ensure the security of their infrastructure for these reasons.
+
+With around 70 physical machines and 800 virtual machines running Ubuntu 14.04 LTS, the end of the five year public support window in 2019 led to the infrastructure team needing to decide whether to upgrade to 18.04 LTS. With two people assigned to maintaining the infrastructure, TIM quickly realised they could not upgrade in the timeframe required.
+
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">ESM has given us the space to plan what comes next. It’s helping us get into a position where we can have a more sustainable infrastructure.</p>
+  <cite class="p-pull-quote__citation">Andy Parker, Engineering Manager, TIM</cite>
+</blockquote>
+
+As a result, TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits (CVEs) to enable them to continue using Ubuntu 14.04 LTS. In turn, this also allows their IT team to focus their resources on other priorities to advance their infrastructure.
+
+Download the case study to learn:
+- How adopting ESM eliminates the need to allocate in-house resource to tracking CVEs.
+- Freeing their IT team up has helped with their cloud migration and alignment with the overall Acuris IT strategy.
+- How TIM are now looking forward to deploying Kubernetes for which they are already supported under Ubuntu Advantage for Infrastructure.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1183,6 +1183,20 @@
           </div>
         </div><!-- 2nd -->
 
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--desktop'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              case study
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/case-study-acuris'>TIM ensures system security and client confidence with ESM</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits.</p>
+          </div>
+        </div>
+
       </div>
     </section>
     {% endblock content %}


### PR DESCRIPTION
## Done

- Created /engage/case-study-acuris according to [design](https://github.com/canonical-web-and-design/ubuntu.com/issues/5927) and [brief](https://docs.google.com/spreadsheets/d/17SMISc4VP9sCkED9cjK-La-ww8pW74teAFwT3CKQk1k/edit#gid=1271849439)
- Added /engage/case-study-acuris card to /engage index

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/case-study-acuris
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [ ] see that the page matches the [design](https://github.com/canonical-web-and-design/ubuntu.com/issues/5927) and the [copy doc](https://docs.google.com/document/d/1rKM8TyZFZipp0NL_QbsIyJ6cn5oPFmN_cD5XDCL003s/edit)
- [ ] validate the page on https://cards-dev.twitter.com/validator, see that the card contains an image, title and description
- [ ] submit the form and see that you are taken to a thank you page and can download the case study
- [ ] visit [/engage](/engage/case-study-acuris) and see that the last card links to this engage page


## Issue / Card

Fixes #5927 
