### PR TITLE
Update toc for /uasd page

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
+++ b/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
@@ -14,7 +14,7 @@
 
         <div class="col-4 p-sticky-toc">
           <aside class="p-table-of-contents">
-            {% include 'legal/data-privacy/_toc.html' %}
+            {% include 'legal/ubuntu-advantage-service-description/_toc.html' %}
           </aside>
         </div>
       </div>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -84,7 +84,7 @@
         <nav>
           <ul class="p-inline-list">
             <li class="u-hide--small p-inline-list__item">
-              <a class="p-button--neutral js-invoke-modal" href="/contact-us"><small>Contact us</small></a>
+              <a class="p-button--neutral" href="/contact-us"><small>Contact us</small></a>
             </li>
             <li class="u-hide--medium u-hide--large p-inline-list__item">
               <a class="p-link--soft" href="/contact-us"><small>Contact us</small></a>


### PR DESCRIPTION
## Done

- Table of contents for /uasd page was using the incorrect include
- Removed modal from footer's contact us, request from legal.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/uasd
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the toc is the correct one for the page.


## Issue / Card

Fixes #6048
