### PR TITLE
Build masters takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
   {% include "takeovers/_1910_takeover.html" %}
   {% include "takeovers/_private-cloud-build-takeover.html" %}
   {% include "takeovers/_linux-security_takeover.html" %}
+  {% include "takeovers/_ubuntu-masters-takeover.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -3,7 +3,7 @@
     <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %} u-vertically-center">
       <div>
         <h1>
-          {{ title }}
+          {{ title | safe }}
         </h1>
         {% if subtitle %}<h4>
           {{ subtitle }}

--- a/templates/takeovers/_ubuntu-masters-takeover.html
+++ b/templates/takeovers/_ubuntu-masters-takeover.html
@@ -1,0 +1,15 @@
+{% with title="Ubuntu Masters: the&nbsp;masters&nbsp;speak",
+subtitle="Brendan Gregg, from Netflix, talks about Extended BPF and kernel-mode applications, the first change to how kernels are used in 50 years.",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
+image_style="width: 270px; height: 150px;",
+image_hide_small=true,
+equal_cols=true,
+primary_url="https://www.youtube.com/watch?v=7pmXdG8-7WU",
+primary_cta="Watch the keynote",
+primary_cta_class="",
+secondary_url="/masters-conference",
+secondary_cta="Read more about our Ubuntu Masters event"
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

Build masters takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the takeover with the heading "Ubuntu Masters: the masters speak"
- See that the takeover matches [the design](https://user-images.githubusercontent.com/36884067/70227054-d4e43b00-1749-11ea-9722-ae7c13f10eff.jpg)
- See that the copy matches [the brief](https://docs.google.com/document/d/1vbdQVEmoEzkh8j6dNYA0d1wtCnllOCHwCQ1GHlnhJhA/)


## Issue / Card

Fixes #6178 
