### PR TITLE
Remove mention of landscape from Ubuntu Pro

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -71,9 +71,9 @@
         </li>
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title">Landscape included</h3>
+            <h3 class="p-matrix__title">The right Ubuntu for you</h3>
             <div class="p-matrix__desc">
-              <p>Landscape provides a complete solution for the patching, compliance reporting and lifecycle management of an Ubuntu cloud fleet via a web UI or API.</p>
+              <p>Canonical brings the three most popular Ubuntu Server distributions to choose from - 14.04 LTS, 16.04 LTS, and 18.04 LTS.</p>
             </div>
           </div>
         </li>


### PR DESCRIPTION
Removed mention of landscape from Ubuntu Pro from the matrix

## Done
Removed mention of landscape from Ubuntu Pro 3x3 table

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the demo with the [copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit#) and accept the changes that are correct.

## Issue / Card

Fixes #6227 


