### PR TITLE
add networking as a product to /internet-of-things contact us page

### DIFF
--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -59,7 +59,7 @@
 
 {% with h1="Contact us about networking",
   intro_text="If you would like to know more about Ubuntu for networking, please fill in your details below and a member of our team will get in touch.",
-  formid="",
+  formid="3484",
   lpId="",
   returnURL="http://ubuntu.com/internet-of-things/thank-you?product=networking" %}
   {% include "shared/_client-contact-us-form.html" %}

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -55,6 +55,16 @@
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
+    {% elif product == 'networking' %}
+
+{% with h1="Contact us about networking",
+  intro_text="If you would like to know more about Ubuntu for networking, please fill in your details below and a member of our team will get in touch.",
+  formid="",
+  lpId="",
+  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=networking" %}
+  {% include "shared/_client-contact-us-form.html" %}
+{% endwith %}
+
   {% else %}
 
 {% with h1="Contact us",

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -16,6 +16,9 @@
 {% elif product == 'automotive' %}
   {% with thanks_context="your interest in Ubuntu for your automotive project", thanks_message="A member of our team will follow up with you shortly." %}{% include "shared/_thank_you.html" %}{% endwith %}
 
+{% elif product == 'networking' %}
+  {% with thanks_context="your interest in Ubuntu for your networking project", thanks_message="A member of our team will follow up with you shortly." %}{% include "shared/_thank_you.html" %}{% endwith %}
+
 {% else %}
   {% with thanks_context="your interest in Ubuntu for the Internet of Things", thanks_message="A member of our team will follow up with you shortly. In the meantime, explore <a href='http://snapcraft.io' class='p-link--external'>snapcraft.io</a>, where vendors and the open source community collaborate to deliver great software, securely, to a wide range of devices and cloud." %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
## Done

- added a networking specific contact us & thank you page to /internet-of-things/contact-us

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/contact-us?product=networking
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page has copy referring specifically to networking
- Visit /internet-of-things/thank-you?product=networking
- See that the page has copy referring specifically to networking

## Issue / Card

Fixes #6262 
