### PR TITLE
Add style override for tutorial headings

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -86,6 +86,10 @@
     &:target {
       display: block;
     }
+
+    h3 {
+      @extend .p-heading--five;
+    }
   }
 
   .l-tutorial-section__footer {


### PR DESCRIPTION
## Done
Override `h3` styles inside tutorial sections with the styles of `h5`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial
- Check that the headings *within* a tutorial are using the same styles as `p-heading--five`


## Issue / Card

Fixes #6409
