### PR TITLE
Add anbox-cloud.io to the enterprise dropdown

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -144,6 +144,7 @@
           <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
           <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>
+          <li class="p-list__item"><a href="https://anbox-cloud.io/" title="Visit Anbox Cloud">Anbox Cloud - Android in the cloud</a></li>
         </ul>
       </div>
       <!-- AI and ML -->
@@ -188,6 +189,7 @@
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/openstack/managed">OpenStack</a></li>
           <li class="p-inline-list__item"><a href="/kubernetes/managed">Kubernetes</a></li>
+          <li class="p-inline-list__item"><a href="https://anbox-cloud.io/" title="Visit Anbox Cloud">Anbox Cloud</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Done

Add anbox-cloud.io to the enterprise dropdown in 2 places

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/server#enterprise
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit?ts=5e2ee865#) and resolve the comments

