### PR TITLE
Update UA-I datasheet to show 48TB

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -14,7 +14,7 @@
       <p>Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry. With OpenStack and Kubernetes support included, Ubuntu Advantage for Infrastructure provides everything you need to future-proof your data centre.</p>
       <p>
         <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Buy online</span></a>
-        <a href="https://assets.ubuntu.com/v1/1298e8fc-UA-I_datasheet_2019-Oct.pdf" class="p-button--neutral">Read the datasheet</a>
+        <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-button--neutral">Read the datasheet</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

- Update datasheet on /support

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the datasheet is downloadable and from October containing 48TB storage [see issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/5920)

## Issue / Card

Fixes #5920
