### PR TITLE
Kata containers engage page and takeover

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -31,7 +31,7 @@
   <div class="row u-equal-height">
     <div class="{% if header_image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
       <div>
-        <h1 {% if header_subtitle is none and header_date is none %}class="u-no-margin--bottom"{% endif %}>
+        <h1 {% if not header_subtitle and not header_date %}class="u-no-margin--bottom"{% endif %}>
           {{ header_title | safe }}
         </h1>
         {% if header_subtitle %}<h4>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1197,7 +1197,20 @@
             <p class='u-no-padding--bottom u-hide--small'>TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits.</p>
           </div>
         </div>
-
+        
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--webinar'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              webinar
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/kata-containers-webinar'>Ensuring security and isolation in Kubernetes with Kata Containers</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation.</p>
+          </div>
+        </div>
       </div>
     </section>
     {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -761,7 +761,7 @@
           </div>
         </div>
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -916,7 +916,7 @@
           </div>
         </div>
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -929,7 +929,7 @@
           </div>
         </div>
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -971,7 +971,7 @@
           </div>
         </div>
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -1056,7 +1056,7 @@
           </div>
         </div>
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -1100,7 +1100,7 @@
         </div>
 
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -1116,7 +1116,7 @@
 
       <div class='row u-equal-height u-clearfix'>
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -1129,7 +1129,7 @@
           </div>
         </div><!-- 1st -->
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -1171,7 +1171,7 @@
           </div>
         </div><!-- 1st -->
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--webinar'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               webinar
             </h5>
@@ -1185,7 +1185,7 @@
         </div><!-- 2nd -->
 
         <div class='col-4 blog-p-card--post'>
-          <header class='blog-p-card__header--desktop'>
+          <header class='blog-p-card__header--case-study'>
             <h5 class='p-muted-heading u-no-margin--bottom'>
               case study
             </h5>

--- a/templates/engage/kata-containers-webinar.md
+++ b/templates/engage/kata-containers-webinar.md
@@ -1,0 +1,21 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Ensuring security and isolation in Kubernetes with Kata Containers"
+     meta_description: "Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation"
+     meta_image: https://assets.ubuntu.com/v1/48c73e93-Meta+data+img.jpg
+     meta_copydoc: "https://docs.google.com/document/d/1KeCbhYudWJuKW2cMuNfsClvQXnyrpz0q2I-ILuwhfcY/edit?ts=5d6de4ad"
+     header_title: "Ensuring security and isolation in Kubernetes with Kata Containers"
+     header_image: "https://assets.ubuntu.com/v1/4cbd0535-kata+containers+kubernetes.svg"
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_class: p-engage-banner--dark
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 373551, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Join Tytus Kurek from Canonical and Eric Ernst from Intel to explore Kata Containers!
+
+Over the last few years, container technologies have dominated the market and become the de facto standard for implementing modern IT infrastructure. However, one of the main adoption concerns is around security and isolation. In response to those concerns, Kata Containers, which use lightweight virtual machines that seamlessly plug into the container ecosystem, have been developed. In this webinar, we will present the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation. 
+
+NOTE: This webinar is going to be interactive. If you would like to spin up your own Charmed Kubernetes cluster with Kata Containers together with us, please make sure that you have an AWS account or a local MAAS environment. Please follow the instructions at https://jaas.ai/docs/installing to install Juju, add your cloud account (for example AWS) and bootstrap a Juju controller prior to the webinar.

--- a/templates/engage/kata-containers-webinar.md
+++ b/templates/engage/kata-containers-webinar.md
@@ -1,6 +1,7 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
+     hide_nav: True
      title: "Ensuring security and isolation in Kubernetes with Kata Containers"
      meta_description: "Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation"
      meta_image: https://assets.ubuntu.com/v1/48c73e93-Meta+data+img.jpg

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,7 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_1910_takeover.html" %}
+  {% include "takeovers/_kata-containers.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/takeovers/_kata-containers.html
+++ b/templates/takeovers/_kata-containers.html
@@ -1,5 +1,5 @@
 {% with title="Ensuring security and isolation in Kubernetes with Kata Containers",
-subtitle="Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation.",
+subtitle="Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation",
 header_image="https://assets.ubuntu.com/v1/4cbd0535-kata+containers+kubernetes.svg",
 class="p-takeover--dark",
 image_style="",

--- a/templates/takeovers/_kata-containers.html
+++ b/templates/takeovers/_kata-containers.html
@@ -4,7 +4,7 @@ header_image="https://assets.ubuntu.com/v1/4cbd0535-kata+containers+kubernetes.s
 class="p-takeover--dark",
 image_style="",
 image_hide_small=true,
-equal_cols="",
+equal_cols="true",
 primary_url="/engage/kata-containers-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Containers_Kata_WBN",
 primary_cta="Register for the webinar",
 primary_cta_class="p-button--positive",

--- a/templates/takeovers/_kata-containers.html
+++ b/templates/takeovers/_kata-containers.html
@@ -1,0 +1,15 @@
+{% with title="Ensuring security and isolation in Kubernetes with Kata Containers",
+subtitle="Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation.",
+header_image="https://assets.ubuntu.com/v1/4cbd0535-kata+containers+kubernetes.svg",
+class="p-takeover--dark",
+image_style="",
+image_hide_small=true,
+equal_cols="",
+primary_url="/engage/kata-containers-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Containers_Kata_WBN",
+primary_cta="Register for the webinar",
+primary_cta_class="p-button--positive",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+  {% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -45,6 +45,7 @@
 {% include "takeovers/_iot-business.html" %}
 {% include "takeovers/_iot-devops_takeover.html" %}
 {% include "takeovers/_juju-webinar-takeover.html" %}
+{% include "takeovers/_kata-containers.html" %}
 {% include "takeovers/_kubernetes-enterprise-takeover.html" %}
 {% include "takeovers/_kubernetes-month.html" %}
 {% include "takeovers/_kubernetes_webinar.html" %}


### PR DESCRIPTION
## Done

- added kata containers engage page and takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the kata containers takeover
- Compare it to the [brief](https://docs.google.com/spreadsheets/d/1UTIqPG9KSnnBr_r403jzCLD4JhcAmya_axqA2H60kds/edit#gid=2113339190) and [design](https://github.com/canonical-web-and-design/web-squad/issues/1937#issuecomment-548414064)
- Follow the CTA to the engage page
- Compare it to the [brief](https://docs.google.com/spreadsheets/d/1UTIqPG9KSnnBr_r403jzCLD4JhcAmya_axqA2H60kds/edit#gid=2113339190) and [design](https://github.com/canonical-web-and-design/web-squad/issues/1937#issuecomment-548414064)
- Test the engage page on https://cards-dev.twitter.com/validator, see that the card contains the image, title and description given in the [brief](https://docs.google.com/spreadsheets/d/1UTIqPG9KSnnBr_r403jzCLD4JhcAmya_axqA2H60kds/edit#gid=2113339190)
- Visit http://0.0.0.0:8001/takeovers, see that it contains the takeover
- Visit http://0.0.0.0:8001/engage, see that it includes a link to the engage page

## Issue / Card

Fixes #6041 
