### PR TITLE
Add min height to tutorial section

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.2.0
 canonicalwebteam.templatefinder==0.2.2
 canonicalwebteam.image-template==1.0.0
-canonicalwebteam.discourse-docs==0.8.0
+canonicalwebteam.discourse-docs==0.8.1
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -6,6 +6,7 @@
 
     @media only screen and (min-width: $breakpoint-medium) {
       flex-direction: row;
+      min-height: calc(100vh - 225px); // minus header, nav and footer height
     }
   }
 

--- a/templates/templates/small-footer.html
+++ b/templates/templates/small-footer.html
@@ -1,4 +1,4 @@
-<div class="p-footer p-strip is-shallow">
+<div class="p-footer p-strip">
   <div class="u-fixed-width">
     <div class="p-footer--secondary row">
       <div class="col-7">


### PR DESCRIPTION
## Done

Gave minimum height to tutorial section on dropbox so footer is positioned at the bottom edge of the screen

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials/tutorial-install-ubuntu-desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Find a section of the tutorial which has a short amount of content, less than your viewport height
- See that the footer is positioned at the bottom edge of the screen


## Issue / Card

Fixes #6372 