### PR TITLE
Get security notices from the database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@ version: 2
 defaults: &defaults
   docker:
     - image: canonicalwebteam/dev:v1.6.7
-
+  environment:
+    - DATABASE_URL: sqlite:///
 jobs:
   test-site:
     <<: *defaults

--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
 ADVANTAGE_API=https://contracts.canonical.com/
+DATABASE_URL=sqlite:///usn.sqlite3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pymacaroons==0.13.0
 pybreaker==0.6.0
 Flask-WTF==0.14.2
 requests==2.22.0
+sqlalchemy==1.3.10

--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -11,5 +11,9 @@
     color: $color-mid-dark;
     font-size: 14px;
     padding: .1rem .4rem;
+
+    &:visited {
+      color: $color-mid-dark;
+    }
   }
 }

--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -3,4 +3,13 @@
   [class*="p-button"].is-wide {
     width: 100%;
   }
+
+  .p-button--tag {
+    @extend %p-button;
+
+    border-radius: 3px;
+    color: $color-mid-dark;
+    font-size: 14px;
+    padding: .1rem .4rem;
+  }
 }

--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -1,12 +1,11 @@
-<article>
-  <h3><a href="/security/notices/{{notice.id}}">{{notice.id}}: {{notice.title}}</a></h3>
-  <p style="font-size: 14px; color: #666;">{{ notice.published.strftime("%d %B %Y") }}</p>
-  <p>{{ notice.summary | safe }}</p>
-
-  <ul class="p-inline-list u-no-margin--bottom">
+<article class="notice" style="padding-bottom: 32px;">
+  <h3 class="u-no-margin p-heading--four" style="padding-bottom: 8px;"><a href="/security/notices/{{notice.id}}">{{ notice.id }}: {{ notice.title }} ›</a></h3>
+  <p class="u-no-margin u-no-padding--top" style="color: #666; font-size: 14px; padding-bottom: 8px;">{{ notice.published.strftime("%d %B %Y") }}</p>
+  <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">{{ notice.summary | safe }}</p>
+  <ul class="p-inline-list u-no-margin">
     {% for release in notice.releases %}
       <li class="p-inline-list__item">
-        <a href="/security/notices?release={{release.id}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
+        <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
       </li>
     {% endfor %}
   </ul>

--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -1,12 +1,12 @@
 <article>
   <h3><a href="/security/notices/{{notice.id}}">{{notice.id}}: {{notice.title}}</a></h3>
-  <p style="font-size: 14px; color: #666;">{{ notice.published }}</p>
-  <p>{{ notice.summary }}</p>
+  <p style="font-size: 14px; color: #666;">{{ notice.published.strftime("%d %B %Y") }}</p>
+  <p>{{ notice.summary | safe }}</p>
 
   <ul class="p-inline-list u-no-margin--bottom">
     {% for release in notice.releases %}
       <li class="p-inline-list__item">
-        <a href="/security/notices?release={{release.id}}" class="p-button--tag">{{ release.name }}</a>
+        <a href="/security/notices?release={{release.id}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
       </li>
     {% endfor %}
   </ul>

--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -1,0 +1,13 @@
+<article>
+  <h3><a href="/security/notices/{{notice.id}}">{{notice.id}}: {{notice.title}}</a></h3>
+  <p style="font-size: 14px; color: #666;">{{ notice.published }}</p>
+  <p>{{ notice.summary }}</p>
+
+  <ul class="p-inline-list u-no-margin--bottom">
+    {% for release in notice.releases %}
+      <li class="p-inline-list__item">
+        <a href="/security/notices?release={{release.id}}" class="p-button--tag">{{ release.name }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+</article>

--- a/templates/security/_subscribe.html
+++ b/templates/security/_subscribe.html
@@ -1,0 +1,17 @@
+<div class="p-card">
+  <h2 class="p-heading--four">Subscribe</h2>
+  <ul class="p-list u-no-margin--bottom">
+    <li class="p-list__item u-sv1">
+      <a href="#" style="display: flex; align-items: center;">
+        <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+        RSS
+      </a>
+    </li>
+    <li class="p-list__item">
+      <a href="#" style="display: flex; align-items: center;">
+        <i class="p-icon--email" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+        Mailing list
+      </a>
+    </li>
+  </ul>
+</div>

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -6,9 +6,9 @@
 <section class="p-strip--suru-topped is-bordered">
   <div class="row">
     <div class="col-8">
-	    <h1> USN-{{ notice.id }}: {{ notice.title }}</h1>
-	<p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
-	<p>{{ notice.summary|safe }}</p>
+	    <h1>USN-{{ notice.id }}: {{ notice.title }}</h1>
+      <p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
+      <p>{{ notice.summary|safe }}</p>
     </div>
   </div>
 </section>
@@ -32,8 +32,8 @@
     <div class="col-12">
       <h2>Packages</h2>
       <ul class="p-list">
-	{% for package in notice.packages %}
-	<li class="p-list__item">{{ package.name }}</li>
+        {% for package in notice.packages %}
+          <li class="p-list__item">{{ package.name }}</li>
       	{% endfor %}
       </ul>
     </div>

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -1,0 +1,59 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}USN-{{ notice.id }}: {{ notice.title }} | Ubuntu security notices{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-topped is-bordered">
+  <div class="row">
+    <div class="col-8">
+	    <h1> USN-{{ notice.id }}: {{ notice.title }}</h1>
+	<p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
+	<p>{{ notice.summary|safe }}</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2>Releases</h2>
+      <ul class="p-inline-list u-no-margin--bottom">
+        {% for release in notice.releases %}
+          <li class="p-inline-list__item">
+            <a href="/security/notices?release={{release.id}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+
+  {% if notice.packages %}
+  <div class="row">
+    <div class="col-12">
+      <h2>Packages</h2>
+      <ul class="p-list">
+	{% for package in notice.packages %}
+	<li class="p-list__item">{{ package.name }}</li>
+      	{% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="row">
+    <div class="col-8">
+      <h2>Details</h2>
+      <p>{{ notice.details|safe }}</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h2>Update instructions</h2>
+      <p>{{ notice.instructions|safe }}</p>
+    </div>
+  </div>
+</section>
+
+{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+{% endblock %}

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -20,7 +20,7 @@
       <ul class="p-inline-list u-no-margin--bottom">
         {% for release in notice.releases %}
           <li class="p-inline-list__item">
-            <a href="/security/notices?release={{release.id}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
+            <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
           </li>
         {% endfor %}
       </ul>

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -6,9 +6,13 @@
 <section class="p-strip--suru-topped">
   <div class="row">
     <div class="col-8">
-	    <h1>Ubuntu Security Notices</h1>
-      <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="#">official Ubuntu package</a>.</p>
-      <p>To report a security vulnerability in an Ubuntu package, please <a href="#">contact the Security Team</a>.</p>
+      {% if request.args.get('release') %}
+        <h1>Ubuntu Security Notices search results</h1>
+      {% else %}
+        <h1>Ubuntu Security Notices</h1>
+        <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="#">official Ubuntu package</a>.</p>
+        <p>To report a security vulnerability in an Ubuntu package, please <a href="#">contact the Security Team</a>.</p>
+      {% endif %}
     </div>
   </div>
 </section>
@@ -22,9 +26,9 @@
     <div class="col-4">
       <label for="release">Release:</label>
       <select name="release" id="release">
-        <option value="" selected="">Any</option>
+        <option value="all" selected>Any</option>
         {% for release in releases %}
-          <option value="{{ release.codename }}" {%  if request.args.get("release") == release.codename %}selected{% endif%}>Ubuntu {{ release.version }}</option>
+          <option value="{{ release.codename }}" {%  if request.args.get('release') == release.codename %}selected{% endif%}>Ubuntu {{ release.version }}</option>
         {% endfor %}
       </select>
     </div>
@@ -36,11 +40,11 @@
         </div>
 
         <div class="col-4">
-          <input type="text" name="details" id="details" value="{{ request.args.get("details", "") }}"/>
+          <input type="text" name="details" id="details" value="{{ request.args.get('details', '') }}"/>
         </div>
   
         <div class="col-2">
-          <button type="submit" class="p-button--positive">Search{% if request.args %} again{% endif %}</button>
+          <button type="submit" class="p-button--positive">Search{% if request.args.get('release') %} again{% endif %}</button>
         </div>
       </div>
     </div>
@@ -48,6 +52,42 @@
 </section>
 
 <section class="p-strip">
+  {% if request.args.get('release') %}
+    <div class="row">
+      <div class="col-6">
+        {% set first = 1 %}
+        {% set last = 1 %}
+        <h2 class="p-heading--four">{{ first }} - {{ last }} of {{ notices|length }} results</h2>
+      </div>
+
+      <div class="col-6">
+        <form action="/security/notices" method="GET" class="row p-form--inline js-sort-form">
+          <input type="hidden" name="release" value="{{ request.args.get('release', '') }}"/>
+          <input type="hidden" name="details" value="{{ request.args.get('details', '') }}"/>
+          <div class="p-form__group u-align--right">
+            <label class="p-form__label" for="sort-by">Sort by:</label>
+            <select name="sort" id="sort" style="width: auto;">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+            </select>
+          </div>
+        </form>
+
+        <script>
+          var form = document.querySelector('.js-sort-form');
+
+          form.addEventListener('change', function() {
+            form.submit();
+          })
+        </script>
+      </div>
+    </div>
+
+    <div class="u-fixed-width">
+      <hr style="margin: 1rem 0;" />
+    </div>
+  {% endif %}
+
   <div class="row">
     <div class="col-9">
       <h2>Latest notices</h2>
@@ -58,30 +98,38 @@
       {% endfor %}
     </div>
 
-    <div class="col-3">
-      <div class="p-card">
-        <h2 class="p-heading--four">Subscribe</h2>
+    {% if not request.args.get('release') %}
+      <div class="col-3">
+        <div class="p-card">
+          <h2 class="p-heading--four">Subscribe</h2>
 
-        <ul class="p-list u-no-margin--bottom">
-          <li class="p-list__item u-sv1">
-            <a href="#" style="display: flex; align-items: center;">
-              <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
-              RSS
-            </a>
-          </li>
+          <ul class="p-list u-no-margin--bottom">
+            <li class="p-list__item u-sv1">
+              <a href="#" style="display: flex; align-items: center;">
+                <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+                RSS
+              </a>
+            </li>
 
-          <li class="p-list__item">
-            <a href="#" style="display: flex; align-items: center;">
-              <i class="p-icon--email" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
-              Mailing list
-            </a>
-          </li>
-        </ul>
+            <li class="p-list__item">
+              <a href="#" style="display: flex; align-items: center;">
+                <i class="p-icon--email" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+                Mailing list
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
+    {% endif %}
   </div>
 
-  {% if featured_notices %}
+  {% if request.args.get('release') %}
+    {% with %}
+      {% set total_pages = 5 %}
+      {% set current_page = 1 %}}
+      {% include "shared/_pagination.html" %}
+    {% endwith %}
+  {% elif featured_notices %}
     <div class="u-fixed-width">
       <hr class="p-separator" />
     </div>

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -22,9 +22,9 @@
     <div class="col-4">
       <label for="release">Release:</label>
       <select name="release" id="release">
-        <option value="all" selected="">Any</option>
+        <option value="" selected="">Any</option>
         {% for release in releases %}
-          <option value="{{ release.id }}">{{ release.name }}</option>
+          <option value="{{ release.codename }}" {%  if request.args.get("release") == release.codename %}selected{% endif%}>Ubuntu {{ release.version }}</option>
         {% endfor %}
       </select>
     </div>
@@ -36,11 +36,11 @@
         </div>
 
         <div class="col-4">
-          <input type="text" name="details" id="details" />
+          <input type="text" name="details" id="details" value="{{ request.args.get("details", "") }}"/>
         </div>
   
         <div class="col-2">
-          <button type="submit" class="p-button--positive" disabled>Search{% if request.args %} again{% endif %}</button>
+          <button type="submit" class="p-button--positive">Search{% if request.args %} again{% endif %}</button>
         </div>
       </div>
     </div>
@@ -51,19 +51,7 @@
   <div class="row">
     <div class="col-9">
       <h2>Latest notices</h2>
-
-      {% set notice = { 
-        "id": "123",
-        "title": "Placeholder notice",
-        "published": "14 January 2020",
-        "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et augue id ipsum eleifend aliquam eu a nisi. Praesent turpis tellus, finibus quis aliquet nec, imperdiet eget mi.",
-        "releases": [
-          { "id": "1", "name": "19.04 Ubuntu" },
-          { "id": "2", "name": "15.04 Ubuntu" }
-        ]       
-      } %}
-
-      {% for n in ['1', '2', '3', '4'] %}
+      {% for notice in notices %}
         {% with notice=notice %}
           {% include "security/_notice-brief.html" %}
         {% endwith %}
@@ -93,21 +81,22 @@
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row">
-    <div class="col-9">
-      <h2>Featured</h2>
-
-      {% for n in ['1', '2', '3', '4'] %}
-        {% with notice=notice %}
-          {% include "security/_notice-brief.html" %}
-        {% endwith %}
-      {% endfor %}
+  {% if featured_notices %}
+    <div class="u-fixed-width">
+      <hr class="p-separator" />
     </div>
-  </div>
+
+    <div class="row">
+      <div class="col-9">
+        <h2>Featured</h2>
+        {% for notice in featured_notices %}
+          {% with notice=notice %}
+            {% include "security/_notice-brief.html" %}
+          {% endwith %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
 </section>
 
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -1,1 +1,115 @@
 {% extends "templates/one-column.html" %}
+
+{% block title %}Security notices{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col-8">
+	    <h1>Ubuntu Security Notices</h1>
+      <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="#">official Ubuntu package</a>.</p>
+      <p>To report a security vulnerability in an Ubuntu package, please <a href="#">contact the Security Team</a>.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-shallow">
+  <div class="u-fixed-width">
+    <h2>Search</h2>
+  </div>
+
+  <form action="/security/notices" method="GET" class="row">
+    <div class="col-4">
+      <label for="release">Release:</label>
+      <select name="release" id="release">
+        <option value="all" selected="">Any</option>
+        {% for release in releases %}
+          <option value="{{ release.id }}">{{ release.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="col-6">
+      <div class="row">
+        <div class="col-5">
+          <label for="details">Details contain:</label>
+        </div>
+
+        <div class="col-4">
+          <input type="text" name="details" id="details" />
+        </div>
+  
+        <div class="col-2">
+          <button type="submit" class="p-button--positive" disabled>Search{% if request.args %} again{% endif %}</button>
+        </div>
+      </div>
+    </div>
+  </form>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-9">
+      <h2>Latest notices</h2>
+
+      {% set notice = { 
+        "id": "123",
+        "title": "Placeholder notice",
+        "published": "14 January 2020",
+        "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec et augue id ipsum eleifend aliquam eu a nisi. Praesent turpis tellus, finibus quis aliquet nec, imperdiet eget mi.",
+        "releases": [
+          { "id": "1", "name": "19.04 Ubuntu" },
+          { "id": "2", "name": "15.04 Ubuntu" }
+        ]       
+      } %}
+
+      {% for n in ['1', '2', '3', '4'] %}
+        {% with notice=notice %}
+          {% include "security/_notice-brief.html" %}
+        {% endwith %}
+      {% endfor %}
+    </div>
+
+    <div class="col-3">
+      <div class="p-card">
+        <h2 class="p-heading--four">Subscribe</h2>
+
+        <ul class="p-list u-no-margin--bottom">
+          <li class="p-list__item u-sv1">
+            <a href="#" style="display: flex; align-items: center;">
+              <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+              RSS
+            </a>
+          </li>
+
+          <li class="p-list__item">
+            <a href="#" style="display: flex; align-items: center;">
+              <i class="p-icon--email" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+              Mailing list
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-9">
+      <h2>Featured</h2>
+
+      {% for n in ['1', '2', '3', '4'] %}
+        {% with notice=notice %}
+          {% include "security/_notice-brief.html" %}
+        {% endwith %}
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+{% endblock %}

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -1,155 +1,149 @@
 {% extends "templates/one-column.html" %}
-
 {% set search = request.args.get('release') or request.args.get('details') %}
-
 {% block title %}Security notices{% endblock %}
-
 {% block content %}
 <section class="p-strip--suru-topped">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
       {% if search %}
-        <h1>Ubuntu Security Notices search results</h1>
+      <h1 class="p-heading--two">Ubuntu Security Notices - Search Results</h1>
       {% else %}
-        <h1>Ubuntu Security Notices</h1>
-        <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="#">official Ubuntu package</a>.</p>
-        <p>To report a security vulnerability in an Ubuntu package, please <a href="#">contact the Security Team</a>.</p>
+      <h1>Ubuntu Security Notices</h1>
+      {% endif %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      {% if not search %}
+      <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="#">official Ubuntu package</a>.</p>
+      <p>To report a security vulnerability in an Ubuntu package, please <a href="#">contact the Security Team</a>.</p>
       {% endif %}
     </div>
   </div>
 </section>
-
 <section class="p-strip--light is-shallow">
+  {% if not search %}
   <div class="u-fixed-width">
     <h2>Search</h2>
   </div>
-
-  <form action="/security/notices" method="GET" class="row">
-    <div class="col-4">
-      <label for="release">Release:</label>
-      <select name="release" id="release">
-        <option value="all" selected>Any</option>
-        {% for release in releases %}
-          <option value="{{ release.codename }}" {%  if search == release.codename %}selected{% endif%}>Ubuntu {{ release.version }}</option>
-        {% endfor %}
-      </select>
-    </div>
-
-    <div class="col-6">
-      <div class="row">
-        <div class="col-5">
-          <label for="details">Details contain:</label>
-        </div>
-
-        <div class="col-4">
-          <input type="text" name="details" id="details" value="{{ request.args.get('details', '') }}"/>
-        </div>
-  
-        <div class="col-2">
-          <button type="submit" class="p-button--positive">Search{% if search %} again{% endif %}</button>
+  {% endif %}
+  <form action="/security/notices" method="GET" class="p-form js-form">
+    <input class="js-order-input" type="hidden" name="order" value="newest">
+    <div class="row u-equal-height">
+      <div class="col-4">
+        <label class="p-form__label" for="release">Release:</label>
+        <select class="p-form__control js-release" name="release" id="release">
+          <option value="">Any</option>
+          {% for release in releases %}
+          <option value="{{ release.codename }}"
+            {% if request.args.get('release') == release.codename %}selected{% endif %}>
+            Ubuntu {{ release.version }} {% if release.lts %} LTS {% endif %}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-8">
+        <div class="row">
+          <div class="col-6">
+            <label class="p-form__label" for="details">Details contain:</label>
+            <input class="p-form__control js-details" type="text" name="details" id="details"
+              value="{{ request.args.get('details', '') }}" />
+          </div>
+          <div class="col-2 u-align--right" style="display: flex; align-items: flex-end;">
+            <button type="submit" class="p-button--positive js-submit" style="width:100%;">Search{% if search %} again{% endif %}</button>
+          </div>
         </div>
       </div>
     </div>
   </form>
 </section>
-
 <section class="p-strip">
   {% if search %}
-    <div class="row">
-      <div class="col-6">
-        {% set first = 1 %}
-        {% set last = 1 %}
-        <h2 class="p-heading--four">{{ first }} - {{ last }} of {{ notices|length }} results</h2>
-      </div>
-
-      <div class="col-6">
-        <form action="/security/notices" method="GET" class="row p-form--inline js-sort-form">
-          <input type="hidden" name="release" value="{{ request.args.get('release', '') }}"/>
-          <input type="hidden" name="details" value="{{ request.args.get('details', '') }}"/>
-          <div class="p-form__group u-align--right">
-            <label class="p-form__label" for="sort-by">Sort by:</label>
-            <select name="sort" id="sort" style="width: auto;">
-              <option value="newest">Newest first</option>
-              <option value="oldest">Oldest first</option>
-            </select>
-          </div>
-        </form>
-
-        <script>
-          var form = document.querySelector('.js-sort-form');
-
-          form.addEventListener('change', function() {
-            form.submit();
-          })
-        </script>
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--four">
+        {{ notices|length }} of {{ pagination.total_results }} results
+      </h2>
+    </div>
+    <div class="col-4 p-form p-form--inline">
+      <div class="p-form__group">
+        <label class="p-form__label">Sort by:</label>
+        <select class="p-form__control u-no-margin--bottom js-order-select">
+          <option value="newest" {% if request.args.get('order') == 'newest'%} selected {% endif %}>Newest</option>
+          <option value="oldest" {% if request.args.get('order') == 'oldest'%} selected {% endif %}>Oldest</option>
+        </select>
       </div>
     </div>
-
-    <div class="u-fixed-width">
-      <hr style="margin: 1rem 0;" />
-    </div>
+  </div>
+  <div class="u-fixed-width" style="margin-bottom: 2rem; margin-top: 2rem;">
+    <hr class="u-hide--small"/>
+  </div>
   {% endif %}
-
   <div class="row">
     <div class="col-9">
-      <h2>Latest notices</h2>
+      {% if not search %}
+      <h2>Latest Notices</h2>
+      {% endif %}
+      {% if notices %}
       {% for notice in notices %}
-        {% with notice=notice %}
-          {% include "security/_notice-brief.html" %}
-        {% endwith %}
+      {% include "security/_notice-brief.html" %}
       {% endfor %}
+      {% else %}
+      <h2>No notices found...</h2>
+      {% endif %}
     </div>
-
     {% if not search %}
-      <div class="col-3">
-        <div class="p-card">
-          <h2 class="p-heading--four">Subscribe</h2>
-
-          <ul class="p-list u-no-margin--bottom">
-            <li class="p-list__item u-sv1">
-              <a href="#" style="display: flex; align-items: center;">
-                <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
-                RSS
-              </a>
-            </li>
-
-            <li class="p-list__item">
-              <a href="#" style="display: flex; align-items: center;">
-                <i class="p-icon--email" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
-                Mailing list
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
+    <div class="col-3 u-hide--small">
+      {% include "security/_subscribe.html" %}
+    </div>
     {% endif %}
   </div>
-
-  {% if search %}
-    {% with 
-      total_pages = 5,
-      current_page = 1  
-    %}
-      {% include "shared/_pagination.html" %}
-    {% endwith %}
-  {% elif featured_notices %}
-    <div class="u-fixed-width">
-      <hr class="p-separator" />
+  {% with total_pages = pagination.total_pages, current_page=pagination.current_page %}
+  {% include "shared/_pagination.html" %}
+  {% endwith %}
+  {% if not search %}
+  <div class="row u-hide--medium u-hide--large">
+    <div class="col-12">
+      {% include "security/_subscribe.html" %}
     </div>
-
-    <div class="row">
-      <div class="col-9">
-        <h2>Featured</h2>
-        {% for notice in featured_notices %}
-          {% with notice=notice %}
-            {% include "security/_notice-brief.html" %}
-          {% endwith %}
-        {% endfor %}
-      </div>
-    </div>
+  </div>
   {% endif %}
 </section>
+{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html" %}
+{% endwith %}
+<script>
+  var form = document.querySelector(".js-form");
+  var orderInput = document.querySelector(".js-order-input");
+  var orderSelect = document.querySelector(".js-order-select");
+  var details = document.querySelector(".js-details");
+  var release = document.querySelector(".js-release");
+  var submit = document.querySelector(".js-submit");
 
-{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+  // Submit form on order select change 
+  if (orderSelect != null) {
+    orderSelect.onchange = function(event) {
+      orderInput.value = event.target.value;
+      form.submit();
+    }
+  }
 
+  // Disable search when form is empty
+  function toogleSearch() {
+    submit.disabled = !details.value && !release.value;
+  }
+
+  // Toggle on form change
+  form.onchange = function() {
+    toogleSearch();
+  }
+
+  // Toggle on details input keyup
+  details.onkeyup = function() {
+    toogleSearch();
+  }
+
+  // Toggle on page load
+  toogleSearch();
+</script>
 {% endblock %}

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -1,12 +1,14 @@
 {% extends "templates/one-column.html" %}
 
+{% set search = request.args.get('release') or request.args.get('details') %}
+
 {% block title %}Security notices{% endblock %}
 
 {% block content %}
 <section class="p-strip--suru-topped">
   <div class="row">
     <div class="col-8">
-      {% if request.args.get('release') %}
+      {% if search %}
         <h1>Ubuntu Security Notices search results</h1>
       {% else %}
         <h1>Ubuntu Security Notices</h1>
@@ -28,7 +30,7 @@
       <select name="release" id="release">
         <option value="all" selected>Any</option>
         {% for release in releases %}
-          <option value="{{ release.codename }}" {%  if request.args.get('release') == release.codename %}selected{% endif%}>Ubuntu {{ release.version }}</option>
+          <option value="{{ release.codename }}" {%  if search == release.codename %}selected{% endif%}>Ubuntu {{ release.version }}</option>
         {% endfor %}
       </select>
     </div>
@@ -44,7 +46,7 @@
         </div>
   
         <div class="col-2">
-          <button type="submit" class="p-button--positive">Search{% if request.args.get('release') %} again{% endif %}</button>
+          <button type="submit" class="p-button--positive">Search{% if search %} again{% endif %}</button>
         </div>
       </div>
     </div>
@@ -52,7 +54,7 @@
 </section>
 
 <section class="p-strip">
-  {% if request.args.get('release') %}
+  {% if search %}
     <div class="row">
       <div class="col-6">
         {% set first = 1 %}
@@ -98,7 +100,7 @@
       {% endfor %}
     </div>
 
-    {% if not request.args.get('release') %}
+    {% if not search %}
       <div class="col-3">
         <div class="p-card">
           <h2 class="p-heading--four">Subscribe</h2>
@@ -123,10 +125,10 @@
     {% endif %}
   </div>
 
-  {% if request.args.get('release') %}
+  {% if search %}
     {% with %}
       {% set total_pages = 5 %}
-      {% set current_page = 1 %}}
+      {% set current_page = 1 %}
       {% include "shared/_pagination.html" %}
     {% endwith %}
   {% elif featured_notices %}

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -126,9 +126,10 @@
   </div>
 
   {% if search %}
-    {% with %}
-      {% set total_pages = 5 %}
-      {% set current_page = 1 %}
+    {% with 
+      total_pages = 5,
+      current_page = 1  
+    %}
       {% include "shared/_pagination.html" %}
     {% endwith %}
   {% elif featured_notices %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -30,6 +30,8 @@ from webapp.context import (
     get_navigation,
     releases,
 )
+from webapp.database import db_engine
+from webapp.models import Base
 from webapp.views import (
     advantage_view,
     blog_blueprint,
@@ -37,10 +39,16 @@ from webapp.views import (
     blog_custom_topic,
     blog_press_centre,
     download_thank_you,
+    notice,
+    notices,
     releasenotes_redirect,
 )
 from webapp.login import login_handler, logout
 
+
+# Create all tables
+
+Base.metadata.create_all(db_engine)
 
 # Set up application
 # ===
@@ -109,7 +117,7 @@ app.add_url_rule(
     "/search", "search", build_search_view(template_path="search.html")
 )
 
-# /blog section
+# blog section
 app.add_url_rule(
     "/blog/topics/<regex('maas|design|juju|robotics|snapcraft'):slug>",
     view_func=blog_custom_topic,
@@ -120,6 +128,10 @@ app.add_url_rule(
 )
 app.add_url_rule("/blog/press-centre", view_func=blog_press_centre)
 app.register_blueprint(blog_blueprint, url_prefix="/blog")
+
+# usn section
+app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
+app.add_url_rule("/security/notices", view_func=notices)
 
 # Login
 app.add_url_rule("/login", methods=["GET", "POST"], view_func=login_handler)

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -1,0 +1,12 @@
+# Standard library
+import os
+
+# Packages
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+
+db_engine = create_engine(os.environ["DATABASE_URL"])
+db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+)

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -1,0 +1,53 @@
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+
+Base = declarative_base()
+
+
+notice_releases = Table(
+    "notice_releases",
+    Base.metadata,
+    Column("notice_id", Integer, ForeignKey("notice.id")),
+    Column("release_id", String, ForeignKey("release.id")),
+)
+
+
+class Package(Base):
+    __tablename__ = "package"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class Release(Base):
+    __tablename__ = "release"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    version = Column(String, unique=True)
+    codename = Column(String, unique=True)
+    lts = Column(Boolean)
+
+
+class Notice(Base):
+    __tablename__ = "notice"
+
+    id = Column(String, primary_key=True)
+    title = Column(String)
+    published = Column(DateTime)
+    summary = Column(String)
+    details = Column(String)
+    instructions = Column(String)
+    featured = Column(Boolean)
+    packages = Column(String)
+    releases = relationship("Release", secondary=notice_releases)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import datetime
+from math import ceil
 
 # Packages
 import feedparser
@@ -12,6 +13,7 @@ from canonicalwebteam.blog.flask import build_blueprint
 from geolite2 import geolite2
 from mistune import Markdown
 from requests.exceptions import HTTPError
+from sqlalchemy import asc, desc
 
 # Local
 from webapp import auth
@@ -21,7 +23,9 @@ from webapp.models import Notice, Release
 
 
 ip_reader = geolite2.reader()
-markdown_parser = Markdown(parse_block_html=True, parse_inline_html=True)
+markdown_parser = Markdown(
+    hard_wrap=True, parse_block_html=True, parse_inline_html=True
+)
 
 
 def download_thank_you(category):
@@ -267,29 +271,45 @@ def notice(notice_id):
 
 
 def notices():
-    details = flask.request.args.get("details", default=None, type=str)
-    release = flask.request.args.get("release", default=None, type=str)
+    page = flask.request.args.get("page", default=1, type=int)
+    details = flask.request.args.get("details", type=str)
+    release = flask.request.args.get("release", type=str)
+    order_by = flask.request.args.get("order", type=str)
 
+    releases = db_session.query(Release).all()
     notices_query = db_session.query(Notice)
 
     if release:
         notices_query = notices_query.join(Release, Notice.releases).filter(
             Release.codename == release
         )
+
     if details:
         notices_query = notices_query.filter(
             Notice.details.ilike(f"%{details}%")
         )
 
-    notices = notices_query.all()
-    featured_notices = (
-        db_session.query(Notice).filter(Notice.featured).all()
+    # Snapshot total results for search
+    page_size = 10
+    total_results = notices_query.count()
+    total_pages = ceil(total_results / page_size)
+    offset = page * page_size - page_size
+
+    sort = asc if order_by == "oldest" else desc
+    notices = (
+        notices_query.order_by(sort(Notice.published))
+        .offset(offset)
+        .limit(page_size)
+        .all()
     )
-    releases = db_session.query(Release).all()
 
     return flask.render_template(
         "security/notices.html",
-        featured_notices=featured_notices,
         notices=notices,
         releases=releases,
+        pagination=dict(
+            current_page=page,
+            total_pages=total_pages,
+            total_results=total_results,
+        ),
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -10,14 +10,18 @@ import flask
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
 from geolite2 import geolite2
+from mistune import Markdown
 from requests.exceptions import HTTPError
 
 # Local
 from webapp import auth
 from webapp.api import advantage
+from webapp.database import db_session
+from webapp.models import Notice, Release
 
 
 ip_reader = geolite2.reader()
+markdown_parser = Markdown(parse_block_html=True, parse_inline_html=True)
 
 
 def download_thank_you(category):
@@ -236,3 +240,56 @@ def blog_press_centre():
     )
 
     return flask.render_template("blog/press-centre.html", **context)
+
+
+# USN
+# ===
+
+
+def notice(notice_id):
+    notice = db_session.query(Notice).get(notice_id)
+
+    if not notice:
+        flask.abort(404)
+
+    notice = {
+        "id": notice.id,
+        "title": notice.title,
+        "published": notice.published,
+        "summary": notice.summary,
+        "details": markdown_parser(notice.details),
+        "instructions": markdown_parser(notice.instructions),
+        "packages": notice.packages,
+        "releases": notice.releases,
+    }
+
+    return flask.render_template("security/notice.html", notice=notice)
+
+
+def notices():
+    details = flask.request.args.get("details", default=None, type=str)
+    release = flask.request.args.get("release", default=None, type=str)
+
+    notices_query = db_session.query(Notice)
+
+    if release:
+        notices_query = notices_query.join(Release, Notice.releases).filter(
+            Release.codename == release
+        )
+    if details:
+        notices_query = notices_query.filter(
+            Notice.details.ilike(f"%{details}%")
+        )
+
+    notices = notices_query.all()
+    featured_notices = (
+        db_session.query(Notice).filter(Notice.featured).all()
+    )
+    releases = db_session.query(Release).all()
+
+    return flask.render_template(
+        "security/notices.html",
+        featured_notices=featured_notices,
+        notices=notices,
+        releases=releases,
+    )


### PR DESCRIPTION
## Done

Implement views to fetch security notices from a database.
This work includes adding all the necessary boilerplate to connect to the database.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)



## Issue / Card

Fixes #6324
Fixes #6322 
Fixes #6323 
Fixes #2196
