### PR TITLE
Update Kubernetes release chart

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -179,7 +179,7 @@ function formatKeyLabel(key) {
   var formattedKey = keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
   formattedKey = formattedKey.replace(' lts ', ' LTS ');
   formattedKey = formattedKey.replace(' openstack ', ' OpenStack ');
-  formattedKey = formattedKey.replace('Cdk ', 'CDK ');
+  formattedKey = formattedKey.replace('k', 'K');
   return formattedKey;
 }
 

--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -475,68 +475,74 @@ export var kubernetesReleases = [
     startDate: new Date('2016-12-01T00:00:00'),
     endDate: new Date('2017-09-01T00:00:00'),
     taskName: 'Kubernetes 1.5',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
 
   {
     startDate: new Date('2017-03-01T00:00:00'),
     endDate: new Date('2017-12-01T00:00:00'),
     taskName: 'Kubernetes 1.6',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2017-06-01T00:00:00'),
     endDate: new Date('2018-03-01T00:00:00'),
     taskName: 'Kubernetes 1.7',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2017-09-01T00:00:00'),
     endDate: new Date('2018-07-01T00:00:00'),
     taskName: 'Kubernetes 1.8',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2017-12-01T00:00:00'),
     endDate: new Date('2018-09-01T00:00:00'),
     taskName: 'Kubernetes 1.9',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2018-03-01T00:00:00'),
     endDate: new Date('2018-12-01T00:00:00'),
     taskName: 'Kubernetes 1.10',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2018-07-01T00:00:00'),
     endDate: new Date('2019-03-01T00:00:00'),
     taskName: 'Kubernetes 1.11',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2018-09-01T00:00:00'),
     endDate: new Date('2019-06-01T00:00:00'),
     taskName: 'Kubernetes 1.12',
-    status: 'CDK_EXPIRED_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2018-12-01T00:00:00'),
     endDate: new Date('2019-09-01T00:00:00'),
     taskName: 'Kubernetes 1.13',
-    status: 'CDK_SUPPORT'
+    status: 'CHARMED_KUBERNETES_EXPIRED_SUPPORT'
   },
   {
     startDate: new Date('2019-03-01T00:00:00'),
     endDate: new Date('2019-12-01T00:00:00'),
     taskName: 'Kubernetes 1.14',
-    status: 'CDK_SUPPORT'
+    status: 'CHARMED_KUBERNETES_SUPPORT'
   },
   {
     startDate: new Date('2019-06-14T00:00:00'),
     endDate: new Date('2020-03-02T00:00:00'),
     taskName: 'Kubernetes 1.15',
-    status: 'CDK_SUPPORT'
+    status: 'CHARMED_KUBERNETES_SUPPORT'
+  },
+  {
+    startDate: new Date('2019-09-14T00:00:00'),
+    endDate: new Date('2020-06-15T00:00:00'),
+    taskName: 'Kubernetes 1.16',
+    status: 'CHARMED_KUBERNETES_SUPPORT'
   }
 ];
 
@@ -560,8 +566,8 @@ export var openStackStatus = {
 };
 
 export var kubernetesStatus = {
-  CDK_SUPPORT: 'chart__bar--orange',
-  CDK_EXPIRED_SUPPORT: 'chart__bar--grey',
+  CHARMED_KUBERNETES_SUPPORT: 'chart__bar--orange',
+  CHARMED_KUBERNETES_EXPIRED_SUPPORT: 'chart__bar--grey',
 };
 
 export var desktopServerReleaseNames = [
@@ -623,6 +629,7 @@ export var openStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  'Kubernetes 1.16',
   'Kubernetes 1.15',
   'Kubernetes 1.14',
   'Kubernetes 1.13',

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -583,8 +583,8 @@
   <div class="row">
     <div class="col-8">
       <h2 id="charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</h2>
-      <p>The release cycle of the Charmed Distribution of Kubernetes is tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of nine months, subject to changes in the upstream release cycle.</p>
-      <p>The CDK support lifecycle can be represented this way:</p>
+      <p>The release cycle of the Charmed Kubernetes is tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of nine months, subject to changes in the upstream release cycle.</p>
+      <p>The Charmed Kubernetes support lifecycle can be represented this way:</p>
     </div>
   </div>
 
@@ -600,6 +600,11 @@
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td><strong>Kubernetes 1.16</strong></td>
+            <td>Sep 2019</td>
+            <td>Jun 2020</td>
+          </tr>
           <tr>
             <td><strong>Kubernetes 1.15</strong></td>
             <td>Jun 2019</td>
@@ -660,7 +665,7 @@
     </div>
   </div>
   <div class="row">
-    <p>For more information on previous and current releases of CDK, please see the <a href="/kubernetes/docs/release-notes">CDK release notes</a>.</p>
+    <p>For more information on previous and current releases of Charmed Kubernetes, please see the <a href="/kubernetes/docs/release-notes">Charmed Kubernetes release notes</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Add Kubernetes 1.16 to the chart on `/about/release-cycle`
- Replace `CDk` with `CK` 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure Kubernetes 1.16 is added to the chart. Check mobile app as well
- See that `CDK` is replaced with `CD`


## Issue / Card

Fixes #5866 
