### PR TITLE
fix typo in suru pattern

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -210,7 +210,7 @@
 
     @media only screen and (max-width: $breakpoint-small) {
       background-blend-mode: normal;
-      background-image: linear-gradient(todeg, #E95422 0%, #772953 49.5%, #2C001E 100%);
+      background-image: linear-gradient(251deg, #E95422 0%, #772953 49.5%, #2C001E 100%);
       background-position: left top;
       background-repeat: no-repeat;
       background-size: 100% 76.5%;


### PR DESCRIPTION
## Done

- fixed `.p-strip-suru-half-top` on small screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View the page on a small screen, see that the suru isn't broken.


## Issue / Card

Fixes #6340 

## Screenshots

**Fixed:**
![Screenshot 2020-01-10 at 10 08 47](https://user-images.githubusercontent.com/2376968/72144889-3f177d80-3391-11ea-8156-2c77d276ac47.png)

**Broken:**
![Screenshot 2020-01-10 at 10 08 30](https://user-images.githubusercontent.com/2376968/72144908-463e8b80-3391-11ea-97f8-4386cfcc1295.png)

