### PR TITLE
Fix the opt-in checkbox in the dynamic contact us form

### DIFF
--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -16,6 +16,17 @@
       });
     });
 
+    // recaptcha submitCallback
+    CaptchaCallback = function() {
+      let recaptchas = document.querySelectorAll("div[class^=g-recaptcha]");
+      recaptchas.forEach(function(field){
+        if (!field.hasAttribute('data-widget-id')) {
+          recaptchaWidgetId = grecaptcha.render(field, {'sitekey' : '6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if'});
+          field.setAttribute("data-widget-id", recaptchaWidgetId);
+        }
+      });
+    }
+
     // Fetch, load and initialise form
     function fetchForm(formData, contactButton) {
       fetch(formData.formLocation)

--- a/static/js/dynamic-contact-form.js
+++ b/static/js/dynamic-contact-form.js
@@ -16,15 +16,6 @@
       });
     });
 
-    // recaptcha submitCallback
-    var CaptchaCallback = function() {
-      let recaptchas = document.querySelectorAll("div[class^=g-recaptcha]");
-      recaptchas.forEach(function(field){
-        recaptchaWidgetId = grecaptcha.render(field, {'sitekey' : '6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if'});
-        field.setAttribute("data-widget-id", recaptchaWidgetId);
-      });
-    }
-
     // Fetch, load and initialise form
     function fetchForm(formData, contactButton) {
       fetch(formData.formLocation)

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -10,12 +10,9 @@
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">
-          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
-          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>&nbsp;<span class="mktFormMsg"></span>
+          <input class="mktFormCheckbox" name="canonicalOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical’s products and services.</label>&nbsp;<span class="mktFormMsg"></span>
         </span>
-      </li>
-      <li class="p-list__item">
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
       </li>
       <li class="p-list__item u-no-margin--top">
         In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.


### PR DESCRIPTION
## Done
Make the checkbox id unique.
Remove the recapture from the foot newletter sign up

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8001/internet-of-things/gateways
- Scroll to the bottom and hit "Get in touch"
- Fill in the form and on the final step check both the "I agree to receive information about Canonical’s products and services." check box and recapture works

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6336

