### PR TITLE
Update the livepatch link

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -47,7 +47,7 @@
     <div class="col-12">
       <h2>Free for personal use</h2>
       <p>All you need is an Ubuntu One account. Free for 3 machines.</p>
-      <p><a class="p-button--positive"  href="/advantage">Get Livepatch</a></p>
+      <p><a class="p-button--positive"  href="https://auth.livepatch.canonical.com/">Get Livepatch</a></p>
       <h2>Part of Ubuntu Advantage</h2>
       <p>Buy as part of Ubuntu Advantage from Canonical. Buy online.</p>
       <p><a class="p-button--positive"  href="/advantage#livepatch">Get Ubuntu Advantage</a></p>


### PR DESCRIPTION
## Done
Update the link to livepatch portal instead of advantage.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the link which states Free for personal use goes to livepatch portal 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6145

