### PR TITLE
Fix feed issue with articles without category

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask_base==0.3.3
 canonicalwebteam.http==1.0.1
-canonicalwebteam.blog==4.0.1
+canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
 canonicalwebteam.image-template==1.0.0


### PR DESCRIPTION
## Done

Update canonicalwebteam.blog to 4.0.2 to fix an issue with the blog feeds
https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/128

## QA

- Check out this feature branch
- Run the site using the command `./run clean && ./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that http://0.0.0.0:8001/blog/feed/ works
- Ensure that http://0.0.0.0:8001/blog/author/agentofchange/feed/ works


## Issue / Card
https://github.com/canonical-web-and-design/canonicalwebteam.blog/issues/127
