### PR TITLE
Use coreutils sha256sum instead of Perl's shasum

### DIFF
--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -5,7 +5,7 @@
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
-        <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
+        <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | sha256sum --check</code><br />
         <small>You should get the following output:</small><br />
         <code style="display: block; margin-top: 1rem;">ubuntu-{{ version }}-{{ system }}-{{ architecture }}.iso: OK</code><br />
         <small>Or follow this tutorial to learn <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>


### PR DESCRIPTION
Current download verify dialog shows this:

echo "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso" | shasum -a 256 --check

but the `shasum` is a program implemented in Perl, which might not be
installed. On my distro, I am able to have entire system installed
without any Perl at all, and no shasum program by default at all.

However, it is very likely to have GNU coreutils installed. It would
be actually hard not to have it installed.

So the dialog should show instead:

echo "96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso" | sha256sum --check

As a bonus, sha256sum is slightly faster: I also done minor benchmarks,
and sha256sum was about 6% faster.
(Perl shasum -a 256: 8.68s, coreutils sha256sum: 8.13s; real time).

The input / output format is exactly the same.

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
