### PR TITLE
Add tag name to /blog/tag/<tag_name> pages title

### DIFF
--- a/templates/blog/tag.html
+++ b/templates/blog/tag.html
@@ -1,5 +1,7 @@
 {% extends "templates/one-column.html" %}
 
+{% block title %}{{ tag.name }}{% endblock %}
+
 {% block content %}
   <div class="p-strip--light is-shallow">
     <div class="row">


### PR DESCRIPTION
## Done

- Add tag name to `/blog/tag/<tag_name>` pages title

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/tag/server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the tag name is displayed in the window tab like “GNOME | Ubuntu”, “IBM | Ubuntu”, or “Snaps | Ubuntu”

## Issue / Card

Fixes #6062 

## Screenshots

- Before
![image](https://user-images.githubusercontent.com/40214246/68203708-536c8200-ffbe-11e9-9afc-ba7381a8a296.png)

- After
![image](https://user-images.githubusercontent.com/40214246/68203745-68491580-ffbe-11e9-87d6-5698a716ba7c.png)

