### PR TITLE
Add Download Ubuntu Core to contextual footer in core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -505,12 +505,17 @@ store for access to all the standard apps, or curate your own collection.</p>
 
 <section class="p-strip">
   <div class="row p-divider">
-    <div class="col-6 p-divider__block">
+    <div class="col-4 p-divider__block">
+      <h4>Download Ubuntu Core</h4>
+      <p>Try Ubuntu Core 18 on one of a popular development board</p>
+      <p><a class="p-button--neutral" href="https://docs.ubuntu.com/core/en/guides/build-device/image-building?from=corepage">Download and install Ubuntu Core 18</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
       <h4>Make your own Ubuntu Core device</h4>
       <p>Walk through the steps to build an image for a device.</p>
-      <p><a class="p-button--neutral" href="http://docs.ubuntu.com/core/en/guides/build-device/image-building?from=corepage"><span class="p-link--external">Build a custom Ubuntu Core image</span></a></p>
+      <p><a class="p-button--neutral" href="https://docs.ubuntu.com/core/en/guides/build-device/image-building?from=corepage"><span class="p-link--external">Build a custom Ubuntu Core image</span></a></p>
     </div>
-    <div class="col-6 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h4>Let&rsquo;s work together</h4>
       <p>Talk to us about using Ubuntu Core for your next project.</p>
       <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Get in touch</a></p>


### PR DESCRIPTION
## Done
Add Download Ubuntu Core to contextual footer in core
Update the links to `https`

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check it matches the [copy doc](https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit#)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6313
