### PR TITLE
add header illustration

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -19,8 +19,8 @@
         image(
           url="https://assets.ubuntu.com/v1/580f3ae7-automotive.svg",
           alt="",
-          width="240",
-          height="240",
+          width="320",
+          height="250",
           hi_def=True,
         ) | safe
       }}

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -14,6 +14,17 @@
       <p>Tell us about your moonshot.</p>
       <p><a href="/internet-of-things/contact-us?product=automotive" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/580f3ae7-automotive.svg",
+          alt="",
+          width="240",
+          height="240",
+          hi_def=True,
+        ) | safe
+      }}
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- added illustration per [copy doc](https://docs.google.com/document/d/1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/automotive
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that the header now includes the illustration shown in the [copy doc](https://docs.google.com/document/d/1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw/edit#)


## Issue / Card

Fixes #6257 
