### PR TITLE
update meta description

### DIFF
--- a/templates/engage/vmware-to-charmed-openstack.md
+++ b/templates/engage/vmware-to-charmed-openstack.md
@@ -2,7 +2,7 @@
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "From VMware to Charmed OpenStack"
-     meta_description: "In this webinar, we present the key similarities and differences between VMware’s virtualisation offerings and Charmed OpenStack."
+     meta_description: "Migrate from VMware to Charmed OpenStack to reduce costs and increase infrastructure efficiency."
      meta_image: https://assets.ubuntu.com/v1/27fed536-vmware-to-charmed-openstack-social.jpg
      meta_copydoc: https://docs.google.com/document/d/13aUs6sT_Z4kTv1-KiISD22yqh_1VOw9xLLqEMftJZyU/edit
      header_title: "From VMware to Charmed&nbsp;OpenStack"


### PR DESCRIPTION
## Done

Updated meta description on /engage/vmware-to-charmed-openstack

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/vmware-to-charmed-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Inspect the page, see that the meta description is "Migrate from VMware to Charmed OpenStack to reduce costs and increase infrastructure efficiency."