### PR TITLE
Move openstack diagram to own section

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -6,17 +6,20 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-6">
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
       <h1>What is OpenStack?</h1>
       <p>OpenStack is an open source cloud computing platform that allows businesses to control large pools of compute, storage and networking in a data centre.</p>
       <p>The fact that OpenStack is open source means that anyone that chooses to use it, can access the source code, make changes, and share these with the community. One of the key benefits of this model is that the source code can then be checked by a much larger set of people than proprietary code, which is restricted to its owners.</p>
-      <p class="u-sv3">Governed by the OpenStack Foundation, there are more than 34,000 individual contributors and over 550 companies that participate in the project. </p>
+      <p class="u-sv3">Governed by the OpenStack Foundation, there are more than 34,000 individual contributors and over 550 companies that participate in the project.</p>
     </div>
-    <div class="col-6 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/2d2a0b2a-what+is+open+stack+diagram.svg" width="500" alt="What is OpenStack?" />
-    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered u-no-padding--top">
+  <div class="u-fixed-width u-align--center">
+    <img src="https://assets.ubuntu.com/v1/2d2a0b2a-what+is+open+stack+diagram.svg" width="1088" alt="What is OpenStack?" />
   </div>
 </section>
 

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -6,20 +6,20 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-7">
       <h1>What is OpenStack?</h1>
       <p>OpenStack is an open source cloud computing platform that allows businesses to control large pools of compute, storage and networking in a data centre.</p>
       <p>The fact that OpenStack is open source means that anyone that chooses to use it, can access the source code, make changes, and share these with the community. One of the key benefits of this model is that the source code can then be checked by a much larger set of people than proprietary code, which is restricted to its owners.</p>
-      <p class="u-sv3">Governed by the OpenStack Foundation, there are more than 34,000 individual contributors and over 550 companies that participate in the project.</p>
+      <p class="u-no-margin--bottom">Governed by the OpenStack Foundation, there are more than 34,000 individual contributors and over 550 companies that participate in the project.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-bordered u-no-padding--top">
-  <div class="u-fixed-width u-align--center">
-    <img src="https://assets.ubuntu.com/v1/2d2a0b2a-what+is+open+stack+diagram.svg" width="1088" alt="What is OpenStack?" />
+<section class="p-strip is-bordered">
+  <div class="u-fixed-width">
+    <img src="https://assets.ubuntu.com/v1/2d2a0b2a-what+is+open+stack+diagram.svg" width="850" alt="What is OpenStack?" />
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Move the openstack diagram at the top of the page to it's own section and made it full width.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/what-is-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the diagram at the top of the page has it's own section and is full width


## Issue / Card

Fixes #6463