### PR TITLE
Fix bugs in eol charts

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -207,7 +207,7 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
   var width = document.querySelector(chartSelector).clientWidth - margin.right - margin.left;
   var tickSize = 1;
 
-  if (window.innerWidth < 1000) {
+  if (window.innerWidth < 1080) {
     tickSize = 2;
   }
 

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -205,6 +205,11 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
   var timeDomainEnd = d3.time.year.offset(tasks[tasks.length - 1].endDate, +1);
   var height = taskTypes.length * rowHeight;
   var width = document.querySelector(chartSelector).clientWidth - margin.right - margin.left;
+  var tickSize = 1;
+
+  if (window.innerWidth < 1000) {
+    tickSize = 2;
+  }
 
   var x = d3.time
     .scale()
@@ -221,7 +226,7 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
     .axis()
     .scale(x)
     .orient("bottom")
-    .ticks(d3.time.years, 1);
+    .ticks(d3.time.years, tickSize);
 
   var yAxis = d3.svg
     .axis()

--- a/static/js/release-chart.js
+++ b/static/js/release-chart.js
@@ -58,7 +58,7 @@ function clearCharts() {
   }
 }
 
-var mediumBreakpoint = 768;
+var mediumBreakpoint = 875;
 
 // A bit of a hack, but chart doesn't load with full year axis on first load,
 // It has to be loaded once, and then again


### PR DESCRIPTION
## Done

- Reduce year axis to every other year when labels begin to overlap
- Update breakpoint variable so graph doesn't try to render when table is viewed instead causing errors in the console

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Resize the browser and see that when the labels on the year axis on the release charts start to get close to each other they change to every other year, before they turn into tables


## Issue / Card

Fixes #6139

## Screenshots

![eol-chart](https://user-images.githubusercontent.com/501889/69954225-b9cbbe00-14f2-11ea-9f5e-9c50a5c2d2dd.png)

