### PR TITLE
Add ubuntu security takeover and engage

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1239,5 +1239,22 @@
           </div>
         </div><!-- 3rd -->
       </div>
+
+      <div class='row u-equal-height u-clearfix'>
+        <div class='col-4 blog-p-card--post'>
+          <header class='blog-p-card__header--webinar'>
+            <h5 class='p-muted-heading u-no-margin--bottom'>
+              webinar
+            </h5>
+          </header>
+          <div class='blog-p-card__content'>
+            <h4>
+              <a href='/engage/linux_security_webinar'>Linux security with Ubuntu</a>
+            </h4>
+            <p class='u-no-padding--bottom u-hide--small'>Ubuntu is built with security in mind from the outset, which is one of the reasons it’s such a popular Linux distribution used by developers.</p>
+          </div>
+        </div><!-- 1st -->
+
+      </div>
     </section>
     {% endblock content %}

--- a/templates/engage/linux_security_webinar.md
+++ b/templates/engage/linux_security_webinar.md
@@ -1,0 +1,27 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Linux security with Ubuntu"
+     meta_description: "Get the full Ubuntu security story and see how our teams are securing Ubuntu systems across open, multi-cloud infrastructures."
+     meta_image: https://assets.ubuntu.com/v1/5fe79563-Meta+data+img.jpg
+     meta_copydoc: https://docs.google.com/document/d/1p80NTWLpj6iIQJyZUKJwrSSDT0l2Uh7PF1XYIDUswMw
+     header_title: "Linux security with Ubuntu"
+     header_subtitle: "Securing Ubuntu systems for reduced downtime and optimum CVE coverage."
+     header_image: "https://assets.ubuntu.com/v1/eaef1d37-shields-security.svg"
+     header_url: '#register-section'
+     header_cta: Register for the webinar
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--dark
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 375740, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Ubuntu is built with security in mind from the outset, which is one of the reasons it’s such a popular Linux distribution used by developers. The security team at Canonical is constantly working to review threats, fix vulnerabilities and upgrade security capabilities for releases to protect your systems and workloads in production.
+
+Get the full Ubuntu security story and see how our teams are securing Ubuntu systems across open, multi-cloud infrastructures.
+
+In this webinar, join our team to learn how:
+
+- Ubuntu is built with security in mind from the ground up, and how we keep you protected against major vulnerabilities
+- Security and support is provided for a full range of open source technologies
+- Specific security services that can help you achieve maximum availability by reducing downtime and providing access to high and critical CVE fixes
+- Ubuntu helps organisations remain compliant with government and industry standards and regulations, including Common Criteria EAL2 with FIPS 140-2 Level 1 certified crypto modules

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
   {% include "takeovers/_1910_takeover.html" %}
   {% include "takeovers/_kata-containers.html" %}
   {% include "takeovers/_private-cloud-build-takeover.html" %}
+  {% include "takeovers/_linux-security_takeover.html" %}
 {% endblock takeover_content %}
 
 

--- a/templates/takeovers/_linux-security_takeover.html
+++ b/templates/takeovers/_linux-security_takeover.html
@@ -1,0 +1,16 @@
+{% with title="Linux security with Ubuntu",
+subtitle="Securing Ubuntu systems for reduced downtime and optimum CVE coverage.",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/eaef1d37-shields-security.svg",
+image_style="width: 332px; margin: 1.5rem 0;",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/linux_security_webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_UA_WBN_LinuxSecurity",
+primary_cta="Register for the webinar",
+primary_cta_class="p-button--positive",
+secondary_url="",
+secondary_cta="",
+lang="",
+locale="" %}
+  {% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -91,4 +91,6 @@
 {% include "takeovers/_edge-month_takeover.html" %}
 <p>17 Oct 2019</p>
 {% include "takeovers/_1910_takeover.html" %}
+<p>20 Nov 2019</p>
+{% include "takeovers/_linux-security_takeover.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add Ubuntu Security takeover
- Add Ubuntu Security engage


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ & http://0.0.0.0:8001/engage/linux_security_webinar
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design](https://github.com/canonical-web-and-design/web-squad/issues/1979) and [brief](https://docs.google.com/spreadsheets/d/1nTvUth-4li92PzKm2HF9FLjw-MwCfHVGVct-yYT-rbk/edit#gid=2113339190)
- Test the engage page on  http://debug.iframely.com/ and https://cards-dev.twitter.com/validator
- Check the takeover is added to http://0.0.0.0:8001/takeovers
- Check the engage page is added to http://0.0.0.0:8001/engage


## Issue / Card

Fixes #6097 
