### PR TITLE
Implement GeoIP directly on the /download/*/thank-you pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install --no-install-recommends --yes python3 pyth
 ADD . .
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
+# Get mirror list
+ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
+
 # Set git commit ID
 ARG TALISKER_REVISION_ID
 RUN echo "${TALISKER_REVISION_ID}" > version-info.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ canonicalwebteam.blog==4.0.1
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
 canonicalwebteam.image-template==1.0.0
+maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1
 pymacaroons==0.12.0

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -6,13 +6,17 @@ import re
 # Packages
 import feedparser
 import flask
-from requests.exceptions import HTTPError
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
+from geolite2 import geolite2
+from requests.exceptions import HTTPError
 
 # Local
 from webapp import auth
 from webapp.api import advantage as advantage_api
+
+
+ip_reader = geolite2.reader()
 
 
 def download_thank_you(category):
@@ -41,11 +45,18 @@ def download_thank_you(category):
     except IOError:
         mirrors = []
 
+    # Check country code
+    country_code = "NO_COUNTRY_CODE"
+    ip_location = ip_reader.get(flask.request.remote_addr)
+    mirror_list = []
+
+    if ip_location:
+        country_code = ip_location["country"]["iso_code"]
+
     mirror_list = [
         {"link": mirror["link"], "bandwidth": mirror["mirror_bandwidth"]}
         for mirror in mirrors
-        if mirror["mirror_countrycode"]
-        == flask.request.args.get("country", "NO_COUNTRY_CODE")
+        if mirror["mirror_countrycode"] == country_code
     ]
     context["mirror_list"] = json.dumps(mirror_list)
 


### PR DESCRIPTION
IS are replacing the existing Apache+Squid front-end for ubuntu.com with their new Content-cache. As they do this, they'd like to kill [the redirects they're maintaining there](https://pastebin.canonical.com/p/3TXyyNkWkg/).

The most important part of this is a redirect that uses Apache GeoIP to add `?country=XX` to URLs for `/download/*/thank-you` pages, so that people get directed to a local mirror.

We [haven't quite decided](https://docs.google.com/document/d/1YoCt1iKuveK-NvheICwHXfSv-W5OV5fUcRiad5x9FnY/edit#bookmark=id.fuigb9egut1d) whether this should be handled in the app or not - but in anticipation of them being okay with it being in the app, this is the solution I would go for.

QA
--

Do:

``` bash
mkdir etc
wget http://launchpad.net/ubuntu/+cdmirrors-rss -O etc/ubuntu-mirrors-rss.xml
./run
```

Check the site runs fine.

Now check the mirrors list is empty by default (this is 'cos your client IP is like `17.0.0.1` or something):

``` bash
$ curl -s "http://0.0.0.0:8001/download/desktop/thank-you?version=18.04.3&architecture=amd64" | grep "mirrors ="
    var mirrors = [];
```

But if you pretend to come from a UK IP address, you see what looks like a list of UK mirrors:

``` bash
$ curl -sH 'X-Forwarded-For: 81.168.13.58' "http://0.0.0.0:8001/download/desktop/thank-you?version=18.04.3&architecture=amd64" | grep "mirrors ="
    var mirrors = [{"link": "http://mirrors.ukfast.co.uk/sites/ubuntu.com/", "bandwidth": "110"}, {"link": "http://www.mirrorservice.org/sites/releases.ubuntu.com/", "bandwidth": "110"}, {"link": "http://mirror.as29550.net/releases.ubuntu.com/", "bandwidth": "80"}, {"link": "http://mirror.bytemark.co.uk/ubuntu-releases/", "bandwidth": "80"}, {"link": "http://mirror.freethought-internet.co.uk/ubuntu-releases/", "bandwidth": "80"}, {"link": "http://mirror.ox.ac.uk/sites/releases.ubuntu.com/releases/", "bandwidth": "80"}, {"link": "http://mirror.sax.uk.as61049.net/releases.ubuntu.com/", "bandwidth": "80"}, {"link": "http://mirror.sov.uk.goscomb.net/ubuntu-releases/", "bandwidth": "80"}, {"link": "http://mirrors.manchester.m247.com/ubuntu-releases/", "bandwidth": "80"}, {"link": "http://mirrors.melbourne.co.uk/ubuntu-releases/", "bandwidth": "80"}, {"link": "http://releases.ubuntu.mirrors.uk2.net/", "bandwidth": "80"}, {"link": "http://ftp.ticklers.org/releases.ubuntu.org/releases/", "bandwidth": "80"}, {"link": "http://gb.releases.ubuntu.com/", "bandwidth": "80"}, {"link": "http://releases.ubuntu.com/", "bandwidth": "70"}];
```
