### PR TITLE
Add UTM params to get-in-touch form data

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -35,6 +35,7 @@
           formContainer.classList.remove('u-hide');
           formContainer.innerHTML = text.replace(/%% formid %%/g, formData.formId).replace(/%% lpId %%/g, formData.lpId).replace(/%% returnURL %%/g, formData.returnUrl).replace(/%% lpurl %%/g, formData.lpUrl);
           setProductContext(contactButton);
+          setUTMs();
           initialiseForm();
           CaptchaCallback();
         })
@@ -79,6 +80,25 @@
       var productContext = document.getElementById("product-context");
       if (productContext) {
         productContext.value = product;
+      }
+    }
+
+    function setUTMs() {
+      var params = new URLSearchParams(window.location.search);
+
+      var utm_campaign = document.getElementById("utm_campaign");
+      if (utm_campaign) {
+        utm_campaign.value = params.get("utm_campaign");
+      }
+
+      var utm_source = document.getElementById("utm_source");
+      if (utm_source) {
+        utm_source.value = params.get("utm_source");
+      }
+
+      var utm_medium = document.getElementById("utm_medium");
+      if (utm_medium) {
+        utm_medium.value = params.get("utm_medium");
       }
     }
 

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -341,6 +341,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -193,6 +193,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -226,6 +226,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -176,6 +176,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -257,6 +257,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_openstack.html
+++ b/templates/shared/forms/interactive/_openstack.html
@@ -343,6 +343,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -197,6 +197,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_robotics.html
+++ b/templates/shared/forms/interactive/_robotics.html
@@ -210,6 +210,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_storage.html
+++ b/templates/shared/forms/interactive/_storage.html
@@ -185,6 +185,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -703,7 +703,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
-            
+
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href=""
                 >Previous</a

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -699,8 +699,11 @@
                 name="productContext" 
                 id="product-context" 
                 value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
-
+            
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href=""
                 >Previous</a

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -196,6 +196,9 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
             </div>
 
             <div class="pagination">


### PR DESCRIPTION
## Done

* Adds UTM params to get-in-touch form data

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to https://ubuntu-com-canonical-web-and-design-pr-6003.run.demo.haus/internet-of-things/robotics?utm_campaign=foo
- Click on the "Get to market faster" button
- Ensure the source of the form contains "foo" in the utm_campaign hidden field
