### PR TITLE
Fix tutorial pagination

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -92,7 +92,7 @@
                 <i class="p-icon--contextual-menu">Previous step</i>
               </button>
             {% else %}
-              <a href="#{{ loop.previtem['slug']}}" class="l-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" style="margin-right: 1rem;">
+              <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="l-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" style="margin-right: 1rem;">
                 <i class="p-icon--contextual-menu">Previous step</i>
               </a>
             {% endif %}
@@ -102,7 +102,7 @@
                 <i class="p-icon--contextual-menu">Next step</i>
               </button>
             {% else %}
-              <a href="#{{ loop.nextitem['slug']}}" class="l-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom">
+              <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="l-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom">
                 <i class="p-icon--contextual-menu">Next step</i>
               </a>
             {% endif %}


### PR DESCRIPTION
## Done

Update the tutorial section pagination links with the correct fragment identifiers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to a tutorial
- Use the pagination at the bottom of each section to navigate the tutorial
- Check that the correct section is shown each time


## Issue / Card

Fixes #6439 