### PR TITLE
Prevent breadcrumb contextual menu overlap

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -479,3 +479,7 @@ summary {
     justify-content: flex-start;
   }
 }
+
+.breadcrumbs--secondary .p-contextual-menu__dropdown {
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Done
Removed the top margin of the contextual menu in the breadcrumb navigation to avoid it being overlapped by the main navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Hover over `topics` in the breadcrumb navigation
- See that the contextual menu is not partially covered by the main navigation


## Issue / Card

Fixes #6345

## Screenshots
https://user-images.githubusercontent.com/501889/72150818-645eb880-339e-11ea-8f51-8b37cae9ca35.png
