### PR TITLE
Added a link to multipass

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -249,7 +249,7 @@
           Set up your development environment
         </h3>
         <div class="p-stepped-list__content">
-        <p>Set up your development toolchain with Ubuntu Server via <a href="https://multipass.run/>Multipass"</a> or on your Ubuntu Desktop. Install Snapcraft to build a bespoke application stack for your target use case. Benefit from the wealth of tools and libraries available on Ubuntu, and take advantage of the strong community support.</p>
+        <p>Set up your development toolchain with Ubuntu Server via <a href="https://multipass.run/">Multipass</a> or on your Ubuntu Desktop. Install Snapcraft to build a bespoke application stack for your target use case. Benefit from the wealth of tools and libraries available on Ubuntu, and take advantage of the strong community support.</p>
         </div>
       </li>
       <li class="p-stepped-list__item">

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -249,7 +249,7 @@
           Set up your development environment
         </h3>
         <div class="p-stepped-list__content">
-          <p>Set up your development toolchain with Ubuntu Server via Multipass or on your Ubuntu Desktop. Install Snapcraft to build a bespoke application stack for your target use case. Benefit from the wealth of tools and libraries available on Ubuntu, and take advantage of the strong community support.</p>
+        <p>Set up your development toolchain with Ubuntu Server via <a href="https://multipass.run/>Multipass"</a> or on your Ubuntu Desktop. Install Snapcraft to build a bespoke application stack for your target use case. Benefit from the wealth of tools and libraries available on Ubuntu, and take advantage of the strong community support.</p>
         </div>
       </li>
       <li class="p-stepped-list__item">


### PR DESCRIPTION
Added a link to https://multipass.run/ in the text.

## Done

Added a link to https://multipass.run/ in the text.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the page against the [page](https://ubuntu.com/internet-of-things/robotics) and [copy doc](https://docs.google.com/document/d/1cDxhPCQbHA0r6n9JXNmO50ANLPZhCFdgwATX6f90guU/edit#) and accept the changes.

## Issue / Card

Fixes #6428 