### PR TITLE
Added multipass download link to page

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -119,7 +119,7 @@
       </p>
 
       <p>
-        <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>
+        <a href="https://multipass.run" class="p-link--external">Learn more about Multipass</a>
       </p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -145,4 +145,22 @@
   {% include "shared/contextual_footers/_contextual_footer.html" %}
 {% endwith %}
 
+<script>
+  var multipassOScta = document.getElementById('multipass-os-cta');
+  var baseInstallURL = multipassOScta.getAttribute('href');
+  var ctaSpan = multipassOScta.querySelector('span')
+  var os = 'linux';
+
+  if (navigator.appVersion.indexOf('Win') != -1) { os = 'Windows' };
+  if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macOS' };
+  if (navigator.appVersion.indexOf('Mac OS') != -1) { os = 'macOS' };
+  if (navigator.appVersion.indexOf('Macintosh') != -1) { os = 'macOS' };
+
+  multipassOScta.setAttribute(
+    'href', 
+    baseInstallURL + '/installing-on-' + os.toLowerCase()
+  );
+  ctaSpan.innerText = 'Install on ' + os;
+</script>
+
 {% endblock content %}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -108,33 +108,7 @@
   </div>
 </div>
 
-<section class="p-strip is-shallow">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Multipass for instant Ubuntu VMs</h2>
-      <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
-
-      <p>
-        <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
-      </p>
-
-      <p>
-        <a href="https://multipass.run" class="p-link--external">Learn more about Multipass</a>
-      </p>
-    </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
-          alt="",
-          width="160",
-          height="160",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+{% include 'download/shared/_multipass-install.html' %}
 
 {% with first_item="_download_desktop_installation",
   first_item_class="",
@@ -144,23 +118,5 @@
   third_item_class="" %}
   {% include "shared/contextual_footers/_contextual_footer.html" %}
 {% endwith %}
-
-<script>
-  var multipassOScta = document.getElementById('multipass-os-cta');
-  var baseInstallURL = multipassOScta.getAttribute('href');
-  var ctaSpan = multipassOScta.querySelector('span')
-  var os = 'linux';
-
-  if (navigator.appVersion.indexOf('Win') != -1) { os = 'Windows' };
-  if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macOS' };
-  if (navigator.appVersion.indexOf('Mac OS') != -1) { os = 'macOS' };
-  if (navigator.appVersion.indexOf('Macintosh') != -1) { os = 'macOS' };
-
-  multipassOScta.setAttribute(
-    'href', 
-    baseInstallURL + '/installing-on-' + os.toLowerCase()
-  );
-  ctaSpan.innerText = 'Install on ' + os;
-</script>
 
 {% endblock content %}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -108,6 +108,34 @@
   </div>
 </div>
 
+<section class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>Multipass for instant Ubuntu VMs</h2>
+      <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
+
+      <p>
+        <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
+      </p>
+
+      <p>
+        <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
+          alt="",
+          width="160",
+          height="160",
+          hi_def=True,
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
 {% with first_item="_download_desktop_installation",
   first_item_class="",
   second_item="_download_try_desktop",

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -62,33 +62,7 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Multipass for instant Ubuntu VMs</h2>
-      <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
-
-      <p>
-        <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
-      </p>
-
-      <p>
-        <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>
-      </p>
-    </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
-          alt="",
-          width="160",
-          height="160",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+{% include 'download/shared/_multipass-install.html' %}
 
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row">
@@ -163,23 +137,5 @@
 </section>
 
 {% with first_item="_download_server_installation", second_item="_download_server_guide", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-<script>
-  var multipassOScta = document.getElementById('multipass-os-cta');
-  var baseInstallURL = multipassOScta.getAttribute('href');
-  var ctaSpan = multipassOScta.querySelector('span')
-  var os = 'linux';
-
-  if (navigator.appVersion.indexOf('Win') != -1) { os = 'Windows' };
-  if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macOS' };
-  if (navigator.appVersion.indexOf('Mac OS') != -1) { os = 'macOS' };
-  if (navigator.appVersion.indexOf('Macintosh') != -1) { os = 'macOS' };
-
-  multipassOScta.setAttribute(
-    'href', 
-    baseInstallURL + '/installing-on-' + os.toLowerCase()
-  );
-  ctaSpan.innerText = 'Install on ' + os;
-</script>
 
 {% endblock content %}

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -1,0 +1,45 @@
+<section class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>Multipass for instant Ubuntu VMs</h2>
+      <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
+
+      <p>
+        <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
+      </p>
+
+      <p>
+        <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
+          alt="",
+          width="160",
+          height="160",
+          hi_def=True,
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<script>
+  var multipassOScta = document.getElementById('multipass-os-cta');
+  var baseInstallURL = multipassOScta.getAttribute('href');
+  var ctaSpan = multipassOScta.querySelector('span')
+  var os = 'linux';
+
+  if (navigator.appVersion.indexOf('Win') != -1) { os = 'Windows' };
+  if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macOS' };
+  if (navigator.appVersion.indexOf('Mac OS') != -1) { os = 'macOS' };
+  if (navigator.appVersion.indexOf('Macintosh') != -1) { os = 'macOS' };
+
+  multipassOScta.setAttribute(
+    'href', 
+    baseInstallURL + '/installing-on-' + os.toLowerCase()
+  );
+  ctaSpan.innerText = 'Install on ' + os;
+</script>

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -4,9 +4,7 @@
       <h2>Multipass for instant Ubuntu VMs</h2>
       <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
 
-      <p>
-        <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
-      </p>
+      <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
 
       <p>
         <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>


### PR DESCRIPTION
Added multipass download link to page as per the [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#heading=h.9lozrwd819is).

## Done

Added the multipass download strip from /download/server to the download/desktop page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare it to the copy doc and accept the changed content


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
