### PR TITLE
Reduce 5 free machines to 3 for UA on ESM

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -66,7 +66,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Free for personal use</h2>
-      <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 5 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a> we will gladly increase that to 50 machines. Your personal subscription will also cover <a href="/livepatch">Livepatch</a>, FIPS and CIS hardening tools.</p>
+      <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 3 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a> we will gladly increase that to 50 machines. Your personal subscription will also cover <a href="/livepatch">Livepatch</a>, FIPS and CIS hardening tools.</p>
       <a href="/advantage" class="p-button--positive u-no-margin--bottom">Get ESM now</a>
     </div>
   </div>


### PR DESCRIPTION
## Done
Reduce 5 free machines to 3 for UA on ESM

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check it matches [the copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit#)

Fixes: https://github.com/canonical-web-and-design/ubuntu.com/issues/6312
