### PR TITLE
Update kubeflow features page illustrations

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -262,7 +262,7 @@ kubeflow:
   children:
     - title: Overview
       path: /kubeflow
-    - title: What is Kubeflow?
+    - title: What is Kubeflow
       path: /kubeflow/what-is-kubeflow
     - title: Features
       path: /kubeflow/features

--- a/templates/kubeflow/features.html
+++ b/templates/kubeflow/features.html
@@ -17,7 +17,7 @@
       <p><a class="js-invoke-modal" href="/kubeflow/contact-us?product=ai-features">Contact us for machine learning, deep learning and AI consulting&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 col-start-large-9 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="Kubeflow" width="323" />
+      <img src="https://assets.ubuntu.com/v1/1d5e357d-AI+ML_AW.svg" alt="Kubeflow" width="323" />
     </div>
   </div>
 </section>
@@ -80,107 +80,108 @@
       <p>TensorFlow  is an open source software library for high-performance numerical computation. Its flexible architecture allows easy deployment of computation across a variety of platforms (CPUs, GPUs, TPUs), and from desktops to clusters of servers to mobile and edge devices. Originally developed by researchers and engineers from the Google Brain team within Google’s AI organization, it comes with strong support for machine learning and deep learning and the flexible numerical computation core is used across many other scientific domains.</p>
       <p>TensorFlow comes with visualisation technology &mdash; TensorBoard. It features graphs, histograms and helps with visualising learning.</p>
       <p><a href="https://www.tensorflow.org/" class="p-link--external">Learn more about Tensorflow</a>
+      </div>
+      <div class="col-4 u-hide--small u-vertically-center">
+        <figure class="u-no-margin">
+          <img src="https://assets.ubuntu.com/v1/710ddd41-mnist_tensorboard.png?w=323" width="323" class="p-image--shadowed" alt="" />
+          <figcaption>Tensorflow from Google is officially published for Ubuntu</figcaption>
+        </figure>
+      </div>
     </div>
-    <div class="col-4 u-hide--small u-vertically-center">
-      <figure class="u-no-margin">
-        <img src="https://assets.ubuntu.com/v1/710ddd41-mnist_tensorboard.png?w=323" width="323" class="p-image--shadowed" alt="" />
-        <figcaption>Tensorflow from Google is officially published for Ubuntu</figcaption>
-      </figure>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip is-bordered u-image-position">
-  <div class="row">
-    <div class="col-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/3df02300-jupyterpreview.png?w=500" alt="" style="width: 45vw; max-width: 500px;" width="500" class="u-image-position--bottom u-hide--small"/>
+  <section class="p-strip is-bordered u-image-position">
+    <div class="row">
+      <div class="col-6 u-hide--small">
+        <img src="https://assets.ubuntu.com/v1/3df02300-jupyterpreview.png?w=500" alt="" style="width: 45vw; max-width: 500px;" width="500" class="u-image-position--bottom u-hide--small"/>
+      </div>
+      <div class="col-6">
+        <h2>JupyterHub</h2>
+        <p>With <a href="https://jupyterhub.readthedocs.io/" class="p-link--external">JupyterHub</a> you can create a multi-user Hub which spawns, manages, and proxies multiple instances of the single-user <a href="https://jupyter-notebook.readthedocs.io/" class="p-link--external">Jupyter notebook</a> server.</p>
+        <p>Project Jupyter created JupyterHub to support many users. The Hub can offer notebook servers to a class of students, a corporate data science workgroup, a scientific research project, or a high performance computing group.</p>
+        <p><a href="https://jupyter.org/" class="p-link--external">Learn more about the Jupyter project</a></p>
+      </div>
     </div>
-    <div class="col-6">
-      <h2>JupyterHub</h2>
-      <p>With <a href="https://jupyterhub.readthedocs.io/" class="p-link--external">JupyterHub</a> you can create a multi-user Hub which spawns, manages, and proxies multiple instances of the single-user <a href="https://jupyter-notebook.readthedocs.io/" class="p-link--external">Jupyter notebook</a> server.</p>
-      <p>Project Jupyter created JupyterHub to support many users. The Hub can offer notebook servers to a class of students, a corporate data science workgroup, a scientific research project, or a high performance computing group.</p>
-      <p><a href="https://jupyter.org/" class="p-link--external">Learn more about the Jupyter project</a></p>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Operations automation</h2>
-      <p>The real challenge of Kubeflow is everyday operations automation, year after year, while Kubeflow continues to evolve rapidly. This includes the everyday automation of the stack under Kubeflow. Canonical solves this problem with model-driven operations that decouple your architectural choices from the operations codebase that supports upgrades, scaling, integration and security.</p>
-      <h3>Total automation of gpgpu enabled infrastructure</h3>
-      <p>Eliminate the extra steps needed to take advantage of your gpgpu&rsquo;s by leveraging Kubeflow. With drivers tailored to your chipset, you&rsquo;ll get the most out of your investment, and speed up your deep learning initiatives.</p>
+  <section class="p-strip--light is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Operations automation</h2>
+        <p>The real challenge of Kubeflow is everyday operations automation, year after year, while Kubeflow continues to evolve rapidly. This includes the everyday automation of the stack under Kubeflow. Canonical solves this problem with model-driven operations that decouple your architectural choices from the operations codebase that supports upgrades, scaling, integration and security.</p>
+        <h3>Total automation of gpgpu enabled infrastructure</h3>
+        <p>Eliminate the extra steps needed to take advantage of your gpgpu&rsquo;s by leveraging Kubeflow. With drivers tailored to your chipset, you&rsquo;ll get the most out of your investment, and speed up your deep learning initiatives.</p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Artificial Intelligence infrastructure architecture</h2>
-      <p class="u-sv3">To get the most out of Kubeflow, you&rsquo;ll want to run it on an effective supporting stack. Minimally, leveraging the Charmed Distribution of Kubernetes (CDK) gives you the benefits of perfect portability between your private data-center and the public cloud.  CDK on Canonical Openstack unlocks further benefits, as described below.</p>
+  <section class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Artificial Intelligence infrastructure architecture</h2>
+        <p class="u-sv3">To get the most out of Kubeflow, you&rsquo;ll want to run it on an effective supporting stack. Minimally, leveraging the Charmed Distribution of Kubernetes (CDK) gives you the benefits of perfect portability between your private data-center and the public cloud.  CDK on Canonical Openstack unlocks further benefits, as described below.</p>
+      </div>
     </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-6">
-      <h3>Compute</h3>
-      <hr class="u-sv1" />
-      <p>Every ounce of performance matters. If you&rsquo;re building a private cloud you want the maximum performance for your workloads, the maximum utilisation in your data center, and the maximum economic efficiency. Canonical delivers all three.</p>
+    <div class="row u-equal-height">
+      <div class="p-card col-6">
+        <h3>Compute</h3>
+        <hr class="u-sv1" />
+        <p>Every ounce of performance matters. If you&rsquo;re building a private cloud you want the maximum performance for your workloads, the maximum utilisation in your data center, and the maximum economic efficiency. Canonical delivers all three.</p>
+      </div>
+      <div class="p-card col-6">
+        <h3>Storage</h3>
+        <hr class="u-sv1" />
+        <p>Storage performance and economics are tricky to balance in a cloud environment. Canonical will help you architect your storage across the cluster to balance price and performance, ensuring the right mix of resilience, latency, iops and integrity for your particular deployment.</p>
+      </div>
     </div>
-    <div class="p-card col-6">
-      <h3>Storage</h3>
-      <hr class="u-sv1" />
-      <p>Storage performance and economics are tricky to balance in a cloud environment. Canonical will help you architect your storage across the cluster to balance price and performance, ensuring the right mix of resilience, latency, iops and integrity for your particular deployment.</p>
+    <div class="row u-equal-height">
+      <div class="p-card col-6">
+        <h3>Networking</h3>
+        <hr class="u-sv1" />
+        <p>Network performance is critical for speeding up large deep learning exercises. The major factor in perceived cloud performance is aggregate network throughput and latency across the underlying cluster. Canonical&rsquo;s work with hyperscale public clouds ensures that we have deep insight into the dynamics of cloud network performance and security best practices for large-scale multi-tenanted operations. Our work with telco groups for NFV and edge clouds ensures that we can work well in complex environments where latency and security are critical.</p>
+      </div>
+      <div class="p-card col-6">
+        <h3>Operational Dashboards</h3>
+        <hr class="u-sv1" />
+        <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Canonical delivers a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elastic Search and Kibana stack (ELK), and Nagios.</p>
+      </div>
     </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-6">
-      <h3>Networking</h3>
-      <hr class="u-sv1" />
-      <p>Network performance is critical for speeding up large deep learning exercises. The major factor in perceived cloud performance is aggregate network throughput and latency across the underlying cluster. Canonical&rsquo;s work with hyperscale public clouds ensures that we have deep insight into the dynamics of cloud network performance and security best practices for large-scale multi-tenanted operations. Our work with telco groups for NFV and edge clouds ensures that we can work well in complex environments where latency and security are critical.</p>
+    <div class="row">
+      <p>
+        <a href="/openstack/features">Learn more about OpenStack&rsquo;s features&nbsp;&rsaquo;</a>
+      </p>
+    </section>
+
+    <section class="p-strip is-bordered">
+      <div class="row">
+        <div class="col-6">
+          <h2>Operational dashboards</h2>
+          <p>These dashboards can be customised or integrated into existing monitoring systems at your business.</p>
+        </div>
+      </div>
+      <div class="u-fixed-width">
+        <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040" alt="" width="1040" />
+      </div>
+    </section>
+
+    {% include "kubeflow/shared/_learn-more.html" %}
+
+    <section class="p-strip">
+      <div class="row u-equal-height">
+        <div class="col-7">
+          <h2>Get the most from your workloads</h2>
+          <p>Find out why Ubuntu is the standard for enterprise machine learning for Fortune 50 companies and for startups.</p>
+          <p><a class="p-button--positive js-invoke-modal" href="/kubeflow/contact-us?product=ai-features">Get in touch</a></p>
+        </div>
+        <div class="col-5 u-align--center u-hide--small">
+          <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" style="height:200px" alt="">
+        </div>
+      </div>
+    </section>
+    {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
-    <div class="p-card col-6">
-      <h3>Operational Dashboards</h3>
-      <hr class="u-sv1" />
-      <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Canonical delivers a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elastic Search and Kibana stack (ELK), and Nagios.</p>
-    </div>
-  </div>
-  <div class="row">
-    <p>
-      <a href="/openstack/features">Learn more about OpenStack&rsquo;s features&nbsp;&rsaquo;</a>
-    </p>
-</section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-6">
-      <h2>Operational dashboards</h2>
-      <p>These dashboards can be customised or integrated into existing monitoring systems at your business.</p>
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040" alt="" width="1040" />
-  </div>
-</section>
-
-{% include "kubeflow/shared/_learn-more.html" %}
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h2>Get the most from your workloads</h2>
-      <p>Find out why Ubuntu is the standard for enterprise machine learning for Fortune 50 companies and for startups.</p>
-      <p><a class="p-button--positive js-invoke-modal" href="/kubeflow/contact-us?product=ai-features">Get in touch</a></p>
-    </div>
-  </div>
-</section>
-{% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-
-
-
-{% endblock content %}
+    {% endblock content %}

--- a/templates/kubeflow/shared/_learn-more.html
+++ b/templates/kubeflow/shared/_learn-more.html
@@ -8,7 +8,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="">
           <h4 class="p-heading-icon__title">Webinars</h4>
         </div>
       </div>
@@ -31,7 +31,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="">
           <h4 class="p-heading-icon__title">Articles</h4>
         </div>
       </div>
@@ -64,7 +64,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="">
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -21,7 +21,7 @@
           {% with section=nav_sections.kubernetes %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
-          {% with section=nav_sections.security %}
+          {% with section=nav_sections.kubeflow %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
@@ -31,17 +31,20 @@
           {% with section=nav_sections.desktop %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
-          {% with section=nav_sections.server %}
+          {% with section=nav_sections.iot %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          {% with section=nav_sections.iot %}
+          {% with section=nav_sections.server %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
           {% with section=nav_sections.support %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
+          {% with section=nav_sections.security %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>


### PR DESCRIPTION
## Done

Update kubeflow features page illustrations
Add kubeflow to the footer as it was oddly missing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1DT5nCRSJH-OkvDmlyKh6vVhofeHPHZJHTTBDNu44wCY/edit) and resolve the comments


## Issue / Card

Fixes #6467
