### PR TITLE
Switch Ubuntu 19.10 takeover buttons

### DIFF
--- a/templates/takeovers/_1910_takeover.html
+++ b/templates/takeovers/_1910_takeover.html
@@ -9,19 +9,14 @@
           Ubuntu 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train live-migration extensions for easier infrastructure deployments and more.
         </h4>
         <div class="u-hide--small">
-
+					<p>
+						<a href="/engage/19-10-webinar?utm_source=takeover&utm_campaign=7013z000001Ftb0" class="p-button--positive u-no-margin--bottom">
+							Register for the webinar
+						</a>
+					</p>
           <p>
-            <a href="/download" class="p-button--positive u-no-margin--bottom">Get Ubuntu
-            </a>
+            <a href="/download" class="p-link--inverted">Download Ubuntu 19.10&nbsp;&rsaquo;</a>
           </p>
-
-
-          <p>
-            <a href="/engage/19-10-webinar?utm_source=takeover&utm_campaign=7013z000001Ftb0" class=" p-link--inverted">
-              Register for the webinar&nbsp;›
-            </a>
-          </p>
-
         </div>
       </div>
     </div>
@@ -443,15 +438,14 @@
     <div class="u-hide--medium u-hide--large">
 
       <p>
-        <a href="/download" class="p-button--positive">Get Ubuntu
-        </a>
+				<a href="/engage/19-10-webinar?utm_source=takeover&utm_campaign=7013z000001Ftb0" class="p-button--positive u-no-margin--bottom">
+					Register for the webinar
+				</a>
       </p>
 
 
       <p>
-        <a href="/engage/19-10-webinar" class=" p-link--inverted">
-          Register for the webinar&nbsp;›
-        </a>
+				<a href="/download" class="p-link--inverted">Download Ubuntu 19.10&nbsp;&rsaquo;</a>
       </p>
 
     </div>


### PR DESCRIPTION
## Done

- Switch buttons on Ubuntu19.10 takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the `Get Ubuntu` button is below the `Register for webinar link`


## Issue / Card

Fixes #6073 

