### PR TITLE
Remove the matrix image override

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -269,11 +269,6 @@ abbr[title] {
   margin-bottom: 0;
 }
 
-.p-matrix__img[src*="svg"] {
-  height: auto !important;
-  width: 100% !important;
-}
-
 // Override for wordpress use of <figure>
 .blog-article figure {
   @extend %max-width--p;


### PR DESCRIPTION
## Done
Remove the override which is making images far to large.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/flavours and http://0.0.0.0:8001/desktop/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that the matrix images look better then the live versions of the site.
