### PR TITLE
Fix loading of tutorial page

### DIFF
--- a/static/js/tutorials.js
+++ b/static/js/tutorials.js
@@ -23,7 +23,7 @@
     // which prevents the page from jumping
     window.setTimeout(function() {
       window.scrollTo(0, 0);
-    });
+    }, 0);
   }
 
   var navigationLinks = document.querySelectorAll('.l-tutorial__nav-link');


### PR DESCRIPTION
## Done

Fix loading of tutorial page with timeout parameter to run the scroll after the event loop

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials/tutorial-install-ubuntu-desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page loads scrolled to the top so the header and navigation are visible
- Navigate between sections using both the side nav and the arrows at the bottom of each section
- Check that the page always loads scrolled to the top so the header and navigation are visible


## Issue / Card

Fixes #6359 