### PR TITLE
Add suru to kubeflow pages

### DIFF
--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -6,7 +6,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-bordered">
+<section class="p-strip--suru-bottomed">
   <div class="row">
     <div class="col-8">
       <h1>

--- a/templates/kubeflow/features.html
+++ b/templates/kubeflow/features.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<section class="p-strip is-bordered">
+<section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Canonical&rsquo;s AI and ML solutions feature&hellip;</h1>

--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -6,7 +6,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1mJq8PxH8FVRVF9i1Xzh0f6M73eyjqZE4NaKYHRcRAKM/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--suru-image is-deep is-bordered">
   <div class="row">
     <div class="col-7">
       <h1>AI / ML from workstation to production</h1>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -6,7 +6,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1KVyyvZsDyrfoi5tK2m5SLWs9YuHg9hgqVz0c8cWHsf8/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--light is-deep is-bordered">
+<section class="p-strip--suru-topped is-deep is-bordered">
   <div class="row">
     <div class="col-8">
       <h1>Install Kubeflow on Ubuntu</h1>


### PR DESCRIPTION
## Done

Add suru to top of Kubeflow pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the Kubeflow homepage and all it's subpages have a suru at the top of the page


## Issue / Card

Fixes #6453 
