### PR TITLE
add blog-header suru to /robotics

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -2,6 +2,7 @@
 @mixin ubuntu-p-strip {
   @include ubuntu-p-strip-suru;
   @include ubuntu-p-strip-suru-background;
+  @include ubuntu-p-strip-suru-blog-header;
   @include ubuntu-p-strip-suru-blog-hero;
   @include ubuntu-p-strip-suru-bottomed;
   @include ubuntu-p-strip-suru-half-and-half;
@@ -326,6 +327,23 @@
     &.is-dark {
       color: $color-x-light;
     }
+  }
+}
+
+@mixin ubuntu-p-strip-suru-blog-header {
+  .p-strip--suru-blog-header {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal;
+    background-image:
+      linear-gradient(150deg, rgba(228, 228, 228, 0.54) 0%, rgba(228, 228, 228, 0.54) 54.9%, rgba(228, 228, 228, 0) 55%, rgba(228, 228, 228, 0) 100%),
+      linear-gradient(to bottom left, rgba(216, 216, 216, 0.54) 0%, rgba(216, 216, 216, 0.54) 49.9%, rgba(216, 216, 216, 0) 50%, rgba(216, 216, 216, 0) 100%),
+      linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    background-position: bottom left, bottom 0 right, 0% 0%;
+    background-repeat: no-repeat;
+    background-size: 100% 100%, 60% 100%, auto;
+    color: $color-x-light;
+    overflow: hidden;
+    position: relative;
   }
 }
 // sass-lint:enable no-color-literals hex-notation

--- a/templates/_docs/strips.html
+++ b/templates/_docs/strips.html
@@ -451,4 +451,46 @@
     </div>
 </section>
 
+<!-- p-strip--suru-blog-hero -->
+<section class="p-strip is-deep is-bordered u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-blog-header is-dark">
+    <div class="row">
+      <div class="col-7">
+        <h1>
+          p-strip--suru-blog-header
+        </h1>
+        <p>
+          This strip should be used on blog indexes that don't have featured posts.
+        </p>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/5ee71af0-Robot+arm+-+white.svg" class="u-hide--small" alt="" width="200" />
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <div class="row"> <div class="col-8"> <pre><code>&lt;section class="p-strip--suru-blog-hero is-dark"&gt;
+  &lt;div class="row"&gt;
+    &lt;div class="col-7"&gt;
+      &lt;h1&gt;
+        &lt;-- title --&gt;
+      &lt;/h1&gt;
+      &lt;p class="p-heading--four"&gt;
+        &lt;-- copy --&gt;
+      &lt;/p&gt;
+    &lt;/div&gt;
+
+    &lt;div class="col-5 u-align--center u-vertically-center"&gt;
+      &lt;-- img --&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/section&gt;
+      </code></pre>
+      </div>
+    </div>
+</section>
+
 {% endblock content %}

--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <section class="p-strip is-deep is-bordered u-image-position">
+  <section class="p-strip--suru-blog-header is-dark is-bordered u-image-position">
     <div class="row u-equal-height">
       <div class="col-6">
         <div class="p-heading-icon">
@@ -19,12 +19,12 @@
         </div>
 
         <p>
-          <a class="p-link--external" href="/internet-of-things/robotics">Learn more about robotics from Canonical</a>
+          <a class="p-link--external p-link--inverted" href="/internet-of-things/robotics">Learn more about robotics from Canonical</a>
         </p>
       </div>
 
       <div class="col-5 col-start-large-8 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/5b16cbb9-robot_2px.svg" class="u-hide--small" alt="" />
+        <img src="https://assets.ubuntu.com/v1/5ee71af0-Robot+arm+-+white.svg" class="u-hide--small" alt="" width="200" />
       </div>
     </div>
   </section>

--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -21,7 +21,7 @@
         </p>
       </div>
 
-      <div class="col-5 col-start-large-8 u-align--center u-vertically-center">
+      <div class="col-5 u-align--center u-vertically-center">
         <img src="https://assets.ubuntu.com/v1/5ee71af0-Robot+arm+-+white.svg" class="u-hide--small" alt="" width="200" />
       </div>
     </div>

--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -8,18 +8,16 @@
 
   <section class="p-strip--suru-blog-header is-dark is-bordered u-image-position">
     <div class="row u-equal-height">
-      <div class="col-6">
+      <div class="col-7">
         <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="" style="margin-top: .25rem"/>
-            
+          <div class="p-heading-icon__header">            
             <h1 class="p-heading--one">Robotics</h1>
           </div>
-          <p>Whether you’re starting in the lab or already in production, Canonical can help manage the complexity of the open-source software underpinning your robot’s brains and personality.</p>
+          <p class="p-heading--four">Whether you’re starting in the lab or already in production, Canonical can help manage the complexity of the open-source software underpinning your robot’s brains and personality.</p>
         </div>
 
         <p>
-          <a class="p-link--external p-link--inverted" href="/internet-of-things/robotics">Learn more about robotics from Canonical</a>
+          <a class="p-link--inverted" href="/internet-of-things/robotics">Learn more about robotics from Canonical&nbsp;&rsaquo;</a>
         </p>
       </div>
 


### PR DESCRIPTION
## Done

- Created a blog-header suru, added it to /blog/topics/robotics

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/topics/robotics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the suru matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1802#issuecomment-550346588)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1875

## Screenshots

![Screenshot 2019-11-11 at 10 48 06](https://user-images.githubusercontent.com/2376968/68581675-c9fef900-0470-11ea-9f01-b0913c8d6475.png)

