### PR TITLE
Sort tutorials by difficulty

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -55,9 +55,8 @@
       <div class="p-form__group">
         <label for="tutorials-sort">Sorted by:</label>
         <select name="tutorials-sort" id="tutorials-sort" class="u-no-margin--bottom">
-          <option value="">Choose</option>
-          <option value="difficulty-desc">Most difficult</option>
           <option value="difficulty-asc">Least difficult</option>
+          <option value="difficulty-desc">Most difficult</option>
         </select>
       </div>
     </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -181,7 +181,7 @@ def index():
             metadata, key=lambda k: k["difficulty"], reverse=True
         )
 
-    if sort == "difficulty-asc":
+    if sort == "difficulty-asc" or not sort:
         metadata = sorted(
             metadata, key=lambda k: k["difficulty"], reverse=False
         )


### PR DESCRIPTION
## Done

Sort tutorials by least difficult as default

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the tutorials are sorted by least difficult by default
- Check that changing the "Sorted by" menu does what you'd expect


## Issue / Card

Fixes #6400 