### PR TITLE
Fix tutorial page jump on load

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -124,6 +124,7 @@
         link.classList.remove('is-active');
       }
     });
+    scrollToTop();
   };
 
   function scrollToTop() {


### PR DESCRIPTION
## Done

Fix page jump on tutorial page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial page
- Make sure the content doesn't scroll down to the beginning of the tutorial


## Issue / Card

Fixes #6407 