### PR TITLE
“Installation instructions” > “How to upgrade”

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -524,7 +524,7 @@
       <div class="col-4 p-card--highlighted">
         <h3>Do you want to upgrade your OS?</h3>
         <p class="p-card__content">If you are already running Ubuntu, you can upgrade with the Software Updater.</p>
-        <p class="p-card__content"><a href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop" class="p-link--external">Installation instructions</a></p>
+        <p class="p-card__content"><a href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop" class="p-link--external">How to upgrade</a></p>
       </div>
       <div class="col-4 p-card--highlighted">
         <h3>Let’s connect</h3>


### PR DESCRIPTION
## Done

On /download/desktop/thank-you, changes “Do you want to upgrade your OS?” link from “Installation instructions” to “How to upgrade”.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop/thank-you?country=

## Issue / Card

Fixes #5361.