### PR TITLE
Change tutorial step links to numbers

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -30,7 +30,7 @@
     <ol class="l-tutorial__nav p-stepped-list u-hide--small">
       {% for section in document.sections %}
         <li class="p-stepped-list__item l-tutorial__nav-item">
-          <a class="p-stepped-list__title l-tutorial__nav-link" href="#{{ section['slug'] }}">
+          <a class="p-stepped-list__title l-tutorial__nav-link" href="#{{ loop.index - 1 }}">
             {{ section["title"]}}
           </a>
         </li>
@@ -39,7 +39,7 @@
   </aside>
   <div class="l-tutorial__content">
     {% for section in document.sections %}
-    <section class="l-tutorial-section" id="{{ section['slug']}}">
+    <section class="l-tutorial-section" id="{{ loop.index - 1 }}">
       <h2 class="p-heading--four">{{ loop.index }}. {{ section["title"]}}</h2>
 
       <article class="l-tutorial-section__content">


### PR DESCRIPTION
## Done

Update the tutorial step links to use numbers in the URL hash and IDs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial and see that the steps update the URL with numbers as they do on tutorials.ubuntu.com
