### PR TITLE
Fix tutorials style issues

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -496,7 +496,3 @@ html {
 .u-text-light {
   color: $color-mid-dark;
 }
-
-.u-text-dark {
-  color: $color-dark;
-}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -68,7 +68,7 @@
       {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
         <div class="col-4 blog-p-card--post">
           <header class="blog-p-card__header--tutorial">
-            <h5 class="p-muted-heading u-no-margin--bottom u-text-dark">
+            <h5 class="p-muted-heading u-no-margin--bottom">
               {{ item.categories }}
             </h5>
           </header>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -36,7 +36,7 @@
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>
-        <select name="tutorials-topic" id="tutorials-topic">
+        <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
           <option value="">Any</option>
           <option value="cloud">Cloud</option>
           <option value="community">Community</option>
@@ -52,7 +52,7 @@
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-sort">Sorted by:</label>
-        <select name="tutorials-sort" id="tutorials-sort">
+        <select name="tutorials-sort" id="tutorials-sort" class="u-no-margin--bottom">
           <option value="">Choose</option>
           <option value="difficulty-desc">Most difficult</option>
           <option value="difficulty-asc">Least difficult</option>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -62,7 +62,7 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow has-shadow">
+<section class="p-strip has-shadow">
   <div class="row u-equal-height">
     {% for item in metadata %}
       {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}


### PR DESCRIPTION
## Done

- Remove shallow style for tutorial cards section
- Remove margins from search filters
- Remove dark text on card muted headings

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the section wrapping the tutorial cards is not shallow
- Check that there are no bottom margins on the search filters
- Check that the text colour on the card topic headings is mid gray


## Issue / Card

Fixes #6402, #6401, #6403
