### PR TITLE
Update title of /internet-of-things/appstore page

### DIFF
--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -1,7 +1,7 @@
 {% extends "internet-of-things/base_things.html" %}
 
 
-{% block title %}White label app store for IOT | Ubuntu for the Internet of Things {% endblock %}
+{% block title %}White label app store for Linux and IoT | Ubuntu for the Internet of Things {% endblock %}
 {% block meta_description %}For cloud based and enterprise IoT app stores, control, manage and monetise software deployments on your connected Linux devices.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit{% endblock meta_copydoc %}
 
@@ -11,7 +11,7 @@
   <div class="p-strip--suru-half-and-half">
     <div class="row u-equal-height">
       <div class="col-7 col-medium-4">
-        <h1>White-label app stores<br class="u-hide--small" />for IoT</h1>
+        <h1>White-label app stores<br class="u-hide--small" />for Linux and IoT</h1>
         <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation. We provide the infrastructure for secure management and seamless software updates for your fleet of devices. Whether you need a branded app store for your IoT devices or private application repository on premise, we can accommodate your requirements.</p>
         <ul class="p-inline-list u-no-margin--bottom">
           <li class="p-inline-list__item">

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -11,7 +11,7 @@
   <div class="p-strip--suru-half-and-half">
     <div class="row u-equal-height">
       <div class="col-7 col-medium-4">
-        <h1>White-label app stores<br class="u-hide--small" />for Linux and IoT</h1>
+        <h1>White-label app stores <br class="u-hide--small" />for Linux and IoT</h1>
         <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation. We provide the infrastructure for secure management and seamless software updates for your fleet of devices. Whether you need a branded app store for your IoT devices or private application repository on premise, we can accommodate your requirements.</p>
         <ul class="p-inline-list u-no-margin--bottom">
           <li class="p-inline-list__item">
@@ -261,7 +261,7 @@
         <li class="p-list__item is-ticked">24/7 phone and web support</li>
         <li class="p-list__item is-ticked">Access to our world-class technical team and library</li>
       </ul>
-      <a class="p-button--positive u-no-margin--bottom" href="/legal/ubuntu-advantage-service-description">Ubuntu Advantage service description</a>
+      <a class="p-button--positive u-no-margin--bottom" href="/pricing/devices">Find out more about App Store pricing</a>
     </div>
 
     <div class="col-6 p-card">
@@ -274,7 +274,9 @@
         <li class="p-list__item is-ticked">Manage users allowed to override revisions</li>
         <li class="p-list__item is-ticked">Maximise bandwidth and speed by caching downloads</li>
       </ul>
-      <a class="p-button--positive u-no-margin--bottom" href="https://docs.ubuntu.com/snap-store-proxy/en/"><span class="p-link--external">Snap store proxy</span></a>
+      <p>
+        <a class="p-link--external" href="https://docs.ubuntu.com/snap-store-proxy/en/">Learn more about the Snap store proxy</a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update the title and h1 of the /iot/appstore page per content meeting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/appstore
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit#heading=h.dfrcx0l5a0jf
)

