### PR TITLE
Build WSLConf engage page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -617,6 +617,8 @@ legal:
           hidden: True
         - title: Survey
           path: /legal/data-privacy/survey
+        - title: Events
+          path: /legal/data-privacy/events
           hidden: True
 
     - title: Trademarks

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1433,5 +1433,20 @@
       </div>
     </div><!-- 3rd -->
   </div>
+  <div class='row u-equal-height u-clearfix'>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--webinar">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          event
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h4>
+          <a href="/engage/wslconf">Register for WSLConf</a>
+        </h4>
+        <p class="u-no-padding--bottom u-hide--small">WSLConf is a community-organized event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.</p>
+      </div>
+    </div> <!-- 1st -->  
+  </div>
 </section>
 {% endblock content %}

--- a/templates/engage/wslconf.html
+++ b/templates/engage/wslconf.html
@@ -1,0 +1,105 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Register for WSLConf{% endblock %}
+{% block meta_description %}Join us for two days of community, workshops, and talks on Windows Subsystem for Linux.{% endblock %}
+{% block meta_image %}20fd85e8-Embedded+social+media+banner+2.jpg{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1X_sAqWQZZVj73I6aY-oILDN4d5FuYTZTXebv6JQoLjQ{% endblock %}
+
+{% block content %}
+
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      <img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="32" alt="Ubuntu">
+    </a>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-7 u-vertically-center">
+      <div>
+        <h1>Register for WSLConf</h1>
+        <h4>Join us for two days of community, workshops, and talks on Windows Subsystem for Linux.</h4>
+      </div>
+      
+      <noscript>
+        <p>
+          <a class="p-button--positive p-link--external" href="https://www.eventbrite.com/e/wslconf-tickets-83357202637" rel="noopener noreferrer" target="_blank">
+            Register on Eventbrite
+          </a>
+        </p>
+      </noscript>
+  
+      <!-- hidden by default so isn't displayed with JS disabled -->
+      <p class="u-hide" id="wslconf-button">
+        <button class="p-button--positive" id="eventbrite-widget-modal-trigger-83357202637" type="button">Sign up</button>
+      </p>
+      <script>
+        var wslconfBtn = document.getElementById("wslconf-button");
+        wslconfBtn.classList.remove("u-hide");
+      </script>
+
+      <script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
+  
+      <script>
+        // Button widget
+        window.EBWidgets.createWidget({
+          widgetType: 'checkout',
+          eventId: '83357202637',
+          modal: true,
+          modalTriggerElementId: 'eventbrite-widget-modal-trigger-83357202637',
+          iframeContainerId: 'eventbrite-widget-container-83357202637',
+          iframeContainerHeight: 425 // default
+        });
+
+        // Form widget
+        window.EBWidgets.createWidget({
+          widgetType: 'checkout',
+          eventId: '83357202637',
+          iframeContainerId: 'eventbrite-widget-container-83357202637',
+          iframeContainerHeight: 865
+        });
+      </script>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <p>WSLConf is a community-organised event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.</p>
+      <p>Hear from and interact with:</p>
+      <ul>
+        <li>Windows Subsystem for Linux team at Microsoft</li>
+        <li>Ubuntu on WSL team from Canonical</li>
+        <li>Patrick Wu, the creator of WSL Utilities</li>
+        <li>Carlos Ramirez and the team behind Pengwin, Pengwin Enterprise, and Fedora Remix for WSL</li>
+        <li>Simon Ferquel from the Docker team who created the new WSL2-powered Docker Desktop</li>
+      </ul>      
+      <p>Topics will include:</p>
+      <ul>
+        <li>The new Docker Desktop for Windows</li>
+        <li>microk8s on WSL2</li>
+        <li>Using WSL in IT administration and DevOps</li>
+        <li>Cross-platform C++ development with Visual Studio and WSL</li>
+        <li>WSL integration with CLion</li>
+        <li>The story behind Pengwin</li>
+      </ul>
+      <p>WSLConf was created by the founder of Pengwin, Hayden Barnes, and is sponsored by Canonical.</p>
+      <p>WSLconf is being held on the campus of Microsoft Headquarters.</p>
+      <p>March 10-11, 2020</p>
+      <p>
+        Microsoft Reactor<br>
+        Building 20<br>
+        Microsoft HQ<br>
+        3709 NE 39th Street<br>
+        Redmond, WA
+      </p>
+      <p>WSLConf will be free. Space is limited.</p>
+    </div>
+  </div>
+</section>
+
+<!-- the contents of this get shown in a modal when the sign up button is clicked -->
+<div class="u-hide" id="eventbrite-widget-container-83357202637"></div>
+
+{% endblock %}

--- a/templates/legal/data-privacy/events.md
+++ b/templates/legal/data-privacy/events.md
@@ -1,0 +1,128 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Privacy Notice – Events"
+  description: This Privacy Notice tells you about the information collected from you when you participate in the Canonical event.
+  copydoc: https://docs.google.com/document/d/1-2bcVP8SVKnfe-qdCrqWM0rCRk8A0JKo_dcKR8jJ2wY
+---
+
+<h4 class="p-muted-heading">Version - December 2019</h4>
+<hr style="margin-bottom: 2rem;" />
+
+# Privacy Notice – Events
+
+This Privacy Notice tells you about the information collected from you when you participate in an event and agree to your personal data being stored by Canonical. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
+
+## Who are we?
+
+We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of “Legal”.
+
+We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
+
+## What personal data do we collect?
+
+When you participate in an event, we ask you for your name, address, contact telephone number, email address and we may collect audio and video recordings from you. Such audio and video recordings are held on an anonymous basis. We may retain your contact details to follow up with you on the event, to provide you with information about Canonical’s products and services and to participate in future events.
+
+## Why do we collect this information?
+
+Your information may be used by us to follow up with you on the event, to provide you with information about Canonical’s products and services and to participate in future events.
+
+## What do we do with your information?
+
+Your information is stored in our database and may be processed outside of the European Economic Area. 
+
+Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of you personal information. If you would like further information please contact us (see “Your right to complain” below). 
+
+Your data may be shared with third parties as reasonably required for Canonical to process and store your data in accordance with this privacy notice or respond to your request.
+
+## Our legal basis to use your Personal information
+
+*Our legitimate business interests*
+
+Our legal basis for using your personal information is that it is necessary for our legitimate interest in providing the event for your participation in accordance with the terms and conditions between us and the business you are associated with.
+
+By participating in an event, our legal basis for processing your personal information is that it is necessary for our legitimate interests in conducting our business and meeting the requirements of you, our current and prospective customers.
+
+We may contact you from time to time with information about products and services that we offer (see [Marketing Communications to Businesses](/legal/data-privacy/partner-portal#mkt-comms)). Our legal basis for using your personal information to contact you is that it is necessary for our legitimate interest in keeping you informed of the products and services that we offer. You can opt out of marketing communications as set out below.
+
+*Your consent*
+
+If you participate in an event, you will have the option to provide your consent to us sending you information about the products and services that we offer (see [Email Marketing Communications](/legal/data-privacy/partner-portal#mkt-comms)). You can withdraw your consent at any time.
+
+## How long do we keep your information for?
+
+We keep your information for as long as you continue to consent to participate in the event and thereafter for so long as reasonably required in accordance with our record retention policy.
+
+## Your rights over your information
+
+You have a number of important rights under data protection laws. In summary, those include rights to:
+
+- fair processing of information and transparency over how we use your personal information;
+- access to your personal information and to certain other supplementary information that this Privacy Notice is already designed to address;
+- require us to correct any mistakes in your information which we hold;
+- require the erasure of personal information concerning you in certain situations;
+- receive the personal information concerning you which you have provided to us, in a structured, commonly used and machine-readable format and have the right to transmit that data to a third party in certain situations;
+- object at any time to processing of personal information concerning you for direct marketing;
+- object to decisions being taken by automated means which produce legal effects concerning you or similarly significantly affect you;
+- object in certain other situations to our continued processing of your personal information;
+- otherwise restrict our processing of your personal information in certain circumstances;
+- claim compensation for damages caused by out breach of any data protection laws.
+
+For further information on each of those rights, including the circumstances in which they apply, see the Guidance from the UK Information Commissioner’s Office (ICO) on individuals rights.
+
+If you would like to exercise any of those rights, please:
+
+- email, call or write to us, please see “Your right to complain” section below;
+- let us have enough information to identify you;
+- let us have proof of your identity and address (a copy of your driving licence or passport and a recent utility or credit card bill); and
+- let us know the information to which your request relates.
+
+If you would like to unsubscribe from any email please see below.
+
+By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.
+
+You can also ask us to give you a copy of the information and to stop using your information for a period of time if you believe we are not doing so lawfully.
+
+To submit a request by email, post or telephone, please use the contact information provided above.
+
+## Email marketing communications
+
+Canonical offers a free email newsletter subscription service to keep you informed of our products and services. You may receive these marketing communications from us. We incorporate a tracking system in our email marketing communications which allows us to monitor whether the email has been opened and which links are the most popular. This allows us to tailor and refine our service to ensure that the emails you receive are relevant to your interests.
+
+Where you have consented to receiving email marketing material from us or are currently receiving material relating to similar products or services, you may at any time ask us to cease sending you such material by (i) clicking the unsubscribe button at the end of the email, (ii) reply to the email with “STOP”,  (iii) sending an email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com), or (iv) navigating to your subscription centre page (you will need to login if you have not already done so) and click the 'unsubscribe' link at the foot of the page as appropriate.
+
+## Keeping your personal information secure
+
+We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorised way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorised manner and are subject to a duty of confidentiality.
+
+We also have procedures in place to deal with any suspected data security breach. We will notify you and any applicable regulator of a suspected data breach where we are legally required to do so.
+
+## Changes to this Privacy Notice
+
+This Privacy Notice will be reviewed from time to time. If we decide to change this Privacy Notice we will post the changes here. However, if we intend to make material changes to the way we use your personal information we will notify you before doing so. Any personal information held will be governed by our most current notice.
+
+## Your right to complain
+
+We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
+
+<div style="margin:2rem;">
+Legal, Canonical<br />
+5th Floor, Blue Fin Building<br />
+110 Southwark Street<br />
+London, SE1 0SU<br />
+United Kingdom
+</div>
+
+Alternatively, you can use the relevant contact us form.
+
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at [ico.org.uk/make-a-complaint](https://ico.org.uk/make-a-complaint/) or write to them at:
+
+<div style="margin:2rem;">
+Information Commissioner's Office<br />
+Wycliffe House<br />
+Water Lane<br />
+Wilmslow<br />
+Cheshire<br />
+SK9 5AF<br />
+United Kingdom
+</div>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -36,6 +36,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/partner-portal">Partner Portal privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/esxi">ESXi privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/survey">Survey privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/events">Events privacy notice&nbsp;&rsquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">


### PR DESCRIPTION
## Done

- Built WSLConf enage page
- Built events data privacy page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/wslconf
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page matches the [copy doc]
(https://docs.google.com/document/d/1X_sAqWQZZVj73I6aY-oILDN4d5FuYTZTXebv6JQoLjQ)
- Click the signup button and see that there is a modal that allows you to register for the conference
- Disable JS and see that there is a "Register on eventbrite" button which takes you to the eventbrite page in another tab
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/data-privacy/events
- Check that the page matches the [copy doc](https://docs.google.com/document/d/1-2bcVP8SVKnfe-qdCrqWM0rCRk8A0JKo_dcKR8jJ2wY)


## Issue / Card

Fixes #2039