### PR TITLE
Update image links for new raspberry pi image

### DIFF
--- a/templates/download/raspberry-pi.html
+++ b/templates/download/raspberry-pi.html
@@ -50,14 +50,14 @@
         <div class="p-stepped-list__content">
           <p>Download the Ubuntu Server image:</p>
           <p>
-            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-armhf+raspi3.img.xz">32-bit for Raspberry Pi 2, 3 and 4</a>
+            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/19.10.1/release/ubuntu-19.10.1-preinstalled-server-armhf+raspi3.img.xz">32-bit for Raspberry Pi 2, 3 and 4</a>
           </p>
           <p>
-            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.short_version }}-preinstalled-server-arm64+raspi3.img.xz">64-bit for Raspberry Pi 3 and 4</a>
+            <a class="p-button--neutral" href="http://cdimage.ubuntu.com/releases/19.10.1/release/ubuntu-19.10.1-preinstalled-server-arm64+raspi3.img.xz">64-bit for Raspberry Pi 3 and 4</a>
           </p>
 
           <p>
-            You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
+            You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/19.10.1/release/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/19.10.1/release/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.
           </p>
         </div>
       </li>


### PR DESCRIPTION
As requested by Lukasz Zemczak. This prepares for the imminent release of 19.10.1 of the Raspberry pi images.