### PR TITLE
Build automotive page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -371,6 +371,8 @@ iot:
       path: /internet-of-things/appstore
     - title: Embedded Linux
       path: /embedded
+    - title: Automotive
+      path: /automotive
 
     - title: Thank you
       path: /internet-of-things/newsletter-thank-you

--- a/templates/automotive/base_automotive.html
+++ b/templates/automotive/base_automotive.html
@@ -1,0 +1,8 @@
+{% extends "templates/base.html" %}
+
+
+{% block meta_copydoc %}https://drive.google.com/open?id=1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -1,0 +1,205 @@
+{% extends "automotive/base_automotive.html" %}
+
+{% block title %}Commercial Linux for the automotive sector{% endblock %}
+{% block meta_description %}Canonical is introducing Ubuntu, the most popular commercial-grade and open-source Linux distribution, to the  automotive sector. Ubuntu will accelerate automotive OEMs’ efforts to deliver connected  and autonomous vehicles.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1NvYOhOJzdY5ypifTPs73vH5Nb7rFABRWMzjXyDUQt_U/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h1>Commercial Linux for the automotive sector</h1>
+      <p>Leverage the most popular open source operating system to accelerate time to market for your connected vehicles. Ubuntu is the choice platform to develop cockpit infotainment, edge connectivity, mixed-criticality and AI for automotive applications. What&rsquo;s more, Ubuntu Core is designed to enhance functional safety for critical embedded systems. Canonical brings 15 years of experience, enabling and supporting Linux to the automotive sector.</p>
+      <p>Tell us about your moonshot.</p>
+      <p><a href="/internet-of-things/contact-us?product=automotive" class="p-button--positive js-invoke-modal">Get in touch</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="p-strip is-shallow u-no-padding--top">
+    <div class="row u-equal-height">
+      <div class="col-6">
+        <h2>Security for functional safety</h2>
+        <p>Connected driving is a safety-critical application that demands the highest security standards. Ubuntu delivers the most stringent security features for embedded system software. Ubuntu Core, the embedded distribution of Ubuntu, is built upon tamper-proof application containers. Advanced security features like secure boot and full disk encryption add to the inherently strong integrity of Ubuntu Core. Canonical will be partners with you in achieving compliance with automotive industry security standards.</p>
+        <p><a class="p-link--external" href="https://assets.ubuntu.com/v1/66fcd858-ubuntu-core-security-whitepaper.pdf">Read the Ubuntu Core security whitepaper</a></p>
+      </div>
+      <div class="col-6 u-vertically-center u-align--center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/2697f642-Compliance.svg" alt="" width="335" height="200">
+      </div>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr>
+  </div>
+  <div class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row u-equal-height">
+      <div class="col-6 u-vertically-center u-align-center u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/c53664cd-Security_updates.svg" alt="" width="335" height="200">
+      </div>
+      <div class="col-6">
+        <h2>Long-term software updates for cars in the field</h2>
+        <p>We are bringing our commercial support experience for Linux and open source software to the automotive sector. Ubuntu is delivered with long term support for over ten years. Live kernel patching, CVE fixes and software updates are all part of the package. We have devised a reliable over the air mechanism, that is failure tolerant and optimised for minimal bandwidth. Additionally, our support service is available 24/7 to customers.</p>
+        <p><a class="p-button--neutral p-link--external" href="https://www.brighttalk.com/webcast/6793/356124">Watch our &ldquo;Connected cars&rdquo; webinar</a></p>
+        <p><a href="/engage/snap-deltas">Read our whitepaper on optimising IoT bandwidth&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Lower the cost of R&D with open source</h2>
+  </div>
+  <div class="row p-divider u-equal-height">
+    <div class="col-4 p-divider__block">
+      <h3>Developers</h3>
+      <p>Shorten developer cycles with Ubuntu. Most software developers around the world are already familiar with Ubuntu.  Finding talent is easier, and they&rsquo;ll be up to speed quicker</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3>Collaboration</h3>
+      <p>Build on the shoulders of giants. The open source community around Ubuntu is strong. You do not have to start from scratch, and you can contribute software to existing projects.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3>Flexibility</h3>
+      <p>Snaps package every language runtime in isolated application containers. Your teams can deliver software in the language they are most comfortable.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <p><a href="/engage/developer-desktop">Why developers choose Ubuntu&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h2>Enable emerging technologies</h2>
+      <p>Connected cars require emerging software technologies to be seamlessly integrated into coherent solutions.</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="p-card col-4">
+      <h3 class="p-card__thumbnail">Embedded AI</h3>
+      <hr>
+      <div class="p-card__description">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Support for GPU accelerated hardware on embedded mobile nodes and on edge gateways</li>
+          <li class="p-list__item is-ticked">Infrastructure automation in the cloud and at the edge to support ML workloads</li>
+          <li class="p-list__item is-ticked">Easy integration of machine learning frameworks like Kubeflow</li>
+        </ul>
+        <p><a href="/engage/ai-ml-ubuntu">Watch our webinar &ldquo;AI, ML and Ubuntu&rdquo;&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <h3 class="p-card__thumbnail">Mixed-Criticality</h3>
+      <hr>
+      <div class="p-card__description">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Ubuntu delivers and maintains the latest general purpose Kernel</li>
+          <li class="p-list__item is-ticked">Canonical can deliver a PREEMPT-RT patched Kernel on demand</li>
+          <li class="p-list__item is-ticked">We can enable mixed-critically architectures with optimisations for the requirements of your underlying hardware</li>
+        </ul>
+        <p><a href="https://ubuntu.com/blog/low-latency-real-time-kernels-telco-nfv">Learn about low-latency and real-time kernels&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <h3 class="p-card__thumbnail">Edge computing</h3>
+      <hr>
+      <div class="p-card__description">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Our technology stack can power process, application and systems virtualisation</li>
+          <li class="p-list__item is-ticked">Canonical delivers Kubernetes optimised for the edge with MicroK8s</li>
+          <li class="p-list__item is-ticked">Ubuntu works with multiple container runtimes: Docker, LXD or OCI</li>
+        </ul>
+        <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/362197">Watch our webinar &ldquo;A guide to Edge Computing&rdquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+  
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2>Build innovative applications for connected vehicles</h2>
+      <p>We offer the technology primitives that new automotive applications can be built quickly.</p>
+    </div>
+  </div>
+  <div class="row">
+    <ul class="p-matrix p-matrix--two-col u-clearfix">
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Digital Car Cockpit</h3>
+          <p class="p-matrix__desc">As customers expectations for digital experiences evolve, car manufacturers need to rethink cockpit user experience to deliver an intuitive UX for infotainment, navigation and enhanced passenger safety. Canonical has extensive UX and HMI experience, thanks to Ubuntu Desktop. This experience is encapsulated in our display solutions; Wayland and Mir.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">ADAS</h3>
+          <p class="p-matrix__desc">Enhanced passenger safety is a key benefit of smart cars. Complex sensors need to be integrated into the car to map traffic situations dynamically. Furthermore, advanced communication protocols need to be implemented to transmit the collected data. Ubuntu is open source, with an active developer community. Choosing Ubuntu lowers the technical challenge of integrating sophisticated new technologies.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">Connected ECUs</h3>
+          <p class="p-matrix__desc">We provide the foundations for smart connected ECUs in a mixed-criticality architecture. Our full abstraction of the hardware layer in embedded systems unlocks new possibilities like time-sensitive networking in automotive systems and ECU virtualisation. We collaborate with experienced partners for compliance with safety standards.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title">V2X</h3>
+          <p class="p-matrix__desc">V2X requires the support for a variety of communication stacks and protocols, from the vehicle to other vehicles, infrastructure or roadway users. Our approach to V2X is software-defined networking. We build on infrastructure abstraction and automation, leveraging our edge version of Kubernetes, Snap application containers and cloud orchestration tools like Juju. Enabling hardware standardisation and faster development lead time for V2X solutions.</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+    
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2 class="p-muted-heading u-align--center u-sv3">THESE AUTOMOTIVE INNOVATORS HAVE CHOSEN UBUNTU</h2>
+    <ul class="p-inline-list u-align--center u-no-margin--bottom">
+      <li class="p-inline-list__item">
+        <img src="https://assets.ubuntu.com/v1/3a94f633-Eurotech-logo-02.svg" alt="Eurotech logo" width="200" height="200">
+      </li>
+      <li class="p-inline-list__item">&nbsp;</li>
+      <li class="p-inline-list__item">
+        <img src="https://assets.ubuntu.com/v1/86293916-apollo-logo.svg" alt="Apollo logo" width="200" height="200">
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">We are proud to start this new technological partnership with Canonical. IoT and AI on the Edge are ecosystem plays. With the collaboration between Eurotech and Canonical, customers will have even more choices and more ready-to-use building blocks for their Edge Computing and Edge Inference projects</p>
+        <cite class="p-pull-quote__citation">Marco Carrer, CTO at Eurotech Group</cite>
+      </blockquote>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light u-no-margin--bottom">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h2>Let&rsquo;s work together</h2>
+      <p class="p-heading--four">Talk to us about using Ubuntu Core for your next project.</p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/internet-of-things/contact-us?product=automotive">
+          Get in touch today
+        </a>
+      </p>
+    </div>
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" class="u-hide--small" width="250" height="178" alt="">
+    </div>
+  </div>
+</section>
+      
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+{% endblock content %}

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -85,6 +85,7 @@
             <li class="p-list__item"><a href="/internet-of-things/robotics">Robots and drones with Ubuntu</a></li>
             <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
             <li class="p-list__item"><a href="/embedded">Embedded Linux with Ubuntu</a></li>
+            <li class="p-list__item"><a href="/automotive">Automotive with Ubuntu</a></li>
           </ul>
         </div>
         <!-- Support and services -->
@@ -171,6 +172,7 @@
           <li class="p-inline-list__item"><a href="/internet-of-things/digital-signage">Signage</a></li>
           <li class="p-inline-list__item"><a href="/internet-of-things/robotics">Robotics</a></li>
           <li class="p-inline-list__item"><a href="/internet-of-things/gateways">Gateways</a></li>
+          <li class="p-inline-list__item"><a href="/automotive">Automotive</a></li>
           <li class="p-inline-list__item"><a href="/desktop/organisations">Organisations</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

- Built the automotive page
- Added the link to the IoT navigation
- Added the link to the enterprise menu under IoT and sectors

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/automotive
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the copy matches the [copy doc](https://docs.google.com/document/d/1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw/edit#)
- See that the page matches [the design](https://user-images.githubusercontent.com/36884067/70165219-6efca280-16ba-11ea-8944-79389b6b491b.jpg)
- See that in the enterprise menu there is a link to automotive in the IoT section and the sectors section

## Issue / Card

Fixes #6174 
Fixes #2151
Fixes #2152