### PR TITLE
Specifies 14.04 LTS for /advantage

### DIFF
--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -4,7 +4,7 @@
     <table class="p-table advantage-table">
       <thead>
         <tr>
-          <th><strong>What's included</strong></th>
+          <th><strong>What’s included</strong></th>
           <th class="u-align--center">Essential</th>
           <th class="u-align--center">Standard</th>
           <th class="u-align--center">Advanced</th>
@@ -12,7 +12,7 @@
       </thead>
       <tbody>
         <tr id="esm">
-          <td><a href="/esm">Extended Security Maintenance</a> (ESM)</td>
+          <td><a href="/esm">Extended Security Maintenance</a> (ESM) for Ubuntu 14.04 LTS</td>
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -176,6 +176,7 @@
 
   <div class="row">
     <div class="col-12 u-hide--small">
+      <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
       <table style="width:auto;">
         <tr style="border: 0;">
           <td class="u-align--right">To attach a machine:</td>
@@ -242,7 +243,7 @@
       <h2>Free for personal use</h2>
       <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
       <p class="u-no-margin--bottom">
-        <span class="u-sv1"><small>By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
+        <span class="u-sv1"><small>Initially, free subscription is available for Ubuntu 14.04 LTS only. By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
         <a href="/login" class="p-button--positive" onclick="dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : 'Advantage',


### PR DESCRIPTION
## Done

- In signed-out state:
  - Specified 14.04 LTS above “Register” button
  - Specified 14.04 LTS in enterprise subscription feature table
- In signed-in states:
  - Specified 14.04 LTS above `ua` commands

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Review page contents both signed out and signed in

## Issue / Card

Fixes [Ubuntu-design#199](https://github.com/CanonicalLtd/Ubuntu-design/issues/199)