### PR TITLE
Private cloud takeover

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -42,7 +42,7 @@
         </p>{% endif %}
         {% if header_cta %}<br class="u-hide--medium u-hide--large" />
         <p class="u-hide--medium u-hide--large">
-          <a href="{{ header_url }}" class="p-button--neutral">
+          <a href="{{ header_url }}" class="{% if header_cta_class %}{{ header_cta_class }}{% else %}p-button--neutral{% endif %}">
             {{ header_cta }}
           </a>
         </p>{% endif %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1225,6 +1225,19 @@
             <p class='u-no-padding--bottom u-hide--small'>The Wellcome Sanger Institute, a global centre of excellence for genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular genetics.</p>
           </div>
         </div><!-- 2nd -->
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--webinar'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              webinar
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/private-cloud-build-webinar'>Lessons learned from 100+ Private cloud builds</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>Reducing the complexities of building a private cloud on OpenStack</p>
+          </div>
+        </div><!-- 3rd -->
       </div>
     </section>
     {% endblock content %}

--- a/templates/engage/private-cloud-build-webinar.md
+++ b/templates/engage/private-cloud-build-webinar.md
@@ -1,0 +1,21 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Building a private cloud with Canonical"
+     meta_description: "How Canonical alleviate the complexities of building a private cloud on OpenStack"
+     meta_image: https://assets.ubuntu.com/v1/8a7c58ea-Meta+data+img.jpg
+     meta_copydoc: https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit
+     header_title: "Lessons learned from 100+ Private cloud builds"
+     header_subtitle: "Reducing the complexities of building a private cloud on OpenStack"
+     header_image: "https://assets.ubuntu.com/v1/b743ab26-Private+Cloud+Build.svg"
+     header_url: '#register-section'
+     header_cta: Register for the webinar
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--grad
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 376727, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Building a private cloud based on OpenStack has typically been a complex process with uncertain build costs based on time and materials requiring specialised expertise and low-level Linux OS knowledge. To help enterprises overcome these challenges,Canonical offers Private Cloud Build to provide businesses with a fully deployed OpenStack delivered in as little as two weeks at a fixed cost. 
+
+And as a result, after delivering 100’s of private cloud builds over the last 5 years we’ve learnt a thing or two. Join our webinar to hear Nicholas Dimotakis, VP, Data Center Field Engineering speak about the lessons we’ve learnt, the industry changes he expects to see over the coming years and why businesses such as BT, Tele2, Yahoo! Japan and Allan Gray choose Canonical to deploy their private clouds. In addition, Nicholas will run through the process of implementing a turnkey private cloud in its entirety whilst also providing a detailed breakdown of the costs involved.

--- a/templates/engage/private-cloud-build-webinar.md
+++ b/templates/engage/private-cloud-build-webinar.md
@@ -12,7 +12,6 @@ context:
      header_cta: Register for the webinar
      header_cta_class: p-button--positive
      header_class: p-engage-banner--grad
-     header_lang: en
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 376727, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,7 @@
   {# ALL #}
   {% include "takeovers/_1910_takeover.html" %}
   {% include "takeovers/_kata-containers.html" %}
+  {% include "takeovers/_private-cloud-build-takeover.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/takeovers/_private-cloud-build-takeover.html
+++ b/templates/takeovers/_private-cloud-build-takeover.html
@@ -1,0 +1,14 @@
+{% with title="Lessons learned from 100+ Private Cloud Builds",
+subtitle="After hundreds of Private Cloud Builds we've learnt a thing or two. Join our webinar to hear our learnings and our outlook for the future.",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/b743ab26-Private+Cloud+Build.svg",
+image_style="width: 300px;",
+image_hide_small="",
+primary_url="/engage/private-cloud-build-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_PrivateCloudBuild",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_private-cloud-build-takeover.html
+++ b/templates/takeovers/_private-cloud-build-takeover.html
@@ -7,7 +7,7 @@ primary_url="/engage/private-cloud-build-webinar?utm_source=Takeover&utm_medium=
 primary_cta="Register for the webinar",
 primary_cta_class="",
 secondary_url="",
-secondary_cta="",
-locale="en_GB" %}
+secondary_cta=""
+%}
 {% include "takeovers/_template.html" %}
 {% endwith %}

--- a/templates/takeovers/_private-cloud-build-takeover.html
+++ b/templates/takeovers/_private-cloud-build-takeover.html
@@ -2,7 +2,6 @@
 subtitle="After hundreds of Private Cloud Builds we've learnt a thing or two. Join our webinar to hear our learnings and our outlook for the future.",
 class="p-takeover--grad",
 header_image="https://assets.ubuntu.com/v1/b743ab26-Private+Cloud+Build.svg",
-image_style="width: 300px;",
 image_hide_small="",
 primary_url="/engage/private-cloud-build-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Openstack_WBN_PrivateCloudBuild",
 primary_cta="Register for the webinar",

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -56,6 +56,7 @@
 {% include "takeovers/_multicloud-solutions.html" %}
 {% include "takeovers/_openstack-queens.html" %}
 {% include "takeovers/_openstack_security_takeover.html" %}
+{% include "takeovers/_private-cloud-build-takeover.html" %}
 {% include "takeovers/_private_cloud_economics.html" %}
 {% include "takeovers/_rigado_webinar.html" %}
 {% include "takeovers/_robotics-takeover.html" %}


### PR DESCRIPTION
## Done

- Added private cloud build takeover and webinar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see a takeover with the title "Lessons learned from 100+ Private Cloud Builds"
- See that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1976#issuecomment-552889722) and the [brief](https://docs.google.com/spreadsheets/d/1dV2RFXNnpLnZBo_Gx_iuyv3qwhppGSyXE3_3dweLbQY/edit#gid=2113339190)
- Click the CTA to visit the engage page
- See that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1976#issuecomment-552889722) and the [copy doc](https://docs.google.com/document/d/1EHDg2pDy3KB1DU2hwihoTrCWudTXjAClv0OuJMNmJIc/edit?usp=sharing)
- Test the page on https://cards-dev.twitter.com/validator, ensure the preview contains an image, title and description


## Issue / Card

Fixes #6092 
