### PR TITLE
Contact us illustration and column width updated

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -138,10 +138,10 @@
 
 <section class="p-strip--light">
     <div class="row u-equal-height">
-      <div class="col-6 u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/9c7bda7d-contact-us.svg" alt="">
+      <div class="col-5 u-align--center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" style="height:200px" alt="">
       </div>
-      <div class="col-6 u-vertically-center">
+      <div class="col-7 u-vertically-center">
         <div>
           <h2>Get started with Livepatch today</h2>
           <p>Livepatch is free to use on your own PC or server. To discuss whether Livepatch is right for your business, talk to our team.</p>


### PR DESCRIPTION
## Done

- Replaced the contact us illustration with the updated version
- The illustration is now `col-5` and the text is `col-7`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #6111 

## Screenshots

how it should look like

<img width="1436" alt="Screenshot 2019-11-12 at 13 33 41" src="https://user-images.githubusercontent.com/36884067/68676187-597bd900-0551-11ea-8491-c00b24ed66e4.png">
