### PR TITLE
IOT header suru

### DIFF
--- a/templates/blog/internet-of-things.html
+++ b/templates/blog/internet-of-things.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <section class="p-strip is-dark p-strip--suru-blog-header">
+  <section class="p-strip--suru-blog-header is-dark">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-7">
         <h1>Internet of Things</h1>

--- a/templates/blog/internet-of-things.html
+++ b/templates/blog/internet-of-things.html
@@ -6,17 +6,22 @@
 
 {% block content %}
 
-  <section class="p-strip--image is-dark p-strip--blog-suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/d1d58769-drone-iceland-unsplash-no-logo.jpg')">
+  <section class="p-strip is-dark p-strip--suru-blog-header">
     <div class="row u-equal-height u-vertically-center">
-      <div class="col-6 p-card--suru">
-        <h1 class="p-heading--one">Internet of Things</h1>
-        <h5 style="line-height: 1.75rem;">
+      <div class="col-7">
+        <h1>Internet of Things</h1>
+        <p class="p-heading--four">
           All you need to know about building and managing IoT and embedded devices using Ubuntu.
-        </h5>
+        </p>
         <p>
           <a class="p-link--inverted" href="/internet-of-things">Learn more about Internet of Things&nbsp;&rsaquo;</a>
         </p>
       </div>
+
+      <div class="col-5 u-align--center u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/a3c4eaae-Internet+of+Things_digital-drone-white.svg" class="u-hide--small" alt="" width="200" />
+      </div>
+
       <div id="rtp-banner" class="rtp-banner"></div>
     </div>
   </section>

--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -9,12 +9,10 @@
   <section class="p-strip--suru-blog-header is-dark is-bordered u-image-position">
     <div class="row u-equal-height">
       <div class="col-7">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">            
-            <h1 class="p-heading--one">Robotics</h1>
-          </div>
-          <p class="p-heading--four">Whether you’re starting in the lab or already in production, Canonical can help manage the complexity of the open-source software underpinning your robot’s brains and personality.</p>
+        <div class="p-heading-icon__header">            
+          <h1 class="p-heading--one">Robotics</h1>
         </div>
+        <p class="p-heading--four">Whether you’re starting in the lab or already in production, Canonical can help manage the complexity of the open-source software underpinning your robot’s brains and personality.</p>
 
         <p>
           <a class="p-link--inverted" href="/internet-of-things/robotics">Learn more about robotics from Canonical&nbsp;&rsaquo;</a>

--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <section class="p-strip--suru-blog-header is-dark is-bordered u-image-position">
+  <section class="p-strip--suru-blog-header is-dark">
     <div class="row u-equal-height">
       <div class="col-7">
         <div class="p-heading-icon__header">            


### PR DESCRIPTION
## Done

- added blog header suru to /blog/internet-of-things

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/internet-of-things
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the header strip matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1879#issuecomment-550351474).


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1880
