### PR TITLE
Updated datasheet on /openstack/consulting

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -14,7 +14,7 @@
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>
           <a href="/openstack/contact-us?product=foundation-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Engage Canonical exports', 'eventLabel' : 'Engage Canonical exports - Top CTA', 'eventValue' : undefined });" class="p-button--positive js-invoke-modal">Engage Canonical experts</a>
-          <a href="https://assets.ubuntu.com/v1/b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf" class="p-button--neutral">Read our consulting datasheet</a>
+          <a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf" class="p-button--neutral">Read our consulting datasheet</a>
         </p>
       </div>
     </div>
@@ -108,8 +108,8 @@
       </div>
 
       <div class="col-4 p-card u-align--center">
-        <a href="https://assets.ubuntu.com/v1/b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf"><img class="p-card__icon" src="https://assets.ubuntu.com/v1/3e9e430a-icon-documentation.svg" width="32" alt="Read the datasheet" /></a>
-        <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
+        <a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf"><img class="p-card__icon" src="https://assets.ubuntu.com/v1/3e9e430a-icon-documentation.svg" width="32" alt="Read the datasheet" /></a>
+        <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
 
       <div class="col-4 p-card u-align--center">
@@ -226,7 +226,7 @@
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
         <p><a href="/openstack/features">Find out how</a> Canonical delivers the world’s favourite enterprise OpenStack. The choice of the largest operators in telco, finance, media, pharma, retail and government sectors, Canonical’s OpenStack on Ubuntu offers a flexible architecture and enables integration of GPGPUs, FPGAs and cloud network accelerators.</p>
-        <p class="u-no-margin--top"><a href="https://assets.ubuntu.com/v1/b71c0af7-canonical-foundation-cloud-build-2018-08-09.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- uploaded datasheet to assets
- updated copy doc
- updated datasheet on /openstack/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See there is the new datasheet


## Issue / Card

Fixes #6093


