### PR TITLE
Removed locale from kata takeover

### DIFF
--- a/templates/takeovers/_kata-containers.html
+++ b/templates/takeovers/_kata-containers.html
@@ -10,6 +10,6 @@ primary_cta="Register for the webinar",
 primary_cta_class="p-button--positive",
 secondary_url="",
 secondary_cta="",
-locale="en_GB" %}
+locale="" %}
   {% include "takeovers/_template.html" %}
 {% endwith %}


### PR DESCRIPTION
## Done

* Removing locale from kata takeover.
* The Locale parameter acts as a restrictive filter for takeover display. It should only be set if the takeover is not for a global audienc. Eg. a takeover in french should have its locale set to "fr", a takeover in english should have an empty locale value.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Change your browser lang to german
- Ensure you can see the Kata takeover.

