### PR TITLE
Changed the link to other sec takeover

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -12,7 +12,7 @@
     <div class="col-8">
       <h1>Dedicated to the security of Ubuntu</h1>
       <p>Since its inception in 2004, Ubuntu has been built on a foundation of enterprise-grade, industry leading security practices. From our toolchain to the suite of packages we use and from our update process to our industry standard certifications, Canonical never stops working to keep Ubuntu at the forefront of safety  and reliability.</p>
-      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/290073" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });" ><span class="p-link--external">Watch the Ubuntu security webinar</span></a></p>
+      <p><a class="p-button--positive" href="https://ubuntu.com/engage/linux_security_webinar" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });" ><span class="p-link--external">Watch the Ubuntu security webinar</span></a></p>
     </div>
   </div>
 </section>
@@ -280,7 +280,7 @@
           <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us</a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-link--external p-link--inverted" href="https://ubuntu.com/engage/linux_security_webinar">Watch the Ubuntu security webinar</a>
+          <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/290073">Watch the Ubuntu security webinar</a>
         </li>
       </ul>
     </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -280,7 +280,7 @@
           <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us</a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/290073">Watch the Ubuntu security webinar</a>
+          <a class="p-link--external p-link--inverted" href="https://ubuntu.com/engage/linux_security_webinar">Watch the Ubuntu security webinar</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Changed the link of the sec page to https://ubuntu.com/engage/linux_security_webinar

## Done

Change the link for the "Watch the Ubuntu security webinar" to https://ubuntu.com/engage/linux_security_webinar on ubuntu.com/security
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the changes against the [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit) and accept all changed.


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
