### PR TITLE
Fix the lazy loading images race condition

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -7,9 +7,8 @@
 
   <title>{% block title %}{% endblock %} | Ubuntu</title>
 
-  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   {% block content_experiment %}{% endblock %}
-  <script src="https://assets.ubuntu.com/v1/842d27d3-lazysizes.min.js" defer></script>
+  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js" defer></script>
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" async defer></script>
   <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>


### PR DESCRIPTION
## Done
Removed the other way of doing lazy loading which was sometimes beating the native version. Slightly changed the order of the scripts.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check all the images load in the four sections below the feed
- Refresh a bunch of times and check the images load fine

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6040
