### PR TITLE
Cyberdyne engage

### DIFF
--- a/templates/engage/cyberdyne.md
+++ b/templates/engage/cyberdyne.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
+  meta_description: "Cyberdyne unlocks the ability to seamlessly roll out software updates to robots in the field by switching to snaps"
+  meta_image: 
+  meta_copydoc: "https://docs.google.com/document/d/17JI-RzetZYq5GZF9COAuh-uHG2yHI2pGy25ePdfA9Qk/edit"
+  header_title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
+  header_subtitle: 
+  header_image:
+  header_url: '#register-section'
+  header_cta: Register for the webinar
+  header_class: p-engage-banner--grad
+  header_lang: en
+  form_include: en
+  form_id: 3458
+  form_return_url:
+---
+
+As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo&rsquo;s two main airports. Leveraging artificial intelligence, Cyberdyne&rsquo;s robots are operating alongside human employees to safely and efficiently clean commercial locations.
+
+Despite being advanced in their roll out of robots for such purposes, Cyberdyne faced the challenge of updating the devices once out in the field &mdash; particularly considering their lifespan is expected to be up to five years. Sending engineers out to individual sites or recalling the robots is not a sustainable option or economical as their customer base scales.
+
+Cyberdyne adopted ROS (Robotic Operating System) based on Ubuntu, snaps and the brand store to overcome this challenge and eliminate the need for manual intervention which is delivering advantages to both them and their customers.
+
+Read the case study to learn more, including:
+
+- How OPEX costs and engineering overheads have been reduced through the use of snaps and the brand store
+- How Cyberdyne utilised snap deltas to reduce bandwidth requirements by 95%
+- The time to market improvements and ability to release news features

--- a/templates/engage/cyberdyne.md
+++ b/templates/engage/cyberdyne.md
@@ -3,7 +3,7 @@ wrapper_template: "engage/_base_engage_markdown.html"
 context:
   title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
   meta_description: "Cyberdyne unlocks the ability to seamlessly roll out software updates to robots in the field by switching to snaps"
-  meta_image: 
+  meta_image: "https://assets.ubuntu.com/v1/3bca057e-Meta+data+img.jpg"
   meta_copydoc: "https://docs.google.com/document/d/17JI-RzetZYq5GZF9COAuh-uHG2yHI2pGy25ePdfA9Qk/edit"
   header_title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
   header_subtitle: 

--- a/templates/engage/cyberdyne.md
+++ b/templates/engage/cyberdyne.md
@@ -7,14 +7,14 @@ context:
   meta_copydoc: "https://docs.google.com/document/d/17JI-RzetZYq5GZF9COAuh-uHG2yHI2pGy25ePdfA9Qk/edit"
   header_title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
   header_subtitle: 
-  header_image:
+  header_image: https://assets.ubuntu.com/v1/470ca6c0-logo_cyberdyne.png
   header_url: '#register-section'
   header_cta: Register for the webinar
-  header_class: p-engage-banner--grad
+  header_class: p-engage-banner--dark
   header_lang: en
   form_include: en
   form_id: 3458
-  form_return_url:
+  form_return_url: "https://pages.ubuntu.com/CS_Cyberdyne-TY.html"
 ---
 
 As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo&rsquo;s two main airports. Leveraging artificial intelligence, Cyberdyne&rsquo;s robots are operating alongside human employees to safely and efficiently clean commercial locations.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1446,6 +1446,19 @@
         <p class="u-no-padding--bottom u-hide--small">WSLConf is a community-organized event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.</p>
       </div>
     </div> <!-- 1st -->  
+    <div class='col-4 blog-p-card--post'>
+      <header class='blog-p-card__header--case-study'>
+        <h5 class='p-muted-heading u-no-margin--bottom'>
+          case study
+        </h5>
+      </header>
+      <div class='blog-p-card__content'>
+        <h4>
+          <a href='/engage/cyberdyne'>Cyberdyne keeps cleaning robots up-to-date in the field with snaps</a>
+        </h4>
+        <p class='u-no-padding--bottom u-hide--small'>As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo’s two main airports.</p>
+      </div>
+    </div><!-- 2nd -->
   </div>
 </section>
 {% endblock content %}


### PR DESCRIPTION
## Done

- added /engage/cyberdyne according to the [design](https://github.com/canonical-web-and-design/web-squad/issues/2159#issuecomment-567041059) and [copy doc](https://docs.google.com/document/d/17JI-RzetZYq5GZF9COAuh-uHG2yHI2pGy25ePdfA9Qk/edit).
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/cyberdyne
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2159#issuecomment-567041059) and [copy doc](https://docs.google.com/document/d/17JI-RzetZYq5GZF9COAuh-uHG2yHI2pGy25ePdfA9Qk/edit).
- Test the page on https://cards-dev.twitter.com/validator and see that the appropriate meta info is pulled through to the card (title, description and image)


## Issue / Card

Fixes #6238 
