### PR TITLE
Fix the malformed with for the inclusion of forms

### DIFF
--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -7,49 +7,49 @@
   {% if product == 'containers-docker' %}
 {% with h1="Contact us about Docker Engine on Ubuntu",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964',
-  lpId='3828',
-  returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964",
+  lpId="3828",
+  returnURL="https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes' %}
 {% with h1="Contact us about The Charmed Distribution of Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="2243',
-  lpId='4986',
-  returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes" %}
+  formid="2243",
+  lpId="4986",
+  returnURL="https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes-foundation' %}
 {% with h1="Contact us about Canonical's enterprise Kubernetes packages",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="2243',
-  lpId='4986',
-  returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation" %}
+  formid="2243",
+  lpId="4986",
+  returnURL="https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-lxd' %}
 {% with h1="Contact us about LXD",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964',
-  lpId='3828',
-  returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964",
+  lpId="3828",
+  returnURL="https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-overview' %}
 {% with h1="Contact us about containers on Ubuntu",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964',
-  lpId='3828',
-  returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964",
+  lpId="3828",
+  returnURL="https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
 {% with h1="Contact us about containers",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964',
-  lpId='3828',
-  returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964",
+  lpId="3828",
+  returnURL="https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -7,37 +7,49 @@
   {% if product == 'containers-docker' %}
 {% with h1="Contact us about Docker Engine on Ubuntu",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964',
+  lpId='3828',
+  returnURL='https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes' %}
 {% with h1="Contact us about The Charmed Distribution of Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes" %}
+  formid="2243',
+  lpId='4986',
+  returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes-foundation' %}
 {% with h1="Contact us about Canonical's enterprise Kubernetes packages",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="2243'  lpId='4986' returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation" %}
+  formid="2243',
+  lpId='4986',
+  returnURL='https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-lxd' %}
 {% with h1="Contact us about LXD",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964',
+  lpId='3828',
+  returnURL='https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-overview' %}
 {% with h1="Contact us about containers on Ubuntu",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964',
+  lpId='3828',
+  returnURL='https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
 {% with h1="Contact us about containers",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you" %}
+  formid="1964',
+  lpId='3828',
+  returnURL='https://www.ubuntu.com/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/kubeflow/contact-us.html
+++ b/templates/kubeflow/contact-us.html
@@ -7,57 +7,57 @@
   {% if product == 'ai-index-workshop' %}
 {% with h1="Contact us about our AI workshop",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-index-workshop" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-index-workshop" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-index-assessment' %}
 {% with h1="Contact us about our ML / Data Science assessment",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-index-managed' %}
 {% with h1="Contact us about our managed AI services",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-install' %}
 {% with h1="Contact us about installing Kubeflow",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-consulting' %}
 {% with h1="Contact us about Canonical consulting",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
     {% elif product == 'ai-features' %}
 {% with h1="Contact us about AI on Canonical",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
 {% with h1="Contact us about Artificial Intelligence",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231',
-  lpId='6279',
-  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231",
+  lpId="6279",
+  returnURL="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/kubeflow/contact-us.html
+++ b/templates/kubeflow/contact-us.html
@@ -7,43 +7,57 @@
   {% if product == 'ai-index-workshop' %}
 {% with h1="Contact us about our AI workshop",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-index-workshop" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-index-workshop" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-index-assessment' %}
 {% with h1="Contact us about our ML / Data Science assessment",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-index-managed' %}
 {% with h1="Contact us about our managed AI services",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-install' %}
 {% with h1="Contact us about installing Kubeflow",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-consulting' %}
 {% with h1="Contact us about Canonical consulting",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
     {% elif product == 'ai-features' %}
 {% with h1="Contact us about AI on Canonical",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
 {% with h1="Contact us about Artificial Intelligence",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3231'  lpId='6279' returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
+  formid="3231',
+  lpId='6279',
+  returnURL='https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -8,81 +8,81 @@
   {% if product == 'kubernetes' %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-managed' %}
 {% with h1="Contact us about Managed Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-kubeadm' %}
 {% with h1="Contact us about kubeadm",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'multicloud' %}
 {% with h1="Contact us about multicloud",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=multicloud" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=multicloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-install' %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-features' %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-consulting' %}
 {% with h1="Contact us about Kubernetes consulting",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-add-on' %}
 {% with h1="Contact us about Kubernetes with AI/ML",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-support' %}
 {% with h1="Contact us about Kubernetes support",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230',
-  lpId='6274',
-  returnURL='https://www.ubuntu.com/kubernetes/thank-you" %}
+  formid="3230",
+  lpId="6274",
+  returnURL="https://www.ubuntu.com/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -8,61 +8,81 @@
   {% if product == 'kubernetes' %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-managed' %}
 {% with h1="Contact us about Managed Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-kubeadm' %}
 {% with h1="Contact us about kubeadm",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'multicloud' %}
 {% with h1="Contact us about multicloud",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=multicloud" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=multicloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-install' %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-features' %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-consulting' %}
 {% with h1="Contact us about Kubernetes consulting",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-add-on' %}
 {% with h1="Contact us about Kubernetes with AI/ML",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-support' %}
 {% with h1="Contact us about Kubernetes support",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
 {% with h1="Contact us about Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
-  formid="3230'  lpId='6274' returnURL='https://www.ubuntu.com/kubernetes/thank-you" %}
+  formid="3230',
+  lpId='6274',
+  returnURL='https://www.ubuntu.com/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -78,9 +78,9 @@
 
 {% with h1="Talk to us about building your cloud",
   intro_text="Fill in your details below and a member of our Private Cloud Build team will be in touch.",
-  formid="1251',
-  lpId='2086',
-  returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" %}
+  formid="1251",
+  lpId="2086",
+  returnURL="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -92,9 +92,9 @@
 
 {% with h1="Contact us about OpenStack",
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
-  formid="1251',
-  lpId='2086',
-  returnURL='https://www.ubuntu.com/openstack/thank-you" %}
+  formid="1251",
+  lpId="2086",
+  returnURL="https://www.ubuntu.com/openstack/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -78,7 +78,9 @@
 
 {% with h1="Talk to us about building your cloud",
   intro_text="Fill in your details below and a member of our Private Cloud Build team will be in touch.",
-  formid="1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" %}
+  formid="1251',
+  lpId='2086',
+  returnURL='https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -90,7 +92,9 @@
 
 {% with h1="Contact us about OpenStack",
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
-  formid="1251'  lpId='2086' returnURL='https://www.ubuntu.com/openstack/thank-you" %}
+  formid="1251',
+  lpId='2086',
+  returnURL='https://www.ubuntu.com/openstack/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -59,9 +59,9 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=maas-training-onsit
 
 {% with h1="Contact us about Canonical Training",
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
-  formid="1251',
-  lpId='2086',
-  returnURL='https://www.ubuntu.com/training/thank-you" %}
+  formid="1251",
+  lpId="2086",
+  returnURL="https://www.ubuntu.com/training/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -59,7 +59,9 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=maas-training-onsit
 
 {% with h1="Contact us about Canonical Training",
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
-  formid="1251'  lpId='2086' returnURL='https://www.ubuntu.com/training/thank-you" %}
+  formid="1251',
+  lpId='2086',
+  returnURL='https://www.ubuntu.com/training/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 


### PR DESCRIPTION
## Done
Fix the malformed with for the inclusion of forms across the site

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to following pages and see the form submits and you end up on the thank you page
  - /containers/contact-us 
  - /kubeflow/contact-us
  - /kubernetes/contact-us
  - /openstack/contact-us
  - /training/contact-us
