### PR TITLE
fix typo

### DIFF
--- a/templates/community/code-of-conduct.html
+++ b/templates/community/code-of-conduct.html
@@ -103,7 +103,7 @@
     <h4>Courage and considerateness</h4>
 
     <p>Leadership occasionally requires bold decisions that will not be widely understood, consensual or popular. We value the courage to take such decisions, because they enable the project as a whole to move forward faster than we could if we required
-      complete consensus. Nevertheless, boldness demands considerateness; take bold decisions, but do so mindful of the challenges they present for others, and work to soften the impact of thos decisions on them. Communicating changes and their reasoning
+      complete consensus. Nevertheless, boldness demands considerateness; take bold decisions, but do so mindful of the challenges they present for others, and work to soften the impact of those decisions on them. Communicating changes and their reasoning
       clearly and early on is as important as the implementation of the change itself.</p>
 
     <h4>Conflicts of interest</h4>


### PR DESCRIPTION
## Done

- Fixed typo in code of conduct

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the word "those" is spelled correctly in the line "work to soften the impact of those decisions on them" (compare against [live site](https://ubuntu.com/community/code-of-conduct)).


## Issue / Card

Fixes #6115
