### PR TITLE
Refactor to better handle expired tokens

### DIFF
--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -1,0 +1,100 @@
+import os
+
+from requests import Request, Session
+from pymacaroons import Macaroon
+
+from webapp.macaroons import binary_serialize_macaroons
+
+
+API_URL = os.getenv("ADVANTAGE_API", "https://contracts.canonical.com/")
+api_session = Session()
+
+
+class UnauthorizedRequest(Exception):
+    pass
+
+
+def _prepare_request(method, path, data=None, session=None):
+    request = Request(method=method, url=f"{API_URL}{path}")
+
+    if session:
+        root = Macaroon.deserialize(session["macaroon_root"])
+        discharge = Macaroon.deserialize(session["macaroon_discharge"])
+        bound = root.prepare_for_request(discharge)
+        token = binary_serialize_macaroons([root, bound]).decode("utf-8")
+        request.headers["Authorization"] = f"Macaroon {token}"
+
+    if data is not None:
+        request.json = data
+
+    return request.prepare()
+
+
+def _send(request, timeout=3):
+    response = api_session.send(request, timeout=timeout)
+
+    if response.status_code == 401:
+        raise UnauthorizedRequest
+
+    return response
+
+
+def get_macaroon():
+    response = _send(
+        _prepare_request(method="get", path="v1/canonical-sso-macaroon")
+    )
+
+    payload = response.json()
+    return payload["macaroon"]
+
+
+def get_accounts(session):
+    response = _send(
+        _prepare_request(method="get", path="v1/accounts", session=session)
+    )
+
+    payload = response.json()
+    return payload.get("accounts", [])
+
+
+def get_account_contracts(account, session):
+    account_id = account["id"]
+    response = _send(
+        _prepare_request(
+            method="get",
+            path=f"v1/accounts/{account_id}/contracts",
+            session=session,
+        )
+    )
+
+    payload = response.json()
+    return payload.get("contracts", [])
+
+
+def get_contract_token(contract, session):
+    contract_id = contract["contractInfo"]["id"]
+    response = _send(
+        _prepare_request(
+            method="post",
+            path=f"v1/contracts/{contract_id}/token",
+            data={},
+            session=session,
+        )
+    )
+
+    payload = response.json()
+    return payload.get("contractToken")
+
+
+def get_contract_machines(contract, session):
+    contract_id = contract["contractInfo"]["id"]
+    response = _send(
+        _prepare_request(
+            method="get",
+            path=f"v1/contracts/{contract_id}/context/machines",
+            session=session,
+        )
+    )
+
+    payload = response.json()
+    return payload

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,9 +2,6 @@
 A Flask application for ubuntu.com
 """
 
-# Standard library
-import os
-
 # Packages
 import talisker.requests
 import flask
@@ -46,9 +43,6 @@ app = FlaskBase(
     "ubuntu.com",
     template_folder="../templates",
     static_folder="../static",
-)
-app.config["ADVANTAGE_API"] = os.getenv(
-    "ADVANTAGE_API", "https://contracts.canonical.com/"
 )
 
 app.wsgi_app = ProxyFix(

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -1,0 +1,19 @@
+def is_authenticated(session):
+    """
+    Checks if the user is authenticated from the session
+    Returns True if the user is authenticated
+    """
+    return (
+        "openid" in session
+        and "macaroon_discharge" in session
+        and "macaroon_root" in session
+    )
+
+
+def empty_session(session):
+    """
+    Empty the session, used to logout.
+    """
+    session.pop("macaroon_root", None)
+    session.pop("macaroon_discharge", None)
+    session.pop("openid", None)


### PR DESCRIPTION
## Done
Moved API calls into a separate file, so we can add some extra logic to detect expired macaroons.
Add an handler to clear session and re-login when we detect an expired macaroon.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Make sure `/advantage` still works

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6056
