### PR TITLE
Add preconnect for Cloudinary

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -7,6 +7,8 @@
 
   <title>{% block title %}{% endblock %} | Ubuntu</title>
 
+  <link rel="preconnect" href="https://res.cloudinary.com">
+
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js" defer></script>


### PR DESCRIPTION
## Done

Add preconnect for Cloudinary which will have a positive performance impact when loading images served on Cloudinary.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View source and see that `<link rel="preconnect" href="https://res.cloudinary.com">` is present beneath the `<title>` tag


## Issue / Card

Fixes #5883