### PR TITLE
add safe filter to blog article meta title

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -1,6 +1,6 @@
 {% extends "templates/one-column.html" %}
 
-{% block title %}{{ article.title.rendered }}{% endblock %}
+{% block title %}{{ article.title.rendered|safe }}{% endblock %}
 {% block meta_description %}{{ article.excerpt.raw }}{% endblock %}
 {% block meta_image %}{{ article.image.source_url }}{% endblock %}
 


### PR DESCRIPTION
## Done
- added safe filter to meta title on blog articles

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/chromium-in-ubuntu-deb-to-snap-transition
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- In the browser tab, see that the title of the page contains an em dash, and not "&#8211" (compare to [live u.c](https://ubuntu.com/blog/chromium-in-ubuntu-deb-to-snap-transition))

## Issue / Card

Fixes #5928 
