### PR TITLE
add blog-header suru to /blog/press-center

### DIFF
--- a/templates/blog/press-centre.html
+++ b/templates/blog/press-centre.html
@@ -5,13 +5,12 @@
 {% block meta_description %}The home of Ubuntu media resources, news stories and press releases.{% endblock %}
 
 {% block content %}
-  <section class="p-strip--image is-dark p-strip--blog-suru" style="background-position: center center; background-image:url('https://assets.ubuntu.com/v1/dc337e68-image-partners.jpg')">
+  <section class="p-strip--suru-blog-header is-dark">
     <div class="row u-equal-height u-vertically-center">
-      <div class="col-6 p-card--suru">
+      <div class="col-7 p-card--suru">
         <h1 class="p-heading--one">Press centre</h1>
-        <h5>
-          The home of Ubuntu media resources, news stories and press releases. Journalists seeking further information can contact</h5>
-          <a class="p-link--inverted" href="mailto:pr@canonical.com">pr@canonical.com</a>
+        <p class="p-heading--four">The home of Ubuntu media resources, news stories and press releases. Journalists seeking further information can contact <a class="p-link--inverted" href="mailto:pr@canonical.com">pr@canonical.com</a>
+        </p>
       </div>
       <div id="rtp-banner" class="rtp-banner"></div>
     </div>


### PR DESCRIPTION
## Done

Added new blog header suru to /blog/press-centre

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/press-centre
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the header strip matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/1885#issuecomment-553453856).


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1886
