### PR TITLE
Fix the button padding in the footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -84,7 +84,7 @@
         <nav>
           <ul class="p-inline-list">
             <li class="u-hide--small p-inline-list__item">
-              <a class="p-button--neutral" href="/contact-us"><small>Contact us</small></a>
+              <a class="p-button--neutral" href="/contact-us"><small class="u-no-margin--bottom u-sv1">Contact us</small></a>
             </li>
             <li class="u-hide--medium u-hide--large p-inline-list__item">
               <a class="p-link--soft" href="/contact-us"><small>Contact us</small></a>


### PR DESCRIPTION
## Done
Fix the button padding in the footer

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll to the footer and see the contact us button has the same padding

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6245

## Screenshots
![Screenshot_2019-12-09 The leading operating system for PCs, IoT devices, servers and the cloud Ubuntu](https://user-images.githubusercontent.com/1413534/70452214-a5f9fc00-1a9e-11ea-832d-ccdda7b1e722.png)

