### PR TITLE
Allow HTML in tutorial cards

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -79,7 +79,7 @@
             <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">
               {{ item.topic | replace("inline-onebox", "p-link--soft") | safe }}
             </h3>
-            <p class="u-sv3">{{ item.summary }}</p>
+            <p class="u-sv3">{{ item.summary | safe }}</p>
           </div>
           <footer class="blog-p-card__footer">
             Difficulty: <span class="l-tutorials-meter l-tutorials-meter--{{ item.difficulty }}">{{ item.difficulty }} out of 5</span>


### PR DESCRIPTION
## Done

Allow HTML in tutorial cards

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials?topic=community
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the card for "How to write a tutorial" is rendered HTML properly


## Issue / Card

Fixes #6395 