### PR TITLE
Fix the install help link on the download thank you page

### DIFF
--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,17 +1,17 @@
 <p>
   You can
   <span class="p-contextual-menu--left">
-      <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
-      <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
-        <span class="p-contextual-menu__group">
-          <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
-          <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
-          <small>You should get the following output:</small><br />
-          <code style="display: block; margin-top: 1rem;">ubuntu-{{ version }}-{{ system }}-{{ architecture }}.iso: OK</code><br />
-          <small>Or follow this tutorial to learn <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
-        </span>
+    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
+    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
+      <span class="p-contextual-menu__group">
+        <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
+        <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
+        <small>You should get the following output:</small><br />
+        <code style="display: block; margin-top: 1rem;">ubuntu-{{ version }}-{{ system }}-{{ architecture }}.iso: OK</code><br />
+        <small>Or follow this tutorial to learn <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
-  </span>, or get <a href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server?backURL=https://ubuntu.com/download/server/thank-you" class="p-link--external">help on installing</a>.
+    </span>
+  </span>, or get <a href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you" class="p-link--external">help on installing</a>.
 </p>
 
 <script>


### PR DESCRIPTION
## Done
Use the `system` variable to dynamically set the "help on installing" tutorial link instead of always pointing to server. I had to add a conditional as the system for server is "live-server" and we need "server".

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /download/desktop/thank-you?country=US&version=18.04.3&architecture=amd64
- Check the "Help on installing" link points to the desktop tutorial and returns to the correct thank you page.
- Go to /download/server/thank-you?version=18.04.3&architecture=amd64
- Check the "Help on installing" link points to the server tutorial and returns to the correct thank you page.
