### PR TITLE
Simplify row expansion and add FIPS + EAL warnings

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -397,7 +397,11 @@ summary {
   }
 
   .p-table--open {
-    background-color: $color-mid-x-light;
+    background-color: $color-x-light;
+    border-left: 1px solid $color-mid-light;
+    border-right: 1px solid $color-mid-light;
+    box-shadow: 0 1px 0 0 $color-x-light;
+    z-index: 5;
   }
 
   .u-toggle {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -363,10 +363,6 @@ summary {
   td {
     padding-left: 0.5rem;
     padding-right: 0.5rem;
-
-    &:last-child {
-      padding-right: 0.5rem;
-    }
   }
 
   .p-table__row {

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -152,7 +152,7 @@
                   </div>
                 </div>
                 <div class="col-12 u-align--center">
-                  To activate FIPs: <code>sudo ua enable fips</code>
+                  To activate FIPS: <code>sudo ua enable fips</code>
                 </div>
               </div>
             </td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -144,6 +144,13 @@
             </td>
             <td id="expanded-row-fips-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
               <div class="row">
+                <div class="col-12">
+                  <div class="p-notification--caution">
+                    <p class="p-notification__response">
+                      Older versions of software are used for FIPS-certified packages. Use them only if your organisation requires it.
+                    </p>
+                  </div>
+                </div>
                 <div class="col-12 u-align--center">
                   To activate FIPs: <code>sudo ua enable fips</code>
                 </div>
@@ -151,6 +158,13 @@
             </td>
             <td id="expanded-row-cc-eal-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
               <div class="row">
+                <div class="col-12">
+                  <div class="p-notification--caution">
+                    <p class="p-notification__response">
+                      Older versions of software are used for CC-EAL-certified packages. Use them only if your organisation requires it.
+                    </p>
+                  </div>
+                </div>
                 <div class="col-12 u-align--center">
                   To activate CC-EAL: <code>sudo ua enable cc-eal</code>
                 </div>
@@ -217,7 +231,7 @@
     </div>
     <div class="col-5 col-start-large-8">
       <div class="u-no-margin--bottom p-card">
-        <p class="u-no-margin--bottom">
+        <p>
            Sign in to access your personal or paid subscriptions.
         </p>
         <p class="u-no-margin--bottom">


### PR DESCRIPTION
## Done
- Added a small amount of padding above the Sign in button
- Make the expanded cell white, rather than dark grey, so that it is seamless with the expansion. (Unexpanded cells can still be dark grey on hover.)
- In a FIPS cell expansion, start with a Vanilla caution: “Older versions of software are used for FIPS-certified packages. Use them only if your organisation requires it.”
- Similarly in a CC-EAL cell expansion, start with a Vanilla caution: “Older versions of software are used for CC-EAL-certified packages. Use them only if your organisation requires it.”

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /advantage
- Check there are some more padding above the Sign-in button
- Check the screenshots are good because it's unlikely you have a paid subscription

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5953

## Screenshots
_Imagine it was the FIPs tab that was open_
![Screenshot_2019-11-07 Ubuntu Advantage for Infrastructure Ubuntu](https://user-images.githubusercontent.com/1413534/68380691-3cf23200-0148-11ea-84ad-2f252e0006b2.png)

![Screenshot_2019-11-07 Ubuntu Advantage for Infrastructure Ubuntu(2)](https://user-images.githubusercontent.com/1413534/68381229-2d271d80-0149-11ea-8673-c2f07a9d3515.png)

![Screenshot_2019-11-07 Ubuntu Advantage for Infrastructure Ubuntu(1)](https://user-images.githubusercontent.com/1413534/68381238-30220e00-0149-11ea-8801-49bb98026a23.png)


