### PR TITLE
Display 11 blog posts per page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask_base==0.3.3
 canonicalwebteam.http==1.0.1
-canonicalwebteam.blog==3.1.2
+canonicalwebteam.blog==4.0.1
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
 canonicalwebteam.image-template==1.0.0

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -10,16 +10,19 @@
     {% with topic="" %}{% include "blog/filters.html" %}{% endwith %}
     <div class="row u-equal-height u-clearfix">
     {% for article in articles %}
-      {% if (loop.index - 1) % 3 == 0 and loop.index > 1 %}
-        </div>
-        <div class="row u-equal-height u-clearfix">
-      {% endif %}
-      {% if loop.index == 3 %}
+      {% if loop.index in [1,2] %}
+        {% with summary_visible=True %}{% include "blog/blog-card.html" %}{% endwith %}
+      {% elif loop.index ==3 %}
         <div class="col-4">
           {% include 'blog/newsletter-form.html' %}
         </div>
-      {% elif loop.index <= 2 %}
-        {% with summary_visible=True %}{% include "blog/blog-card.html" %}{% endwith %}
+      </div>
+      <div class="row u-equal-height u-clearfix">
+        {% include 'blog/blog-card.html' %}
+      {% elif (loop.index +1) % 3 == 0 and loop.index > 3 %}
+        {% include 'blog/blog-card.html' %}
+        </div>
+        <div class="row u-equal-height u-clearfix">
       {% else %}
         {% include 'blog/blog-card.html' %}
       {% endif %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -140,7 +140,7 @@ def advantage():
 # Blog
 # ===
 
-blog_views = BlogViews(excluded_tags=[3184, 3265, 3408])
+blog_views = BlogViews(excluded_tags=[3184, 3265, 3408], per_page=11)
 blog_blueprint = build_blueprint(blog_views)
 
 


### PR DESCRIPTION
## Done

- Display 11 blog posts per page (and not hide any)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check if you see the third blog post which is currently not visible on https://ubuntu.com/blog
- Go to http://0.0.0.0:8001/blog?page=2, compare to https://ubuntu.com/blog?page=2 and check there are no posts left out


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1956
