### PR TITLE
Port redirects from the legacy Apache frontend

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -10,7 +10,7 @@
 504Released/?: "/blog"
 ABOUT/?: "/about"
 Community/Participate/Developers/?: "https://discourse.ubuntu.com/"
-GetUbuntu/releasenotes/.+/: "https://wiki.ubuntu.com/Releases"
+GetUbuntu/releasenotes(/.+)?: "https://wiki.ubuntu.com/Releases"
 about/ubuntu-font/?: "https://design.ubuntu.com/font/"
 content/.+/: "/blog"
 news/.+/: "/blog"
@@ -413,8 +413,8 @@ foundation-cloud-build/?: "/openstack/consulting"
 frs/?: "/"
 gateways/?:  "/internet-of-things/gateways"
 get/?: "/download"
-getubuntu.*/?: "/download"
-GetUbuntu.*/?: "/download"
+getubuntu[^/]*/?: "/download"
+GetUbuntu[^/]*/?: "/download"
 hardware-summit/?: "/blog/canonical-hosts-leading-odms-at-ubuntu-hardware-summit/"
 hardy/?: "https://wiki.ubuntu.com/HardyHeron"
 how-can-it-be-free/?: "/desktop"
@@ -777,3 +777,11 @@ blog/topics/snappy/?: /blog/topics/snapcraft
 
 # Removal of the resources section
 resources/?: "/blog"
+
+# Redirects from the soon-to-be-retired Apache+Squid frontend
+# From https://pastebin.canonical.com/p/3TXyyNkWkg/
+search/google-appliance/(?P<query>.*)/?: /search?q={query}
+news/pressreleasearchive/?: /blog/press-centre
+certification/(?P<path>.*)/?: https://certification.ubuntu.com/{path}
+legal/ubuntu-advantage/service-description/?: /legal/ubuntu-advantage-service-description
+download/desktop/questions/?: /download/desktop/thank-you

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,6 +31,7 @@ from webapp.views import (
     blog_custom_topic,
     blog_press_centre,
     download_thank_you,
+    releasenotes_redirect,
 )
 from webapp.login import login_handler, logout
 
@@ -97,6 +98,7 @@ app.add_url_rule(
     "/download/<regex('server|desktop|cloud'):category>/thank-you",
     view_func=download_thank_you,
 )
+app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)
 app.add_url_rule(
     "/search", "search", build_search_view(template_path="search.html")
 )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -54,6 +54,24 @@ def download_thank_you(category):
     )
 
 
+def releasenotes_redirect():
+    """
+    View to redirect to https://wiki.ubuntu.com/ URLs for release notes.
+
+    This used to be done in the Apache frontend, but that is going away
+    to be replace by the content-cache.
+
+    Old apache redirects: https://pastebin.canonical.com/p/3TXyyNkWkg/
+    """
+
+    ver = flask.request.args.get("ver")
+
+    if ver:
+        return flask.redirect(f"https://wiki.ubuntu.com/{ver}/ReleaseNotes")
+    else:
+        return flask.redirect(f"https://wiki.ubuntu.com/Releases")
+
+
 def advantage():
     accounts = None
     personal_account = None


### PR DESCRIPTION
The Apache+Squid frontend of ubuntu.com will soon be replaced
with the new content-cache, which means redirects defined there will
go away:

https://pastebin.canonical.com/p/3TXyyNkWkg/

Many of these redirects are now redundant, so we won't be preseving them:

- /index_kylin has been removed
- The /phone section has been removed
- The old-style /download URLs with "bits" and "release" are 5 years old now, so we won't preserve them
- /getubuntu/releasenotes pages for <16.04 are no longer supported and mostly no longer exist
- /target= and /ibmz are no longer referenced on the public internet

We're not quite sure how we're going to preserve the geolocation
?country= in the /download/*/thank-you pages. One proposal is in
https://github.com/canonical-web-and-design/ubuntu.com/pull/6124

So, apart from all that, I'm porting the following redirects from the
old Apache config in this PR:

- /search/google-appliance/* -> /search?q=*
- /news/pressreleasearchive -> /blog/press-centre
- /certification/* -> https://certification.ubuntu.com/*
- /legal/ubuntu-advantage/service-description -> /legal/ubuntu-advantage-service-description
- /download/desktop/questions -> /download/desktop/thank-you
- /getubuntu/releasenotes?ver=* -> https://wiki.ubuntu.com/*/ReleaseNotes
- /getubuntu/releasenotes -> https://wiki.ubuntu.com/Releases

QA
--

`./run`, and test out the following redirects:

- http://0.0.0.0:8001/search/google-appliance/maas -> http://0.0.0.0:8001/search?q=maas
- http://0.0.0.0:8001/news/pressreleasearchive -> http://0.0.0.0:8001/blog/press-centre
- http://0.0.0.0:8001/certification/make/Lenovo?page=1 -> https://certification.ubuntu.com/make/Lenovo?page=1
- http://0.0.0.0:8001/legal/ubuntu-advantage/service-description -> http://0.0.0.0:8001/legal/ubuntu-advantage-service-description
- http://0.0.0.0:8001/download/desktop/questions -> http://0.0.0.0:8001/download/desktop/thank-you
- http://0.0.0.0:8001/getubuntu/releasenotes?ver=16.04 -> https://wiki.ubuntu.com/XenialXerus/ReleaseNotes?action=show&redirect=16.04%2FReleaseNotes
- http://0.0.0.0:8001/getubuntu/releasenotes -> https://wiki.ubuntu.com/Releases

Check this behaviour basically matches what happens on live.