### PR TITLE
add intro to microk8s takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -813,6 +813,14 @@
       type="case study" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="An intro to MicroK8s",
+      description="Learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started.",
+      slug="intro-to-microk8s-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/intro-to-microk8s-webinar.md
+++ b/templates/engage/intro-to-microk8s-webinar.md
@@ -1,0 +1,28 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "An intro to MicroK8s"
+     meta_description: "Learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started."
+     meta_image: https://assets.ubuntu.com/v1/dd0f6313-social+embedded.jpg
+     meta_copydoc: "https://docs.google.com/document/d/1FCaFi5ZuP_pPMF2POu3ySaB00yt60Qo-nrNJZ9jwhFw/edit"
+     header_title: "An intro to MicroK8s"
+     header_subtitle: "Reliable, fast, small and upstream Kubernetes"
+     header_image: "https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg"
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_class: p-engage-banner--dark
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 378029, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     form_include:
+     form_id:
+     form_return_url:
+---
+
+MicroK8s is a single package that enables developers to get a fully featured, conformant and secure Kubernetes system running in under 60 seconds.  Designed for local development, IoT appliances, CI/CD, and use at the edge, MicroK8s is available as a snap and available on Linux, Windows and Mac.
+
+Join our upcoming webinar to learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started. Learn more about the add-ons available including Kubeflow for AI/ML, Istio, Grafana and Prometheus for monitoring, Kubernetes dashboard and more. 
+
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">Canonical might have assembled the easiest way to provision a single node Kubernetes cluster</p>
+  <cite class="p-pull-quote__citation">Kelsey Hightower, Google</cite>
+</blockquote>

--- a/templates/engage/intro-to-microk8s-webinar.md
+++ b/templates/engage/intro-to-microk8s-webinar.md
@@ -3,7 +3,7 @@ wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "An intro to MicroK8s"
      meta_description: "Learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started."
-     meta_image: https://assets.ubuntu.com/v1/dd0f6313-social+embedded.jpg
+     meta_image: https://assets.ubuntu.com/v1/5ad7901f-Social+banner+microk8s.jpg
      meta_copydoc: "https://docs.google.com/document/d/1FCaFi5ZuP_pPMF2POu3ySaB00yt60Qo-nrNJZ9jwhFw/edit"
      header_title: "An intro to MicroK8s"
      header_subtitle: "Reliable, fast, small and upstream Kubernetes"

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
   {% include "takeovers/_linux-security_takeover.html" %}
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
+  {% include "takeovers/_intro-to-microk8s.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_intro-to-microk8s.html
+++ b/templates/takeovers/_intro-to-microk8s.html
@@ -1,0 +1,13 @@
+{% with title="An intro to MicroK8s",
+subtitle="Learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started.",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg",
+image_style="width: 270px; height: 150px;",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/Intro-to-microk8s-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Kubernetes_WBN_IntrotoMicroK8s",
+primary_cta="Watch the webinar",
+primary_cta_class=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_intro-to-microk8s.html
+++ b/templates/takeovers/_intro-to-microk8s.html
@@ -5,7 +5,7 @@ header_image="https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg"
 image_style="width: 270px; height: 150px;",
 image_hide_small=true,
 equal_cols=false,
-primary_url="/engage/Intro-to-microk8s-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Kubernetes_WBN_IntrotoMicroK8s",
+primary_url="/engage/intro-to-microk8s-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_DC_Kubernetes_WBN_IntrotoMicroK8s",
 primary_cta="Watch the webinar",
 primary_cta_class=""
 %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -93,4 +93,6 @@
 {% include "takeovers/_linux-security_takeover.html" %}
 <p>9 Dec 2019</p>
 {% include "takeovers/_vmware-to-charmed-openstack.html" %}
+<p>19 Dec 2019</p>
+{% include "takeovers/_intro-to-microk8s.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

added /engage/intro-to-microk8s-webinar and associated takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the "Intro to MicroK8s" takeover
- See that it matches the [brief](https://docs.google.com/spreadsheets/d/1FB-iCI2NIXbgENH4U8svB6MMI4FQjmAp3DnfJ5Ug9Ak/edit#gid=1271849439)
- Click the CTA to take you the engage page
- See that it matches the [copy doc](https://docs.google.com/document/d/1FCaFi5ZuP_pPMF2POu3ySaB00yt60Qo-nrNJZ9jwhFw/edit)
- Test the engage page on https://cards-dev.twitter.com/validator, see that it pulls through the appropriate title, description and image

## Issue / Card

Fixes #6300 
