### PR TITLE
Prevent wide pre section stretching out the parent

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -70,7 +70,9 @@
   }
 
   .l-tutorial__content {
+    overflow: hidden; // stops pre from stretching out the flex column
     padding-top: $sp-large;
+    width: 100%;
 
     @media only screen and (min-width: $breakpoint-small) {
       padding-left: 5%;


### PR DESCRIPTION
## Done

Prevent wide pre section from stretching out the parent flex column

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials/install-microk8s-on-a-mac-using-multipass#testing-add-ons
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the width of the tutorial section column (with the title `5. Validating the charm) doesn't extend beyond the site's width


## Issue / Card

Fixes #6377 