### PR TITLE
fix case inaccuracy on "private cloud builds"

### DIFF
--- a/templates/engage/private-cloud-build-webinar.md
+++ b/templates/engage/private-cloud-build-webinar.md
@@ -5,7 +5,7 @@ context:
      meta_description: "How Canonical alleviate the complexities of building a private cloud on OpenStack"
      meta_image: https://assets.ubuntu.com/v1/8a7c58ea-Meta+data+img.jpg
      meta_copydoc: https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit
-     header_title: "Lessons learned from 100+ Private cloud builds"
+     header_title: "Lessons learned from 100+ private cloud builds"
      header_subtitle: "Reducing the complexities of building a private cloud on OpenStack"
      header_image: "https://assets.ubuntu.com/v1/b743ab26-Private+Cloud+Build.svg"
      header_url: '#register-section'
@@ -15,6 +15,6 @@ context:
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 376727, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---
 
-Building a private cloud based on OpenStack has typically been a complex process with uncertain build costs based on time and materials requiring specialised expertise and low-level Linux OS knowledge. To help enterprises overcome these challenges,Canonical offers Private Cloud Build to provide businesses with a fully deployed OpenStack delivered in as little as two weeks at a fixed cost. 
+Building a private cloud based on OpenStack has typically been a complex process with uncertain build costs based on time and materials requiring specialised expertise and low-level Linux OS knowledge. To help enterprises overcome these challenges,Canonical offers private cloud builds to provide businesses with a fully deployed OpenStack delivered in as little as two weeks at a fixed cost. 
 
 And as a result, after delivering 100’s of private cloud builds over the last 5 years we’ve learnt a thing or two. Join our webinar to hear Nicholas Dimotakis, VP, Data Center Field Engineering speak about the lessons we’ve learnt, the industry changes he expects to see over the coming years and why businesses such as BT, Tele2, Yahoo! Japan and Allan Gray choose Canonical to deploy their private clouds. In addition, Nicholas will run through the process of implementing a turnkey private cloud in its entirety whilst also providing a detailed breakdown of the costs involved.

--- a/templates/takeovers/_private-cloud-build-takeover.html
+++ b/templates/takeovers/_private-cloud-build-takeover.html
@@ -1,5 +1,5 @@
-{% with title="Lessons learned from 100+ Private Cloud Builds",
-subtitle="After hundreds of Private Cloud Builds we've learnt a thing or two. Join our webinar to hear our learnings and our outlook for the future.",
+{% with title="Lessons learned from 100+ private cloud builds",
+subtitle="After hundreds of private cloud builds we've learnt a thing or two. Join our webinar to hear our learnings and our outlook for the future.",
 class="p-takeover--grad",
 header_image="https://assets.ubuntu.com/v1/b743ab26-Private+Cloud+Build.svg",
 image_hide_small="",


### PR DESCRIPTION
## Done

- made sure the phrase "private cloud builds" always uses lowercase.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the private cloud build takeover.
- See that the phrase "private cloud builds" is always in lowercase.
- Click the CTA, which will take you to the engage page.
- See that the phrase "private cloud builds" is always in lowercase.


## Issue / Card

Fixes #6129 
