### PR TITLE
Fix tutorials pagination

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -62,9 +62,6 @@
   </div>
 </section>
 
-{% set posts_per_page = 15 %}
-{% set total_pages = metadata | count / posts_per_page %}
-
 <section class="p-strip is-shallow has-shadow">
   <div class="row u-equal-height">
     {% for item in metadata %}
@@ -109,6 +106,10 @@
 
       el.addEventListener('change', function(e) {
         var value = e.target.value;
+
+        if (url.searchParams.has('page')) {
+          url.searchParams.delete('page');
+        }
 
         if (value) {
           if (url.searchParams.has(key)) {

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -5,6 +5,7 @@ A Flask application for ubuntu.com
 # Packages
 import talisker.requests
 import flask
+import math
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam.search import build_search_view
@@ -164,6 +165,7 @@ def index():
     page = flask.request.args.get("page", default=1, type=int)
     topic = flask.request.args.get("topic", default=None, type=str)
     sort = flask.request.args.get("sort", default=None, type=str)
+    posts_per_page = 15
     tutorials_docs.parser.parse()
     if not topic:
         metadata = tutorials_docs.parser.metadata
@@ -184,6 +186,8 @@ def index():
             metadata, key=lambda k: k["difficulty"], reverse=False
         )
 
+    total_pages = math.ceil(len(metadata) / posts_per_page)
+
     return flask.render_template(
         "tutorials/index.html",
         navigation=tutorials_docs.parser.navigation,
@@ -192,6 +196,8 @@ def index():
         page=page,
         topic=topic,
         sort=sort,
+        posts_per_page=posts_per_page,
+        total_pages=total_pages,
     )
 
 


### PR DESCRIPTION
## Done

Fix pagination so that it doesn't link to a final blank page and whilst on last page disables the "next page" button

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Use the pagination to get to the last page
- Check that the final page still has some cards
- Check that the "next page" button in the pagination is disabled


## Issue / Card

Fixes #6389, #6390 
