### PR TITLE
Add hover state to tutorial feedback icons

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -147,6 +147,25 @@
     }
   }
 
+  .l-tutorial__feedback-options {
+
+    .p-inline-list__item {
+      .has-color {
+        display: none;
+      }
+
+      &:hover {
+        .l-tutorial__feedback-icon {
+          display: none;
+        }
+
+        .has-color {
+          display: inline-block;
+        }
+      }
+    }
+  }
+
   .l-tutorial__feedback-icon {
     cursor: pointer;
   }

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -51,13 +51,16 @@
         <p>Was this tutorial useful?</p>
         <ul class="p-inline-list">
           <li class="p-inline-list__item">
-            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/04f445ea-Helpful-yes.svg" alt="Positive response" data-feedback-value="positive">
+            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/aca5f600-Helpful-yes.svg" alt="Positive response" data-feedback-value="positive">
+            <img class="l-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/784c0dc9-Helpful-yes-green.svg" alt="" data-feedback-value="positive">
           </li>
           <li class="p-inline-list__item">
-            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/e03275bf-Helpful-unsure.svg" alt="Neutral response" data-feedback-value="neutral">
+            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/5dacff00-Helpful-unsure.svg" alt="Neutral response" data-feedback-value="neutral">
+            <img class="l-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b601b52c-Helpful-unsure-orange.svg" alt="" data-feedback-value="neutral">
           </li>
           <li class="p-inline-list__item">
-            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/d20e84ba-Helpful-no.svg" alt="Negative response" data-feedback-value="negative">
+            <img class="l-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/4ff77e8e-Helpful-no.svg" alt="Negative response" data-feedback-value="negative">
+            <img class="l-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b45bf2a3-Helpful-no-red.svg" alt="" data-feedback-value="negative">
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Add hover state to tutorial feedback icons

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial
- Navigate to the last step of the tutorial
- Hover over the icons under the "Was this tutorial useful?" section
- Check that the positive response is green when hovered
- Check that the neutral response is orange when hovered
- Check that the negative response is red when hovered


## Issue / Card

Fixes #6416 