### PR TITLE
Define of "free personal subscription" when logged in

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -195,8 +195,7 @@
 
   <div class="row">
     <div class="col-12 u-hide--small">
-      <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply). All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
-      <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
+        <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply). And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>      <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
       <table style="width:auto;">
         <tr style="border: 0;">
           <td class="u-align--right">To attach a machine:</td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -195,6 +195,7 @@
 
   <div class="row">
     <div class="col-12 u-hide--small">
+      <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply). All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
       <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
       <table style="width:auto;">
         <tr style="border: 0;">


### PR DESCRIPTION
## Done
Extend the definition of free personal subscription to the logged in view.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /advantage
- Login and check the explanation of free and community contracts is available in both

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6068

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/69153410-16cc7a80-0ad6-11ea-8710-1ee1493fdded.png)
