### PR TITLE
Remove the login from the global nav

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -2,7 +2,7 @@ import { createNav } from "@canonical/global-nav";
 import cpNs from "./cookie-proxy";
 
 // Initalise the global navigation.
-createNav();
+createNav({ showLogins: false });
 
 // Initalise the cookie policy notification.
 cpNs.cookiePolicy.setup({


### PR DESCRIPTION
## Done

- Remove login from the global nav


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the login in the global nav is removed


## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/67485877-d575b600-f662-11e9-8361-5d3e9421bef2.png)

