### PR TITLE
Tweak 18.04 certification status

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -12,7 +12,7 @@
     <div class="col-8">
       <h1>Security Certifications</h1>
       <p>
-        Canonical has achieved FIPS 140-2 Level 1 certification for several cryptographic modules on Ubuntu 16.04, with 18.04 coming Autumn 2019. Canonical has also achieved Common Criteria EAL2 certification for Ubuntu 16.04. In addition, Defense Information System Agency (DISA) has published Ubuntu 16.04 Security Technical Implementation Guide (STIG) which allows Ubuntu to be used by Federal agencies. The Center for Internet Security (CIS) also publishes benchmarks for hardening the configuration of Ubuntu systems to make them more secure.
+        Canonical has achieved FIPS 140-2 Level 1 certification for several cryptographic modules on Ubuntu 16.04, with 18.04 in progress. Canonical has also achieved Common Criteria EAL2 certification for Ubuntu 16.04. In addition, Defense Information System Agency (DISA) has published Ubuntu 16.04 Security Technical Implementation Guide (STIG) which allows Ubuntu to be used by Federal agencies. The Center for Internet Security (CIS) also publishes benchmarks for hardening the configuration of Ubuntu systems to make them more secure.
       </p>
       <p>
         Canonical has made its security certification offerings available to all Ubuntu Advantage for Infrastructure customers.


### PR DESCRIPTION
## Done

- Change "comming Autumn 2019" to "in progress."

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1CiF-dPqG1Y--h4FWfgKB1ft4G3nC2Boa8NT_JG7D6dQ/edit#)

## Issue / Card

Fixes #6339
