### PR TITLE
Update the Ubuntu Masters takeover text

### DIFF
--- a/templates/takeovers/_ubuntu-masters-takeover.html
+++ b/templates/takeovers/_ubuntu-masters-takeover.html
@@ -1,5 +1,5 @@
 {% with title='200 billion requests per day, 6 data centres&hellip;<br class="u-hide--medium u-hide--small">5 people',
-subtitle="Hear Adobe's Joe Sandoval met massive requirements with a lean approach.",
+subtitle="Hear how Adobe's Joe Sandoval met massive requirements with a lean approach.",
 class="p-takeover--grad",
 header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
 image_style="width: 270px; height: 150px;",

--- a/templates/takeovers/_ubuntu-masters-takeover.html
+++ b/templates/takeovers/_ubuntu-masters-takeover.html
@@ -1,5 +1,5 @@
-{% with title="Ubuntu Masters: the&nbsp;masters&nbsp;speak",
-subtitle="How Adobe scales and delivers applications with high performance and low friction.",
+{% with title='200 billion requests per day, 6 data centres&hellip;<br class="u-hide--medium u-hide--small">5 people',
+subtitle="Hear Adobe's Joe Sandoval met massive requirements with a lean approach.",
 class="p-takeover--grad",
 header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
 image_style="width: 270px; height: 150px;",


### PR DESCRIPTION
## Done

Update the Ubuntu Masters takeover text

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- OPTION 4
Title: 200 billion requests per day, 6 data centres... 5 people
Text: Hear Adobe's Joe Sandoval met massive requirements with a lean approach
Call to action: Watch the keynote
Link for CTA: https://www.youtube.com/watch?v=IUgODRm9Soc&list=PLwFSk464RMxmYizQiyu-yNJ9ZtEISJYqN&index=7&t=580s
Secondary call to action (optional): Read more about our Ubuntu Masters event
Link for secondary CTA: ubuntu.com/masters-conference
