### PR TITLE
add table of contents to /about/release-cycle

### DIFF
--- a/static/sass/_pattern_table-of-contents.scss
+++ b/static/sass/_pattern_table-of-contents.scss
@@ -1,0 +1,7 @@
+@mixin ubuntu-p-table-of-contents {
+  .p-table-of-contents {
+    @media only screen and (max-width: $breakpoint-navigation-threshold) {
+      padding-left: 0;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -54,6 +54,7 @@ $font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen
 @import "pattern_strip-photos";
 @import "pattern_takeunders";
 @import "pattern_takeovers";
+@import "pattern_table-of-contents";
 @import "pattern_table";
 @import "pattern_ubuntu_intro";
 @import "takeovers/financial-services";
@@ -84,6 +85,7 @@ $font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen
 @include ubuntu-p-pie-chart;
 @include ubuntu-p-separator;
 @include ubuntu-p-strip-photos;
+@include ubuntu-p-table-of-contents;
 @include ubuntu-p-tables;
 @include ubuntu-p-takeunders;
 @include ubuntu-p-takeovers;

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -24,6 +24,21 @@
       <h2>Version numbers are YY.MM</h2>
       <p>Releases of Ubuntu get a development codename (‘Breezy Badger’) and are versioned by the year and month of delivery - for example Ubuntu 17.10 was released in October 2017.</p>
     </div>
+
+    <div class="col-4 u-hide--small">
+      <aside class="p-table-of-contents">
+        <div class="p-table-of-contents__section">
+          <h4 class="p-table-of-contents__header">CONTENTS</h4>
+          <nav class="p-table-of-contents__nav">
+            <ul class="p-list">
+              <li><a href="#ubuntu-kernel-release-cycle">Ubuntu kernel release cycle (UA-I)</a></li>
+              <li><a href="#ubuntu-openstack-release-cycle">Ubuntu OpenStack release cycle</a></a></li>
+              <li><a href="#charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</a></a></li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+    </div>
   </div>
 </section>
 
@@ -33,17 +48,6 @@
       <h2>Long term support and interim releases</h2>
       <p>LTS or ‘Long Term Support’ releases are published every two years in April. LTS releases are the ‘enterprise grade’ releases of Ubuntu and are utilised the most. An estimated 95% of all Ubuntu installations are LTS releases, with more than 60% of large-scale production clouds running on the most popular OS images - Ubuntu 18.04, 16.04 and 14.04 LTS.</p>
       <p>Every six months between LTS versions, Canonical publishes an interim release of Ubuntu, with18.10 being the latest example. These are production-quality releases and are supported for their lifespan, with sufficient time provided for users to update, but these releases do not receive the long-term commitment of LTS releases.</p>
-    </div>
-    <div class="col-4">
-      <nav class="u-hide--small p-card">
-        <h3>Contents</h3>
-        <ol class="p-nested-counter-list">
-          <li class="p-nested-counter-list__item"><a href="#ubuntu-kernel-release-cycle">Ubuntu kernel release cycle (UA-I)
-          </li>
-          <li class="p-nested-counter-list__item"><a href="#ubuntu-openstack-release-cycle">Ubuntu OpenStack release cycle</a></li>
-          <li class="p-nested-counter-list__item"><a href="#charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</a></li>
-        </ol>
-      </nav>
     </div>
   </div>
 

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -25,7 +25,7 @@
       <p>Releases of Ubuntu get a development codename (‘Breezy Badger’) and are versioned by the year and month of delivery - for example Ubuntu 17.10 was released in October 2017.</p>
     </div>
 
-    <div class="col-4 u-hide--small">
+    <div class="col-4">
       <aside class="p-table-of-contents">
         <div class="p-table-of-contents__section">
           <h4 class="p-table-of-contents__header">CONTENTS</h4>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -19,17 +19,32 @@
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="u-fixed-width">
-    <h2>Version numbers are YY.MM</h2>
-    <p>Releases of Ubuntu get a development codename (‘Breezy Badger’) and are versioned by the year and month of delivery - for example Ubuntu 17.10 was released in October 2017.</p>
+  <div class="row">
+    <div class="col-8">
+      <h2>Version numbers are YY.MM</h2>
+      <p>Releases of Ubuntu get a development codename (‘Breezy Badger’) and are versioned by the year and month of delivery - for example Ubuntu 17.10 was released in October 2017.</p>
+    </div>
   </div>
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="u-fixed-width">
-    <h2>Long term support and interim releases</h2>
-    <p>LTS or ‘Long Term Support’ releases are published every two years in April. LTS releases are the ‘enterprise grade’ releases of Ubuntu and are utilised the most. An estimated 95% of all Ubuntu installations are LTS releases, with more than 60% of large-scale production clouds running on the most popular OS images - Ubuntu 18.04, 16.04 and 14.04 LTS.</p>
-    <p>Every six months between LTS versions, Canonical publishes an interim release of Ubuntu, with18.10 being the latest example. These are production-quality releases and are supported for their lifespan, with sufficient time provided for users to update, but these releases do not receive the long-term commitment of LTS releases.</p>
+  <div class="row">
+    <div class="col-8">
+      <h2>Long term support and interim releases</h2>
+      <p>LTS or ‘Long Term Support’ releases are published every two years in April. LTS releases are the ‘enterprise grade’ releases of Ubuntu and are utilised the most. An estimated 95% of all Ubuntu installations are LTS releases, with more than 60% of large-scale production clouds running on the most popular OS images - Ubuntu 18.04, 16.04 and 14.04 LTS.</p>
+      <p>Every six months between LTS versions, Canonical publishes an interim release of Ubuntu, with18.10 being the latest example. These are production-quality releases and are supported for their lifespan, with sufficient time provided for users to update, but these releases do not receive the long-term commitment of LTS releases.</p>
+    </div>
+    <div class="col-4">
+      <nav class="u-hide--small p-card">
+        <h3>Contents</h3>
+        <ol class="p-nested-counter-list">
+          <li class="p-nested-counter-list__item"><a href="#ubuntu-kernel-release-cycle">Ubuntu kernel release cycle (UA-I)
+          </li>
+          <li class="p-nested-counter-list__item"><a href="#ubuntu-openstack-release-cycle">Ubuntu OpenStack release cycle</a></li>
+          <li class="p-nested-counter-list__item"><a href="#charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</a></li>
+        </ol>
+      </nav>
+    </div>
   </div>
 
   <div class="row">
@@ -226,7 +241,7 @@
 
 <section class="p-strip is-bordered ">
   <div class="u-fixed-width">
-    <h2>Ubuntu kernel release cycle</h2>
+    <h2 id="ubuntu-kernel-release-cycle">Ubuntu kernel release cycle</h2>
     <p>Canonical maintains multiple kernel packages for each LTS version of Ubuntu, which serve different purposes. Several of the kernel packages address the need for kernels with specific performance priorities, for example the low-latency kernel package. Others are focused on optimisation for a particular hypervisor, for example the kernel packages which are named after public clouds. You are recommended to use the <a class="p-link--external" href="https://wiki.ubuntu.com/Kernel">detailed Ubuntu kernel guide</a> to select the best Ubuntu kernel for your application.</p>
     <p>In general, all of the LTS kernel packages will use the same base version of the Linux kernel, for example Ubuntu 18.04 LTS kernels typically used the 4.15 upstream Linux kernel as a base. Some cloud-specific kernels may use a newer version in order to benefit from improved mechanisms in performance or security that are material to that cloud. These kernels are all supported for the full life of their underlying LTS release.</p>
     <p>In addition, the kernel versions from the subsequent four releases are made available on the latest LTS release of Ubuntu. So Ubuntu 16.04 LTS received the kernels from Ubuntu 16.10, 17.04, 17.10 and 18.04 LTS. These kernels use newer upstream versions and as a result offer an easy path to newer features and newer classes of hardware for many users of Ubuntu. Note however that these kernels ‘roll’ which means that they jump every six months until the next LTS. Large scale deployments that adopt these ‘hardware enablement’ or HWE kernels should manage those transitions explicitly. These newer HWE kernels are accompanied by a collection of userspace tools closely tied to the kernel and hardware, specifically X display enablement on newer graphics cards.</p>
@@ -373,7 +388,7 @@
 <section class="p-strip--light  is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2>Ubuntu OpenStack release cycle</h2>
+      <h2 id="ubuntu-openstack-release-cycle">Ubuntu OpenStack release cycle</h2>
       <p>Canonical’s Cloud Archive allows users the ability to install newer releases of Ubuntu <a href="https://wiki.ubuntu.com/OpenStack" class="p-link--external">OpenStack</a> on an Ubuntu server as they become available. A given LTS release of Ubuntu will have the current release of OpenStack packaged in its release archives. The next four releases of OpenStack will then be published in the Cloud Archive for that LTS.</p>
       <p>That means that it is possible to upgrade OpenStack four times on the same Ubuntu LTS release base operating system (upgrading the OpenStack without upgrading the operating system), and then one has the same OpenStack version that is included with the subsequent LTS release, and can choose to upgrade the operating system without upgrading the OpenStack version.</p>
       <p>The middle OpenStack release (one year after the LTS release and one year before the next LTS release) is maintained for an extended period. Many customers therefore opt to make annual upgrades to their OpenStack rather than tracking each six-monthly release. The actual upgrade is fully supported using Canonical OpenStack tools and operator guides, and involves hopping through the six-monthly versions for database upgrade purposes, but the next effect is an annual upgrade to a version that is fully supportable.</p>
@@ -563,8 +578,8 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2>Charmed Distribution of Kubernetes<sup>&reg;</sup> release cycle</h2>
-      <p>The release cycle of the Charmed Distribution of Kubernetes (CDK) is tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of nine months, subject to changes in the upstream release cycle.</p>
+      <h2 id="charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</h2>
+      <p>The release cycle of the Charmed Distribution of Kubernetes is tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of nine months, subject to changes in the upstream release cycle.</p>
       <p>The CDK support lifecycle can be represented this way:</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added short table of contents to /about/release-cycle

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a table of contents that links to three different sections on the page

## Issue / Card

Fixes #5990 

## Screenshots

![Screenshot 2019-10-22 at 15 23 43](https://user-images.githubusercontent.com/2376968/67296820-eb5b6d80-f4e0-11e9-818a-c4e13f0b8798.png)