### PR TITLE
Fix spacing in code examples on the IOT installation media page

### DIFF
--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -58,14 +58,14 @@
 
           If the Ubuntu image file you have downloaded ends with an `.xz` file extension, run:
         </p>
-        <pre><code>xzcat ~/Downloads/ &lt; image file .xz &gt; | sudo dd of=&lt; drive address &gt; bs=32M</code></pre>
+        <pre><code>xzcat ~/Downloads/&lt;image-file.xz&gt; | sudo dd of=&lt;drive address&gt; bs=32M</code></pre>
       </li>
       <li class="p-stepped-list__item">
         <p class="p-stepped-list__title">
 
           Else, run:
         </p>
-        <pre><code>sudo dd if=~/Downloads/&lt; image file &gt; of=&lt; drive address &gt; bs=32M</code></pre>
+        <pre><code>sudo dd if=~/Downloads/&lt;image-file&gt; of=&lt;drive address&gt; bs=32M</code></pre>
       </li>
       <li class="p-stepped-list__item">
         <p class="p-stepped-list__title">
@@ -189,20 +189,20 @@ Unlocked Encrypted
       </li>
       <li class="p-stepped-list__item">
         <p class="p-stepped-list__title">Unmount your SD card with this command:</p>
-        <pre><code>diskutil unmountDisk &lt; drive address &gt;</code></pre>
+        <pre><code>diskutil unmountDisk &lt;drive address&gt;</code></pre>
       </li>
       <li class="p-stepped-list__item">
         <p class="p-stepped-list__title">
 
           When successful, you should see a message similar to this:
         </p>
-        <pre><code>Unmount of all volumes on &lt; drive address &gt; was successful</code></pre>
+        <pre><code>Unmount of all volumes on &lt;drive address&gt; was successful</code></pre>
       </li>
       <li class="p-stepped-list__item">
         <p class="p-stepped-list__title">
           You can now copy the image to the SD card:
         </p>
-        <pre><code>sudo sh -c 'gunzip -c ~/Downloads/&lt; image file &gt; | sudo dd of=&lt; drive address &gt; bs=32m'</code></pre>
+        <pre><code>sudo sh -c 'gunzip -c ~/Downloads/&lt;image file&gt; | sudo dd of=&lt;drive address&gt; bs=32m'</code></pre>
         <p>When finished you will see this message:</p>
         <pre><code>3719+1 records in
 3719+1 records out


### PR DESCRIPTION
## Done

Fix spacing in code examples on the IOT installation media page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot/installation-media
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the code examples referenced in [the issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6116) match the suggested format i.e. removing spaces between angle brackets


## Issue / Card

Fixes #6116
