### PR TITLE
Add server documention

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -46,6 +46,9 @@ server:
       path: /server
     - title: Hyperscale
       path: /server/hyperscale
+    - title: Docs
+      path: /server/docs
+      persist: True
     - title: Contact us
       path: /server/contact-us
       hidden: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
 canonicalwebteam.image-template==1.0.0
+canonicalwebteam.discourse-docs==0.6.4
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1
 pymacaroons==0.12.0

--- a/static/sass/_layout-documentation.scss
+++ b/static/sass/_layout-documentation.scss
@@ -17,12 +17,8 @@
     pre {
       max-width: 700px;
       overflow-x: auto;
-      width: 95vmax;
-    }
-
-    pre,
-    code {
       white-space: pre;
+      width: 95vmax;
     }
 
     img {

--- a/templates/docs/base_docs.html
+++ b/templates/docs/base_docs.html
@@ -1,0 +1,40 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+<div class="l-documentation">
+  <div class="l-documentation__sidebar">
+    <aside class="p-sidebar" id="navigation">
+      <div class="p-sidebar__banner u-hide--medium u-hide--large">
+        <i class="p-sidebar__toggle p-icon--menu"></i>
+      </div>
+      <div class="p-sidebar__content u-hide--small">
+        <nav class="p-sidebar-nav">
+          {{ navigation | safe }}
+        </nav>
+      </div>
+    </aside>
+  </div>
+
+  <div class="l-documentation__content p-content">
+    {% block content_docs %}{% endblock %}
+  </div>
+</div>
+
+<script>
+  const path = window.location.pathname;
+  const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
+  if (active) {
+    active.classList.add("is-active");
+  }
+
+  const toggleSidebar = document.querySelector(".p-sidebar__toggle");
+  const sidebar = document.querySelector(".p-sidebar__content");
+  if (toggleSidebar) {
+    toggleSidebar.addEventListener("click", function(e) {
+      sidebar.classList.toggle("u-hide--small");
+      toggleSidebar.classList.toggle("p-icon--close");
+      toggleSidebar.classList.toggle("p-icon--menu");
+    });
+  }
+</script>
+{% endblock %}

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,0 +1,23 @@
+
+{% extends "docs/base_docs.html" %}
+
+{% block title %} {{ document.title }} | Server documentation{% endblock %}
+
+{% block content_docs %}
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        {{ document.body_html | safe }}
+    </div>
+</div>
+
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        <div class="p-notification--information">
+            <p class="p-notification__response">
+                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -1,4 +1,4 @@
-{% set breadcrumbs = navigation(request.path).breadcrumbs %}
+{% set breadcrumbs = get_navigation(request.path).breadcrumbs %}
 
 <header id="navigation" class="p-navigation" role="banner">
   {% block header_banner %}
@@ -101,7 +101,7 @@
             {% endfor %}
           {% endif %}
         {% endfor %}
-        
+
         {% for child in breadcrumbs.children %}
           {% if child.path == "/blog/topics" %}
             {% for item in child.children %}
@@ -154,7 +154,7 @@
 
   function setupContextualMenuListeners(contextualMenuSelector) {
     var menus = document.querySelectorAll(contextualMenuSelector);
-    
+
     for (var i = 0; i < menus.length; i++) {
       var toggle = menus[i].querySelector('.p-contextual-menu__toggle'),
           dropdown = menus[i].querySelector('.p-contextual-menu__dropdown'),

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -1,4 +1,4 @@
-{% set nav_sections = navigation(request.path).nav_sections %}
+{% set nav_sections = get_navigation(request.path).nav_sections %}
 
 {% block footer %}
 

--- a/templates/templates/header_noscript.html
+++ b/templates/templates/header_noscript.html
@@ -1,4 +1,4 @@
-{% set nav_sections = navigation(request.path).nav_sections %}
+{% set nav_sections = get_navigation(request.path).nav_sections %}
 
 {% block header %}
   {% with section=nav_sections.openstack %}{% include 'templates/_header_item_noscript.html' %}{% endwith %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -26,7 +26,7 @@ from webapp.context import (
     modify_query,
     month_name,
     months_list,
-    navigation,
+    get_navigation,
     releases,
 )
 from webapp.views import (
@@ -78,7 +78,7 @@ def context():
         "modify_query": modify_query,
         "month_name": month_name,
         "months_list": months_list,
-        "get_navigation": navigation,
+        "get_navigation": get_navigation,
         "product": flask.request.args.get("product", ""),
         "request": flask.request,
         "releases": releases(),

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -11,6 +11,11 @@ from canonicalwebteam.search import build_search_view
 from canonicalwebteam import image_template
 from canonicalwebteam.blog.wordpress_api import api_session
 from werkzeug.middleware.proxy_fix import ProxyFix
+from canonicalwebteam.discourse_docs import (
+    DiscourseAPI,
+    DiscourseDocs,
+    DocParser,
+)
 
 # Local
 from webapp.context import (
@@ -73,7 +78,7 @@ def context():
         "modify_query": modify_query,
         "month_name": month_name,
         "months_list": months_list,
-        "navigation": navigation,
+        "get_navigation": navigation,
         "product": flask.request.args.get("product", ""),
         "request": flask.request,
         "releases": releases(),
@@ -121,3 +126,18 @@ app.add_url_rule("/logout", view_func=logout)
 template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
+
+url_prefix = "/server/docs"
+server_docs_parser = DocParser(
+    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
+    index_topic_id=11322,
+    url_prefix=url_prefix,
+)
+server_docs = DiscourseDocs(
+    parser=server_docs_parser,
+    category_id=26,
+    document_template="/docs/document.html",
+    url_prefix=url_prefix,
+)
+
+server_docs.init_app(app)

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -50,7 +50,7 @@ def _remove_hidden(pages):
     return filtered_pages
 
 
-def navigation(path):
+def get_navigation(path):
     """
     Set "nav_sections" and "breadcrumbs" dictionaries
     as global template variables

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -73,7 +73,10 @@ def navigation(path):
                 # always show "Topics" as active on child topic pages
                 child["active"] = True
                 break
-            elif child["path"] == path:
+            elif child["path"] == path or (
+                child.get("persist") and path.startswith(child["path"])
+            ):
+                # If child path matches current path or has persist set to true
                 child["active"] = True
                 nav_section["active"] = True
                 breadcrumbs["section"] = nav_section


### PR DESCRIPTION
## Done
- Add the discourse-docs module
- Add documentation templates
- Rename `navigation` object to `get_navigation` as there was a clash with the docs module
- Extended the navigation feature to persist to the child nodes also 

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /server/docs
- Check the page renders correctly and matches [the discourse content](https://discourse.ubuntu.com/t/introduction/11322)
- Click through a number of pages and make sure they load correctly
- Do a brief check that the blog navigation still works as expected
- Check a few other sections to ensure the navigation system has no regressions
