### PR TITLE
/security added suru to hero section

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<section class="p-strip--image is-deep is-dark" style="background-image: url('https://assets.ubuntu.com/v1/ebdfffbf-Aubergine_suru_background.png'); background-position: 77% 0%;">
+<section class="p-strip--suru is-dark is-deep">
   <div class="row">
     <div class="col-8">
       <h1>Dedicated to the security of Ubuntu</h1>


### PR DESCRIPTION
## Done

Replaced aubergine background (it was an image) with a suru template.


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #2219
