### PR TITLE
Create dell openstack reference architecture engage page

### DIFF
--- a/templates/engage/dell-openstack-reference-architecture.md
+++ b/templates/engage/dell-openstack-reference-architecture.md
@@ -1,0 +1,21 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Charmed OpenStack reference architecture"
+     meta_description: "Reference architecture guide for Charmed OpenStack (Rocky) solution on Dell EMC hardware delivered by Canonical, including Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking."
+     meta_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
+     meta_copydoc:
+     header_title: "Charmed OpenStack reference architecture"
+     header_subtitle: "With Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking and Canonical"
+     header_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
+     header_url: '#register-section'
+     header_cta: Download the pdf
+     header_class: p-engage-banner--dark
+     header_lang: en
+     form_include: en
+     form_id: 3457
+     form_return_url: "https://pages.ubuntu.com/DC_Dell_RA_Openstack-TY.html"
+---
+This document provides a complete reference architecture guide for Charmed OpenStack (Rocky) solution on Dell EMC hardware delivered by Canonical, including Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking.
+
+This guide discusses the Dell EMC hardware specifications and the tools and services to set up both the hardware and software, including the foundation cluster and the OpenStack cluster. It also covers other tools used for the monitoring and management of the cluster in detail and how all these components work together in the system. The guide also provides the deployment steps and references to configuration developed by Dell EMC and Canonical for the deployment process.

--- a/templates/engage/dell-openstack-reference-architecture.md
+++ b/templates/engage/dell-openstack-reference-architecture.md
@@ -4,7 +4,7 @@ context:
      title: "Charmed OpenStack reference architecture"
      meta_description: "Reference architecture guide for Charmed OpenStack (Rocky) solution on Dell EMC hardware delivered by Canonical, including Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking."
      meta_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
-     meta_copydoc:
+     meta_copydoc: "https://docs.google.com/document/d/1etdmGqolS7mhKtSK0jFwOKMMzCwXkkKkaH69rTmSiWY/edit#"
      header_title: "Charmed OpenStack reference architecture"
      header_subtitle: "With Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking and Canonical"
      header_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"


### PR DESCRIPTION
## Done

- Create dell openstack reference architecture engage page
- **Note** I have not added a link to the /engage index

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/dell-openstack-reference-architecture
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Read the page to see if it makes sense, test the form

## Issue / Card

Fixes #6009 

