### PR TITLE
Corrects alt= text across the site

### DIFF
--- a/templates/_docs/engage_pages.html
+++ b/templates/_docs/engage_pages.html
@@ -33,7 +33,7 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg" width="413" style="max-height: 410px; max-width: 250px;" alt="image for From VMware to Charmed&amp;nbsp;OpenStack" >
+      <img src="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
     </div>
   </div>
 </section>

--- a/templates/_docs/strips.html
+++ b/templates/_docs/strips.html
@@ -70,7 +70,7 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/6c0f3ca0-disco-dingo.svg" width="216" alt="Disco Dingo pictogram" />
+      <img src="https://assets.ubuntu.com/v1/6c0f3ca0-disco-dingo.svg" width="216" alt="" />
     </div>
   </div>
 </section>
@@ -385,21 +385,21 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-4 p-card">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="header image">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="">
         <hr class="u-sv1">
         <h3 class="p-card__title">Raspberry Pi2 and Pi3</h3>
         <p class="p-card__content">For fun, for education and for profit, the RPi makes device development personal and entertaining. With support for both the Pi2 and the new Pi3, Ubuntu Core supports the world’s most beloved board.</p>
       </div>
 
       <div class="col-4 p-card">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="header image">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="">
         <hr class="u-sv1">
         <h3 class="p-card__title">Raspberry Pi2 and Pi3</h3>
         <p class="p-card__content">For fun, for education and for profit, the RPi makes device development personal and entertaining. With support for both the Pi2 and the new Pi3, Ubuntu Core supports the world’s most beloved board.</p>
       </div>
 
       <div class="col-4 p-card">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="header image">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="">
         <hr class="u-sv1">
         <h3 class="p-card__title">Raspberry Pi2 and Pi3</h3>
         <p class="p-card__content">For fun, for education and for profit, the RPi makes device development personal and entertaining. With support for both the Pi2 and the new Pi3, Ubuntu Core supports the world’s most beloved board.</p>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -13,7 +13,7 @@
       <p>Canonical publishes new releases of Ubuntu on a regular cadence, enabling the community, businesses and developers to plan their roadmaps with certainty of access to newer open source upstream capabilities.</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/ed348358-logo-cof.svg" width="200" alt="ubuntu logo">
+      <img src="https://assets.ubuntu.com/v1/ed348358-logo-cof.svg" width="200" alt="">
     </div>
   </div>
 </section>

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -16,7 +16,7 @@
         <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/e0461e14-ceph-dark.svg" width="250" alt="Ceph logo" />
+        <img src="https://assets.ubuntu.com/v1/e0461e14-ceph-dark.svg" width="250" alt="" />
       </div>
     </div>
   </div>
@@ -45,17 +45,17 @@
 
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/5d403409-2018-logo-yahoo-japan.svg" alt="Yahoo! Japan logo" />
+      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/5d403409-2018-logo-yahoo-japan.svg" alt="Yahoo! Japan" />
       <hr class="u-sv1">
       <p class="p-card__content">In the early days of Ceph, Yahoo! Japan searched for a local company who could support them in the implementation of an open-source distributed storage solution from the Linux operating system all the way to Ceph. Canonical provided not only Ceph but also the tooling and expertise that reduced the OPEX associated with managing a large storage cluster.</p>
       <a href="/engage/yahoo-japan-case-study">Find out more about Yahoo! Japan’s Ceph cluster&nbsp;&rsaquo;</a>
     </div>
 
     <div class="col-6 p-card">
-      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d8841399-Wellcome_Sanger_Institute_Logo_Landscape_Digital_RGB_Full_Colour.svg" alt="Wellcome Sanger Institute logo" style="max-width: 6rem;" />
+      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d8841399-Wellcome_Sanger_Institute_Logo_Landscape_Digital_RGB_Full_Colour.svg" alt="Wellcome Sanger Institute" style="max-width: 6rem;" />
       <hr class="u-sv1">
-      <p class="p-card__content">The Wellcome Sanger Institute initially opted for self-maintained Ceph storage., but as their capacity needs grew from 3 PB to over 20 PB, they turned to Canonical to resolve their scaling issues. With the help of Canonical support, The Institute’s latest Ceph roll out decreased from a month to just four days.</p>
-      <a href="/engage/wellcome-sanger-case-study">Find out about Wellcome Sanger's path to a cost-effective Ceph infrastructure&nbsp;&rsaquo;</a>
+      <p class="p-card__content">The Wellcome Sanger Institute initially opted for self-maintained Ceph storage, but as their capacity needs grew from 3 PB to over 20 PB, they turned to Canonical to resolve their scaling issues. With the help of Canonical support, the Institute’s latest Ceph rollout decreased from a month to just four days.</p>
+      <a href="/engage/wellcome-sanger-case-study">Find out about Wellcome Sanger’s path to a cost-effective Ceph infrastructure&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>
@@ -79,7 +79,7 @@
     </div>
 
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/858d6aa5-ceph+++juju.svg" alt="Ceph and Juju logos" />
+      <img src="https://assets.ubuntu.com/v1/858d6aa5-ceph+++juju.svg" alt="" />
     </div>
   </div>
 

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -66,7 +66,7 @@
 <div class="p-strip">
   <div class="row u-equal-height">
     <div class="col-5 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/9b153e96-lxd.svg" alt="LXD logo" width="275px">
+      <img src="https://assets.ubuntu.com/v1/9b153e96-lxd.svg" alt="" width="275px">
     </div>
     <div class="col-7">
       <h2>VM-style containers for legacy applications with LXD</h2>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -34,14 +34,14 @@
     <div class="row p-divider">
       <div class="col-6 p-divider__block">
         <div class="row u-equal-height u-no-margin--bottom">
-          <div class="col-3 col-small-2 col-medium-3 col-2 col-start-large-3 u-align--center"><img src="https://assets.ubuntu.com/v1/94ea495b-2018-logo-Intel.svg" alt="Intel logo" width="143" /></div>
-          <div class="col-3 col-small-2 col-medium-3 col-2 u-align--center"><img src="https://assets.ubuntu.com/v1/b1767848-2018-logo-raspberry-pi.svg" alt="Raspberry PI logo" width="143" /></div>
+          <div class="col-3 col-small-2 col-medium-3 col-2 col-start-large-3 u-align--center"><img src="https://assets.ubuntu.com/v1/94ea495b-2018-logo-Intel.svg" alt="Intel" width="143" /></div>
+          <div class="col-3 col-small-2 col-medium-3 col-2 u-align--center"><img src="https://assets.ubuntu.com/v1/b1767848-2018-logo-raspberry-pi.svg" alt="Raspberry Pi" width="143" /></div>
         </div>
       </div>
       <div class="col-6 p-divider__block">
         <div class="row u-equal-height u-no-margin--bottom">
-          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center"><img src="https://assets.ubuntu.com/v1/0970d532-2018-logo-dell.svg" alt="Dell logo" width="143" /></div>
-          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center"><img src="https://assets.ubuntu.com/v1/a6d7f650-Rigado-logo.svg" alt="Rigado logo" width="143" /></div>
+          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center"><img src="https://assets.ubuntu.com/v1/0970d532-2018-logo-dell.svg" alt="Dell" width="143" /></div>
+          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center"><img src="https://assets.ubuntu.com/v1/a6d7f650-Rigado-logo.svg" alt="Rigado" width="143" /></div>
         </div>
       </div>
     </div>
@@ -117,7 +117,7 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/3505cd01-GRAPHIC_os_image_size.svg" width="335" alt="OS image size comparison">
+      <img src="https://assets.ubuntu.com/v1/3505cd01-GRAPHIC_os_image_size.svg" width="335" alt="Ubuntu Core: 260 MB. Red Hat coreOS: 807 MB.">
     </div>
     <div class="col-6">
       <h4>Minimal core, minimal risk, minimal bugs</h4>
@@ -320,7 +320,7 @@ store for access to all the standard apps, or curate your own collection.</p>
 
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg" width="200" alt="GitHub logo">
+      <img src="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg" width="200" alt="">
     </div>
     <div class="col-6">
       <h4>Harness all things open source</h4>
@@ -414,7 +414,7 @@ store for access to all the standard apps, or curate your own collection.</p>
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/3fe180b5-5B-Off+the+shelf.svg" width="300" alt="Canonical logo">
+      <img src="https://assets.ubuntu.com/v1/3fe180b5-5B-Off+the+shelf.svg" width="300" alt="">
     </div>
     <div class="col-6">
       <h4>Off-the-shelf board support by Canonical</h4>

--- a/templates/engage/14-04-esm.html
+++ b/templates/engage/14-04-esm.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-vertically-center">
     <div class="col-7">

--- a/templates/engage/451-automotive.html
+++ b/templates/engage/451-automotive.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--dark p-takeover--451">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img class="p-takeover__image" src="https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg" width="311" alt="image for 451 Automotive" >
+      <img class="p-takeover__image" src="https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg" width="311" alt="451 Research" >
     </div>
   </div>
 </section>

--- a/templates/engage/ITstrategen-case-study.html
+++ b/templates/engage/ITstrategen-case-study.html
@@ -9,7 +9,7 @@
 {% block content %}
 <section class="p-strip is-deep u-no-margin--bottom u-no-padding--bottom">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row">
     <div class="col-7">

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -21,11 +21,11 @@
 <section {% if header_lang %}lang="{{ header_lang }}"{% endif %} class="{% if header_class %}p-strip {{ header_class }}{% else %}p-strip--light{% endif %}">
   {% if header_class %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   {% else %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   {% endif %}
   <div class="row u-equal-height">
@@ -49,7 +49,7 @@
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if "http" not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for {{ header_title }}" >
+      <img src="{% if "http" not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
     </div>{% endif %}
   </div>
 </section>

--- a/templates/engage/ai-gettingstarted.html
+++ b/templates/engage/ai-gettingstarted.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip p-strip--dark p-takeover--ai">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 u-vertically-center">
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg" alt="image for getting started with ai" style="height: 160px;">
+      <img src="https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg" alt="" style="height: 160px;">
     </div>
   </div>
 </section>

--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -32,7 +32,7 @@
 
 <section class="p-strip p-takeover--ai-webinar">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-9">

--- a/templates/engage/casestudy-botsandus.html
+++ b/templates/engage/casestudy-botsandus.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7  u-vertically-center">
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/4d0d4cc5-botsandus-logo.svg" width="340px" style="max-height: 410px; max-width: 340px;" alt="image for BotsAndUs builds a social robot on Ubuntu">
+      <img src="https://assets.ubuntu.com/v1/4d0d4cc5-botsandus-logo.svg" width="340px" style="max-height: 410px; max-width: 340px;" alt="">
     </div>
   </div>
 </section>

--- a/templates/engage/casestudy-commercetools.html
+++ b/templates/engage/casestudy-commercetools.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
         <div class="row u-equal-height">
           <div class="col-7  u-vertically-center">
@@ -29,7 +29,7 @@
             </div>
           </div>
           <div class="col-5 u-hide--small u-align--center u-vertically-center">
-            <img src="https://assets.ubuntu.com/v1/d519342f-icon-intro-server.svg" width="150px" style="max-height: 410px; max-width: 150px;" alt="image for Commercetools uses Ubuntu Server to power its next-generation ecommerce platform">
+            <img src="https://assets.ubuntu.com/v1/d519342f-icon-intro-server.svg" width="150px" style="max-height: 410px; max-width: 150px;" alt="">
           </div>
         </div>
       </section>

--- a/templates/engage/cloud-economics.html
+++ b/templates/engage/cloud-economics.html
@@ -37,7 +37,7 @@
 </style>
 <section class="p-strip is-deep p-takeover--private-cloud-economics">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-8">

--- a/templates/engage/deploy-ai-ml-model.html
+++ b/templates/engage/deploy-ai-ml-model.html
@@ -32,7 +32,7 @@
 
 <section class="p-strip p-takeover--ai-webinar">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-9">

--- a/templates/engage/developer-desktop.html
+++ b/templates/engage/developer-desktop.html
@@ -9,7 +9,7 @@
 {% block content %}
 <section class="p-strip p-takeover--developer-desktop">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">

--- a/templates/engage/devops-cicd-webinar.html
+++ b/templates/engage/devops-cicd-webinar.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--image is-deep js-takeover is-dark p-takeover">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-vertically-center">
     <div class="col-7">

--- a/templates/engage/edge-month.html
+++ b/templates/engage/edge-month.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip p-strip--dark p-engage-banner--grad">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height u-vertically-center">
     <div class="col-7">

--- a/templates/engage/evolving-software.html
+++ b/templates/engage/evolving-software.html
@@ -6,7 +6,7 @@
 {% block content %}
 <section class="p-strip--image is-dark p-hero--evolving-software">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-8">

--- a/templates/engage/financial-services-month.html
+++ b/templates/engage/financial-services-month.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="p-strip--dark is-deep p-takeover--financial-services">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height u-vertically-center">
     <div class="col-7">

--- a/templates/engage/fingbox-case-study.html
+++ b/templates/engage/fingbox-case-study.html
@@ -9,7 +9,7 @@
 {% block content %}
 <section class="p-strip u-no-margin--bottom u-no-padding--bottom">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row">
     <div class="col-7">

--- a/templates/engage/future-proof-iot.html
+++ b/templates/engage/future-proof-iot.html
@@ -32,7 +32,7 @@
 
 <section class="p-strip p-takeover--ai-webinar">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-9">

--- a/templates/engage/hiri-case-study.html
+++ b/templates/engage/hiri-case-study.html
@@ -10,7 +10,7 @@
 
 <section  class="p-strip p-strip--dark p-takeover--hiri">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7  u-vertically-center">
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/b8255328-download.png" width="192" style="max-height: 410px; max-width: 250px;" alt="image for (( title ))" >
+      <img src="https://assets.ubuntu.com/v1/b8255328-download.png" width="192" style="max-height: 410px; max-width: 250px;" alt="" >
     </div>
   </div>
 </section>

--- a/templates/engage/industrial-drones.html
+++ b/templates/engage/industrial-drones.html
@@ -10,7 +10,7 @@
 <section class="p-takeover--appelix">
   <div class="p-strip p-takeover--appelix-suru">
     <div class="u-fixed-width navigation-logo-engage">
-      <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+      <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
     </div>
     <div class="row u-vertically-center">
       <div class="col-7">

--- a/templates/engage/iot-business-model.html
+++ b/templates/engage/iot-business-model.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="p-strip p-takeover is-deep">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-8 suffix-2">

--- a/templates/engage/k8s-allan-gray.html
+++ b/templates/engage/k8s-allan-gray.html
@@ -6,7 +6,7 @@
 {% block content %}
 <section class="p-strip--light p-takeover--stats">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row">
     <div class="col-7">

--- a/templates/engage/kernel-telco-nfv.html
+++ b/templates/engage/kernel-telco-nfv.html
@@ -6,7 +6,7 @@
 {% block content %}
 <section class="p-strip p-hero--nfv-kernel js-takeover">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7 p-card--overlay">

--- a/templates/engage/modern-cloud.html
+++ b/templates/engage/modern-cloud.html
@@ -9,7 +9,7 @@
 {% block content %}
 <section class="p-strip--image u-image-position p-takeover-trilio">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
     <div class="row u-vertically-center">
       <div class="col-8">

--- a/templates/engage/multi-cloud-guide.html
+++ b/templates/engage/multi-cloud-guide.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
     <div class="row u-vertically-center">
       <div class="col-7" itemscope="" itemtype="https://schema.org/Event">

--- a/templates/engage/northstar.html
+++ b/templates/engage/northstar.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">

--- a/templates/engage/openstack-made-easy.html
+++ b/templates/engage/openstack-made-easy.html
@@ -23,7 +23,7 @@
         <p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical’s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
 
         <h5>Building clouds for the world's leading companies</h5>
-        <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Logos 450 BW.png" alt="Spectrum logo" width="450" />
+        <img src="https://pages.ubuntu.com/rs/066-EOV-335/images/Logos 450 BW.png" alt="Including AT&amp;T, eBay, NTT, Bloomberg, Cisco, Deutsche Telekom, Walmart and Best Buy." width="450" />
         <br>
         <br>
 

--- a/templates/engage/robot-operating-system-choice.html
+++ b/templates/engage/robot-operating-system-choice.html
@@ -6,7 +6,7 @@
 {% block content %}
 <section class="p-strip p-takeover--robotics js-takeover">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-6">

--- a/templates/engage/shared/_header-case-study.html
+++ b/templates/engage/shared/_header-case-study.html
@@ -6,7 +6,7 @@
       </h1>
     </div>
     {% if image %}<div class="col-5 u-align--center u-vertically-center">
-      <img src="{% if 'http' not in image %}https://assets.ubuntu.com/v1/{% endif %}{{ image }}" alt="image for (( title ))" >
+      <img src="{% if 'http' not in image %}https://assets.ubuntu.com/v1/{% endif %}{{ image }}" alt="" >
     </div>{% endif %}
   </div>
 </section>

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -6,11 +6,11 @@
 <section {% if lang %}lang="{{ lang }}"{% endif %} class="{% if class %}p-strip {{ class }}{% else %}p-strip--light{% endif %}">
   {% if class %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   {% else %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   {% endif %}
   <div class="row u-equal-height">
@@ -34,7 +34,7 @@
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if 'http' not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="image for {{ title }}" >
+      <img src="{% if 'http' not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
     </div>{% endif %}
   </div>
 </section>

--- a/templates/engage/shift-to-app-store-experience.html
+++ b/templates/engage/shift-to-app-store-experience.html
@@ -11,7 +11,7 @@
 <section class="p-takeover">
   <div class="p-strip--image is-dark is-deep p-takeover__suru">
     <div class="u-fixed-width navigation-logo-engage">
-      <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+      <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt=""></a>
     </div>
     <div class="row u-equal-height">
       <div class="col-7">

--- a/templates/engage/starting-with-ai.html
+++ b/templates/engage/starting-with-ai.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip p-strip--dark p-takeover--ai">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 u-vertically-center">
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg" alt="image for getting started with ai" style="height: 160px;">
+      <img src="https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg" alt="" style="height: 160px;">
     </div>
   </div>
 </section>

--- a/templates/engage/telco-cloudification-ebook.html
+++ b/templates/engage/telco-cloudification-ebook.html
@@ -33,7 +33,7 @@
                 <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/be345c7f-bSkyb_logo.png?w=141" width="141" alt="Sky">
             </li>
             <li class="p-inline-images__item">
-                <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/3ec677f3-spectrum_logo.png" alt="Spectrum logo" width="250" />
+                <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/3ec677f3-spectrum_logo.png" alt="Spectrum" width="250" />
             </li>
         </ul>
     </div>

--- a/templates/engage/ubuntu-18-10.html
+++ b/templates/engage/ubuntu-18-10.html
@@ -9,7 +9,7 @@
 
 <section class="p-strip--image is-dark p-takeover--1810--webinar">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7">

--- a/templates/engage/ubuntu-compliance.html
+++ b/templates/engage/ubuntu-compliance.html
@@ -9,7 +9,7 @@
 {% block content %}
 <section class="p-strip--image is-dark p-takeover--compliance">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
     <div class="row u-vertically-center">
       <div class="col-6 u-fade-left--medium">

--- a/templates/engage/ubuntu-core-and-kura.html
+++ b/templates/engage/ubuntu-core-and-kura.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="p-strip p-takeover--stats is-deep">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-8 u-vertically-center">

--- a/templates/engage/ubuntu-lime-telco.html
+++ b/templates/engage/ubuntu-lime-telco.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip p-strip--dark p-takeover">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">
@@ -28,7 +28,7 @@
     </div>
 
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/03853de5-Joint+Lime-illustration-white.svg" alt="Lime Microsystems logo" style="width: 320px;">
+      <img src="https://assets.ubuntu.com/v1/03853de5-Joint+Lime-illustration-white.svg" alt="" style="width: 320px;">
     </div>
   </div>
 </section>

--- a/templates/engage/vmware-to-openstack.html
+++ b/templates/engage/vmware-to-openstack.html
@@ -8,7 +8,7 @@
 {% block content %}
 <section class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/78c2eae0-image-server-room.jpg'); background-position: 77% 0%;">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu logo white"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
   <div class="row">
     <div class="col-7">

--- a/templates/engage/whitepaper-iot-security.html
+++ b/templates/engage/whitepaper-iot-security.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu logo dark"></a>
+    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
   </div>
         <div class="row u-equal-height">
           <div class="col-7  u-vertically-center">
@@ -29,7 +29,7 @@
             </div>
           </div>
           <div class="col-5 u-hide--small u-align--center u-vertically-center">
-            <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150" style="max-height: 150px; max-width: 150px;" alt="image for Taking charge of the IoT's security vulnerabilities">
+            <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150" style="max-height: 150px; max-width: 150px;" alt="">
           </div>
         </div>
       </section>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -88,7 +88,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <img src="https://assets.ubuntu.com/v1/0aa9c999-rigado.svg" alt="Rigado logo" />
+    <img src="https://assets.ubuntu.com/v1/0aa9c999-rigado.svg" alt="" />
     <blockquote class="p-pull-quote">
       <p class="p-pull-quote__quote">Large-scale commercial IoT deployments are not one size fits all. They require infrastructure that is open, scalable, and secure, with software that can evolve to meet the changing needs of the customer. Ubuntu Core brings a powerful and open architecture to IoT gateways, ensuring they’re an enabler of business success for customers, now and in the future.</p>
       <cite class="p-pull-quote__citation">Ben Corrado, Co-founder, Rigado</cite>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -114,7 +114,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.screenly.io/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/5917a214-logo-screenly.png?h=65" height="65" alt="Screenly logo" /></a>
+        <a href="https://www.screenly.io/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/5917a214-logo-screenly.png?h=65" height="65" alt="Screenly" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Screenly</h3>
@@ -123,7 +123,7 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.4yousee.com.br/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/391ea778-logo-4yousee.png?h=65" height="65" alt="4YouSee logo" /></a>
+        <a href="https://www.4yousee.com.br/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/391ea778-logo-4yousee.png?h=65" height="65" alt="4YouSee" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">4YouSee</h3>
@@ -133,7 +133,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg" height="65" alt="Intel® NUC logo" /></a>
+        <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg" height="65" alt="Intel® NUC" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Intel<sup>®</sup> NUC</h3>
@@ -141,7 +141,7 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.risevision.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/f2396b21-logo-risevision.png?h=65" height="65" alt="Rise Vision logo" /></a>
+        <a href="https://www.risevision.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/f2396b21-logo-risevision.png?h=65" height="65" alt="Rise Vision" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Rise Vision</h3>
@@ -160,7 +160,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="http://www.boldmind.co.uk/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/d4e5daf4-logo-boldmind.png?h=65" height="65" alt="Boldmind logo" /></a>
+        <a href="http://www.boldmind.co.uk/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/d4e5daf4-logo-boldmind.png?h=65" height="65" alt="Boldmind" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Boldmind</h3>
@@ -169,7 +169,7 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="http://www.limemicro.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/5e68dad7-logo-lime-microsystems.png?h=65" height="65" alt="Lime Micro logo" /></a>
+        <a href="http://www.limemicro.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/5e68dad7-logo-lime-microsystems.png?h=65" height="65" alt="Lime Micro" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Lime Micro</h3>
@@ -180,7 +180,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="http://www.hoxtonanalytics.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/d4ae60aa-logo-hoxton-analytics.svg" height="65" alt="Hoxton Analytics logo" /></a>
+        <a href="http://www.hoxtonanalytics.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/d4ae60aa-logo-hoxton-analytics.svg" height="65" alt="Hoxton Analytics" /></a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Hoxton Analytics</h3>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -157,7 +157,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <img src="https://assets.ubuntu.com/v1/8cb47950-g46.png?h=65" height="65" style="height: 65px;" alt="Intel Up-squared" />
+        <img src="https://assets.ubuntu.com/v1/8cb47950-g46.png?h=65" height="65" style="height: 65px;" alt="" />
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Intel NUC, Up2 , TANK, Joule</h3>
@@ -166,7 +166,7 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <img src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png?h=65" height="65" style="height: 65px;" alt="Raspberry Pi logo" />
+        <img src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png?h=65" height="65" style="height: 65px;" alt="" />
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Raspberry Pi 2,3,4</h3>
@@ -177,7 +177,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <img src="https://assets.ubuntu.com/v1/a8d80d5a-Qualcomm-Logo.svg" style="height: 65px;" height="65" alt="Qualcomm logo" />
+        <img src="https://assets.ubuntu.com/v1/a8d80d5a-Qualcomm-Logo.svg" style="height: 65px;" height="65" alt="" />
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Qualcomm Dragonboard</h3>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -110,7 +110,7 @@
       </li>
 
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="144" alt="Azure logo"  />
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="144" alt="Azure"  />
       </li>
 
       <li class="p-inline-images__item">

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -216,7 +216,7 @@
         </li>
 
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="144" alt="Azure logo"  />
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="144" alt="Azure"  />
         </li>
 
         <li class="p-inline-images__item">

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -29,7 +29,7 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-3 u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/0326ac7d-dena-logo.png?w=144" width="144" alt="Dena logo" />
+      <img src="https://assets.ubuntu.com/v1/0326ac7d-dena-logo.png?w=144" width="144" alt="Dena" />
     </div>
     <div class="col-8 col-start-large-5">
       <blockquote class="p-pull-quote">

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -17,7 +17,7 @@
       <p>If you run into issues, or if you want support, training or architecture design consulting, please <a href="/openstack/contact-us" class="js-invoke-modal">contact Canonical</a> &mdash; we help the world&rsquo;s largest OpenStack users keep their clouds running smoothly.</p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg" alt="OpenStack logo" width="275" />
+      <img src="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg" alt="" width="275" />
     </div>
   </div>
 </section>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -12,7 +12,7 @@
       <h1>Fully managed OpenStack private cloud. Half the cost of VMware.</h1>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg" width="240" alt="OpenStack logo" style="max-width: 240px;" />
+      <img src="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg" width="240" alt="" style="max-width: 240px;" />
     </div>
   </div>
   <div class="row">
@@ -205,34 +205,34 @@
   <div class="u-fixed-width">
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/25de1877-Tele2.svg" width="144" alt="Tele2 logo" />
+        <img src="https://assets.ubuntu.com/v1/25de1877-Tele2.svg" width="144" alt="Tele2" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/d0b7aa28-logo-deutsche-telekom.png?w=144" width="144" alt="Deutsche Telekom logo" />
+        <img src="https://assets.ubuntu.com/v1/d0b7aa28-logo-deutsche-telekom.png?w=144" width="144" alt="Deutsche Telekom" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/481063cd-pccw.svg" width="144" alt="PCCW logo" />
+        <img src="https://assets.ubuntu.com/v1/481063cd-pccw.svg" width="144" alt="PCCW" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/246ea559-COGECO_Peer_1_Logo_RGB-620x250.png?w=144" width="144" alt="Cogeco Datacenters logo" />
+        <img src="https://assets.ubuntu.com/v1/246ea559-COGECO_Peer_1_Logo_RGB-620x250.png?w=144" width="144" alt="Cogeco Datacenters" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" width="144" alt="Rabobank logo" />
+        <img src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" width="144" alt="Rabobank" />
       </li>
       <li class="p-inline-images__item">
         <img src="https://assets.ubuntu.com/v1/7bf5e46b-fibernet-logo-sm-blk_260x47.png?w=144" width="144" alt="Fibernet" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/d56d0b96-Biznet-Gio.png?w=144" width="144" alt="Biznet Gio logo" />
+        <img src="https://assets.ubuntu.com/v1/d56d0b96-Biznet-Gio.png?w=144" width="144" alt="Biznet Gio" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/ff4e18ac-mimedia_logo_lrg.png?w=144" width="144" alt="Mimedia logo" />
+        <img src="https://assets.ubuntu.com/v1/ff4e18ac-mimedia_logo_lrg.png?w=144" width="144" alt="Mimedia" />
       </li>
       <li class="p-inline-images__item">
         <img src="https://assets.ubuntu.com/v1/507a0979-Voidbridge.jpg?w=144" width="144" alt="Voidbridge" />
       </li>
       <li class="p-inline-images__item">
-        <img src="https://assets.ubuntu.com/v1/43586963-uct.svg" width="80" alt="UCT logo" />
+        <img src="https://assets.ubuntu.com/v1/43586963-uct.svg" width="80" alt="UCT" />
       </li>
     </ul>
   </div>

--- a/templates/openstack/shared/_guest-list.html
+++ b/templates/openstack/shared/_guest-list.html
@@ -1,7 +1,7 @@
 <div class="row u-equal-height">
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/bd47d87c-google-cloud.svg" alt="Google Cloud Platform logo" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/bd47d87c-google-cloud.svg" alt="" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Google Cloud Platform</h3>
@@ -9,7 +9,7 @@
   </div>
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/c6fe5e8f-AmazonWebservices_Logo.svg" alt="Amazon Web Services (EC2) logo" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/c6fe5e8f-AmazonWebservices_Logo.svg" alt="" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Amazon Web Services</h3>
@@ -17,7 +17,7 @@
   </div>
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" alt="Oracle Cloud logo" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" alt="" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Oracle Cloud</h3>
@@ -28,7 +28,7 @@
 <div class="row u-equal-height">
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" alt="Azure logo"  />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" alt=""  />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Microsoft Azure</h3>
@@ -36,7 +36,7 @@
   </div>
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/d3959703-T-SYSTEMS-LOGO2013.svg" alt="T Systems logo" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/d3959703-T-SYSTEMS-LOGO2013.svg" alt="" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">T Systems</h3>
@@ -44,7 +44,7 @@
   </div>
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" alt="Rackspace logo" height="35" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" alt="" height="35" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Rackspace</h3>
@@ -55,7 +55,7 @@
 <div class="row u-equal-height">
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/3f403c1f-logo.svg" alt="Packet logo" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/3f403c1f-logo.svg" alt="" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Packet</h3>
@@ -63,7 +63,7 @@
   </div>
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/939e0279-citycloud-logo.svg" alt="citycloud logo" height="35" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/939e0279-citycloud-logo.svg" alt="" height="35" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">citycloud</h3>
@@ -71,7 +71,7 @@
   </div>
   <div class="col-4 p-card">
     <header class="no-border u-align--center u-vertically-center" style="min-height: 7rem;">
-      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/3579c4ed-softlayer.svg" alt="Softlayer logo" />
+      <img style="max-width: 150px;" width="150" src="https://assets.ubuntu.com/v1/3579c4ed-softlayer.svg" alt="" />
     </header>
     <hr class="u-sv1" />
     <h3 class="p-card__title u-hide">Softlayer</h3>

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -53,7 +53,7 @@
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/6c2ebd36-fips-validated-140-2-logo.png" alt="FIPS validated 140-2" width="150">
+      <img src="https://assets.ubuntu.com/v1/6c2ebd36-fips-validated-140-2-logo.png" alt="" width="150">
     </div>
   </div>
 </section>
@@ -73,7 +73,7 @@
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg?w=150" width="150" alt="cesc logo">
+      <img src="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg?w=150" width="150" alt="">
     </div>
   </div>
 </section>
@@ -93,7 +93,7 @@
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/ff9e7377-disa-logo.svg" width="150" alt="disa logo">
+      <img src="https://assets.ubuntu.com/v1/ff9e7377-disa-logo.svg" width="150" alt="">
     </div>
   </div>
 </section>
@@ -110,7 +110,7 @@
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg?w=150" width="150" alt="disa logo">
+      <img src="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg?w=150" width="150" alt="">
     </div>
   </div>
 </section>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -131,19 +131,19 @@
     <h2 class="p-muted-heading u-align--center">Ubuntu is trusted by</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg logo" />
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&amp;T logo" />
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&amp;T" />
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b3315d88-walmart.svg" width="144" alt="Walmart" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg" width="144" alt="Deutshe Telekom logo">
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg" width="144" alt="Deutsche Telekom">
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg" width="144" alt="Ebay logo">
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg" width="144" alt="Ebay">
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" width="144" alt="Cisco" />
@@ -152,7 +152,7 @@
         <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg" width="144" alt="NTT" />
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg" width="144" alt="Best Buy logo">
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg" width="144" alt="Best Buy">
       </li>
       <li class="p-inline-images__item">
         <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" width="144" alt="PayPal" />

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -152,7 +152,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/f38c9ed1-hpe_pri_grn_pos_rgb.svg"  width="200" alt="Hewlett Packard Enterprise logo" />
+        <img src="https://assets.ubuntu.com/v1/f38c9ed1-hpe_pri_grn_pos_rgb.svg"  width="200" alt="Hewlett Packard Enterprise" />
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Canonical has been involved in the development of Moonshot, Hewlett Packard Enterprise&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
@@ -160,7 +160,7 @@
     </div>
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg" width="150" height="45" alt="Arm logo" />
+        <img src="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg" width="150" height="45" alt="Arm" />
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Arm and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
@@ -171,7 +171,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
+        <img src="https://assets.ubuntu.com/v1/d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium" />
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
@@ -179,7 +179,7 @@
     </div>
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation logo" />
+        <img src="https://assets.ubuntu.com/v1/ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation" />
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -186,7 +186,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60bd6cf1-picto-juju.svg" alt="Juju logo" width="100" height="100" />
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60bd6cf1-picto-juju.svg" alt="" width="100" height="100" />
           <h3 class="p-heading-icon__title">
             Juju &mdash; multi-cloud orchestration
           </h3>
@@ -204,7 +204,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="Maas logo" width="100" height="100" />
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="" width="100" height="100" />
           <h3 class="p-heading-icon__title">
             MAAS &mdash; bare metal provisioning
           </h3>

--- a/templates/shared/_case-study-allan-gray.html
+++ b/templates/shared/_case-study-allan-gray.html
@@ -5,6 +5,6 @@
             <p>Allan Gray needed to ensure maximum availability for mission-critical systems, which is why it turned to Canonical for enterprise support for Kubernetes.</p>
             <a class="p-button--neutral" href="/engage/k8s-allan-gray">Read the case study</a>
           </div>
-          <div class="col-4 u-hide--small u-align--center u-vertically-center"><img src="https://assets.ubuntu.com/v1/8c513a03-Allan_Gray_logo.svg" width="200" alt="Allan Gray logo" />
+          <div class="col-4 u-hide--small u-align--center u-vertically-center"><img src="https://assets.ubuntu.com/v1/8c513a03-Allan_Gray_logo.svg" width="200" alt="" />
       </section>
       

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -176,31 +176,31 @@
         <h2 class="p-muted-heading u-align--center">A selection of Ubuntu Advantage customers</h2>
         <ul class="p-inline-images">
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1a062141-logo-bloomberg.svg" width="187" alt="Bloomburg logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1a062141-logo-bloomberg.svg" width="187" alt="Bloomberg">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="at&amp;t  logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&amp;T">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/3161e6ba-logo-walmart.svg" width="210" alt="Walmart logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/3161e6ba-logo-walmart.svg" width="210" alt="Walmart">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg" width="242" alt="Deutshe Telekom logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg" width="242" alt="Deutsche Telekom">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg" width="170" alt="Ebay logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg" width="170" alt="Ebay">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg" width="156" alt="Cisco logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg" width="156" alt="Cisco">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ddb0f9d6-logo-ntt.svg" width="71" alt="NTT logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ddb0f9d6-logo-ntt.svg" width="71" alt="NTT">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg" width="144" alt="Best Buy logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg" width="144" alt="Best Buy">
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" width="166" alt="Paypal logo">
+            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" width="166" alt="Paypal">
           </li>
         </ul>
       </div>

--- a/templates/takeovers/_broadsign-arrow_takeover.html
+++ b/templates/takeovers/_broadsign-arrow_takeover.html
@@ -9,9 +9,9 @@
     </div>
     <div class="col-4 col-start-large-8">
       <p>
-        <img src="https://assets.ubuntu.com/v1/3f59dacd-logos-lines-takeover-digital-signage.svg" class="u-image-position--top u-hide--small" alt="Core, Arrow and Broadsign logos" />
+        <img src="https://assets.ubuntu.com/v1/3f59dacd-logos-lines-takeover-digital-signage.svg" class="u-image-position--top u-hide--small" alt="Ubuntu Core, Arrow and Broadsign" />
         <div class="u-align--center u-hide--large u-hide--medium u-sv3">
-          <img src="https://assets.ubuntu.com/v1/96f63d61-logos-takeover-digital-signage.svg" alt="Core, Arrow and Broadsign logos" />
+          <img src="https://assets.ubuntu.com/v1/96f63d61-logos-takeover-digital-signage.svg" alt="Ubuntu Core, Arrow and Broadsign" />
         </div>
       </p>
       <p class="u-no-margin--bottom u-hide--large u-hide--medium">

--- a/templates/takeovers/_french-k8s-case-study.html
+++ b/templates/takeovers/_french-k8s-case-study.html
@@ -9,7 +9,7 @@
     </div>
     <div class="col-5 u-vertically-center u-align--center">
       <div class="u-sv3">
-        <img src="https://assets.ubuntu.com/v1/1db850da-K8s+logo.svg" alt="Kubernetes logo" class="p-improving-prod-takeover__image" />
+        <img src="https://assets.ubuntu.com/v1/1db850da-K8s+logo.svg" alt="" class="p-improving-prod-takeover__image" />
       </div>
       <p class="u-hide--large u-hide--medium">
         <a href="https://www.brighttalk.com/webcast/17466/354383?utm_source=takeover&utm_campaign=CY19_DC_France_Kubernetes_WBN_WhatCanYouDoK8" class="p-button--neutral"><span class="p-link--extneral">S'inscrire au webinar</span></a>

--- a/templates/takeovers/_improving_productivity_kubernetes.html
+++ b/templates/takeovers/_improving_productivity_kubernetes.html
@@ -10,7 +10,7 @@
     </div>
     <div class="col-5 u-vertically-center u-align--center">
       <div class="u-sv3">
-        <img src="https://assets.ubuntu.com/v1/1db850da-K8s+logo.svg" alt="Kubernetes logo" class="p-improving-prod-takeover__image" />
+        <img src="https://assets.ubuntu.com/v1/1db850da-K8s+logo.svg" alt="" class="p-improving-prod-takeover__image" />
       </div>
       <p class="u-hide--large u-hide--medium"><a href="/engage/kubernetes-case-study?utm_source=takeover&utm_medium=takeover&utm_campaign=2)FY19_Cloud_K8_CStudy_AllanGray"
           class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Boosting efficiency - Kubernetes takeover', 'eventLabel' : 'Download the case study', 'eventValue' : undefined });">Download

--- a/templates/takeovers/_juju-generic-takeover.html
+++ b/templates/takeovers/_juju-generic-takeover.html
@@ -5,7 +5,7 @@
         </div>
 
         <div class="row-hero-text">
-            <img src="https://assets.ubuntu.com/v1/7e21b535-logo-juju.svg" alt="Juju logo" />
+            <img src="https://assets.ubuntu.com/v1/7e21b535-logo-juju.svg" alt="" />
             <h1>All new Juju</h1>
             <div class="for-small align-center twelve-col">
                 <img src="https://assets.ubuntu.com/v1/d3322743-canvas-view_juju-takeover.svg?w=100" alt="JuJu service blocks illustration" />

--- a/templates/takeovers/_kubernetes_webinar.html
+++ b/templates/takeovers/_kubernetes_webinar.html
@@ -4,7 +4,7 @@
       <h1>Build your Kubernetes strategy with Ubuntu</h1>
       <p>Learn how to get started.</p>
       <div class="u-hide--medium u-hide--large  u-align--center">
-        <img src="https://assets.ubuntu.com/v1/331f3baf-kubernetes-logo.svg" alt="Kubernetes logo" />
+        <img src="https://assets.ubuntu.com/v1/331f3baf-kubernetes-logo.svg" alt="" />
       </div>
       <p><a class="p-button--neutral" href="http://ubunt.eu/GUWzfp" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes webinar takeover', 'eventLabel' : 'Watch the webinar', 'eventValue' : undefined });">Watch the webinar</a></p>
       <p><a href="http://ubunt.eu/jMgdKN " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Kubernetes takeover', 'eventLabel' : 'Find out more about Kubernetes', 'eventValue' : undefined });" class="p-link--inverted">Find out more about Kubernetes&nbsp;&rsaquo;</a></p>

--- a/templates/takeovers/_maas_takeover.html
+++ b/templates/takeovers/_maas_takeover.html
@@ -1,7 +1,7 @@
 <section class="row row-hero strip no-border">
     <div class="strip-inner-wrapper">
         <div class="six-col">
-          <img src="https://assets.ubuntu.com/v1/27139694-MAAS_orange_white_horizontal_hex1.svg" alt="MAAS logo" class="row-hero__logo" />
+          <img src="https://assets.ubuntu.com/v1/27139694-MAAS_orange_white_horizontal_hex1.svg" alt="MAAS" class="row-hero__logo" />
             <h1>The smartest way to manage bare metal</h1>
             <p class="intro"><abbr title="Metal as a Service">MAAS</abbr> 1.9 is here.</p>
             <p><a href="http://maas.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Maas takeover - 04-01-2016', 'eventLabel' : 'Learn more link', 'eventValue' : undefined });" class="button--primary">Get started with MAAS</a></p>

--- a/templates/takeovers/_ubuntu-lime-telco_takeover.html
+++ b/templates/takeovers/_ubuntu-lime-telco_takeover.html
@@ -10,7 +10,7 @@
 
     <div class="col-5">
       <p class="p-takeover__image u-align-text--center">
-        <img src="https://assets.ubuntu.com/v1/03853de5-Joint+Lime-illustration-white.svg" alt="Lime Microsystems logo" width="100%"
+        <img src="https://assets.ubuntu.com/v1/03853de5-Joint+Lime-illustration-white.svg" alt="" width="100%"
         />
       </p>
 

--- a/templates/takeovers/shared/_takeover.html
+++ b/templates/takeovers/shared/_takeover.html
@@ -35,7 +35,7 @@
     {% if image %}
       <div class="col-4">
         <p class="{% if imageClass %}{{ imageClass }}{% else %}u-hide-small u-align-text--center u-vertically-center{% endif %}">
-          <img src="{% if 'http' not in image %}https://assets.ubuntu.com/v1/{% endif %}{{ image }}" alt="image for (( title ))" >
+          <img src="{% if 'http' not in image %}https://assets.ubuntu.com/v1/{% endif %}{{ image }}" alt="" >
         </p>
       </div>
     {% endif %}

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -375,7 +375,7 @@
     </div>
     <div class="col-6 p-divider__block">
       <blockquote class="p-pull-quote  has-image">
-        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg"  height="40" alt="spiculelogo">
+        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg"  height="40" alt="AT&amp;T">
         <p class="p-pull-quote__quote">
           We&rsquo;re reinventing how we scale by becoming simpler and modular, similar to how applications have evolved in cloud data centers. Open source and OpenStack innovations represent a unique opportunity to meet these requirements and Canonical&rsquo;s cloud and open source expertise make them a good choice for AT&amp;T.
         </p>

--- a/templates/whitepapers/beta/robotics.html
+++ b/templates/whitepapers/beta/robotics.html
@@ -184,7 +184,7 @@
         </div>
         <div class="row u-obfuscate u-vertically-center">
           <div class="col-start-large-2 col-2">
-            <img class="u-hide--small" src="https://assets.ubuntu.com/v1/e820660a-small-robot-company-logo.jpg" alt="Small Robot Company logo">
+            <img class="u-hide--small" src="https://assets.ubuntu.com/v1/e820660a-small-robot-company-logo.jpg" alt="">
           </div>
           <div class="col-6">
             <blockquote class="p-pull-quote">

--- a/templates/whitepapers/robotics/_content.html
+++ b/templates/whitepapers/robotics/_content.html
@@ -66,7 +66,7 @@
 </div>
 <div class="row u-equal-height">
   <div class="col-start-large-2 col-2 u-vertically-center">
-    <img class="u-hide--small" src="https://assets.ubuntu.com/v1/e820660a-small-robot-company-logo.jpg" alt="Small Robot Company logo">
+    <img class="u-hide--small" src="https://assets.ubuntu.com/v1/e820660a-small-robot-company-logo.jpg" alt="">
   </div>
   <div class="col-6">
     <blockquote class="p-pull-quote">


### PR DESCRIPTION
## Done

Corrects `alt=` text across the site for improved accessibility.

The problems fall into four main categories:
- Logorrhea: for example, our hyperscale partners are not Hewlett Packard Enterprise logo, Arm logo, and Cavium logo — they are Hewlett Packard Enterprise, Arm, and Cavium. (It’s hardly ever appropriate to include the word “logo” in `alt=` text.)
- Redundancy: using `alt=` simply to name an organisation/product (with or without “logo”) when an adjacent heading already does that.
- Mystery: for example, `alt="header image"`, `alt="image for {{ header_title }}"`, or `alt="OS image size comparison"`.
- Typos: for example, “Bloomburg”, “Deutshe Telekom”, and, for AT&T, “spiculelogo”.

 In correcting them I’ve followed [the approach prescribed by the HTML spec](https://html.spec.whatwg.org/multipage/images.html#alt), specifically:

- For [a link or button containing nothing but the image](https://html.spec.whatwg.org/multipage/images.html#a-link-or-button-containing-nothing-but-the-image), I’ve retained the name of the entity, for example, `<a href="/"><img src="`…`logo-ubuntu-white.svg" alt="Ubuntu logo white"></a>` becomes `<a href="/"><img src="`…`logo-ubuntu-white.svg" alt="Ubuntu"></a>`. (There are some cases where an image-only link is adjacent to a text-only link to the same place. Ideally these would be a single link containing both, but fixing those would be much trickier.)

- For [a phrase or paragraph with an alternative graphical representation](https://html.spec.whatwg.org/multipage/images.html#a-phrase-or-paragraph-with-an-alternative-graphical-representation:-charts,-diagrams,-graphs,-maps,-illustrations) I’ve provided equivalent text: `alt="Ubuntu Core: 260 MB. Red Hat coreOS: 807 MB."` and `alt="Including AT&amp;T, eBay, NTT, Bloomberg, Cisco, Deutsche Telekom, Walmart and Best Buy."`

- In remaining cases where a “[logo is being used next to the name of the entity that it represents, then the logo is supplemental, and its `alt` attribute must instead be empty](https://html.spec.whatwg.org/multipage/images.html#a-short-phrase-or-label-with-an-alternative-graphical-representation:-icons,-logos)”. (For review, in many cases it will be necessary to expand the diff to check that the name of the entity is repeated prominently nearby.)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- Visit the site with a text-only browser or screenreader at: http://0.0.0.0:8001/

## Issue / Card

None