### PR TITLE
Remove redundant js

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -10,11 +10,8 @@
   {% include "templates/_tag_manager.html" %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   {% block content_experiment %}{% endblock %}
-  <script src="https://assets.ubuntu.com/v1/f5bf3854-respond.min.js" defer></script>
   <script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" defer></script>
-  <script src="https://assets.ubuntu.com/v1/ec520d10-XMLHttpRequest.min.js" defer></script>
   <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js" defer></script>
-  <script src="https://assets.ubuntu.com/v1/6b7597df-event-listener-polyfill.js" defer></script>
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" async defer></script>
   <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -7,7 +7,6 @@
 
   <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-  {% include "templates/_tag_manager.html" %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" defer></script>
@@ -60,6 +59,8 @@
   <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
   <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
   {% endif %}
+
+  {% include "templates/_tag_manager.html" %}
 </head>
 
 <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
## Done

- Remove external JS libs used to support legacy IE6-8 browsers
- De-prioritise Google Tag Manager

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Ensure no failings tests or errors

