### PR TITLE
Only show tutorial hero on first page

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -15,6 +15,7 @@
   </div>
 </nav>
 
+{% if page == 1 %}
 <section class="p-strip--suru-blog-header is-dark">
   <div class="row">
     <div class="col-6">
@@ -24,6 +25,7 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 <section class="p-strip is-shallow l-tutorials__filters">
   <div class="row">


### PR DESCRIPTION
## Done

Only show tutorials hero on first page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the first page has the suru hero/header
- Click through the pagination to other pages and check that there is no suru hero/header


## Issue / Card

Fixes #6406 