### PR TITLE
Takedown linux security takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,6 @@
 
 {% block takeover_content %}
   {# ALL #}
-  {% include "takeovers/_linux-security_takeover.html" %}
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_intro-to-microk8s.html" %}


### PR DESCRIPTION
## Done

- Takedown linux security takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the linux security takeover is no longer in rotation

## Screenshots

![image](https://user-images.githubusercontent.com/441217/72269034-cf1c2800-361a-11ea-83ba-588b66ec118c.png)
