### PR TITLE
Remove padding from tutorial in tablet view

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -74,7 +74,7 @@
     padding-top: $sp-large;
     width: 100%;
 
-    @media only screen and (min-width: $breakpoint-small) {
+    @media only screen and (min-width: $breakpoint-medium) {
       padding-left: 5%;
     }
   }


### PR DESCRIPTION
## Done

Remove left padding on tutorial section in tablet view

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial
- Resize the browser to tablet
- Check that the padding is even both sides of the tutorial section


## Issue / Card

Fixes #6388
