### PR TITLE
Add a resources link to the footer for SEO from engage

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -102,6 +102,9 @@
               <a class="p-link--soft" href="/blog"><small>Blog</small></a>
             </li>
             <li class="p-inline-list__item">
+              <a class="p-link--soft" href="/engage"><small>Resources</small></a>
+            </li>
+            <li class="p-inline-list__item">
               <a class="p-link--soft" href="/blog/press-centre"><small>Press centre</small></a>
             </li>
           </ul>


### PR DESCRIPTION
## Done
Add a resources link to the footer for SEO from engage

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll to the footer and see the new resources link
- Click and check the /engage page loads

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6026

## Screenshots
![Screenshot_2019-10-28 The leading operating system for PCs, IoT devices, servers and the cloud Ubuntu](https://user-images.githubusercontent.com/1413534/67673505-268eee00-f972-11e9-8ae4-57b7642bb4c8.png)

