### PR TITLE
Update heading on /ceph page

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -29,7 +29,7 @@
       <p>Ceph is a storage solution designed to address the object, block, and file storage needs of data centres adopting open source as the new norm for high-growth block storage, object stores and data lakes. Ceph provides enterprise scalable storage while keeping CAPEX and OPEX costs in line with the underlying bulk commodity disk prices.</p>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="col-10 u-sv3">
       <img src="https://assets.ubuntu.com/v1/b96d5736-Ceph-diagram-1+outlined.svg" alt="Ceph diagram" />
@@ -62,7 +62,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <h2>Ceph is better on Ubuntu</h2>
+    <h2>Ceph storage done right</h2>
     <p>Whether you choose to use your own operational framework or leverage the advantages of Charmed Ceph, the choice is yours. Each Ubuntu LTS release ships a version of Ceph that is supported for up to 10 years. Newer releases of Ceph can be installed from the Ubuntu Cloud Archive allowing flexibility for selecting the right version of Ceph for your environment. To maximise Ceph upgrade flexibility for customers, Ceph versions are regularly released and maintained via the Ubuntu updates and security repositories, as well as the Ubuntu Cloud Archive. This leads to predictability and a flexible mix between remaining at the forefront of innovation and long-term support predictability.</p>
   </div>
 

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -154,7 +154,7 @@
       <h3 class="p-heading--four">Managed Ceph</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Fully managed storage cluster,  on your servers, at your location </li>
-        <li class="p-list__item is-ticked">Built in weeks using a proven reference architecture</li>
+        <li class="p-list__item is-ticked">Built in 2 weeks using a proven reference architecture</li>
         <li class="p-list__item is-ticked">Customise the architecture in iterations based on your storage needs</li>
         <li class="p-list__item is-ticked">Your team has access to all machines at all times</li>
         <li class="p-list__item is-ticked">Modern monitoring and log management</li>


### PR DESCRIPTION
## Done

- Update heading on /ceph page
- Add '2' weeks

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the heading 'Ceph is better on Ubuntu' is now 'Ceph storage done right' from the [copy doc](https://docs.google.com/document/d/17VnBygL00hXjLSECXMo3bF7KOCT5oZGFBLo6Qd6rF3A/edit#heading=h.4h5l8ixjazx1) and 'Built in weeks...' is 'Built in 2 weeks...' 

## Issue / Card

Fixes #6331
