### PR TITLE
Add links to advantage

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -15,7 +15,7 @@
       <span class="u-sv3"><p class="p-heading--four">Security updates for 14.04 LTS until 2022</p></span>
       <p>Continue to receive security updates for the Ubuntu base OS and critical infrastructure components &ndash; Ceph, OpenStack and more &ndash; with ESM in your Ubuntu Advantage subscription.</p>
       <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops. Free for personal use.</p>
-      <p><a href="/advantage#esm" class="p-button--positive">Get started with Ubuntu Advantage</a></p>
+      <p><a href="/advantage" class="p-button--positive">Get started with Ubuntu Advantage</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/fa103ed7-1A-shield.svg" width="200" alt="" />

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -14,8 +14,8 @@
       <span class="u-sv3"><h1>Extended Security Maintenance</h1></span>
       <span class="u-sv3"><p class="p-heading--four">Security updates for 14.04 LTS until 2022</p></span>
       <p>Continue to receive security updates for the Ubuntu base OS and critical infrastructure components &ndash; Ceph, OpenStack and more &ndash; with ESM in your Ubuntu Advantage subscription.</p>
-      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops. And it’s free for personal use.</p>
-      <p><a href="/advantage" class="p-button--positive">Get started with Ubuntu Advantage</a></p>
+      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops. Free for personal use.</p>
+      <p><a href="/advantage#esm" class="p-button--positive">Get started with Ubuntu Advantage</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/fa103ed7-1A-shield.svg" width="200" alt="" />
@@ -47,7 +47,7 @@
     <div class="col-8">
       <h2>Free for personal use</h2>
       <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 5 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a> we will gladly increase that to 50 machines. Your personal subscription will also cover <a href="/livepatch">Livepatch</a>, FIPS and CIS hardening tools.</p>
-      <a href="/advantage#esm" class="p-button--positive u-no-margin--bottom">Get ESM now</a>
+      <a href="/advantage" class="p-button--positive u-no-margin--bottom">Get ESM now</a>
     </div>
   </div>
 

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -14,8 +14,8 @@
       <span class="u-sv3"><h1>Extended Security Maintenance</h1></span>
       <span class="u-sv3"><p class="p-heading--four">Security updates for 14.04 LTS until 2022</p></span>
       <p>Continue to receive security updates for the Ubuntu base OS and critical infrastructure components &ndash; Ceph, OpenStack and more &ndash; with ESM in your Ubuntu Advantage subscription.</p>
-      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops.</p>
-      <p><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Get started with Ubuntu Advantage</span></a></p>
+      <p>Ubuntu Advantage for Infrastructure is available for physical servers, virtual machines, containers, and desktops. And it’s free for personal use.</p>
+      <p><a href="/advantage" class="p-button--positive">Get started with Ubuntu Advantage</a></p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/fa103ed7-1A-shield.svg" width="200" alt="" />
@@ -43,6 +43,18 @@
 </section>
 
 <section class="p-strip is-deep is-bordered" id="get-esm">
+  <div class="row">
+    <div class="col-8">
+      <h2>Free for personal use</h2>
+      <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 5 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a> we will gladly increase that to 50 machines. Your personal subscription will also cover <a href="/livepatch">Livepatch</a>, FIPS and CIS hardening tools.</p>
+      <a href="/advantage#esm" class="p-button--positive u-no-margin--bottom">Get ESM now</a>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
+
   <div class="row" id="benefits">
     <div class="col-10">
       <h2>What’s covered?</h2>

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -47,10 +47,10 @@
     <div class="col-12">
       <h2>Free for personal use</h2>
       <p>All you need is an Ubuntu One account. Free for 3 machines.</p>
-      <p><a class="p-button--positive"  href="https://auth.livepatch.canonical.com/"><span class="p-link--external">Get Livepatch</span></a></p>
+      <p><a class="p-button--positive"  href="/advantage#livepatch">Get Livepatch</a></p>
       <h2>Part of Ubuntu Advantage</h2>
       <p>Buy as part of Ubuntu Advantage from Canonical. Buy online.</p>
-      <p><a class="p-button--positive"  href="https://buy.ubuntu.com/"><span class="p-link--external">Get Ubuntu Advantage</span></a></p>
+      <p><a class="p-button--positive"  href="/advantage">Get Ubuntu Advantage</a></p>
     </div>
   </div>
 </section>

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -47,10 +47,10 @@
     <div class="col-12">
       <h2>Free for personal use</h2>
       <p>All you need is an Ubuntu One account. Free for 3 machines.</p>
-      <p><a class="p-button--positive"  href="/advantage#livepatch">Get Livepatch</a></p>
+      <p><a class="p-button--positive"  href="/advantage">Get Livepatch</a></p>
       <h2>Part of Ubuntu Advantage</h2>
       <p>Buy as part of Ubuntu Advantage from Canonical. Buy online.</p>
-      <p><a class="p-button--positive"  href="/advantage">Get Ubuntu Advantage</a></p>
+      <p><a class="p-button--positive"  href="/advantage#livepatch">Get Ubuntu Advantage</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Add links to advantage on the ESM and livepatch pages.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /esm and check it matches [the copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit)
- Go to /livepatch and check it matches  [the copy doc](https://docs.google.com/document/d/1Ofw9bQ4I40gy9hDIjuDMApz6sDK8qSdHI03-oY7xs-A/edit)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/5965
