### PR TITLE
Add contract details to the expanding name

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -416,6 +416,7 @@ summary {
   .u-toggle {
     background: transparent;
     border: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -76,11 +76,11 @@
           {% for contract in enterprise_contracts %}
           <tr class="p-table__row">
             <td>
-              <button class="u-toggle" aria-controls="#expanded-details-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+              <button class="u-toggle u-no-padding--left" aria-controls="#expanded-details-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
                   {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
             </td>
-            <td style="text-transform: capitalize">{{ contract['supportLevel'] }}</td>
+            <td style="text-transform: capitalize"><span style="padding-top:.35rem;">{{ contract['supportLevel'] }}</span></td>
             <td class="u-align--center {% if loop.index == 1 %}p-table--open{% endif %}">
               <button class="u-toggle" aria-controls="#expanded-row-token-{{ loop.index }}" aria-expanded="{% if loop.index == 1 %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
                 {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if loop.index == 1 %}u-rotate{% endif %}">Open</i>
@@ -93,7 +93,7 @@
                 <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
-              N/A
+              <span style="padding-top:.35rem;">N/A</span>
               {% endif %}
             </td>
             <td class="u-align--center">
@@ -102,7 +102,7 @@
                 <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
-              N/A
+              <span style="padding-top:.35rem;">N/A</span>
               {% endif %}
             </td>
             <td class="u-align--center">
@@ -111,7 +111,7 @@
                 <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
-              N/A
+              <span style="padding-top:.35rem;">N/A</span>
               {% endif %}
             </td>
             <td class="u-align--center">
@@ -120,17 +120,17 @@
                 <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
-              N/A
+              <span style="padding-top:.35rem;">N/A</span>
               {% endif %}
             </td>
 
             <td id="expanded-details-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
               <div class="row">
                 <div class="col-12 u-align--center">
-                  <ul class="p-list u-no-margin--bottom">
-                    <li class="p-list__item">Created: <strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></li>
-                    <li class="p-list__item">Effective from: <strong>{{ contract['contractInfo']['effectiveFromFormatted'] }}</strong></li>
-                  </ul>
+                  <div class="col-12 u-align--center">
+                    Created on: <code>{{ contract['contractInfo']['createdAtFormatted'] }}</code><br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    Effective from: <code>{{ contract['contractInfo']['effectiveFromFormatted'] }}</code>
+                  </div>
                 </div>
               </div>
             </td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -128,8 +128,8 @@
               <div class="row">
                 <div class="col-12 u-align--center">
                   <div class="col-12 u-align--center">
-                    Created on: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong><br/>
-                    Effective from: &nbsp;&nbsp;<strong>{{ contract['contractInfo']['effectiveFromFormatted'] }}</strong>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Created on: &nbsp;<strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong><br/>
+                    Effective from: &nbsp;<strong>{{ contract['contractInfo']['effectiveFromFormatted'] }}</strong>
                   </div>
                 </div>
               </div>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -59,7 +59,7 @@
       <table class="p-table-expanding p-table--advantage">
         <thead>
           <tr class="p-table__row">
-            <th>Name</th>
+            <th>{{ enterprise_contracts[0]['accountInfo']['name'] }}</th>
             <th>UA</th>
             <th class="u-align--center">Attached</th>
             <th class="u-align--center">ESM</th>
@@ -75,18 +75,22 @@
         <tbody>
           {% for contract in enterprise_contracts %}
           <tr class="p-table__row">
-            <td>{{ contract['contractInfo']['name'] }}</td>
+            <td>
+              <button class="u-toggle" aria-controls="#expanded-details-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                  {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
+              </button>
+            </td>
             <td style="text-transform: capitalize">{{ contract['supportLevel'] }}</td>
             <td class="u-align--center {% if loop.index == 1 %}p-table--open{% endif %}">
               <button class="u-toggle" aria-controls="#expanded-row-token-{{ loop.index }}" aria-expanded="{% if loop.index == 1 %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
-                {{ contract['machineCount'] }} <i class="p-icon--contextual-menu {% if loop.index == 1 %}u-rotate{% endif %}">Open</i>
+                {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if loop.index == 1 %}u-rotate{% endif %}">Open</i>
               </button>
             </td>
 
             <td class="u-align--center">
               {% if contract['entitlements']['esm'] == True %}
               <button class="u-toggle" aria-controls="#expanded-row-esm-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <i class="p-icon--success"></i> <i class="p-icon--contextual-menu">Open</i>
+                <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
               N/A
@@ -95,7 +99,7 @@
             <td class="u-align--center">
               {% if contract['entitlements']['livepatch'] == True %}
               <button class="u-toggle" aria-controls="#expanded-row-livepatch-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <i class="p-icon--success"></i> <i class="p-icon--contextual-menu">Open</i>
+                <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
               N/A
@@ -104,7 +108,7 @@
             <td class="u-align--center">
               {% if contract['entitlements']['fips']  == True %}
               <button class="u-toggle" aria-controls="#expanded-row-fips-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <i class="p-icon--success"></i> <i class="p-icon--contextual-menu">Open</i>
+                <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
               N/A
@@ -113,11 +117,22 @@
             <td class="u-align--center">
               {% if contract['entitlements']['cc-eal']  == True %}
               <button class="u-toggle" aria-controls="#expanded-row-cc-eal-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <i class="p-icon--success"></i> <i class="p-icon--contextual-menu">Open</i>
+                <i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i>
               </button>
               {% else %}
               N/A
               {% endif %}
+            </td>
+
+            <td id="expanded-details-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+              <div class="row">
+                <div class="col-12 u-align--center">
+                  <ul class="p-list u-no-margin--bottom">
+                    <li class="p-list__item">Created: <strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></li>
+                    <li class="p-list__item">Effective from: <strong>{{ contract['contractInfo']['effectiveFromFormatted'] }}</strong></li>
+                  </ul>
+                </div>
+              </div>
             </td>
 
             <td id="expanded-row-token-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if loop.index == 1 %}false{% else %}true{% endif %}">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -127,10 +127,14 @@
             <td id="expanded-details-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
               <div class="row">
                 <div class="col-12 u-align--center">
-                  <div class="col-12 u-align--center">
-                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Created on: &nbsp;<strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong><br/>
-                    Effective from: &nbsp;<strong>{{ contract['contractInfo']['effectiveFromFormatted'] }}</strong>
-                  </div>
+                  <dl>
+                    <dt style="display: inline-block; width: 130px; text-align: right;">Created on:</dt>
+                    <dd style="display: inline-block;">{{ contract['contractInfo']['createdAtFormatted'] }}</dd>
+                  </dl>
+                  <dl>
+                    <dt style="display: inline-block; width: 130px; text-align: right;">Effective from:</dt>
+                    <dd style="display: inline-block;">{{ contract['contractInfo']['effectiveFromFormatted'] }}</dd>
+                  </dl>
                 </div>
               </div>
             </td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -128,8 +128,8 @@
               <div class="row">
                 <div class="col-12 u-align--center">
                   <div class="col-12 u-align--center">
-                    Created on: <code>{{ contract['contractInfo']['createdAtFormatted'] }}</code><br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                    Effective from: <code>{{ contract['contractInfo']['effectiveFromFormatted'] }}</code>
+                    Created on: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong><br/>
+                    Effective from: &nbsp;&nbsp;<strong>{{ contract['contractInfo']['effectiveFromFormatted'] }}</strong>
                   </div>
                 </div>
               </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import datetime
 
 # Packages
 import feedparser
@@ -147,6 +148,22 @@ def advantage():
                                     "affordances"
                                 ]["supportLevel"]
                         contract["entitlements"] = entitlements
+                        contract["contractInfo"][
+                            "createdAtFormatted"
+                        ] = datetime.datetime.strptime(
+                            contract["contractInfo"]["createdAt"],
+                            "%Y-%m-%dT%H:%M:%S.%fZ",
+                        ).strftime(
+                            "%d %B %Y"
+                        )
+                        contract["contractInfo"][
+                            "effectiveFromFormatted"
+                        ] = datetime.datetime.strptime(
+                            contract["contractInfo"]["effectiveFrom"],
+                            "%Y-%m-%dT%H:%M:%S.%fZ",
+                        ).strftime(
+                            "%d %B %Y"
+                        )
                         enterprise_contracts.append(contract)
         except HTTPError as http_error:
             # We got an unauthorized request, so we likely


### PR DESCRIPTION
## Done
- Added expandable information to the contract name
- Display the account name as a table header.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- It's unlikely you have enterprise contracts to test
- Check the code and screenshot is ok

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6155

## Screenshots
![Screenshot_2019-12-06 Ubuntu Advantage for Infrastructure Ubuntu](https://user-images.githubusercontent.com/1413534/70343543-786b4380-184f-11ea-8375-4bf599233e67.png)

