### PR TITLE
Apply image template to public cloud page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test-python": "python3 -m unittest discover tests",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "sass-lint 'static/sass/**/*.scss' --verbose --no-exit --max-warnings=0 -i static/sass/prism.scss",
-    "test-links": "./entrypoint 0.0.0.0:${PORT} && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --no-warnings http://127.0.0.1:8000",
+    "test-links": "./entrypoint 0.0.0.0:${PORT} && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --ignore-url /server/docs --no-warnings http://127.0.0.1:8000",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
     "build-js": "webpack",
     "build": "yarn run build-css && yarn run build-js",

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -16,7 +16,7 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="u-fixed-width">
-    {% with title="A, selection of our certified public cloud partners", json_feed_url="https://partners.ubuntu.com/partners.json?programme__name=Certified%20Public%20Cloud&featured=true", feed_item_limit=10 %}{% include "shared/_partner-logos.html" %}{% endwith %}
+    {% with title="A selection of our certified public cloud partners", json_feed_url="https://partners.ubuntu.com/partners.json?programme__name=Certified%20Public%20Cloud&featured=true", feed_item_limit=10 %}{% include "shared/_partner-logos.html" %}{% endwith %}
     <p class="u-align--center"><a class="p-link--external" href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud ">View all certified public cloud partners</a></p>
   </div>
 </section>
@@ -71,13 +71,33 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h2 class="p-heading--three">Fast service deployment with&nbsp;Juju</h2>
-      <p class="u-hide--small u-align--center"><img src="https://assets.ubuntu.com/v1/162002c2-charms_juju.svg" alt="Grid of juju charm icons including wordpress, hadoop, django, MySQL, MongoDB and OpenStack" /></p>
+      <div class="u-hide--small u-align--center u-sv1">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/162002c2-charms_juju.svg",
+            alt="Grid of juju charm icons including wordpress, hadoop, django, MySQL, MongoDB and OpenStack",
+            height="208",
+            width="504",
+            hi_def=True,
+          ) | safe
+        }}
+      </div>
       <p>Juju is the fastest way to deploy and scale out your workloads on the leading public clouds. With Juju charm bundles, you can launch an entire cloud environment with one click, or just one command using the CLI. Use Juju to  deploy your entire application infrastructure, all in one.</p>
       <p><a class="p-link--external" href="https://jujucharms.com/">Learn more about Juju</a></p>
     </div>
     <div class="col-6 p-divider__block">
       <h2 class="p-heading--three">The best management and&nbsp;support</h2>
-      <p class="u-hide--small u-align--center"><img src="https://assets.ubuntu.com/v1/434e177d-cloud-landscape-chart.jpg" alt="Landscape managing 913 machines screenshot" width="371" /></p>
+      <div class="u-hide--small u-align--center u-sv1">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/434e177d-cloud-landscape-chart.jpg",
+            alt="Landscape managing 913 machines screenshot",
+            height="208",
+            width="371",
+            hi_def=True,
+          ) | safe
+        }}
+      </div>
       <p>The Ubuntu Advantage support service has flexible Ubuntu Virtual Guest options, designed for virtualised enterprise workloads on Ubuntu-certified public clouds. Thanks to Landscape, efficient management of all your Ubuntu instances is only a few clicks away. And with the Canonical Livepatch Service, you can apply critical kernel patches without rebooting.</p>
       <p><a href="/support">Find out all about support&nbsp;&rsaquo;</a></p>
     </div>
@@ -92,7 +112,15 @@
       <p><a href="/desktop/developers">Learn more about Ubuntu for developers&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-7 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/79439f53-Dell_XPS_Laptop_Front-Developer.png?w=1080" alt="" width="540" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/79439f53-Dell_XPS_Laptop_Front-Developer.png",
+          alt="",
+          height="272",
+          width="540",
+          hi_def=True,
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -113,7 +141,15 @@
     </div>
 
     <div class="col-4 u-hide--small u-vertically-center u-align--center">
-      <img src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg" alt="" width="210" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+          alt="",
+          height="125",
+          width="210",
+          hi_def=True,
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Fix typo in the partners logo heading
- Apply image template to thumbnail images

**Note:** The image template won't work with the partners logos because we don't know the dimensions of the images. See [this issue](https://github.com/canonical-web-and-design/canonicalwebteam.image-template/issues/38).

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images load for the following sections:
  - Fast service deployment with Juju
  - The best management and support
  - Developers' favourite
  - Ready to get started


## Issue / Card

Fixes #6221 
