### PR TITLE
Update link on the AWS pro page

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -12,7 +12,7 @@
         <h1>Ubuntu Pro for AWS</h1>
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for AWS is a premium image designed by Canonical to provide the most comprehensive feature set for production environments running in the public cloud. Offered as an AMI through AWS Marketplace, it includes a subscription to critical security and compliance services by default. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations &mdash; no contract necessary.</p>
-        <p><a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Launch Ubuntu Pro 18.04 LTS on AWS</a></p>
+        <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on AWS</span></a></p>
         <p><a href="https://assets.ubuntu.com/v1/537fb75d-Ubuntu_Pro_AWS_03.11.19.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done
Update the link on the hero CTA

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/pro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- check that the launch Ubuntu Pro button in the hero good to AWS and not open the contact model
