### PR TITLE
Vmware engage update

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -137,9 +137,11 @@
       </form>
       <!-- /MARKETO FORM -->
     </div>
-    {% else %}
+    {% endif %}
   </div>
 </section>
+
+{% if webinar_code %}
 <!-- webinar -->
 <section class="p-strip is-shallow" id="register-section">
   <div class="row" id="register-section">
@@ -147,7 +149,6 @@
   </div>
 </section>
 {% endif %}
-  </div>
-</section>
+
 {% endblock %}
 {% endblock %}

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -46,6 +46,9 @@
             {{ header_cta }}
           </a>
         </p>{% endif %}
+        {% if header_supplemental %}
+          {{ header_supplemental | safe }}
+        {% endif %}
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1104,7 +1104,6 @@
           OpenStack?</p>
       </div>
     </div>
-
   </div>
   <div class='row u-equal-height u-clearfix'>
     <div class='col-4 blog-p-card--post'>

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -11,20 +11,21 @@ context:
      header_url:
      header_cta:
      header_class: p-engage-banner--dark
-     header_supplemental: '<br /><p><a href="#" class="p-button--positive">Download the whitepaper</a> <a href="#register-section" class="p-button--neutral">Watch the webinar</a></p>'
+     header_supplemental: '<br /><p><a href="#" class="p-button--positive">Download the whitepaper</a> <a href="#webinar" class="p-button--neutral">Watch the webinar</a></p>'
      header_lang: en
-     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
-     form_include:
-     form_id:
+     webinar_code: '<div id="webinar" class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     form_include: en
+     form_id: 3470
      form_return_url:
 ---
 
-Over the last decade, organizations have started virtualizing their IT workloads and migrating from legacy monolithic infrastructure to cloud environments. Many choose VMware as a provider for their virtualised infrastructure. However, because of the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other platforms such as OpenStack. In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack. In addition, we'll provide a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack. This webinar also provides a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis.
-
 Due to the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other open-source platforms such as OpenStack.
  
-This whitepaper, compares VMware’s proprietary virtualisation offerings with an open-source approach, Canonical’s Charmed OpenStack, presents the economic and efficiency benefits of taking an open-source approach provides a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack. 
+This whitepaper:
+- Compares VMware’s proprietary virtualisation offerings with an open-source approach, Canonical’s Charmed OpenStack.
+- Presents the economic and efficiency benefits of taking an open-source approach.
+- Provides a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack.
  
-Also, watch the ‘From VMware to Charmed OpenStack’ webinar for a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using the Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis®. 
+Also, watch the ‘From VMware to Charmed OpenStack’ <a href="#webinar">webinar</a> for a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using the Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis®. 
  
 Coriolis is the simplest way to migrate Windows or Linux virtual machines alongside their associated storage and networking configurations across multiple cloud platforms. Among the advantages of Coriolis are it’s scalable architecture, agentless design, integrated scheduler and REST API allowing automated operations.

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -16,7 +16,7 @@ context:
      webinar_code: '<div id="webinar" class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include: en
      form_id: 3470
-     form_return_url:
+     form_return_url: "https://pages.ubuntu.com/VMwaretoOpenstack-TY.html"
 ---
 
 Due to the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other open-source platforms such as OpenStack.

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -8,10 +8,10 @@ context:
      header_title: "From VMware to Charmed&nbsp;OpenStack"
      header_subtitle: "Reduce costs and increase the efficiency of your infrastructure with open source adoption"
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
-     header_url: '#'
-     header_cta: Download the whitepaper
+     header_url:
+     header_cta:
      header_class: p-engage-banner--dark
-     header_supplemental: '<p><a href="#" class="p-button--positive u-hide--small">Download the whitepaper</a> <a href="#register-section" class="p-button--neutral">Watch the webinar</a></p>'
+     header_supplemental: '<br /><p><a href="#" class="p-button--positive">Download the whitepaper</a> <a href="#register-section" class="p-button--neutral">Watch the webinar</a></p>'
      header_lang: en
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include:

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -11,7 +11,7 @@ context:
      header_url: '#'
      header_cta: Download the whitepaper
      header_class: p-engage-banner--dark
-     header_supplemental: '<br class="u-hide--small" /><p class="u-hide--small"><a href="#" class="p-button--positive">Download the whitepaper</a> <a href="#register-section" class="p-button--positive">Watch the webinar</a></p>'
+     header_supplemental: '<p><a href="#" class="p-button--positive u-hide--small">Download the whitepaper</a> <a href="#register-section" class="p-button--neutral">Watch the webinar</a></p>'
      header_lang: en
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include:

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -6,11 +6,12 @@ context:
      meta_image: https://assets.ubuntu.com/v1/27fed536-vmware-to-charmed-openstack-social.jpg
      meta_copydoc: https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit
      header_title: "From VMware to Charmed&nbsp;OpenStack"
-     header_subtitle:
+     header_subtitle: "Reduce costs and increase the efficiency of your infrastructure with open source adoption"
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
-     header_url: '#register-section'
-     header_cta: Register for the webinar
+     header_url: '#'
+     header_cta: Download the whitepaper
      header_class: p-engage-banner--dark
+     header_supplemental: '<br class="u-hide--small" /><p class="u-hide--small"><a href="#" class="p-button--positive">Download the whitepaper</a> <a href="#register-section" class="p-button--positive">Watch the webinar</a></p>'
      header_lang: en
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include:
@@ -18,14 +19,12 @@ context:
      form_return_url:
 ---
 
-Over the last decade, organisations have started virtualising their IT workloads and migrating from legacy monolithic infrastructure to cloud environments. Many choose VMware as a provider for their virtualised infrastructure. However, because of the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other platforms such as OpenStack.
+Over the last decade, organizations have started virtualizing their IT workloads and migrating from legacy monolithic infrastructure to cloud environments. Many choose VMware as a provider for their virtualised infrastructure. However, because of the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other platforms such as OpenStack. In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack. In addition, we'll provide a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack. This webinar also provides a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis.
+
+Due to the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other open-source platforms such as OpenStack.
  
-In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack. In addition, we'll provide a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack. 
+This whitepaper, compares VMware’s proprietary virtualisation offerings with an open-source approach, Canonical’s Charmed OpenStack, presents the economic and efficiency benefits of taking an open-source approach provides a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack. 
  
-This webinar also provides a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using the Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis®. 
+Also, watch the ‘From VMware to Charmed OpenStack’ webinar for a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using the Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis®. 
  
 Coriolis is the simplest way to migrate Windows or Linux virtual machines alongside their associated storage and networking configurations across multiple cloud platforms. Among the advantages of Coriolis are it’s scalable architecture, agentless design, integrated scheduler and REST API allowing automated operations.
-
-<div class="u-align--center">
-<img src="https://assets.ubuntu.com/v1/ac8bdd57-CBSL-Logo-Web-Dark.png?w=300" width="300px"/>
-</div>

--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -11,7 +11,7 @@ context:
      header_url:
      header_cta:
      header_class: p-engage-banner--dark
-     header_supplemental: '<br /><p><a href="#" class="p-button--positive">Download the whitepaper</a> <a href="#webinar" class="p-button--neutral">Watch the webinar</a></p>'
+     header_supplemental: '<br /><p><a href="#register-section" class="p-button--positive">Download the whitepaper</a> <a href="#webinar" class="p-button--neutral">Watch the webinar</a></p>'
      header_lang: en
      webinar_code: '<div id="webinar" class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 348935, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include: en
@@ -22,10 +22,13 @@ context:
 Due to the costs associated with VMware licencing, support and professional services, many are not able to meet their primary goal - significantly reduced TCO. In search of alternative solutions, organisations have recently started exploring other open-source platforms such as OpenStack.
  
 This whitepaper:
-- Compares VMware’s proprietary virtualisation offerings with an open-source approach, Canonical’s Charmed OpenStack.
-- Presents the economic and efficiency benefits of taking an open-source approach.
-- Provides a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack.
- 
+
+<ul class="p-list">
+     <li class="p-list__item is-ticked">Compares VMware’s proprietary virtualisation offerings with an open-source approach, Canonical’s Charmed OpenStack.</li>
+     <li class="p-list__item is-ticked">Presents the economic and efficiency benefits of taking an open-source approach.</li>
+     <li class="p-list__item is-ticked">Provides a detailed cost analysis highlighting the savings an organisation can make by migrating from VMware to Charmed OpenStack.</li>
+</ul>
+
 Also, watch the ‘From VMware to Charmed OpenStack’ <a href="#webinar">webinar</a> for a demonstration showing how to migrate an IT workload from VMware to Charmed OpenStack using the Cloud Migration as a Service tool from Cloudbase Solutions - Coriolis®. 
  
 Coriolis is the simplest way to migrate Windows or Linux virtual machines alongside their associated storage and networking configurations across multiple cloud platforms. Among the advantages of Coriolis are it’s scalable architecture, agentless design, integrated scheduler and REST API allowing automated operations.

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
   {% include "takeovers/_private-cloud-build-takeover.html" %}
   {% include "takeovers/_linux-security_takeover.html" %}
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
+  {% include "takeovers/_vmware-to-charmed-openstack.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -81,8 +81,6 @@
 {% include "takeovers/_data-pipelines-kubeflow.html" %}
 {% include "takeovers/_developing-android-on-ubuntu.html" %}
 {% include "takeovers/_enterprise-snap-management.html" %}
-<p>4 Sept 2019</p>
-{% include "takeovers/_vmware-to-charmed-openstack.html" %}
 <p>6 Sept 2019</p>
 {% include "takeovers/_buy-ubuntu-advantage.html" %}
 <p>11 Sept 2019</p>
@@ -93,4 +91,6 @@
 {% include "takeovers/_1910_takeover.html" %}
 <p>20 Nov 2019</p>
 {% include "takeovers/_linux-security_takeover.html" %}
+<p>9 Dec 2019</p>
+{% include "takeovers/_vmware-to-charmed-openstack.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Updated /engage/vmware-to-charmed-openstack to match [copy doc](https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the VMWare to Charmed Openstack takeover, click the CTA, see that the page matches the [copy doc](https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit#), and that both CTAs work


## Issue / Card

Fixes #6090 
