### PR TITLE
add linux enterprise whitepaper engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -821,6 +821,16 @@
       type="webinar" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+  </div>
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Ubuntu Desktop for the enterprise",
+      description="Linux is increasingly emerging in enterprises as a desktop operating system (OS) alternative to Windows and Mac.",
+      slug="linux-enterprise-whitepaper",
+      group="desktop",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/linux-enterprise-whitepaper.md
+++ b/templates/engage/linux-enterprise-whitepaper.md
@@ -1,0 +1,31 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Ubuntu Desktop for the enterprise"
+     meta_description: "Linux is increasingly emerging in enterprises as a desktop operating system (OS) alternative to Windows and Mac."
+     meta_image: https://assets.ubuntu.com/v1/1fbcea93-Embedded+social+media+banner.jpg
+     meta_copydoc: https://docs.google.com/document/d/1rycA9y7Sx5bdwbRMtfBVU9nAkz5d5EIkvUv9jzhwMh4/edit
+     header_title: "Ubuntu Desktop for the enterprise"
+     header_subtitle: "Learn why enterprises are beginning to adopt Linux as a desktop operating system"
+     header_image: "https://assets.ubuntu.com/v1/5e2df4f0-Eoan+Ermine+laptop.png"
+     header_url: '#register-section'
+     header_cta: Download whitepaper
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--grad
+     form_include: en
+     form_id: 3481
+     form_return_url:
+---
+
+Linux is increasingly emerging in enterprises as a desktop operating system (OS) alternative to Windows and Mac. While Linux, particularly Ubuntu, has always been a popular choice amongst developers, enterprises are starting to adopt elsewhere within their organisation.
+
+Traditionally, Linux has given rise to ‘shadow IT’ concerns and security issues where employees have brought it into the organisation without formal approval. Rather than locking down and preventing the use of Linux, IT departments can offer employees their first choice OS as an officially supported platform. As Ubuntu Desktop is open source, this can offer many economic and efficiency benefits while ensuring it is used in a secure, compliant and productive manner.
+
+This whitepaper explains how Ubuntu Desktop can benefit an enterprise, including:
+
+- The long term support, predictable roadmap and security features Ubuntu Desktop offers for enterprises to meet their compliance needs and plan their deployments with certainty.
+
+- Integration with Microsoft and existing infrastructure environments to ensure other IT investments continue to deliver value.
+
+- The range of essential apps and office suites available on Linux to ensure all employees are productive and the selection of certified hardware Ubuntu Desktop is available on.  
+

--- a/templates/engage/linux-enterprise-whitepaper.md
+++ b/templates/engage/linux-enterprise-whitepaper.md
@@ -14,7 +14,7 @@ context:
      header_class: p-engage-banner--grad
      form_include: en
      form_id: 3481
-     form_return_url:
+     form_return_url: "https://pages.ubuntu.com/LinuxEnterprise-TY.html"
 ---
 
 Linux is increasingly emerging in enterprises as a desktop operating system (OS) alternative to Windows and Mac. While Linux, particularly Ubuntu, has always been a popular choice amongst developers, enterprises are starting to adopt elsewhere within their organisation.

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_intro-to-microk8s.html" %}
+  {% include "takeovers/_linux-enterprise.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_linux-enterprise.html
+++ b/templates/takeovers/_linux-enterprise.html
@@ -1,0 +1,15 @@
+{% with title="Ubuntu Desktop for the enterprise",
+subtitle="Learn what security, economic and efficiency benefits businesses can expect by adopting Ubuntu as a desktop operating system.",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/5e2df4f0-Eoan+Ermine+laptop.png",
+image_style="width: 464px;",
+image_hide_small=true,
+equal_cols="false",
+primary_url="/engage/linux-enterprise-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY19_IOT_Desktop_WBN_LinuxEnterprise",
+primary_cta="Download whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -95,4 +95,5 @@
 {% include "takeovers/_vmware-to-charmed-openstack.html" %}
 <p>19 Dec 2019</p>
 {% include "takeovers/_intro-to-microk8s.html" %}
+{% include "takeovers/_linux-enterprise.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

added /engage/linux-enterprise-whitepaper and associated takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the "Ubuntu Desktop for the enterprise" takeover
- See that it matches the [brief](https://docs.google.com/spreadsheets/d/1NLbSg_HAaLEknFNk30CJ2kwqxjaL7iUuw-fZQW3YGfM/edit#gid=1595677042) and the [design](https://github.com/canonical-web-and-design/web-squad/issues/2162#issuecomment-567103222)
- Click the CTA to take you the engage page
- See that it matches the [copy doc](https://docs.google.com/document/d/1rycA9y7Sx5bdwbRMtfBVU9nAkz5d5EIkvUv9jzhwMh4/edit) and the [design](https://github.com/canonical-web-and-design/web-squad/issues/2162#issuecomment-567103222)
- Test the engage page on https://cards-dev.twitter.com/validator, see that it pulls through the appropriate title, description and image

## Issue / Card

Fixes #6239 
