### PR TITLE
Change takeover rotation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,9 +27,7 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_anbox-takeover.html" %}
-  {% include "takeovers/_ubuntu-masters-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
-  {% include "takeovers/_linux-enterprise.html" %}
   {% include "takeovers/_451-microk8s.html" %}
 {% endblock takeover_content %}
 


### PR DESCRIPTION
## Done

> 09:58 <davidcalle> In this case, let's maybe try to get back to 3 takeovers, we have been between 4 and 5 for several months now
> 09:59 <SarahD> +1
> 10:00 <davidcalle> Maybe: Anbox, MicroK8s, VMware
> 10:00 <davidcalle> To cover 2 big topics + 1 shiny thing
> 10:01 <SarahD> Official marketing terminology
> :nerd_face:
> 10:01 <sewaddle> that sounds good to me
> 10:06 <sewaddle> shall we do that?
> 10:07 <SarahD> yep fine with me

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there are just anbox, microk8s and vmware takeovers live

