### PR TITLE
Display footer links inline on tablet and up

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -301,4 +301,16 @@
       margin-left: $sp-small;
     }
   }
+
+  .p-footer--secondary__nav {
+    @media only screen and (min-width: $breakpoint-small) {
+      .p-inline-list__item {
+        display: inline-block;
+
+        &::after {
+          display: block;
+        }
+      }
+    }
+  }
 }

--- a/templates/templates/_footer-copyright-and-legal.html
+++ b/templates/templates/_footer-copyright-and-legal.html
@@ -1,6 +1,6 @@
 <p class="p-footer--secondary__content"><small>&copy; {{ current_year() }} Canonical Ltd. Ubuntu and Canonical are
     registered trademarks of Canonical Ltd.</small></p>
-<nav>
+<nav class="p-footer--secondary__nav">
   <ul class="p-inline-list--middot u-no-margin--bottom">
     <li class="p-inline-list__item">
       <a class="p-link--soft" accesskey="8" href="/legal"><small>Legal information</small></a>


### PR DESCRIPTION
## Done

Make the legal information, data privacy and report a bug on this site links display inline on tablet view and up

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Resize the viewport to tablet size (~768px)
- Check that the legal information, data privacy and report a bug on this site links are displayed inline


## Issue / Card

Fixes #6357 