### PR TITLE
Trusted managed service provider section

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -313,6 +313,10 @@
   </section>
 
   <section class="p-strip is-bordered">
+    {% include "shared/_trusted-managed-service-provider.html" %}
+  </section>
+
+  <section class="p-strip--light is-bordered">
     <div class="row">
       <div class="col-8">
         <h2>Count on Canonical&rsquo;s Kubernetes and OpenStack expertise</h2>
@@ -360,7 +364,7 @@
     </div>
   </section>
 
-  <section class="p-strip--light is-bordered">
+  <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-8">
         <h2>Shape it to your needs</h2>
@@ -400,7 +404,7 @@
     </div>
   </section>
 
-  <section class="p-strip is-bordered">
+  <section class="p-strip--light is-bordered">
     <div class="row">
       <div class="col-8">
         <h2>Managed Kubernetes pricing</h2>
@@ -409,7 +413,7 @@
     </div>
   </section>
 
-  <section class="p-strip--light">
+  <section class="p-strip">
     <div class="row">
       <div class="col-8">
         <h3>Talk to Canonical&rsquo;s remote operations team about building and operating your Kubernetes cluster today.</h3>

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -343,7 +343,11 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip is-bordered">
+  {% include "shared/_trusted-managed-service-provider.html" %}
+</section>
+
+<section class="p-strip--light is-deep is-bordered">
   <div class="u-fixed-width">
     <h2>Count on Canonical’s OpenStack expertise</h2>
   </div>
@@ -394,7 +398,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>Build, operate, transfer and support</h2>
     <p>The best way to keep costs down and ensure a high quality cloud is to use a repeatable, standardised methodology for workload analysis, requirements gathering, deployment and operations.</p>
@@ -470,7 +474,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Customisable cloud</h2>
   </div>

--- a/templates/shared/_trusted-managed-service-provider.html
+++ b/templates/shared/_trusted-managed-service-provider.html
@@ -1,0 +1,42 @@
+<div class="row">
+  <h2>Trusted Managed Service Provider</h2>
+  <p>By ensuring the confidentiality and privacy of our customers’ data, and applying security best practices, we are proud to have been awarded the following certifications:</p>
+</div>
+
+<div class="row">
+  <div class="col-6 u-vertically-center">
+  </div>
+  <div class="col-6 u-vertically-center">
+    <h3>SOC 2 Type 2</h3>
+    <p>System and Organisation Controls Type 2 compliance certification is granted by <a href="https://www.aicpa.org/about.html" class="p-link--external">AICPA</a> to companies which have passed a rigorous audit performed by an independent certified public accountant. SOC2 Type 2 confirms that our managed services offering is designed to keep your sensitive data secure.</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-6 u-vertically-center">
+    <h3>GDPR</h3>
+    
+    <p>The General Data Protection Regulation is an EU (European Union) regulation on data protection and privacy of EU citizens. GDPR certification is granted by an independent, accredited standards body based on a detailed audit. The compliance with GDPR ensures the privacy of your data when using Canonical’s managed services.</p>
+  </div>
+  <div class="col-6 u-vertically-center"></div>
+</div>
+
+<div class="row u-equal-height">
+  <div class="col-6 u-vertically-center u-align--center">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/3c7d6f78-iso_27001_02.png",
+        alt="",
+        height="200",
+        width="200",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
+      ) | safe
+    }}
+  </div>
+  <div class="col-6 u-vertically-center">
+    <h3>ISO 27001/27002</h3>
+
+    <p>The ISO27000 standard family outlines best practice recommendations on information security management. The standards are published by the International Organisation for Standardisation, while the certification is assigned by accredited registrars. Complying with 27001 and 27002 standards guarantees the security of your information assets on Canonical’s managed services platform.</p>
+  </div>
+</div>

--- a/templates/shared/_trusted-managed-service-provider.html
+++ b/templates/shared/_trusted-managed-service-provider.html
@@ -4,7 +4,17 @@
 </div>
 
 <div class="row">
-  <div class="col-6 u-vertically-center">
+  <div class="col-6 u-vertically-center u-align--center">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/4e65dcef-SOC2TYPE2.png",
+        alt="",
+        height="180",
+        width="400",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
+      ) | safe
+    }}
   </div>
   <div class="col-6 u-vertically-center">
     <h3>SOC 2 Type 2</h3>

--- a/templates/shared/_trusted-managed-service-provider.html
+++ b/templates/shared/_trusted-managed-service-provider.html
@@ -20,6 +20,7 @@
     <h3>SOC 2 Type 2</h3>
     <p>System and Organisation Controls Type 2 compliance certification is granted by <a href="https://www.aicpa.org/about.html" class="p-link--external">AICPA</a> to companies which have passed a rigorous audit performed by an independent certified public accountant. SOC2 Type 2 confirms that our managed services offering is designed to keep your sensitive data secure.</p>
   </div>
+  <hr class="p-separator" />
 </div>
 
 <div class="row">
@@ -29,6 +30,7 @@
     <p>The General Data Protection Regulation is an EU (European Union) regulation on data protection and privacy of EU citizens. GDPR certification is granted by an independent, accredited standards body based on a detailed audit. The compliance with GDPR ensures the privacy of your data when using Canonical’s managed services.</p>
   </div>
   <div class="col-6 u-vertically-center"></div>
+  <hr class="p-separator" />
 </div>
 
 <div class="row u-equal-height">

--- a/templates/shared/_trusted-managed-service-provider.html
+++ b/templates/shared/_trusted-managed-service-provider.html
@@ -64,9 +64,9 @@
   <div class="col-6 u-vertically-center u-align--center">
     {{
       image(
-        url="https://assets.ubuntu.com/v1/d53fe335-cyber-verify-logo.png",
+        url="https://assets.ubuntu.com/v1/f68b6350-MSPA_Cyber-Verify-Seal-AA_.png",
         alt="",
-        height="130",
+        height="220",
         width="220",
         hi_def=True,
         attrs={"class": "u-hide--small"},
@@ -74,7 +74,7 @@
     }}
     {{
       image(
-        url="https://assets.ubuntu.com/v1/674325da-cloud-verify-logo.png",
+        url="https://assets.ubuntu.com/v1/b53d04d6-cloud-verify.png",
         alt="",
         height="110",
         width="227",

--- a/templates/shared/_trusted-managed-service-provider.html
+++ b/templates/shared/_trusted-managed-service-provider.html
@@ -51,4 +51,36 @@
 
     <p>The ISO27000 standard family outlines best practice recommendations on information security management. The standards are published by the International Organisation for Standardisation, while the certification is assigned by accredited registrars. Complying with 27001 and 27002 standards guarantees the security of your information assets on Canonical’s managed services platform.</p>
   </div>
+  <hr class="p-separator" />
+</div>
+
+<div class="row u-equal-height">
+  <div class="col-6 u-vertically-center">
+    <h3>Cyber Verify AA Rating & Cloud Verify Certification</h3>
+
+    <p>Canonical achieved the AA Cyber Verify™ Risk Assurance Rating for Managed Services and Cloud Providers from the MSPAlliance® and successfully completed the MSP Cloud Verify Program (MSPCV) certification process for its OpenStack and Kubernetes cloud and managed service offerings and Ubuntu Advantage for Infrastructure commercial support programme. Cyber Verify and MSPCV is based on 10 control objectives of the Unified Certification Standard™ (UCS) for Cloud and Managed Service Providers.</p>
+  </div>
+
+  <div class="col-6 u-vertically-center u-align--center">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/d53fe335-cyber-verify-logo.png",
+        alt="",
+        height="130",
+        width="220",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
+      ) | safe
+    }}
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/674325da-cloud-verify-logo.png",
+        alt="",
+        height="110",
+        width="227",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
+      ) | safe
+    }}
+  </div>
 </div>

--- a/templates/shared/_trusted-managed-service-provider.html
+++ b/templates/shared/_trusted-managed-service-provider.html
@@ -29,7 +29,18 @@
     
     <p>The General Data Protection Regulation is an EU (European Union) regulation on data protection and privacy of EU citizens. GDPR certification is granted by an independent, accredited standards body based on a detailed audit. The compliance with GDPR ensures the privacy of your data when using Canonical’s managed services.</p>
   </div>
-  <div class="col-6 u-vertically-center"></div>
+  <div class="col-6 u-vertically-center u-align--center">
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/83332791-GDPR_compliant1.svg",
+        alt="",
+        height="191",
+        width="156",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
+      ) | safe
+    }}
+  </div>
   <hr class="p-separator" />
 </div>
 


### PR DESCRIPTION
## Done

- Added trusted managed service provider section to /kubernetes/managed and /openstack/managed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the [copy doc](https://docs.google.com/document/d/1Qv379nYnod9e4jMrsdDND8D7mbPyqELi2lowjkfD-gU/edit#)
- Visit http://0.0.0.0:8001/openstack/managed
- See that the page matches the [copy doc](https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit#)


## Issue / Card

Fixes #6355 & #6356 
