### PR TITLE
Remove compatibility field renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,5 @@
       "depTypeList": ["devDependencies"],
       "extends": [":automergeMinor"]
     }
-  ],
-  "compatibility": {
-    "python": "2.7"
-  }
+  ]
 }


### PR DESCRIPTION
## Done

This field was added when ubuntu.com was still running on the old infra. https://github.com/canonical-web-and-design/ubuntu.com/pull/4584

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/4906

## QA

- Not much to qa since no impact on the site itself