### PR TITLE
Changed takeover rotation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
   {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_451-microk8s.html" %}
+  {% include "takeovers/_ubuntu-masters-takeover.html" %}
 {% endblock takeover_content %}
 
 {#


### PR DESCRIPTION

## Done

Include ubuntu masters takeover in the rotation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
