### PR TITLE
Add ceph to enterprise dropdown

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -141,6 +141,7 @@
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS - fast server provisioning</a></li>
           <li class="p-list__item"><a href="https://jaas.ai.com" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
+          <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
           <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>
         </ul>


### PR DESCRIPTION
## Done

- Added Ceph to the enterprise dropdown

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/#enterprise
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit)


## Issue / Card

Fixes #6329
