### PR TITLE
Anbox takeover and engage page

### DIFF
--- a/templates/engage/anbox-cloud-gaming-whitepaper.md
+++ b/templates/engage/anbox-cloud-gaming-whitepaper.md
@@ -1,0 +1,36 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Cloud gaming for Android: building a high performing and scalable platform"
+     meta_description: ""
+     meta_image: https://assets.ubuntu.com/v1/783c70b5-Embedded+social+media+banner.jpg
+     meta_copydoc: https://docs.google.com/document/d/14g03JZZTrO_2slipTCNADAW1ct6eVIJF5ZDlEx7O2wA/edit
+     header_title: "Cloud gaming for Android"
+     header_subtitle: "Building a high performing and scalable platform"
+     header_image: "https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg"
+     header_url: '#register-section'
+     header_cta: Download whitepaper
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--grad
+     form_include: en
+     form_id: 3494
+     form_return_url: "https://pages.ubuntu.com/AnboxCloud_TY.html"
+---
+
+The game industry is changing quickly due to the increasing opportunity and demand to stream games from the cloud, but this poses challenges for game developers and service providers. Challenges associated with mobile gaming—such as lowering latency, maintaining video quality and achieving scalability - are coupled with the pressure of remaining profitable.
+
+Canonical has created [Anbox Cloud](http://anbox-cloud.io) - a platform that containerises workloads using Android<sup><a href="#android">1</a></sup> as a guest operating system enabling enterprises to distribute applications from the cloud. Allowing game developers to deliver mobile applications at scale, more securely and independently of a device’s hardware capabilities, Anbox Cloud offloads compute intensive workloads to the cloud.
+
+When combined with the Intel® Visual Cloud Accelerator Card – Rendering (Intel® VCAC-R), Anbox Cloud delivers an excellent gaming experience as well as cost-effective unit economics on x86 architectures.
+
+In this whitepaper, joint with Intel, you will learn:
+
+- The trends and associated challenges in mobile game streaming
+
+- An overview of how Anbox Cloud works with the underlying hardware and software
+
+- How the high container density drives optimised performance with superior economics  
+
+<hr>
+
+<p><small><a id="android">1.</a> Android is a trademark of Google LLC. Anbox Cloud uses assets available through the Android Open Source Project.</small></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,6 @@
   {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
-  {% include "takeovers/_intro-to-microk8s.html" %}
   {% include "takeovers/_linux-enterprise.html" %}
   {% include "takeovers/_451-microk8s.html" %}
 {% endblock takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,7 @@
 
 {% block takeover_content %}
   {# ALL #}
+  {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_intro-to-microk8s.html" %}

--- a/templates/takeovers/_anbox-takeover.html
+++ b/templates/takeovers/_anbox-takeover.html
@@ -1,0 +1,15 @@
+{% with title="Cloud gaming for Android",
+subtitle="Building a high performing and scalable platform.",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg",
+image_style="width: 338px; height: 246px;",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -98,4 +98,7 @@
 {% include "takeovers/_linux-enterprise.html" %}
 <p>08 Jan 2020</p>
 {% include "takeovers/_451-microk8s.html" %}
+<p>21 Jan 2020</p>
+{% include "takeovers/_anbox-takeover.html" %}
 {% endblock %}
+


### PR DESCRIPTION
## Done

Added anbox gaming takeover and white paper engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and see the takeover
- View the engage page http://0.0.0.0:8001/engage/anbox-cloud-gaming-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #6375 
