### PR TITLE
New Dell k8s reference architecture engage page

### DIFF
--- a/templates/engage/dell-k8s-reference-architecture.md
+++ b/templates/engage/dell-k8s-reference-architecture.md
@@ -1,0 +1,21 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Charmed Kubernetes reference architecture"
+     meta_description: "Charmed Kubernetes reference architecture  integration with VxFlex OS delivered by Dell EMC and Canonical"
+     meta_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
+     meta_copydoc:
+     header_title: "Charmed Kubernetes reference architecture"
+     header_subtitle: "With VxFlex OS delivered by Dell EMC and Canonical"
+     header_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
+     header_url: '#register-section'
+     header_cta: Download the pdf
+     header_class: p-engage-banner--dark
+     header_lang: en
+     form_include: en
+     form_id: 3456
+     form_return_url: "https://pages.ubuntu.com/Dell_RA_Kubernetes-TY.html"
+---
+This document provides a complete guide of integration of Charmed Kubernetes delivered by Canonical with VxFlex OS (previously known as ScaleIO) from Dell EMC - scalable and resilient solution of software-defined storage.
+
+This guide discusses the method of integration, as well as the benefits that businesses can take from it. It also contains the steps that allow deploying Canonicals Charmed Kubernetes on the bare metal servers (and it can be extrapolated to any other platform) from scratch, followed by the steps of enabling VxFlex OS client in Kubernetes cluster that allows using VxFlex OS as the backend for Kubernetes persistent volumes.

--- a/templates/engage/dell-k8s-reference-architecture.md
+++ b/templates/engage/dell-k8s-reference-architecture.md
@@ -4,7 +4,7 @@ context:
      title: "Charmed Kubernetes reference architecture"
      meta_description: "Charmed Kubernetes reference architecture  integration with VxFlex OS delivered by Dell EMC and Canonical"
      meta_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
-     meta_copydoc:
+     meta_copydoc: "https://docs.google.com/document/d/1hW5FBZueDnzd-AHehKHIDQ2qTr9uVjgl5d8LCPT9OWg/edit"
      header_title: "Charmed Kubernetes reference architecture"
      header_subtitle: "With VxFlex OS delivered by Dell EMC and Canonical"
      header_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"


### PR DESCRIPTION
## Done

- New Dell k8s reference architecture engage page
- **Note** I didn't add it to the engage index

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/dell-k8s-reference-architecture
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it looks ok and the form works.


## Issue / Card

Fixes #6066 

