### PR TITLE
Add headers to advantage page

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -60,6 +60,7 @@ def advantage():
     enterprise_contracts = []
     entitlements = {}
     openid = flask.session.get("openid")
+    headers = {"Cache-Control": "no-cache"}
 
     if auth.is_authenticated(flask.session):
         try:
@@ -126,14 +127,17 @@ def advantage():
             )
 
             auth.empty_session(flask.session)
-            return flask.render_template("advantage/index.html")
+            return flask.render_template("advantage/index.html"), headers
 
-    return flask.render_template(
-        "advantage/index.html",
-        openid=openid,
-        accounts=accounts,
-        enterprise_contracts=enterprise_contracts,
-        personal_account=personal_account,
+    return (
+        flask.render_template(
+            "advantage/index.html",
+            openid=openid,
+            accounts=accounts,
+            enterprise_contracts=enterprise_contracts,
+            personal_account=personal_account,
+        ),
+        headers,
     )
 
 


### PR DESCRIPTION
## Done

Add cache-control headers to advantage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Check `Cache-Control` is set to `no-cache`


## Issue / Card

Fixes #6081 
