### PR TITLE
Capture advantage API exceptions in Sentry

### DIFF
--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -10,10 +10,6 @@ API_URL = os.getenv("ADVANTAGE_API", "https://contracts.canonical.com/")
 api_session = Session()
 
 
-class UnauthorizedRequest(Exception):
-    pass
-
-
 def _prepare_request(method, path, data=None, session=None):
     request = Request(method=method, url=f"{API_URL}{path}")
 
@@ -32,10 +28,7 @@ def _prepare_request(method, path, data=None, session=None):
 
 def _send(request, timeout=3):
     response = api_session.send(request, timeout=timeout)
-
-    if response.status_code == 401:
-        raise UnauthorizedRequest
-
+    response.raise_for_status()
     return response
 
 


### PR DESCRIPTION
## Done
Capture advantage API exceptions in Sentry

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Set SENTRY_DSN=`<askme>`
- Go to `/advantage` and login
- Swap to use the staging contracts API
- Go to `/advantage`
- See you have a new exception logged in sentry


