### PR TITLE
Add a wiki link to the advantage page

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -194,7 +194,7 @@
       <dl>
         <dt>To attach a machine:</dt>
         <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></dd>
-        <dt>To check status:</dt>
+        <dt style="border-top: 0;">To check status:</dt>
         <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</pre></code></dd>
       </dl>
       <hr style="margin: 1.25rem 0 1.5rem 0;" />

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -187,6 +187,7 @@
           <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</code></pre></td>
         </tr>
       </table>
+      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a>.</p>
     </div>
     <div class="col-12 u-hide--medium u-hide--large">
       <dl>
@@ -195,15 +196,11 @@
         <dt>To check status:</dt>
         <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</pre></code></dd>
       </dl>
+      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a>.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-shallow" style="background: #e5e5e5; padding: 1rem 0;">
-  <div class="row">
-      <p class="u-no-margin--bottom">For more information visit <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">the UA wikipage</a></p>
-  </div>
-</section>
 
 {% if not enterprise_contracts %}
 <section class="p-strip is-shallow is-bordered">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -188,7 +188,7 @@
         </tr>
       </table>
       <hr style="margin: 1.25rem 0 1.5rem 0;" />
-      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a></p>
+      <p class="u-no-margin--bottom">For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a></p>
     </div>
     <div class="col-12 u-hide--medium u-hide--large">
       <dl>
@@ -198,7 +198,7 @@
         <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</pre></code></dd>
       </dl>
       <hr style="margin: 1.25rem 0 1.5rem 0;" />
-      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a></p>
+      <p class="u-no-margin--bottom">For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a></p>
     </div>
   </div>
 </section>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -187,7 +187,8 @@
           <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</code></pre></td>
         </tr>
       </table>
-      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a>.</p>
+      <hr style="margin: 1.25rem 0 1.5rem 0;" />
+      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a></p>
     </div>
     <div class="col-12 u-hide--medium u-hide--large">
       <dl>
@@ -196,7 +197,8 @@
         <dt>To check status:</dt>
         <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</pre></code></dd>
       </dl>
-      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a>.</p>
+      <hr style="margin: 1.25rem 0 1.5rem 0;" />
+      <p>For further options <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">visit the UA wiki page</a></p>
     </div>
   </div>
 </section>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -199,6 +199,11 @@
   </div>
 </section>
 
+<section class="p-strip is-shallow" style="background: #e5e5e5; padding: 1rem 0;">
+  <div class="row">
+      <p class="u-no-margin--bottom">For more information visit <a href="https://wiki.ubuntu.com/UAclient" class="p-link--external">the UA wikipage</a></p>
+  </div>
+</section>
 
 {% if not enterprise_contracts %}
 <section class="p-strip is-shallow is-bordered">


### PR DESCRIPTION
## Done
Had a punt at putting a link to the wiki on the logged in version of the dashboard.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /advantage
- Log in
- Check the link to the wiki under the token section.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6070

## Screenshots
![Screenshot_2019-11-06 Ubuntu Advantage for Infrastructure Ubuntu](https://user-images.githubusercontent.com/1413534/68312263-b50a1a80-00aa-11ea-9dde-d81155070471.png)

