### PR TITLE
Add fallback for tutorial time remaining

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -75,7 +75,15 @@
         </div>
         <div class="col-6 col-small-2 col-medium-3 u-align--right">
           <div class="l-tutorial__duration">
-            <small><span class="u-hide--small">about </span>{{ section["remaining_duration"] }} minutes to go</small>
+            <small>
+              <span class="u-hide--small">about</span>
+              {% if section["remaining_duration"] %}
+                {{ section["remaining_duration"] }}
+              {% else %}
+                0
+              {% endif %}
+              minutes to go
+            </small>
           </div>
           <div class="l-tutorial__pagination">
             {% if loop.first %}


### PR DESCRIPTION
## Done

Add fallback to tutorial duration so if no duration exists it defaults to 0

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials/deploy-clustered-redis#well-done
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the remaining time at the end of the tutorial is 0


## Issue / Card

Fixes #6418
