### PR TITLE
Add mirror list to dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN python3 -m pip install --no-cache-dir -r requirements.txt
 ARG TALISKER_REVISION_ID
 RUN echo "${TALISKER_REVISION_ID}" > version-info.txt
 ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
+ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
## Done

- The site was downloading directly from release.ubuntu.com.
- From a bad revert we forgot to add the file list that was downloaded from launchpad.

## QA

- Check out this feature branch
- `./run build`
- ` docker build --build-arg TALISKER_REVISION_ID=test --tag ubuntu.com .`
- ` docker run -ti -p 8004:80 ubuntu.com`
- go on http://localhost:8004/download/server/thank-you?version=18.04.3&architecture=amd64&country=CA
- make sure that the download doens't come from releases.ubuntu.com