### PR TITLE
Remove kata containers takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,6 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_1910_takeover.html" %}
-  {% include "takeovers/_kata-containers.html" %}
   {% include "takeovers/_private-cloud-build-takeover.html" %}
   {% include "takeovers/_linux-security_takeover.html" %}
 {% endblock takeover_content %}


### PR DESCRIPTION
## Done

- Remove `Kata containers takeover` from home page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure `kata containers takeover` is not there anymore

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1988
