### PR TITLE
update contact us illustration and changed the height

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -87,7 +87,7 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-5 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/9c7bda7d-contact-us.svg" alt="">
+      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" style="height:200px" alt="">
     </div>
     <div class="col-7 u-vertically-center">
       <div>


### PR DESCRIPTION
## Done

- updated 'contact us' illustration
- changed the height to 200px

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ESM
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #6044 
