### PR TITLE
fix line height of p-p--small

### DIFF
--- a/static/sass/_vanilla-placeholders.scss
+++ b/static/sass/_vanilla-placeholders.scss
@@ -46,6 +46,7 @@ h4,
 .p-p--small {
   &:not(.is-v-condensed) {
     @extend %small-text-fixed;
+    line-height: 1.25rem;
   }
 
   &.is-v-condensed {


### PR DESCRIPTION
## Done

- Slightly increased line-height of `p-p--small`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click any of the dropdowns in the main nav, see that the paragraph copy below the headings within have a greater line height than they currently do on the [live site](https://ubuntu.com/)


## Issue / Card

Fixes #5947 
