### PR TITLE
Corrects STIG link

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -89,7 +89,7 @@
         DISA has in conjunction with Canonical developed a STIG for Ubuntu 16.04.
       </p>
       <p>
-        <a class="p-link--external" href="https://iasecontent.disa.mil/stigs/zip/U_Canonical_Ubuntu_16-04_LTS_V1R1_STIG.zip">Read the STIG</a>
+        <a href="https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Canonical_Ubuntu_16-04_LTS_V1R2_STIG.zip">Download the STIG</a>
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

- Updated link target, now that the DoD has reorganised their site
- Changed “Read” to “Download”, to indicate that it will be a download
- Removed external-link icon, since it’s a download (see discussion in #5269)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications

## Issue / Card

None