### PR TITLE
Add kubecon19 banner

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,6 @@
   {% include "takeovers/_linux-security_takeover.html" %}
 {% endblock takeover_content %}
 
-
 {#
   # Creating notices
 
@@ -51,6 +50,7 @@
 #}
 
 {% block notices_content %}
+  {% include "takeovers/_kubecon19.html" %}
   {% with lang="ja", text="私たちの日本のウェブサイトを試してみてください", url="https://jp.ubuntu.com", icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
     {% include "shared/_notice_default.html" %}
   {% endwith %}

--- a/templates/takeovers/_kubecon19.html
+++ b/templates/takeovers/_kubecon19.html
@@ -1,0 +1,14 @@
+<section class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-2 u-vertically-center">
+      <img class="u-hide--small u-no-margin--bottom" style="height: 50px; margin-bottom: .95rem;" src="https://portworx.com/wp-content/uploads/2017/02/kubecon-logo.png" height="50" alt="">
+    </div>
+    <div class="col-10 u-vertically-center">
+      <h4 class="u-no-max-width u-no-margin--bottom">
+        <a href="blog/ubuntu-kubecon-americas-2019">
+          Visit the Ubuntu booth (P36) at Kubecon’19 to win a MicroK8s t-shirt&nbsp;&rsaquo; 
+        </a>
+      </h4>
+    </div>
+  </div>
+</section>

--- a/templates/takeovers/_kubecon19.html
+++ b/templates/takeovers/_kubecon19.html
@@ -1,11 +1,11 @@
 <section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height">
     <div class="col-2 u-vertically-center">
-      <img class="u-hide--small u-no-margin--bottom" style="height: 50px; margin-bottom: .95rem;" src="https://portworx.com/wp-content/uploads/2017/02/kubecon-logo.png" height="50" alt="">
+      <img class="u-hide--small" style="height: 50px;" src="https://portworx.com/wp-content/uploads/2017/02/kubecon-logo.png" height="50" alt="">
     </div>
     <div class="col-10 u-vertically-center">
-      <h4 class="u-no-max-width u-no-margin--bottom">
-        <a href="blog/ubuntu-kubecon-americas-2019">
+      <h4 class="u-no-max-width  u-no-margin--bottom">
+        <a href="/blog/ubuntu-kubecon-americas-2019">
           Visit the Ubuntu booth (P36) at Kubecon’19 to win a MicroK8s t-shirt&nbsp;&rsaquo;
         </a>
       </h4>

--- a/templates/takeovers/_kubecon19.html
+++ b/templates/takeovers/_kubecon19.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-shallow">
+<section class="p-strip is-shallow is-bordered">
   <div class="row u-equal-height">
     <div class="col-2 u-vertically-center">
       <img class="u-hide--small u-no-margin--bottom" style="height: 50px; margin-bottom: .95rem;" src="https://portworx.com/wp-content/uploads/2017/02/kubecon-logo.png" height="50" alt="">
@@ -6,7 +6,7 @@
     <div class="col-10 u-vertically-center">
       <h4 class="u-no-max-width u-no-margin--bottom">
         <a href="blog/ubuntu-kubecon-americas-2019">
-          Visit the Ubuntu booth (P36) at Kubecon’19 to win a MicroK8s t-shirt&nbsp;&rsaquo; 
+          Visit the Ubuntu booth (P36) at Kubecon’19 to win a MicroK8s t-shirt&nbsp;&rsaquo;
         </a>
       </h4>
     </div>


### PR DESCRIPTION
## Done

- Add a KubeCon19 notice to the homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [brief doc](https://docs.google.com/document/d/163wevrv2xmezH8PEmbRZRVhER1NOo64jFQesXkiNXW8/edit?ts=5dd2108c#)

