### PR TITLE
use article card template on engage index

### DIFF
--- a/templates/engage/_article-card.html
+++ b/templates/engage/_article-card.html
@@ -1,0 +1,13 @@
+<article class="col-4 blog-p-card--post">
+  <header class="blog-p-card__header--{{group}}">
+    <h5 class="p-muted-heading u-no-margin--bottom">
+      {{type}}
+    </h5>
+  </header>
+  <div class="blog-p-card__content">
+    <h4>
+      <a href="/engage/{{slug}}">{{title | safe}}</a>
+    </h4>
+    <p class="u-no-padding--bottom u-hide--small">{{description | safe}}</p>
+  </div>
+</article>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -9,7 +9,6 @@
 
 {% block content %}
 
-
 <section class="p-strip u-no-padding--bottom">
   <div class="row">
     <h1>Ubuntu case studies, whitepapers and webinars</h1>
@@ -18,1507 +17,802 @@
 
 <section class="p-strip is-shallow" id="posts-list">
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/14-04-esm">ESM for Ubuntu 14.04 LTS Trusty Tahr </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Extended Security Maintenance (ESM) will be available for Ubuntu
-          14.04 LTS Trusty Tahr for continued security and compliance of the most popular linux operating system.</p>
-      </div>
-    </article>
+    {% with title="ESM for Ubuntu 14.04 LTS Trusty Tahr",
+      description="Extended Security Maintenance (ESM) will be available for Ubuntu 14.04 LTS Trusty Tahr for continued security and compliance of the most popular linux operating system.",
+      slug="14-04-esm",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/19-04-webinar">With the release of Ubuntu 19.04 </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Our most advanced release to date offers developers and innovators
-          the first chance to experience the latest open source software available including the Linux 5.0 Kernel,
-          OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.</p>
-      </div>
-    </article>
+    {% with title="With the release of Ubuntu 19.04",
+      description="Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.",
+      slug="19-04-webinar",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/451-automotive">Connected cars and autonomous driving</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">The automotive industry is expanding its frontiers with the
-          arrival of connected cars and autonomous driving. Find out the challenges brought by this revolution and what
-          is being done to overcome them.</p>
-      </div>
-    </article>
+    {% with title="Connected cars and autonomous driving",
+      description="The automotive industry is expanding its frontiers with the arrival of connected cars and autonomous driving. Find out the challenges brought by this revolution and what is being done to overcome them.",
+      slug="451-automotive",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/451-cloud-economics">Busting the myth of private cloud economics </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Canonical took part in 451 Research Cloud Price Index (CPI) in
-          Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and
-          market distributions.</p>
-      </div>
-    </article>
+    {% with title="Busting the myth of private cloud economics",
+      description="Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.",
+      slug="451-cloud-economics",
+      group="cloud-and-server",
+      type="case-study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ai-gettingstarted">How to get started and progress with an AI program </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Whether you are just exploring the opportunities that AI can hold
-          for your business or are preparing to deploy in production at scale join us to learn what you need to achieve
-          your goals.</p>
-      </div>
-    </article>
+    {% with title="How to get started and progress with an AI program",
+      description="Whether you are just exploring the opportunities that AI can hold for your business or are preparing to deploy in production at scale join us to learn what you need to achieve your goals.",
+      slug="ai-gettingstarted",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ai-ml-ubuntu">Artificial intelligence, machine learning and Ubuntu</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">An introduction to AI and ML workloads on Ubuntu workstations,
-          servers and in the cloud on a Kubernetes stack.</p>
-      </div>
-    </article>
+    {% with title="Artificial intelligence, machine learning and Ubuntu",
+      description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.",
+      slug="ai-ml-ubuntu",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/apparmor-intro">An introduction to AppArmor </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">An explanation of AppArmor, its key features and why the principle
-          of least privilege is recommended.</p>
-      </div>
-    </article>
+    {% with title="An introduction to AppArmor",
+      description="An explanation of AppArmor, its key features and why the principle of least privilege is recommended.",
+      slug="apparmor-intro",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-azeti">Azeti uses Ubuntu Core to improve deployment and security</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Ubuntu is an open source software operating system that runs from
-          the desktop, to the cloud, to all your internet connected things.</p>
-      </div>
-    </article>
+    {% with title="Azeti uses Ubuntu Core to improve deployment and security",
+      description="Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.",
+      slug="casestudy-azeti",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-azlogica">AZLOGICA utilise Ubuntu Core for customised IoT agricultural
-            solutions</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Learn how Azlogica, a Latin American IoT company, turned to Ubuntu
-          to help their client, Oceanos, to maximise shrimp production and revenues utilising Ubuntu Core and Dell Edge
-          Gateways.</p>
-      </div>
-    </article>
+    {% with title="AZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions",
+      description="Learn how Azlogica, a Latin American IoT company, turned to Ubuntu to help their client, Oceanos, to maximise shrimp production and revenues utilising Ubuntu Core and Dell Edge Gateways.",
+      slug="casestudy-azlogica",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-botsandus">BotsAndUs builds a social robot on Ubuntu</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">To bring its robot, Bo, to market, BotsAndUs needed an OS that
-          could support the wide variety of hardware and software involved in the product;
-          and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and
-          suitability for embedded projects.</p>
-      </div>
-    </article>
+    {% with title="BotsAndUs builds a social robot on Ubuntu",
+      description="To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects.",
+      slug="casestudy-botsandus",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-cinergy">Cinergy makes significant digital signage saving with Screenly Pro and
-            Ubuntu Core </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Find out why Cinergy turned to Screenly Pro and Ubuntu Core to
-          help with their content management needs in such a marketing driven business.</p>
-      </div>
-    </article>
+    {% with title="Cinergy makes significant digital signage saving with Screenly Pro and Ubuntu Core",
+      description="Find out why Cinergy turned to Screenly Pro and Ubuntu Core to help with their content management needs in such a marketing driven business.",
+      slug="casestudy-cinergy",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-city-network">City Network brings OpenStack cloud hosting to the financial services
-            sector with Canonical </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">In the global cloud hosting arena, City Network stands out from
-          the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance.</p>
-      </div>
-    </article>
+    {% with title="City Network brings OpenStack cloud hosting to the financial services sector with Canonical",
+      description="In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance.",
+      slug="casestudy-city-network",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-commercetools">Commercetools uses Ubuntu Server to power its next-generation
-            ecommerce platform </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Commercetools helps enterprises to digitally transform their
-          entire sales operations across all channels.</p>
-      </div>
-    </article>
+    {% with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform",
+      description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels.",
+      slug="casestudy-commercetools",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-imsevolve">IMS Evolve adopts Ubuntu Core to provide IoT-enabled business
-            intelligence in the supply chain </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Find out how IMS Evolve adopted Ubuntu Core running on Dell Edge
-          Gateways to run the cold-chain solutions of some of the recognisable food retailers.</p>
-      </div>
-    </article>
+    {% with title="IMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in the supply chain",
+      description="Find out how IMS Evolve adopted Ubuntu Core running on Dell Edge Gateways to run the cold-chain solutions of some of the recognisable food retailers.",
+      slug="casestudy-imsevolve",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-innovapos">How Ubuntu helped InnovaPOS revolutionise the vending machine
-            industry</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">The smart vending machines market is on the rise with estimates of
-          2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15%
-          over the same period.</p>
-      </div>
-    </article>
+    {% with title="How Ubuntu helped InnovaPOS revolutionise the vending machine industry",
+      description="The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period.",
+      slug="casestudy-innovapos",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ITstrategen-case-study">ITstrategen keeps legacy applications secure with Extended Security
-            Maintenance </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Extended Security Maintenance extends official support for the
-          operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from
-          costly application updates.</p>
-      </div>
-    </article>
+    {% with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance",
+      description="Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.",
+      slug="ITstrategen-case-study",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-nexiona">NEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">IoT is delivering real value for many smart businesses and is
-          capturing people’s imagination because of its immense openness and flexibility.</p>
-      </div>
-    </article>
+    {% with title="NEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE",
+      description="IoT is delivering real value for many smart businesses and is capturing people’s imagination because of its immense openness and flexibility.",
+      slug="casestudy-nexiona",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-rocketchat">Rocket.Chat communication platform enables simplicity through snaps
-          </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">As Rocket.Chat has evolved, it has been keen to get its platform
-          into the hands of as many users as possible without the difficulties of installation often associated with
-          bespoke Linux deployments.</p>
-      </div>
-    </article>
+    {% with title="Rocket.Chat communication platform enables simplicity through snaps",
+      description="As Rocket.Chat has evolved, it has been keen to get its platform into the hands of as many users as possible without the difficulties of installation often associated with bespoke Linux deployments.",
+      slug="casestudy-rocketchat",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/casestudy-sensape">Sensape uses Landscape to remotely support revolutionary interactive
-            retail displays </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Sensape is teaching computers to see, understand and interact with
-          people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape
-          systems senses its environment and reacts accordingly.</p>
-      </div>
-    </article>
+    {% with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays",
+      description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.",
+      slug="casestudy-sensape",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/cloud-economics">Busting the myth of private cloud economics </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Private cloud costs: the new report from 451 Research found
-          Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud
-          Price benchmark.</p>
-      </div>
-    </article>
+    {% with title="Busting the myth of private cloud economics",
+      description="Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.",
+      slug="cloud-economics",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/cloud-fray">How to face the challenges of becoming a cloud operator </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">In a shifting market, the traditional revenues of telcos and
-          service providers are under threat. Voice revenues are at an all-time low, and high wireless data costs are
-          negatively impacting margins.</p>
-      </div>
-    </article>
+    {% with title="How to face the challenges of becoming a cloud operator",
+      description="In a shifting market, the traditional revenues of telcos and service providers are under threat. Voice revenues are at an all-time low, and high wireless data costs are negatively impacting margins.",
+      slug="cloud-fray",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/cloud-init-whitepaper">Cloud init</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Private cloud, public cloud, hybrid cloud, multi-cloud… the
-          variety of locations, platforms and physical substrate you can start a cloud instance on is vast.</p>
-      </div>
-    </article>
+    {% with title="Cloud init",
+      description="Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast.",
+      slug="cloud-init-whitepaper",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/core18-security">Why Ubuntu Core is the most secure choice for IoT</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Join this webinar hosted by Alex Murray, Technical Lead of the
-          Ubuntu Security Team to find out about the latest security features of Ubuntu Core, the tiny, transactional
-          version of Ubuntu designed specifically for IoT.</p>
-      </div>
-    </article>
+    {% with title="Why Ubuntu Core is the most secure choice for IoT",
+      description="Join this webinar hosted by Alex Murray, Technical Lead of the Ubuntu Security Team to find out about the latest security features of Ubuntu Core, the tiny, transactional version of Ubuntu designed specifically for IoT.",
+      slug="core18-security",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/cto-guide-sdn-nfv-vnf">CTO’s guide to SDN, NFV &amp; VNF </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Networking and communications standards and methodologies are
-          undergoing the greatest transition since the migration from analogue to digital: from function-specific,
-          proprietary devices to software-enabled commodity hardware.</p>
-      </div>
-    </article>
+    {% with title="CTO’s guide to SDN, NFV &amp; VNF",
+      description="Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital: from function-specific, proprietary devices to software-enabled commodity hardware.",
+      slug="cto-guide-sdn-nfv-vnf",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/deploy-ai-ml-model">How to build and deploy your first AI/ML model on Ubuntu</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">An introduction to AI and ML workloads on Ubuntu workstations,
-          servers and in the cloud on a Kubernetes stack.</p>
-      </div>
-    </article>
+    {% with title="How to build and deploy your first AI/ML model on Ubuntu",
+      description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.",
+      slug="deploy-ai-ml-model",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/developer-desktop">Six reasons why developers choose Ubuntu Desktop </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">What's the most popular Linux OS? This whitepaper examines six key
-          reasons why the developer community turn to Ubuntu.</p>
-      </div>
-    </article>
+    {% with title="Six reasons why developers choose Ubuntu Desktop",
+      description="What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu.",
+      slug="developer-desktop",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/devops-cicd-webinar">Get started with DevOps best practices: CI/CD </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">A webinar to learn how to automate Continuous Integration,
-          Continuous Delivery, and Continuous Deployment with Kubernetes</p>
-      </div>
-    </article>
+    {% with title="Get started with DevOps best practices: CI/CD",
+      description="A webinar to learn how to automate Continuous Integration, Continuous Delivery, and Continuous Deployment with Kubernetes",
+      slug="devops-cicd-webinar",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/devops-iot-webinar">The transformation of the DevOps journey in IoT</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Traditional development methods do not scale into the IoT sphere
-        </p>
-      </div>
-    </article>
+    {% with title="The transformation of the DevOps journey in IoT",
+      description="Traditional development methods do not scale into the IoT sphere",
+      slug="devops-iot-webinar",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ebook-maas">Server Provisioning: What Network Admins &amp; IT Pros Need to Know</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Server provisioning tools help organisations to take full
-          advantage of existing investments by maximising hardware efficiency.</p>
-      </div>
-    </article>
+    {% with title="Server Provisioning: What Network Admins &amp; IT Pros Need to Know",
+      description="Server provisioning tools help organisations to take full advantage of existing investments by maximising hardware efficiency.",
+      slug="ebook-maas",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/edge-month">A guide to edge computing and the tools you need </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Join Canonical Product Managers for a series of webinars on edge
-          computing to learn what is driving businesses to process their data at the edge and how you can add an edge
-          computing layer to your business infrastructure.</p>
-      </div>
-    </article>
+    {% with title="A guide to edge computing and the tools you need",
+      description="Join Canonical Product Managers for a series of webinars on edge computing to learn what is driving businesses to process their data at the edge and how you can add an edge computing layer to your business infrastructure.",
+      slug="edge-month",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/essential-guide-big-data-solutions">The essential guide for Telecoms and Service Providers
-            adopting big data solutions </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This eBook provides telecom and service provider executives with a
-          basic introduction to big data and analytics processing in the telecom industry.</p>
-      </div>
-    </article>
+    {% with title="The essential guide for Telecoms and Service Providers adopting big data solutions",
+      description="This eBook provides telecom and service provider executives with a basic introduction to big data and analytics processing in the telecom industry.",
+      slug="essential-guide-big-data-solutions",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/evolving-software">Keep up with evolving software</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Software keeps evolving and management complexity tends to
-          increase with successive stack updates. Learn how using Juju can solve software management complexity and how
-          it provides a familiar approach to managing any type of stack.</p>
-      </div>
-    </article>
+    {% with title="Keep up with evolving software",
+      description="Software keeps evolving and management complexity tends to increase with successive stack updates. Learn how using Juju can solve software management complexity and how it provides a familiar approach to managing any type of stack.",
+      slug="evolving-software",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/financial-services-month">Canonical presents Financial Services Month </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">The fintech infrastructure is moving on. A series of webinars to
-          have an understanding of the emerging technologies: multi-cloud, AI/ML, Blockchain and Containers, and their
-          impact on the financial services industry.</p>
-      </div>
-    </article>
+    {% with title="Canonical presents Financial Services Month",
+      description="The fintech infrastructure is moving on. A series of webinars to have an understanding of the emerging technologies: multi-cloud, AI/ML, Blockchain and Containers, and their impact on the financial services industry.",
+      slug="financial-services-month",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/fingbox-case-study">Fing serves 30,000 customers with a secure, future-proof IoT device </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Case study: using Ubuntu Core and an IoT appstore enabled Fing to
-          bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades.
-        </p>
-      </div>
-    </article>
+    {% with title="Fing serves 30,000 customers with a secure, future-proof IoT device",
+      description="Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades.",
+      slug="fingbox-case-study",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/finserv-multi-cloud">Multi-cloud fundamental to financial services transformation</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This whitepaper highlights the need for the finserv industry to
-          evolve its infrastructure and the means to achieve it without friction.</p>
-      </div>
-    </article>
+    {% with title="Multi-cloud fundamental to financial services transformation",
+      description="This whitepaper highlights the need for the finserv industry to evolve its infrastructure and the means to achieve it without friction.",
+      slug="finserv-multi-cloud",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/future-proof-iot">Future-proofing Fingbox, the IoT home network monitoring device </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">In this webinar, you’ll learn how Fingbox was built with Ubuntu
-          Core and how Fingbox’s key features are updated and improved ongoing using Snaps.</p>
-      </div>
-    </article>
+    {% with title="Future-proofing Fingbox, the IoT home network monitoring device",
+      description="In this webinar, you’ll learn how Fingbox was built with Ubuntu Core and how Fingbox’s key features are updated and improved ongoing using Snaps.",
+      slug="future-proof-iot",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/hiri-case-study">Hiri successfully monetises their snap </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Business focused email client demonstrates that proprietary apps
-          can be monetised on the Linux desktop.</p>
-      </div>
-    </article>
+    {% with title="Hiri successfully monetises their snap",
+      description="Business focused email client demonstrates that proprietary apps can be monetised on the Linux desktop.",
+      slug="hiri-case-study",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/industrial-drones-case-study">Apellix engineers safer work environments with Ubuntu powered
-            aerial robotics</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This case study presents how Apellix, an industrial drone company,
-          engineers safer work environments with Ubuntu.</p>
-      </div>
-    </article>
+    {% with title="Apellix engineers safer work environments with Ubuntu powered aerial robotics",
+      description="This case study presents how Apellix, an industrial drone company, engineers safer work environments with Ubuntu.",
+      slug="industrial-drones-case-study",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/industrial-drones">Precision drones on Ubuntu: flying at the edge of innovation </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This webinar discusses how Apellix uses Ubuntu to solve industrial
-          IoT challenges with precision drones.</p>
-      </div>
-    </article>
+    {% with title="Precision drones on Ubuntu: flying at the edge of innovation",
+      description="This webinar discusses how Apellix uses Ubuntu to solve industrial IoT challenges with precision drones.",
+      slug="industrial-drones",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/iot-business-model">Establishing a software defined IoT business model</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Whitepaper: How device manufacturers can go from building single
-          function devices with little to no software strategy to building devices defined by software and software
-          business models, powered by app stores and ecosystems of 3rd party ISVs.</p>
-      </div>
-    </article>
+    {% with title="Establishing a software defined IoT business model",
+      description="Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs.",
+      slug="iot-business-model",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/iot-devops">The transformation of the DevOps journey in IoT</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Traditional development methods do not scale into the IoT sphere.
-          Strong inter-dependencies and blurred boundaries among components in the edge device stack result in
-          fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms</p>
-      </div>
-    </article>
+    {% with title="The transformation of the DevOps journey in IoT",
+      description="Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms",
+      slug="iot-devops",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/iot-disk-encryption">Securing IoT device data against physical access</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">A technical overview of how Ubuntu Core with full disk encryption
-          and secure boot can be implemented in IoT devices to provide protection in data sensitive scenarios.</p>
-      </div>
-    </article>
+    {% with title="Securing IoT device data against physical access",
+      description="A technical overview of how Ubuntu Core with full disk encryption and secure boot can be implemented in IoT devices to provide protection in data sensitive scenarios.",
+      slug="iot-disk-encryption",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ITstrategen-case-study">ITstrategen keeps legacy applications secure with Extended Security
-            Maintenance</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">ITstrategen keeps legacy applications secure with Extended
-          Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical.</p>
-      </div>
-    </article>
+    {% with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance",
+      description="ITstrategen keeps legacy applications secure with Extended Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical.",
+      slug="ITstrategen-case-study",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/k8s-allan-gray">Allan Gray unlocks unprecedented availability and productivity with Charmed
-            Kubernetes </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Canonical's Charmed Kubernetes cut financial servies company,
-          Allan Gray's, Kubernetes cluster deployment time from two months to two weeks, with enterprise Kubernetes
-          support provided to ensure maximum availability.</p>
-      </div>
-    </article>
+    {% with title="Allan Gray unlocks unprecedented availability and productivity with Charmed Kubernetes",
+      description="Canonical's Charmed Kubernetes cut financial servies company, Allan Gray's, Kubernetes cluster deployment time from two months to two weeks, with enterprise Kubernetes support provided to ensure maximum availability.",
+      slug="k8s-allan-gray",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/kernel-telco-nfv">Low latency and real-time kernels for telco and NFV </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Which kernel provides the most balanced operational efficiency? A
-          detailed analysis comparing real-time kernel assumptions against test results designed to reflect telco and
-          NFV workloads.</p>
-      </div>
-    </article>
+    {% with title="Low latency and real-time kernels for telco and NFV",
+      description="Which kernel provides the most balanced operational efficiency? A detailed analysis comparing real-time kernel assumptions against test results designed to reflect telco and NFV workloads.",
+      slug="kernel-telco-nfv",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/low-latency-report">Low latency and real time kernels for telco and NFV </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This special report provides data on dozens of kernel-specific
-          benchmark scenarios, and a complete analysis of their outcomes.</p>
-      </div>
-    </article>
+    {% with title="Low latency and real time kernels for telco and NFV",
+      description="This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes.",
+      slug="low-latency-report",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/lxd-whitepaper">How to build a lightweight system container cluster </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">LXD, the system container manager, developed by Canonical and
-          shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and
-          manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them.</p>
-      </div>
-    </article>
+    {% with title="How to build a lightweight system container cluster",
+      description="LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them.",
+      slug="lxd-whitepaper",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/microsoft-active-directory">How to integrate Ubuntu Desktop with Active Directory </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Ubiquitous use of Microsoft tools coupled with increasing
-          popularity of open source Linux software for enterprise presents new challenges for non-Microsoft operating
-          systems that require seamless integration with Active Directory for authentication and identity management.
-        </p>
-      </div>
-    </article>
+    {% with title="How to integrate Ubuntu Desktop with Active Directory",
+      description="Ubiquitous use of Microsoft tools coupled with increasing popularity of open source Linux software for enterprise presents new challenges for non-Microsoft operating systems that require seamless integration with Active Directory for authentication and identity management.",
+      slug="microsoft-active-directory",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--desktop">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/modern-cloud">Modernise your cloud </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This webinar discusses how Trilio and Canonical help organisations
-          transition to new, maintainable cloud architecture in just weeks.</p>
-      </div>
-    </article>
+    {% with title="Modernise your cloud",
+      description="This webinar discusses how Trilio and Canonical help organisations transition to new, maintainable cloud architecture in just weeks.",
+      slug="modern-cloud",
+      group="desktop",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/multi-cloud-guide">CIO guide to multi-cloud operations </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">What is the right cloud strategy for your business? A whitepaper
-          with objective discussion of the various approaches to cloud computing and a clear definition for each of
-          them: public cloud, private cloud, managed cloud, hybrid cloud and multi-cloud.</p>
-      </div>
-    </article>
+    {% with title="CIO guide to multi-cloud operations",
+      description="What is the right cloud strategy for your business? A whitepaper with objective discussion of the various approaches to cloud computing and a clear definition for each of them: public cloud, private cloud, managed cloud, hybrid cloud and multi-cloud.",
+      slug="multi-cloud-guide",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/nfv-sdn-openstack">NFV and SDN on OpenStack</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Network Functions Virtualisation (NFV) and Software-Defined
-          Networking
-          (SDN) are two of the hottest infrastructure technologies around</p>
-      </div>
-    </article>
+    {% with title="NFV and SDN on OpenStack",
+      description="Network Functions Virtualisation (NFV) and Software-Defined Networking (SDN) are two of the hottest infrastructure technologies around",
+      slug="nfv-sdn-openstack",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/northstar">North America‘s first autonomous runway snowplough </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Northstar Robotics, a Canadian tech start-up founded in 2016,
-          wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire
-          network of vehicles can be powered by a single intelligent control system.</p>
-      </div>
-    </article>
+    {% with title="North America‘s first autonomous runway snowplough",
+      description="Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.",
+      slug="northstar",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/openstack-made-easy">OpenStack made easy </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">The change from traditional, monolithic software to multi-host
-          microservices-based big software demands that you approach the challenge from a different perspective.</p>
-      </div>
-    </article>
+    {% with title="OpenStack made easy",
+      description="The change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge from a different perspective.",
+      slug="openstack-made-easy",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/openstack-security-webinar">Private cloud security</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">In regulated sectors, private cloud security needs to meet the
-          highest requirements. This webinar explains how to deliver on these with an Openstack cloud.</p>
-      </div>
-    </article>
+    {% with title="Private cloud security",
+      description="In regulated sectors, private cloud security needs to meet the highest requirements. This webinar explains how to deliver on these with an Openstack cloud.",
+      slug="openstack-security-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/openstack-security-whitepaper">Private cloud security </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">In regulated sectors, private cloud security needs to meet the
-          highest requirements. This Whitepaper explains how to deliver on these with an Openstack cloud.</p>
-      </div>
-    </article>
+    {% with title="Private cloud security",
+      description="In regulated sectors, private cloud security needs to meet the highest requirements. This Whitepaper explains how to deliver on these with an Openstack cloud.",
+      slug="openstack-security-whitepaper",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/openstack-telco-clouds">Telcos and Service Providers expect near 100% uptime </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Discover why Ubuntu OpenStack enables Telcos to maximise margins,
-          reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.</p>
-      </div>
-    </article>
+    {% with title="Telcos and Service Providers expect near 100% uptime",
+      description="Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.",
+      slug="openstack-telco-clouds",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/private-cloud">Building a private cloud? Take the leap! </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">With Ubuntu OpenStack, you can deploy a cloud infrastructure on
-          your laptop or on a small group of test machines to get your cloud strategy underway.</p>
-      </div>
-    </article>
+    {% with title="Building a private cloud? Take the leap!",
+      description="With Ubuntu OpenStack, you can deploy a cloud infrastructure on your laptop or on a small group of test machines to get your cloud strategy underway.",
+      slug="private-cloud",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/public-cloud">Make IT rain: public cloud on Ubuntu OpenStack </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Read this eBook to understand the basics about running Ubuntu
-          OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu
-          OpenStack deployment.</p>
-      </div>
-    </article>
+    {% with title="Make IT rain: public cloud on Ubuntu OpenStack",
+      description="Read this eBook to understand the basics about running Ubuntu OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu OpenStack deployment.",
+      slug="public-cloud",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/robot-operating-system-choice">Key considerations when choosing a robot’s operating system
-          </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Robots have been the subject of science fiction films for decades,
-          but with technological advances, including the rise of internet connected devices, a real robotic revolution
-          is beginning to emerge.</p>
-      </div>
-    </article>
+    {% with title="Key considerations when choosing a robot’s operating system",
+      description="Robots have been the subject of science fiction films for decades, but with technological advances, including the rise of internet connected devices, a real robotic revolution is beginning to emerge.",
+      slug="robot-operating-system-choice",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/small-robot-company">Small Robot Company sows the seeds for autonomous and more profitable
-            farming </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">In Europe, the cost of running a cereal farm – cultivating wheat,
-          rice, and other grains – has risen by 85% in the last 25 years, yet crop yields and revenues have stagnated.
-          And while farms struggle to remain profitable, it won’t be long before those static yields become insufficient
-          to support growing populations.</p>
-      </div>
-    </article>
+    {% with title="Small Robot Company sows the seeds for autonomous and more profitable farming",
+      description="In Europe, the cost of running a cereal farm – cultivating wheat, rice, and other grains – has risen by 85% in the last 25 years, yet crop yields and revenues have stagnated. And while farms struggle to remain profitable, it won’t be long before those static yields become insufficient to support growing populations.",
+      slug="small-robot-company",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/snap-deltas">Optimising IoT bandwidth with delta updates </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Learn how snap deltas" over-the-air updates are efficient and
-          effective.</p>
-      </div>
-    </article>
+    {% with title="Optimising IoT bandwidth with delta updates",
+      description="Learn how snap deltas' over-the-air updates are efficient and effective.",
+      slug="snap-deltas",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/starting-with-ai">Getting started with AI </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">From the smallest startups to the largest enterprises alike,
-          organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed
-          decisions to overcome their biggest business challenges.</p>
-      </div>
-    </article>
+    {% with title="Getting started with AI",
+      description="From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges.",
+      slug="starting-with-ai",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/stuckstack-ebook">How to escape StuckStack and profit from your OpenStack investment</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This eBook offers a four-point plan to remobilising the StuckStack
-          infrastructure and regaining organisational agility.</p>
-      </div>
-    </article>
+    {% with title="How to escape StuckStack and profit from your OpenStack investment",
+      description="This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.",
+      slug="stuckstack-ebook",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          eBook
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/telco-cloudification-ebook">Carrier Cloudification: What every telecom executive needs to
-            know </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This eBook is designed to help telecom executives understand
-          industry best practices as they move towards ‘cloudification’ of their network infrastructure.</p>
-      </div>
-    </article>
+    {% with title="Carrier Cloudification: What every telecom executive needs to know",
+      description="This eBook is designed to help telecom executives understand industry best practices as they move towards ‘cloudification’ of their network infrastructure.",
+      slug="telco-cloudification-ebook",
+      group="",
+      type="eBook" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ubuntu-18-10">What's New in Ubuntu 18.10 </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">An overview of the Ubuntu 18.10 release updates from the Canonical
-          product team. Features of the 18.10 software release focus on multi-cloud deployments, AI software
-          development, a new community desktop theme and richer snap desktop integration.</p>
-      </div>
-    </article>
+    {% with title="What's New in Ubuntu 18.10",
+      description="An overview of the Ubuntu 18.10 release updates from the Canonical product team. Features of the 18.10 software release focus on multi-cloud deployments, AI software development, a new community desktop theme and richer snap desktop integration.",
+      slug="ubuntu-18-10",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ubuntu-compliance">Securing the enterprise: how Ubuntu is at the forefront of security and
-            compliance </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This webinar discusses how Ubuntu’s trusted security and
-          compliance solutions solve regulatory issues across a range of industries, including government, financial
-          services and healthcare.</p>
-      </div>
-    </article>
+    {% with title="Securing the enterprise: how Ubuntu is at the forefront of security and compliance",
+      description="This webinar discusses how Ubuntu’s trusted security and
+      compliance solutions solve regulatory issues across a range of industries, including government, financial services and healthcare.",
+      slug="ubuntu-compliance",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ubuntu-core-and-kura">Ubuntu Core and Kura: A framework for IoT gateways </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">A combination of Ubuntu Core, snaps and Kura can solve the
-          limitations that come with Linux distributions for IoT edge gateway devices.</p>
-      </div>
-    </article>
+    {% with title="Ubuntu Core and Kura: A framework for IoT gateways",
+      description="A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices.",
+      slug="ubuntu-core-and-kura",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/ubuntu-lime-telco">The future of mobile connectivity</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Unlike the introduction of 4G which was dominated by consumer
-          benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60
-          percent of the world’s data by 2025.</p>
-      </div>
-    </article>
+    {% with title="The future of mobile connectivity",
+      description="Unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025.",
+      slug="ubuntu-lime-telco",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/vmware-to-charmed-openstack">From VMWare To Charmed OpenStack </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Ready to make the migration from proprietary virtualisation to
-          OpenStack?</p>
-      </div>
-    </article>
+    {% with title="From VMWare To Charmed OpenStack",
+      description="Ready to make the migration from proprietary virtualisation to OpenStack?",
+      slug="vmware-to-charmed-openstack",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/whats-new-ubuntu-14-04-lts">Learn What's New In Ubuntu Server 14.04 LTS </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Released in April 2014, Ubuntu Server 14.04 is the latest LTS
-          release of Ubuntu server. It includes OpenStack Icehouse and many new features and tools for cloud and
-          hyperscale computing.</p>
-      </div>
-    </article>
+    {% with title="Learn What's New In Ubuntu Server 14.04 LTS",
+      description="Released in April 2014, Ubuntu Server 14.04 is the latest LTS release of Ubuntu server. It includes OpenStack Icehouse and many new features and tools for cloud and hyperscale computing.",
+      slug="whats-new-ubuntu-14-04-lts",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/whitepaper-containers">For CTOs: the no-nonsense way to accelerate your business with
-            containers</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This eBook is designed to help telecom executives understand
-          industry best practices as they move towards ‘cloudification’ of their network infrastructure.</p>
-      </div>
-    </article>
+    {% with title="For CTOs: the no-nonsense way to accelerate your business with containers",
+      description="This eBook is designed to help telecom executives understand industry best practices as they move towards ‘cloudification’ of their network infrastructure.",
+      slug="whitepaper-containers",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/whitepaper-iot-security">Taking charge of the IoT's security vulnerabilities </a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Canonical&#39;s report examines closely the behaviours and
-          attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry,
-          and asks how they might be addressed.</p>
-      </div>
-    </article>
+    {% with title="Taking charge of the IoT's security vulnerabilities",
+      description="Canonical&#39;s report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed.",
+      slug="whitepaper-iot-security",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/shift-to-app-store-experience">A shift to the Linux app store experience</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Linux app stores are successfully alleviating historical
-          challenges faced by software developers whilst improving visibility to enterprises and end users.</p>
-      </div>
-    </article>
+    {% with title="A shift to the Linux app store experience",
+      description="Linux app stores are successfully alleviating historical challenges faced by software developers whilst improving visibility to enterprises and end users.",
+      slug="shift-to-app-store-experience",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/maas-hardware-testing">Creating a cloud-like bare metal experience in the data centre</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">For organisations looking to turn the management of bare-metal
-          server resources into a cloud-like environment, hardware testing is a must-do.</p>
-      </div>
-    </article>
+    {% with title="Creating a cloud-like bare metal experience in the data centre",
+      description="For organisations looking to turn the management of bare-metal server resources into a cloud-like environment, hardware testing is a must-do.",
+      slug="maas-hardware-testing",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/data-pipelines-kubeflow">Creating accurate AI models with data</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Learn how Kubeflow and machine learning help you maximise your
-          data</p>
-      </div>
-    </article>
+    {% with title="Creating accurate AI models with data",
+      description="Learn how Kubeflow and machine learning help you maximise your data",
+      slug="data-pipelines-kubeflow",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/developing-android-on-ubuntu">A guide to developing Android apps on Ubuntu</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Android is the most popular mobile operating system and is
-          continuing to grow its market share. IDC expects that Android will have 85.5% of the market by 2022,
-          demonstrating that app development on Android will continue to be an in-demand skill.</p>
-      </div>
-    </article>
+    {% with title="A guide to developing Android apps on Ubuntu",
+      description="Android is the most popular mobile operating system and is continuing to grow its market share. IDC expects that Android will have 85.5% of the market by 2022, demonstrating that app development on Android will continue to be an in-demand skill.",
+      slug="developing-android-on-ubuntu",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/enterprise-snap-management">How to manage snaps in an enterprise environment</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">How the Snap Store Proxy overcomes challenges presented by
-          restricted networks and management policies.</p>
-      </div>
-    </article>
+    {% with title="How to manage snaps in an enterprise environment",
+      description="How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies.",
+      slug="enterprise-snap-management",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/get-started-with-ai-part-2">Machine Learning Operations (MLOps)</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">This webinar will dive into what success looks like when deploying
-          machine learning models, including training, at scale.</p>
-      </div>
-    </article>
+    {% with title="Machine Learning Operations (MLOps)",
+      description="This webinar will dive into what success looks like when deploying machine learning models, including training, at scale.",
+      slug="get-started-with-ai-part-2",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/deeptech">Accelerating deep tech with Ubuntu</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">How innovators are leveraging open source to create life-changing
-          tech.</p>
-      </div>
-    </article><!-- 1st -->
+    {% with title="Accelerating deep tech with Ubuntu",
+      description="How innovators are leveraging open source to create life-changing tech.",
+      slug="deeptech",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/edge-month">Canonical presents edge month</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Join us for a month of webinars on edge computing. Learn how edge
-          computing provides enterprises with real-time data processing, cost-effective security and scalability.</p>
-      </div>
-    </article><!-- 2nd -->
+    {% with title="Canonical presents edge month",
+      description="Join us for a month of webinars on edge computing. Learn how edge computing provides enterprises with real-time data processing, cost-effective security and scalability.",
+      slug="edge-month",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/yahoo-japan-case-study">Yahoo! Japan builds their IaaS environment with Canonical</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Using Ubuntu and a wide range of Canonical’s management tools,
-          Yahoo! Japan has been able to reduce both CAPEX and OPEX costs while successfully building and operating a
-          large scale IaaS environment.</p>
-      </div>
-    </article><!-- 3rd -->
+    {% with title="Yahoo! Japan builds their IaaS environment with Canonical",
+      description="Using Ubuntu and a wide range of Canonical’s management tools, Yahoo! Japan has been able to reduce both CAPEX and OPEX costs while successfully building and operating a large scale IaaS environment.",
+      slug="yahoo-japan-case-study",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--cloud-and-server">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/domotz-case-study">How Domotz streamlined provisioning of IoT devices</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Domotz eases provisioning and maintenance with snap-based,
-          enterprise remote network monitoring and management device.</p>
-      </div>
-    </article><!-- 1st -->
+    {% with title="How Domotz streamlined provisioning of IoT devices",
+      description="Domotz eases provisioning and maintenance with snap-based, enterprise remote network monitoring and management device.",
+      slug="domotz-case-study",
+      group="cloud-and-server",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/19-10-webinar">What’s new in Ubuntu 19.10</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Ubuntu 19.10 includes enhanced K8s capabilities for edge and
-          AI/ML, OpenStack Train live-migration extensions for easier infrastructure deployments and more.</p>
-      </div>
-    </article><!-- 2nd -->
+    {% with title="What’s new in Ubuntu 19.10",
+      description="Ubuntu 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train live-migration extensions for easier infrastructure deployments and more.",
+      slug="19-10-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--case-study">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/case-study-acuris">TIM ensures system security and client confidence with ESM</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">TIM turned to Canonical’s Extended Security Maintenance - part of
-          Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and
-          exploits.</p>
-      </div>
-    </article><!-- 3rd -->
+    {% with title="TIM ensures system security and client confidence with ESM",
+      description="TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits.",
+      slug="case-study-acuris",
+      group="case-study",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/kata-containers-webinar">Ensuring security and isolation in Kubernetes with Kata
-            Containers</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Learn the benefits of using Kata Containers in a Charmed
-          Kubernetes environment to provide better security and isolation.</p>
-      </div>
-    </article><!-- 1st -->
+    {% with title="Ensuring security and isolation in Kubernetes with Kata Containers",
+      description="Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation.",
+      slug="kata-containers-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--case-study">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/wellcome-sanger-case-study">The Wellcome Sanger Institute turns to Canonical for high level
-            Ceph support</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">The Wellcome Sanger Institute, a global centre of excellence for
-          genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular
-          genetics.</p>
-      </div>
-    </article><!-- 2nd -->
+    {% with title="The Wellcome Sanger Institute turns to Canonical for high level Ceph support",
+      description="The Wellcome Sanger Institute, a global centre of excellence for genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular genetics.",
+      slug="wellcome-sanger-case-study",
+      group="case-study",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/private-cloud-build-webinar">Lessons learned from 100+ Private cloud builds</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Reducing the complexities of building a private cloud on OpenStack
-        </p>
-      </div>
-    </article><!-- 3rd -->
+    {% with title="Lessons learned from 100+ Private cloud builds",
+      description="Reducing the complexities of building a private cloud on OpenStack",
+      slug="private-cloud-build-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          webinar
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/linux_security_webinar">Linux security with Ubuntu</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Ubuntu is built with security in mind from the outset, which is
-          one of the reasons it’s such a popular Linux distribution used by developers.</p>
-      </div>
-    </article><!-- 1st -->
+    {% with title="Linux security with Ubuntu",
+      description="Ubuntu is built with security in mind from the outset, which is one of the reasons it’s such a popular Linux distribution used by developers.",
+      slug="linux_security_webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--internet-of-things">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          whitepaper
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/build-smart-devices-with-mir-whitepaper">Build smart display devices with Mir: fast to
-            production, secure, open-source</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">Industrial robots, home appliances, advertising screens, office
-          information boards&hellip; devices of every type around us are getting connected. As they do, their screens turn
-          from single purpose displays to reconfigurable, multi-purpose smart display.</p>
-      </div>
-    </article><!-- 2nd -->
+    {% with title="Build smart display devices with Mir: fast to production, secure, open-source",
+      description="Industrial robots, home appliances, advertising screens, office information boards&hellip; devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display.",
+      slug="build-smart-devices-with-mir-whitepaper",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--case-study">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/sbi-casestudy">SBI Group unlocks infrastructure automation with secure, on-premises OpenStack cloud</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">SBI BITS provides IT services and infrastructure to the SBI Group &mdash; Japan&rsquo;s market leading financial services company group &mdash; which is made up of over 250 companies, and 6,000 employees.</p>
-      </div>
-    </article><!-- 3rd -->
+    {% with title="SBI Group unlocks infrastructure automation with secure, on-premises OpenStack cloud",
+      description="SBI BITS provides IT services and infrastructure to the SBI Group &mdash; Japan&rsquo;s market leading financial services company group &mdash; which is made up of over 250 companies, and 6,000 employees.",
+      slug="sbi-casestudy",
+      group="case-study",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--webinar">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          event
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/wslconf">Register for WSLConf</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">WSLConf is a community-organized event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.</p>
-      </div>
-    </article> <!-- 1st -->  
+    {% with title="Register for WSLConf",
+      description="WSLConf is a community-organized event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.",
+      slug="wslconf",
+      group="webinar",
+      type="event" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <article class="col-4 blog-p-card--post">
-      <header class="blog-p-card__header--case-study">
-        <h5 class="p-muted-heading u-no-margin--bottom">
-          case study
-        </h5>
-      </header>
-      <div class="blog-p-card__content">
-        <h4>
-          <a href="/engage/cyberdyne">Cyberdyne keeps cleaning robots up-to-date in the field with snaps</a>
-        </h4>
-        <p class="u-no-padding--bottom u-hide--small">As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo’s two main airports.</p>
-      </div>
-    </article><!-- 2nd -->
+    {% with title="Cyberdyne keeps cleaning robots up-to-date in the field with snaps",
+      description="As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo’s two main airports.",
+      slug="cyberdyne",
+      group="case-study",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}


### PR DESCRIPTION
## Done

- moved re-used markup on /engage into a partial, making it easier to add new entries.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page looks identical to https://ubuntu.com/engage
