### PR TITLE
add (sticky) vanilla table of contents to /legal pages

### DIFF
--- a/static/sass/_pattern_table-of-contents.scss
+++ b/static/sass/_pattern_table-of-contents.scss
@@ -7,12 +7,30 @@
 
   .p-sticky-toc {
     @media (max-width: $breakpoint-small - 1px) {
+      margin-bottom: 2rem;
       order: -1;
     }
 
     .p-table-of-contents {
       position: sticky;
       top: 1rem;
+
+      @media (max-width: $breakpoint-small - 1px) {
+        border-bottom: 1px solid $color-mid-light;
+        border-top: 0;
+      }
+    }
+
+    .p-table-of-contents__section {
+      @media (max-width: $breakpoint-small - 1px) {
+        &:first-child {
+          padding-top: 0;
+        }
+
+        &:last-child {
+          padding-bottom: 1.5rem;
+        }
+      }
     }
   }
 }

--- a/static/sass/_pattern_table-of-contents.scss
+++ b/static/sass/_pattern_table-of-contents.scss
@@ -4,4 +4,15 @@
       padding-left: 0;
     }
   }
+
+  .p-sticky-toc {
+    @media (max-width: $breakpoint-small - 1px) {
+      order: -1;
+    }
+
+    .p-table-of-contents {
+      position: sticky;
+      top: 1rem;
+    }
+  }
 }

--- a/templates/legal/data-privacy/_older-versions.html
+++ b/templates/legal/data-privacy/_older-versions.html
@@ -1,5 +1,0 @@
-<h3>Older versions</h3>
-<ul class="p-list">
-  <li class="p-list__item"><a href="/legal/data-privacy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
-  <li class="p-list__item"><a href="/legal/data-privacy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
-</ul>

--- a/templates/legal/data-privacy/_toc.html
+++ b/templates/legal/data-privacy/_toc.html
@@ -1,42 +1,28 @@
-<h3>Contents</h3>
-<ul class="p-list--divided">
-  <li class="p-list__item">
-    <a href="#privacy-notices">Privacy notices</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#information-we-collect-from-you">Information we collect from you</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#how-information-is-collected-from-you">How information is collected from you</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#what-are-your-rights">What are your rights</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#cookies">Cookies</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#how-we-use-the-information-we-collect">How we use the information we collect</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#disclosure-of-your-information">Disclosure of your information</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#contact">Contact</a>
-  </li>
-  <li class="p-list__item">
-    <a href="#your-right-to-complain">Your right to complain</a>
-  </li>
-</ul>
+<div class="p-table-of-contents__section">
+  <h4 class="p-table-of-contents__header">CONTENTS</h4>
+  <nav class="p-table-of-contents__nav">
+    <ul class="p-list u-no-margin--bottom">
+      <li><a href="#privacy-notices">Privacy notices</a></li>
+      <li><a href="#information-we-collect-from-you">Information we collect from you</a></li>
+      <li><a href="#how-information-is-collected-from-you">How information is collected from you</a></li>
+      <li><a href="#what-do-we-do-with-your-personal-data">What do we do with your personal data</a></li>
+      <li><a href="#what-are-your-rights">What are your rights</a></li>
+      <li><a href="#cookies">Cookies</a></li>
+      <li><a href="#how-do-we-protect-the-information-we-collect">How do we protect the information we collect</a></li>
+      <li><a href="#how-we-use-the-information-we-collect">How we use the information we collect</a></li>
+      <li><a href="#disclosure-of-your-information">Disclosure of your information</a></li>
+      <li><a href="#where-we-transfer-and-store-your-information">Where we transfer and store your information</a></li>
+      <li><a href="#changes-to-our-privacy-policy">Changes to our privacy policy</a></li>
+      <li><a href="#contact">Contact</a></li>
+      <li><a href="#your-right-to-complain">Your right to complain</a></li>
+    </ul>
+  </nav>
+</div>
+
+<div class="p-table-of-contents__section">
+  <h4 class="p-table-of-contents__header">Older versions</h4>
+  <ul class="p-list">
+    <li><a href="/legal/data-privacy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
+    <li><a href="/legal/data-privacy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
+  </ul>
+</div>

--- a/templates/legal/data-privacy/_toc.html
+++ b/templates/legal/data-privacy/_toc.html
@@ -21,7 +21,7 @@
 
 <div class="p-table-of-contents__section">
   <h4 class="p-table-of-contents__header">Older versions</h4>
-  <ul class="p-list">
+  <ul class="p-list u-no-margin--bottom">
     <li><a href="/legal/data-privacy/2013-03-25">25 March 2013&nbsp;&rsaquo;</a></li>
     <li><a href="/legal/data-privacy/2016-02-08">08 February2016&nbsp;&rsaquo;</a></li>
   </ul>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -5,18 +5,10 @@
 
 {% block content %}
 
-<div class="p-strip is-deep">
+<div class="p-strip is-deep" style="overflow-x: visible;">
   <div class="row">
     <div class="col-8">
       <h1>Data privacy</h1>
-      <div class="u-hide--medium u-hide--large">
-        <div class="p-card">
-          {% include 'legal/data-privacy/_older-versions.html' %}
-        </div>
-        <div class="p-card">
-          {% include 'legal/data-privacy/_toc.html' %}
-        </div>
-      </div>
       <p>Canonical collects personal information from you in a number of different ways. For example, when you download one of our products, receive services from us or use one of our websites (including <a href="https://www.canonical.com">www.canonical.com</a> and <a href="https://www.ubuntu.com">www.ubuntu.com</a>).</p>
       <p><a href="/legal/websites">Full list of websites&nbsp;&rsaquo;</a></p>
       <p>At Canonical, we consider your privacy to be extremely important to us. These are the fundamental principles that we follow in relation to your personal information:</p>
@@ -156,101 +148,88 @@
         <li class="p-list__item"><strong>Targeting cookies</strong>. These cookies record your visit to our website, the pages you have visited and the links you have followed. We will use this information to make our website and the advertising displayed on it more relevant to your interests. We may also share this information with third parties for this purpose.</li>
       </ul>
       <p>You can find more information about the individual cookies we use and the purposes for which we use them in the table below:</p>
-    </div>
-    <div class="col-4">
-      <div class="p-card u-hide--small">
-        {% include 'legal/data-privacy/_older-versions.html' %}
-      </div>
 
-      <div class="p-card u-hide--small">
-        {% include 'legal/data-privacy/_toc.html' %}
-      </div>
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <table class="p-table">
-      <thead>
-        <tr>
-          <th>Cookie</th>
-          <th>Name</th>
-          <th>Purpose</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Site cookie acceptance</td>
-          <td><code>_cookies_accepted</code></td>
-          <td>This cookie is used to record if a user has accepted the use of cookies on our website. To withdraw your consent after accepting this cookie, delete the <code>_cookies_accepted</code> cookie.</td>
-        </tr>
-        <tr>
-          <td>Google Tag Manager with Google Analytics</td>
-          <td><code>_utma</code>, <code>_utmb</code>, <code>_utmc</code>, <code>_utmz</code>, <code>_ga</code>, <code>_gid</code>, <code>_id_cpn</code>, <code>_id_eml</code>, <code>trwsa.sid</code>, <code>trwsb.cpv</code>, <code>trwsb.sid</code>, <code>trwsb.stu</code>, <code>trwv.crd</code>, <code>trwv.cvd</code>, <code>trwv.eml</code>, <code>trwv.lvd</code>, <code>trwv.uid</code>, <code>trwv.uid</code>, <code>waiting_in_queue</code>, <code>lc_window_state</code>, <code>_dc_gtm_UA-XXXXXXX-X</code>, <code>__lc.visitor_id.XXXXXXX</code></td>
-          <td>
-            <p>Google Tag Manager to set most of our trackers as well as Google Analytics.</p>
-            <p><a class="p-link--external" href="https://policies.google.com/privacy?hl=en-GB&gl=uk">Google&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>Crazyegg</td>
-          <td><code>_ceir</code>, <code>is_returning</code>, <code>_CEFT</code>, <code>ceg.s</code>,<code>ceg.u</code></td>
-          <td>
-            <p>Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimize our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site's traffic accurately. No personal information is stored within the cookie.</p>
-            <p><a class="p-link--external" href="https://www.crazyegg.com/privacy">Crazy Egg&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>Marketo Munchkin</td>
-          <td><code>_mkto_trk</code>, <code>BIGipServersjrtp3_https</code>, <code>firstTouchGA</code>, <code>LPVID</code>, <code>_A_source</code>, <code>_A_time</code></td>
-          <td>
-            <p>Marketo&rsquo;s cookie allows us to track repeated visits to the website, and link each visit to the information voluntarily provided by the visitor. For example, if the visitor is asked to provide us with their name, company name and email address, we will know the identity of the visitor when they visit the site at a later date, or when we send them email.</p>
-            <p><a class="p-link--external" href="https://documents.marketo.com/legal/privacy/">Marketo&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>Facebook</td>
-          <td><code>fr</code>, <code>datr</code>, <code>reg_ext_ref</code>, <code>reg_fb_gate</code>, <code>reg_fb_ref</code>, <code>sb</code>, <code>wb</code></td>
-          <td>
-            <p>The Facebook pixel allows us to see how many people take action on our ads and which ad led to a conversion.</p>
-            <p><a class="p-link--external" href="https://www.facebook.com/about/privacy/">Facebook&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>LinkedIn</td>
-          <td><code>bcookie</code>, <code>lidc</code>, <code>BizoID</code>, <code>UserMatchHistory</code>, <code>lang</code>, <code>bscookie</code></td>
-          <td>
-            <p>LinkedIn tracking allows us to see how many people take action on our ads and which ad led to a conversion.</p>
-            <p><a class="p-link--external" href="https://www.linkedin.com/legal/privacy-policy">LinkedIn&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>Twitter</td>
-          <td><code>guest_id</code>, <code>personalization_id</code>, <code>_ga</code>, <code>_gid</code></td>
-          <td>
-            <p>Twitter tracking allows us to see how many people take action on our ads and which ad led to a conversion.</p>
-            <p><a class="p-link--external" href="https://twitter.com/en/privacy">Twitter&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>LiveChat</td>
-          <td><code>__livechat</code>, <code>recent_window</code>, <code>notifications[]</code>, <code>message_text</code>, <code>main_window_timestamp</code>, <code>__lc_vv</code>, <code>__livechat</code>, <code>__livechat_lastvisit</code></td>
-          <td>
-            <p>LiveChat allows potential customers to talk to our sales people through live chat. Cookies help the service function.</p>
-            <p><a class="p-link--external" href="https://www.livechatinc.com/privacy-policy/">LiveChat&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-        <tr>
-          <td>Vimeo</td>
-          <td><code>vuid</code></td>
-          <td>
-            <p>Vimeo hosts our videos. Their cookies provides more information about how many people view our videos and for how long.</p>
-            <p><a class="p-link--external" href="https://vimeo.com/privacy">Vimeo&rsquo;s privacy policy</a></p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="row">
-    <div class="col-8">
+      <table class="p-table">
+        <thead>
+          <tr>
+            <th>Cookie</th>
+            <th>Name</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Site cookie acceptance</td>
+            <td><code>_cookies_accepted</code></td>
+            <td>This cookie is used to record if a user has accepted the use of cookies on our website. To withdraw your consent after accepting this cookie, delete the <code>_cookies_accepted</code> cookie.</td>
+          </tr>
+          <tr>
+            <td>Google Tag Manager with Google Analytics</td>
+            <td><code>_utma</code>, <code>_utmb</code>, <code>_utmc</code>, <code>_utmz</code>, <code>_ga</code>, <code>_gid</code>, <code>_id_cpn</code>, <code>_id_eml</code>, <code>trwsa.sid</code>, <code>trwsb.cpv</code>, <code>trwsb.sid</code>, <code>trwsb.stu</code>, <code>trwv.crd</code>, <code>trwv.cvd</code>, <code>trwv.eml</code>, <code>trwv.lvd</code>, <code>trwv.uid</code>, <code>trwv.uid</code>, <code>waiting_in_queue</code>, <code>lc_window_state</code>, <code>_dc_gtm_UA-XXXXXXX-X</code>, <code>__lc.visitor_id.XXXXXXX</code></td>
+            <td>
+              <p>Google Tag Manager to set most of our trackers as well as Google Analytics.</p>
+              <p><a class="p-link--external" href="https://policies.google.com/privacy?hl=en-GB&gl=uk">Google&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Crazyegg</td>
+            <td><code>_ceir</code>, <code>is_returning</code>, <code>_CEFT</code>, <code>ceg.s</code>,<code>ceg.u</code></td>
+            <td>
+              <p>Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimize our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site's traffic accurately. No personal information is stored within the cookie.</p>
+              <p><a class="p-link--external" href="https://www.crazyegg.com/privacy">Crazy Egg&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Marketo Munchkin</td>
+            <td><code>_mkto_trk</code>, <code>BIGipServersjrtp3_https</code>, <code>firstTouchGA</code>, <code>LPVID</code>, <code>_A_source</code>, <code>_A_time</code></td>
+            <td>
+              <p>Marketo&rsquo;s cookie allows us to track repeated visits to the website, and link each visit to the information voluntarily provided by the visitor. For example, if the visitor is asked to provide us with their name, company name and email address, we will know the identity of the visitor when they visit the site at a later date, or when we send them email.</p>
+              <p><a class="p-link--external" href="https://documents.marketo.com/legal/privacy/">Marketo&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Facebook</td>
+            <td><code>fr</code>, <code>datr</code>, <code>reg_ext_ref</code>, <code>reg_fb_gate</code>, <code>reg_fb_ref</code>, <code>sb</code>, <code>wb</code></td>
+            <td>
+              <p>The Facebook pixel allows us to see how many people take action on our ads and which ad led to a conversion.</p>
+              <p><a class="p-link--external" href="https://www.facebook.com/about/privacy/">Facebook&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>LinkedIn</td>
+            <td><code>bcookie</code>, <code>lidc</code>, <code>BizoID</code>, <code>UserMatchHistory</code>, <code>lang</code>, <code>bscookie</code></td>
+            <td>
+              <p>LinkedIn tracking allows us to see how many people take action on our ads and which ad led to a conversion.</p>
+              <p><a class="p-link--external" href="https://www.linkedin.com/legal/privacy-policy">LinkedIn&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Twitter</td>
+            <td><code>guest_id</code>, <code>personalization_id</code>, <code>_ga</code>, <code>_gid</code></td>
+            <td>
+              <p>Twitter tracking allows us to see how many people take action on our ads and which ad led to a conversion.</p>
+              <p><a class="p-link--external" href="https://twitter.com/en/privacy">Twitter&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>LiveChat</td>
+            <td><code>__livechat</code>, <code>recent_window</code>, <code>notifications[]</code>, <code>message_text</code>, <code>main_window_timestamp</code>, <code>__lc_vv</code>, <code>__livechat</code>, <code>__livechat_lastvisit</code></td>
+            <td>
+              <p>LiveChat allows potential customers to talk to our sales people through live chat. Cookies help the service function.</p>
+              <p><a class="p-link--external" href="https://www.livechatinc.com/privacy-policy/">LiveChat&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Vimeo</td>
+            <td><code>vuid</code></td>
+            <td>
+              <p>Vimeo hosts our videos. Their cookies provides more information about how many people view our videos and for how long.</p>
+              <p><a class="p-link--external" href="https://vimeo.com/privacy">Vimeo&rsquo;s privacy policy</a></p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
       <p>Please note that third parties (including, for example, advertising networks and providers of external services like web traffic analysis services) may also use cookies, over which we have no control. These cookies are likely to be analytical/performance cookies or targeting cookies.</p>
       <p>You block cookies by activating the setting on your browser that allows you to refuse the setting of all or some cookies. However, if you use your browser settings to block all cookies (including essential cookies) you may not be able to access all or parts of our site.</p>
       <h2 id="how-do-we-protect-the-information-we-collect">How do we protect the information we collect</h2>
@@ -296,14 +275,21 @@
       <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a class="p-link--external" href="https://ico.org.uk/concerns/">ico.org.uk/concerns/</a> or write to them at:</p>
       <div style="margin: 2rem;">
         <p>
-        Information Commissioner's Office<br />
-        Wycliffe House<br />
-        Water Lane<br />
-        Wilmslow<br />
-        Cheshire<br />
-        SK9 5AF<br />
-        United Kingdom
-      </p>
+          Information Commissioner's Office<br />
+          Wycliffe House<br />
+          Water Lane<br />
+          Wilmslow<br />
+          Cheshire<br />
+          SK9 5AF<br />
+          United Kingdom
+        </p>
+      </div>
+    </div>
+
+    <div class="col-4 p-sticky-toc">
+      <aside class="p-table-of-contents">
+        {% include 'legal/data-privacy/_toc.html' %}
+      </aside>
     </div>
   </div>
 </div>

--- a/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
+++ b/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
@@ -5,46 +5,21 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1vQNdVmpsB3iQP7SnJHxT3A8rbD5jSAzTEoYUOepR-SM/edit#{% endblock meta_copydoc %}
 
 {% block outer_content %}
-
-    {% block content %}
-    <div class="p-strip is-deep">
+  {% block content %}
+    <div class="p-strip is-deep" style="overflow-x: visible;">
       <div class="row" id="service-description">
         <div class="col-8 l-legal-pages">
-{{ content | safe }}
+          {{ content | safe }}
         </div>
-        <div class="col-4">
-          <nav class="u-hide--small p-card">
-            <h3>Contents</h3>
-            <ol class="p-nested-counter-list">
-              <li class="p-nested-counter-list__item"><a href="#uasd-ua-infrastructure">Ubuntu Advantage for Infrastructure (UA-I)
-                <ol class="p-nested-counter-list">
-                  <li class="p-nested-counter-list__item"><a href="#uasd-subscription">Subscriptions</a></li>
-                  <li class="p-nested-counter-list__item"><a href="#uasd-support-levels">Support Levels</a></li>
-                  <li class="p-nested-counter-list__item"><a href="#uasd-managed-services">Managed Services</a></li>
-                  <li class="p-nested-counter-list__item"><a href="#uasd-virtual-machines">Virtual Machines and Cloud Instances</a></li>
-                  <li class="p-nested-counter-list__item"><a href="#uasd-desktop-support">Desktop support</a></li>
-                  <li class="p-nested-counter-list__item"><a href="#uasd-add-ons">Add-Ons</a></li>
-                  <li class="p-nested-counter-list__item"><a href="#uasd-maas-support">MAAS Support</a></li>
-                </ol>
-              </li>
-              <li class="p-nested-counter-list__item"><a href="#uasd-software">Software</a></li>
-              <li class="p-nested-counter-list__item"><a href="#uasd-professional-support">Professional Support Services</a></li>
-              <li class="p-nested-counter-list__item"><a href="#uasd-ua-support-services">Ubuntu Advantage Support Services Process</a></li>
-              <li class="p-nested-counter-list__item"><a href="#uasd-definitions">Definitions</a></li>
-            </ol>
-          </nav>
-          <nav class="p-card">
-            <h3>Japanese translation</h3>
-            <ul class="p-list">
-              <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA サービス範囲&nbsp;&rsaquo;</a></li>
-            </ul>
-          </nav>
+
+        <div class="col-4 p-sticky-toc">
+          <aside class="p-table-of-contents">
+            {% include 'legal/data-privacy/_toc.html' %}
+          </aside>
         </div>
       </div>
     </div>
+  {% endblock %}
 
-    {% endblock %}
-
-    {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
+  {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 {% endblock %}

--- a/templates/legal/ubuntu-advantage-service-description/_toc.html
+++ b/templates/legal/ubuntu-advantage-service-description/_toc.html
@@ -18,7 +18,7 @@
 <div class="p-table-of-contents__section">
   <h4 class="p-table-of-contents__header">Japanese translation</h4>
   <nav class="p-table-of-contents__nav">
-    <ul class="p-list">
+    <ul class="p-list u-no-margin--bottom">
       <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA サービス範囲&nbsp;&rsaquo;</a></li>
     </ul>
   </nav>

--- a/templates/legal/ubuntu-advantage-service-description/_toc.html
+++ b/templates/legal/ubuntu-advantage-service-description/_toc.html
@@ -1,0 +1,25 @@
+<div class="p-table-of-contents__section">
+  <h4 class="p-table-of-contents__header">Contents</h4>
+  <nav class="p-table-of-contents__nav">
+    <ul class="p-list u-no-margin--bottom">
+      <li><a href="#uasd-ua-infrastructure">Ubuntu Advantage for Infrastructure (UA-I)</a></li>
+      <li><a href="#uasd-subscription">Subscriptions</a></li>
+      <li><a href="#uasd-support-levels">Support Levels</a></li>
+      <li><a href="#uasd-managed-services">Managed Services</a></li>
+      <li><a href="#uasd-virtual-machines">Virtual Machines and Cloud Instances</a></li>
+      <li><a href="#uasd-desktop-support">Desktop support</a></li>
+      <li><a href="#uasd-add-ons">Add-Ons</a></li>
+      <li><a href="#uasd-maas-support">MAAS Support</a></li>
+      <li><a href="/legal/data-privacy/2016-02-08">08 February 2016&nbsp;&rsaquo;</a></li>
+    </ul>
+  </nav>
+</div>
+
+<div class="p-table-of-contents__section">
+  <h4 class="p-table-of-contents__header">Japanese translation</h4>
+  <nav class="p-table-of-contents__nav">
+    <ul class="p-list">
+      <li class="p-list__item"><a href="/legal/ubuntu-advantage-service-description/ja">UA サービス範囲&nbsp;&rsaquo;</a></li>
+    </ul>
+  </nav>
+</div>


### PR DESCRIPTION
## Done

- added sticky tables of content to /legal/ubuntu-advantage-service-description and /legal/data-privacy

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/ubuntu-advantage-service-description and http://0.0.0.0:8001/legal/data-privacy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the tables of content on each page use the [Vanilla pattern](https://docs.vanillaframework.io/patterns/table-of-contents/)

## Issue / Card

Fixes #5993 
