### PR TITLE
Update link to /advantage page on /esm

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -96,7 +96,7 @@
       <h2>Common questions</h2>
 
       <h4 class="u-no-max-width">Do all levels of Ubuntu Advantage for Infrastructure have access to Ubuntu ESM?</h4>
-      <p>Yes. Ubuntu ESM is available for UA-I Essential, Standard and Advanced customers. For more information on levels please visit our <a href="/pricing">pricing page</a>. Existing UA customers can request their credentials through the <a class="p-link--external" href="https://support.canonical.com/ua/s/article/obtain-ESM-credentials-and-modify-your-apt-sources-to-get-ESM-updates">Canonical support portal</a>.</p>
+      <p>Yes. Ubuntu ESM is available for UA-I Essential, Standard and Advanced customers. For more information on levels please visit our <a href="/pricing">pricing page</a>. Existing UA customers can retrieve their credentials through the <a href="/advantage">Ubuntu Advantage portal</a>.</p>
 
       <h4 class="u-no-max-width">How can we ensure the security of our Ubuntu systems after the end of Standard Security Maintenance?</h4>
       <p>Sign up to Ubuntu Advantage now, and you will benefit from UA services immediately without having a gap in service when a particular release reaches the end of its Standard Security Maintenance window. For more details of initial release dates and maintenance cadence, see <a href="https://wiki.ubuntu.com/Releases">wiki.ubuntu.com/Releases</a>. Ubuntu Advantage is available at <a class="p-link--external" href="https://buy.ubuntu.com/">buy.ubuntu.com</a> and through the <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B01MZ1LSBQ?qid=1486382973569&sr=0-1&ref_=srh_res_product_title">AWS Marketplace</a>.</p>


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/esm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it links to the /advtange page and compare to the [copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit)


## Issue / Card

Fixes #6347

## Screenshots

![image](https://user-images.githubusercontent.com/441217/72246733-4a65e580-35eb-11ea-9ff6-9a0f554de9a8.png)

