### PR TITLE
Add feedback section to tutorial page

### DIFF
--- a/static/js/tutorials.js
+++ b/static/js/tutorials.js
@@ -49,4 +49,24 @@
     window.location.hash = firstSectionLink.getAttribute('href');
     scrollToTop();
   }
+
+  var tutorialFeedbackOptions = document.querySelector('.l-tutorial__feedback-options');
+  var tutorialFeedbackIcons = document.querySelectorAll('.l-tutorial__feedback-icon');
+  var tutorialFeedbackResult = document.querySelector('.l-tutorial__feedback-result');
+
+  tutorialFeedbackIcons.forEach(function(icon) {
+    icon.addEventListener('click', function(e) {
+      var feedbackValue = e.target.getAttribute('data-feedback-value');
+      dataLayer.push({
+        'event' : 'GAEvent',
+        'eventCategory' : 'feedback',
+        'eventAction' : feedbackValue,
+        'eventLabel' : feedbackValue,
+        'eventValue' : undefined
+      });
+
+      tutorialFeedbackOptions.classList.add('u-hide');
+      tutorialFeedbackResult.classList.remove('u-hide');
+    });
+  });
 })();

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -142,4 +142,8 @@
       transform: rotate(-90deg);
     }
   }
+
+  .l-tutorial__feedback-icon {
+    cursor: pointer;
+  }
 }

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -44,6 +44,28 @@
       <article class="l-tutorial-section__content">
         {{ section.content | safe }}
       </article>
+
+      {% if loop.last %}
+      <div class="l-tutorial__feedback-options">
+        <p>Was this tutorial useful?</p>
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item">
+            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/04f445ea-Helpful-yes.svg" alt="Positive response" data-feedback-value="positive">
+          </li>
+          <li class="p-inline-list__item">
+            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/e03275bf-Helpful-unsure.svg" alt="Neutral response" data-feedback-value="neutral">
+          </li>
+          <li class="p-inline-list__item">
+            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/d20e84ba-Helpful-no.svg" alt="Negative response" data-feedback-value="negative">
+          </li>
+        </ul>
+      </div>
+
+      <div class="l-tutorial__feedback-result u-hide">
+        <p>Thank you for your feedback.</p>
+      </div>
+      {% endif %}
+
       <hr class="u-sv3">
       <footer class="l-tutorial-section__footer row">
         <div class="col-6 col-small-2 col-medium-3 u-vertically-center">


### PR DESCRIPTION
## Done

Add feedback section to final step in tutorial page

## QA

- Go to `/tutorials` and click through to a tutorial
- Go to the last section of the tutorial
- See that there is the same smiley face feedback section as the current tutorials site
- Click the options and see that they are sending the correct events (this chrome extension can help with that: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en)

## Issue / Card

Fixes #6360 