### PR TITLE
Update /openstack/install command + update server docs links

### DIFF
--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -74,7 +74,7 @@
       <p class="u-sv3">These instructions use <a href="https://snapcraft.io/microstack" class="p-link--external">MicroStack</a>, an upstream single-node OpenStack deployment which can run directly on your workstation. MicroStack is OpenStack in a <a href="https://snapcraft.io/" class="p-link--external">snap</a> which means that all services and supporting libraries are together in a single package that can be easily installed, upgraded or removed. MicroStack includes all key OpenStack components: Keystone, Nova, Neutron, Glance, and is evolving extremely fast. You can use it for development, prototyping and testing, but it is also perfectly suitable for the network edge, IoT and appliances.</p>
     </div>
   </div>
-  
+
   <div class="u-fixed-width">
     <h3>Installation instructions</h3>
     <ol class="p-stepped-list--detailed">
@@ -142,7 +142,7 @@ password: keystone</code></pre>
           <p><strong>CLI:</strong></p>
           <p>You can also interact withOpenStack via the CLI by using the microstack.openstack command. The MicroStack CLI syntax is identical to the client delivered by the <a href="https://docs.openstack.org/python-openstackclient/latest/cli/command-list.html" class="p-link--external">python-openstackclient</a> package.</p>
           <p>For example, to list available OpenStack endpoints run:</p>
-          
+
           <div class="p-code-copyable">
             <input aria-label="code snippet" class="p-code-copyable__input" value="microstack.openstack catalog list" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
@@ -198,7 +198,7 @@ password: keystone</code></pre>
           <p>The quickest way to launch your first OpenStack instance (or a VM) is to run the following command:</p>
 
           <div class="p-code-copyable">
-            <input aria-label="code snippet" class="p-code-copyable__input" value="microstack.launch test" readonly="readonly">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="microstack.launch cirros —name test" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
 
@@ -218,7 +218,7 @@ You can also visit the openstack dashboard at 'http://10.20.20.1/'</code></pre>
 
           <pre><code>uptime
 14:51:42 up 4 min,  1 users,  load average: 0.00, 0.00, 0.00</code></pre>
-          
+
           <p>In order to disconnect from the instance type exit.</p>
 
           <p>You can also view the instance from the web GUI. Go to <a href="http://10.20.20.1/">http://10.20.20.1/</a> and click on the "Instances" tab on the left:</p>

--- a/templates/shared/contextual_footers/_download_documentation.html
+++ b/templates/shared/contextual_footers/_download_documentation.html
@@ -2,9 +2,7 @@
   <h3 class="p-heading--four">Detailed documentation</h3>
 
   <ul class="p-list">
-    <li><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation/UbuntuServerGuide" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c server guide', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server Guide</a></li>
-
-    <li><a href="https://help.ubuntu.com/" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c LTS', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu {{ releases.lts.short_version }} LTS documentation</a></li>
+    <li><a href="/server/docs"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server docs&nbsp;&rsaquo;</a></li>
 
     <li><a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download</a></li>
   </ul>

--- a/templates/shared/contextual_footers/_download_server_guide.html
+++ b/templates/shared/contextual_footers/_download_server_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Ubuntu Server guide</h3>
+  <h3 class="p-heading--four">Ubuntu Server docs</h3>
   <p>Read the official Ubuntu Server documentation.</p>
-  <p><a class="p-link--external" href="https://help.ubuntu.com/lts/serverguide/index.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c server guide', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{ releases.lts.short_version }} LTS documentation</a></p>
+  <p><a href="/server/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{ releases.lts.short_version }} LTS documentation&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -136,6 +136,7 @@
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS - fast server provisioning</a></li>
           <li class="p-list__item"><a href="https://jujucharms.com" title="Visit jujucharms.com - external site">Multi cloud operations</a></li>
           <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
+          <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>
         </ul>
       </div>
       <!-- AI and ML -->


### PR DESCRIPTION
## Done

- Updated command in OpenStack install instructions
- Updated links to Ubuntu Server docs
- Added Ubuntu Server docs to the dropdown navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit#heading=h.q81t5vetlzyd)


## Issue / Card

Fixes #6137

## Screenshots

![image](https://user-images.githubusercontent.com/441217/69259340-012e8200-0bb6-11ea-9415-4b2c40c5d14b.png)

