### PR TITLE
Fix typo on /kubernetes/install page

### DIFF
--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -103,7 +103,7 @@
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
           <p><strong>Install specific Kubernetes version</strong></p>
-          <p>This command will install a the stable 1.14 version of MicroK8s:</p>
+          <p>This command will install the stable 1.14 version of MicroK8s:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="sudo snap install microk8s --classic --channel=1.14/stable" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -114,7 +114,7 @@
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">Useful tips</h3>
         <div class="p-stepped-list__content">
-          <p>This command will install a the stable 1.14 version of MicroK8s:</p>
+          <p>This command will install the stable 1.14 version of MicroK8s:</p>
           <p>After installing MicroK8s, you should verify it is ready. Use this command:</p>
           <div class="p-code-copyable">
             <input class="p-code-copyable__input" value="microk8s.status" readonly="readonly">


### PR DESCRIPTION
## Done

- Fix typo on `/kubernetes/install`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the phrase containing `the stable 1.14 version` makes sense


## Issue / Card

Fixes #5971 
