### PR TITLE
Switch to the subset font

### DIFF
--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -9,3 +9,4 @@ $circle-of-friends-compensation: 0; // padding compensation to create visually e
 $contrast-ratio: 5%;
 $color-whitepaper-accent: #772a54;
 $color-mid-x-light: #e5e5e5;
+$font-use-subset-latin: true;


### PR DESCRIPTION
## Done
Switch to using the subset font via Vanilla.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the live site has download 431kb of fonts
- Check this branch loads 143kb of fonts