### PR TITLE
Updated the public cloud page

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -10,15 +10,6 @@
     <div class="col-8">
       <h1>Ubuntu on public clouds</h1>
       <p>Ubuntu is the world’s most popular cloud operating system across public clouds. Thanks to its security, versatility and policy of regular updates, Ubuntu is the leading cloud guest OS and the only free cloud operating system with the option of enterprise-grade commercial support. </p>
-
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Canonical guarantees the consistency, security and performance of Ubuntu on public clouds</li>
-        <li class="p-list__item is-ticked">Enterprise-grade commercial support is available</li>
-        <li class="p-list__item is-ticked">Twice as popular on the Amazon cloud as all other operating systems combined <a href="#fn1" id="r1">*</a></li>
-      </ul>
-      <p>
-        <a href="/support" class="p-button--positive">Get support</a>&emsp;<a class="p-button--neutral" href="/download/cloud">Start using Ubuntu today</a>
-      </p>
     </div>
   </div>
 </section>
@@ -62,7 +53,7 @@
       </p>
       
       <p>
-        <a class="p-link--external" href="https://assets.ubuntu.com/v1/537fb75d-Ubuntu_Pro_AWS_03.11.19.pdf">Get the Ubuntu Pro datasheet</a>
+        <a class="p-link--external" href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf">Get the Ubuntu Pro datasheet</a>
       </p>
 
       <p>
@@ -124,14 +115,6 @@
     <div class="col-4 u-hide--small u-vertically-center u-align--center">
       <img src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg" alt="" width="210" />
     </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <p id="fn1" class="note">
-      <a href="#r1">*</a> <a href="http://www.zdnet.com/article/ubuntu-linux-continues-to-rule-the-cloud/" class="p-link--external">zdnet.com</a>, 27 August 2015
-    </p>
   </div>
 </section>
 


### PR DESCRIPTION
Updated the public cloud page copy and changed the datasheet.

## Done

- Removed the bullet points from the top of the page
- Changed the datasheet to https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf
- Removed the section at the end of the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check https://ubuntu.com/public-cloud against the [copy doc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit?ts=5de57c60#) and accepting my suggestions if correct

## Issue / Card

Fixes #6225 

