### PR TITLE
update /automotive copy doc link

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Commercial Linux for the automotive sector{% endblock %}
 {% block meta_description %}Canonical is introducing Ubuntu, the most popular commercial-grade and open-source Linux distribution, to the  automotive sector. Ubuntu will accelerate automotive OEMs’ efforts to deliver connected  and autonomous vehicles.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1NvYOhOJzdY5ypifTPs73vH5Nb7rFABRWMzjXyDUQt_U/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw/edit{% endblock meta_copydoc %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

- updated copy doc meta url to correct one

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/automotive
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- using the copy doc [browser extension](https://github.com/canonical-web-and-design/ubuntu-copy-docs), see that the link to the copy doc is correct


## Issue / Card

Fixes #6256 
