### PR TITLE
Add tutorials module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
 canonicalwebteam.image-template==1.0.0
-canonicalwebteam.discourse-docs==0.6.4
+canonicalwebteam.discourse-docs==0.6.5
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -143,3 +143,19 @@ server_docs = DiscourseDocs(
 )
 
 server_docs.init_app(app)
+
+url_prefix = "/tutorials"
+tutorials_docs_parser = DocParser(
+    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
+    index_topic_id=13611,
+    url_prefix=url_prefix,
+)
+tutorials_docs = DiscourseDocs(
+    parser=tutorials_docs_parser,
+    category_id=34,
+    document_template="/docs/document.html",
+    url_prefix=url_prefix,
+    blueprint_name="tutorials",
+)
+
+tutorials_docs.init_app(app)


### PR DESCRIPTION
## Done

Add tutorials endpoints

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- http://0.0.0.0:8001/tutorials
- http://0.0.0.0:8001/tutorials/tutorial-install-ubuntu-desktop
