### PR TITLE
Switch to BUILD_ID in the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ COPY --from=build-css /srv/static/css static/css
 ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
 
 # Set revision ID
-ARG TALISKER_REVISION_ID
-ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
+ARG BUILD_ID
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
 
 # Setup commands to run server


### PR DESCRIPTION
We've agreed to use `BUILD_ID` instead of `TALISKER_REVISION_ID` for the docker build arg.

QA
--

``` bash
DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=fish --tag ucom .
docker run -ti -p 8777:80 ucom
```

Check http://localhost:8777 works.

Run:

``` bash
$ curl -I http://localhost:8777
X-VCS-Revision: fish
```

 ^ Check the build ID is there