### PR TITLE
Update /training page and add MAAS course

### DIFF
--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -44,9 +44,20 @@
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
+{% elif product == 'maas-training-onsite' %}
+
+{% with h1="Contact us about our MAAS Deployment and Operations training",
+intro_text="Fill in your details below and a member of our training team will be in touch.",
+formid="1448",
+lpId="2661",
+returnURL="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" %}
+{% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+
   {% else %}
 
-{% with h1="Contact us about OpenStack",
+{% with h1="Contact us about Canonical Training",
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
   formid="1251'  lpId='2086' returnURL='https://www.ubuntu.com/training/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -1,8 +1,7 @@
 {% extends "training/_base_training.html" %}
 
-
 {% block title %}Training{% endblock %}
-{% block meta_description %}Canonical run OpenStack, Kubernetes and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
+{% block meta_description %}Canonical run OpenStack, Kubernetes, MAAS and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
 
 {% block outer_content %}
@@ -33,7 +32,7 @@
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
       <p>A three-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
-      <p><a class="p-link--external" href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (PDF)</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
@@ -46,7 +45,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -67,7 +66,7 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -85,6 +84,7 @@
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
       <p>A five-day hands-on course at your premises for up to 15 people that guides you through all aspects of performing effective operations on your Ubuntu OpenStack cloud. A follow-up course to OpenStack Fundamentals, it guides you through operational tasks such as monitoring, troubleshooting, patching, scaling, and upgrading, while keeping your cloud available and performing.</p>
+      <p><a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
@@ -97,7 +97,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -110,7 +110,7 @@
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
       <p>A three-day hands-on course at your premises for up to 15 students, that teaches you how to install and administer Ubuntu Server.</p>
-      <p><a class="p-link--external" href="http://insights.ubuntu.com/wp-content/uploads/1ee7/Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/f2dbacb1-Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
@@ -123,7 +123,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="u-fixed-width">
@@ -133,7 +133,7 @@
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
       <p>You&rsquo;ve been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive three-day hands-on course in which you will learn and use advanced techniques.</p>
-      <p><a class="p-link--external" href="https://assets.ubuntu.com/v1/bb64a38e-Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/bb64a38e-Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
@@ -146,7 +146,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -166,7 +166,7 @@
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
       <p>A three-day hands-on course at your premises for up to 15 people that guides you through Charmed Kubernetes. You will learn about Kubernetes, how to deploy it and configure it, as well as how to perform operational actions such as live upgrades.</p>
-      <p><a class="p-link--external" href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
@@ -179,7 +179,7 @@
         <dt class="p-inline-definition-list__title">Availability</dt>
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
-      <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -201,17 +201,51 @@
         <dt class="p-inline-definition-list__title">Location</dt>
         <dd class="p-inline-definition-list__item">Your premises</dd>
       </dl>
-      <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" class="js-invoke-modal">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>Metal as a Service (MAAS)</h2>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr />
+    <h3>Deployment and Operations training</h3>
+  </div>
+
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>A two-day hands-on course at your premises for up to 15 people that guides you through MAAS and how to treat your bare metal estate as a cloud. The aim of this training is to help users understand MAAS components, installing and configuring them, as well on-going MAAS operations for physical and virtual machines (KVM), network configuration and image management.</p>
+      <p><a href="https://assets.ubuntu.com/v1/dc6e1ec3-Canonical_training-MAAS_Deployment_and_Operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">2 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">14,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+
+<section class="p-strip">
   <div class="row">
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/9b170f06-picto-help-orange.svg" width="135" alt="" />

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -15,6 +15,8 @@
   {% with thanks_context="enquiring about our on-site training courses" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% elif product == 'openstack-training-server-admin' %}
   {% with thanks_context="enquiring about our server admin training courses" %}{% include "shared/_thank_you.html" %}{% endwith %}
+{% elif product == 'maas-training-onsite' %}
+  {% with thanks_context="enquiring about our MAAS Deployment and Operations training course" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% else %}
   {% with thanks_context="enquiring about training" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
## Done

- Update /training page and add MAAS course to the training page and the contact-us and thank-you page
- Removed the modal forms as they do not reflect the correct marketo forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the OpenStack operations course has a pdf and the maas section has been added correctly
- Resolve comments in the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit#)

## Issue / Card

Fixes #5942 
