### PR TITLE
Remove extra spacing on kubeflow consulting page

### DIFF
--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -12,7 +12,7 @@
       <h1>
         AI consulting and delivery
       </h1>
-      <h4 class="u-sv3">
+      <h4>
         Canonical and leading data scientists team up to consult on the full enterprise AI stack.
       </h4>
       <p>
@@ -36,7 +36,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Develop your data science capabilities</h2>
-      <h4 class="u-sv3">
+      <h4>
         Stay focused and productive in a fast-moving landscape of code and data.
       </h4>
       <p>
@@ -49,7 +49,7 @@
       <p>
         That’s why it pays off to bring Canonical and data scientists in early. The right resources and experts accelerate delivery and keep your team focused on your particular data streams and particular business objectives. Together, we help deliver a five-day/five-step AI design sprint with your analytics and infrastructure teams. At the end of the engagement you will have a pattern for productive AI development - spanning developer workstations, machine learning infrastructure (in the cloud or on-premises), and AI applications - delivering daily insights, powered by your data.
       </p>
-      <p class="u-sv3">
+      <p>
         With our structured program, we can approach any situation and provide the infrastructure and capabilities that your business needs. Proven best practices mean that we can take the guesswork and experimentation out of your AI adoption, and fast-track you to value without breaking your budget.
       </p>
       <p>
@@ -85,16 +85,16 @@
 <section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>AI design sprint</h2>
-    <h4 class="u-sv3">
+    <h4>
       Produce tangible results in one week with agile AI technologies and methodologies.
     </h4>
     <p>
       The core of our one week engagement centers on the AI design sprint - an introduction to our AI technologies and methodologies, combined with developing a proof of concept (PoC) that solves a real business challenge for your organization. The blueprints that are produced during this sprint will serve as a foundation for your ongoing AI innovations.
     </p>
-    <p class="u-sv3">
+    <p>
       Additional key outcomes that you can expect from this week are a baseline architecture for iterative solution development – which includes a working continuous integration pipeline – and a high level strategy that addresses your AI transformation journey. Please note: this week typically relies on having the right infrastructure in place to support the AI technology stack.
     </p>
-    <h3 class="u-sv3">
+    <h3>
       The AI design process in more detail
     </h3>
   </div>
@@ -202,7 +202,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Perfectly portable AI workloads</h2>
-      <h4 class="u-sv3">
+      <h4>
         Open and pluggable machine learning workflows for multi-cloud AI, ML and DL.
       </h4>
       <p>


### PR DESCRIPTION
## Done

Remove extra spacing on kubeflow consulting page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the spacing between text is less than on the live site


## Issue / Card

Fixes #6469 