### PR TITLE
add blog header suru to /blog/cloud-and-server

### DIFF
--- a/templates/blog/cloud-and-server.html
+++ b/templates/blog/cloud-and-server.html
@@ -5,17 +5,18 @@
 {% block meta_description %}All you need to know about designing, building and managing your Openstack private cloud, Kubernetes cluster or Ubuntu Server scale‑out deployment.{% endblock %}
 
 {% block content %}
-  <section class="p-strip--image is-dark p-strip--blog-suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg')">
+  <section class="p-strip--suru-blog-header is-dark is-bordered">
     <div class="row u-equal-height u-vertically-center">
-      <div class="col-6 p-card--suru">
+      <div class="col-7">
         <h1 class="p-heading--one">Cloud and Server</h1>
-        <h5 style="line-height: 1.75rem;">
+        <p class="p-heading--four">
           All you need to know about designing, building and managing your Openstack private cloud, Kubernetes cluster or Ubuntu Server scale‑out deployment.
-        </h5>
+        </p>
         <p>
           <a class="p-link--inverted" href="/cloud">Learn more about Cloud and Server&nbsp;&rsaquo;</a>
         </p>
       </div>
+
       <div id="rtp-banner" class="rtp-banner"></div>
     </div>
   </section>

--- a/templates/blog/cloud-and-server.html
+++ b/templates/blog/cloud-and-server.html
@@ -5,7 +5,7 @@
 {% block meta_description %}All you need to know about designing, building and managing your Openstack private cloud, Kubernetes cluster or Ubuntu Server scale‑out deployment.{% endblock %}
 
 {% block content %}
-  <section class="p-strip--suru-blog-header is-dark is-bordered">
+  <section class="p-strip--suru-blog-header is-dark">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-7">
         <h1 class="p-heading--one">Cloud and Server</h1>


### PR DESCRIPTION
## Done

- added blog header suru to /blog/cloud-and-server

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/cloud-and-server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the header strip matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1883#issuecomment-550282448).


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1884