### PR TITLE
Prevent tutorial page breadcrumb wrapping

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -16,7 +16,7 @@
         </h5>
       </a>
       <ul class="breadcrumbs--secondary">
-        <li class="breadcrumbs__item">
+        <li class="breadcrumbs__item" style="width: 100%;"> <!-- style only applies to this template -->
           <a class="breadcrumbs__link p-link--soft" href="{{ document['slug'] }}">{{ document.title }}</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

Prevent tutorial breadcrumb from wrapping unnecessarily

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial
- Resize your viewport to mobile size (~320px wide)
- Check that the breadcrumb of the tutorial title doesn't wrap unnecessarily i.e. unless it spans more that the viewport width


## Issue / Card

Fixes #6422 
