### PR TITLE
Add no-nav v2

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -15,10 +15,11 @@
 //sass-lint:disable no-url-domains
 @font-face {
   font-display: optional;
-  font-family: 'UbtuOverride';
+  font-family: "UbtuOverride";
   font-style: normal;
   font-weight: 300;
-  src: url('https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2') format('woff2'), url('https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff') format('woff');
+  src: url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2") format("woff2"),
+    url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
 }
 
 // import vanilla-framework
@@ -287,7 +288,7 @@ summary {
 }
 
 .organisations-hero {
-  background-image: url('#{$assets-path}214648ba-_M8A2368-final.jpg');
+  background-image: url("#{$assets-path}214648ba-_M8A2368-final.jpg");
   background-position: right bottom;
   background-size: 1200px auto;
 
@@ -430,4 +431,19 @@ summary {
     margin-left: 0 !important;
     margin-top: 1rem !important;
   }
+}
+
+// Styling for ubuntu navigation logo for engage pages
+.navigation-logo-engage {
+  margin-top: -2.2rem;
+  padding-bottom: 1.75rem;
+
+  @media screen and (max-width: $breakpoint-large - 1px) {
+    padding-top: 2rem;
+  }
+
+  a img {
+    width: 143px;
+  }
+
 }

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -1,3 +1,4 @@
+{% set hide_nav = True %}
 {% extends "templates/base.html" %}
 
 {% block title %}{{ title }}{% endblock title %}
@@ -10,7 +11,21 @@
 
 {% block outer_content %}
 {% block content %}
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
 <section {% if header_lang %}lang="{{ header_lang }}"{% endif %} class="{% if header_class %}p-strip {{ header_class }}{% else %}p-strip--light{% endif %}">
+  {% if header_class %}
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+  </div>
+  {% else %}
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+  </div>
+  {% endif %}
   <div class="row u-equal-height">
     <div class="{% if header_image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
       <div>

--- a/templates/engage/base_engage.html
+++ b/templates/engage/base_engage.html
@@ -1,3 +1,4 @@
+{% set hide_nav = True %}
 {% extends "templates/base.html" %}
 
 {% block meta_copydoc %}https://drive.google.com/drive/folders/1FyMcu6vqGnyQMdWLRjvxJVWm8gHgslk4{% endblock meta_copydoc %}

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -1,4 +1,18 @@
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
 <section {% if lang %}lang="{{ lang }}"{% endif %} class="{% if class %}p-strip {{ class }}{% else %}p-strip--light{% endif %}">
+  {% if class %}
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+  </div>
+  {% else %}
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+  </div>
+  {% endif %}
   <div class="row u-equal-height">
     <div class="{% if image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
       <div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -69,7 +69,10 @@
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </noscript>
   <!-- end google tag manager -->
-  {% include "templates/_navigation.html" %}
+  
+  {% if not(hide_nav == True) %}
+    {% include "templates/_navigation.html" %}
+  {% endif %}
 
   <div class="wrapper u-no-margin--top">
     <div id="main-content" class="inner-wrapper">


### PR DESCRIPTION
## Done

- Implement `no-nav v2` for `/engage` pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on any engage page and check if main navigation is replaced by Ubuntu logo
- Compare to [design](https://github.com/canonical-web-and-design/web-squad/issues/1867)
- Go to http://0.0.0.0:8001/engage/whitepaper-containers and check if the logo is dark


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1868

## Screenshots

![image](https://user-images.githubusercontent.com/40214246/67950947-868bcb80-fbe2-11e9-9411-b6961f5baf00.png)


[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/40214246/67950906-6e1bb100-fbe2-11e9-84c0-c5cfae4f81af.png)

