### PR TITLE
Update illustrations on kubeflow consulting page

### DIFF
--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -100,7 +100,7 @@
   </div>
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/5d8aa78b-1+Discovery.svg" alt="" width="335px"/>
+      <img src="https://assets.ubuntu.com/v1/e68fd355-1+discovery_AW.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
       <h4>1 - Discovery</h4>
@@ -130,7 +130,7 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/0bb09a0a-2+Assessment.svg" alt="" width="335px"/>
+      <img src="https://assets.ubuntu.com/v1/146a6eba-2+assessment_AW.svg" alt="" width="335px"/>
     </div>
   </div>
 
@@ -140,7 +140,7 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/3f8aaa5f-3+Design.svg" alt="" width="335px"/>
+      <img src="https://assets.ubuntu.com/v1/455740b4-3+design_AW.svg" alt="" width="335px"/>
     </div>
     <div class="col-6">
       <h4>3 - Design</h4>
@@ -162,7 +162,7 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/273fd9ee-4+Implementation.svg" alt="" width="335px"/>
+      <img src="https://assets.ubuntu.com/v1/ae0d7b33-4+implementation_AW.svg" alt="" width="335px"/>
     </div>
   </div>
 
@@ -173,7 +173,7 @@
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
       <img
-        src="https://assets.ubuntu.com/v1/2021203f-5+Operation+and+feedback.svg"
+        src="https://assets.ubuntu.com/v1/70227781-5+operation+and+feedback_AW.svg"
         alt=""
         width="335px"
       />

--- a/templates/kubeflow/shared/_learn-more.html
+++ b/templates/kubeflow/shared/_learn-more.html
@@ -8,7 +8,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="">
           <h4 class="p-heading-icon__title">Webinars</h4>
         </div>
       </div>
@@ -31,7 +31,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="">
           <h4 class="p-heading-icon__title">Articles</h4>
         </div>
       </div>
@@ -64,7 +64,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/cd7a3a3c-white-paper-icon.svg" width="32" alt="">
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="">
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>


### PR DESCRIPTION
##  Done

Updated the illustrations on /kubeflow/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the illustrations on the page match [the copy doc](https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit)


## Issue / Card

Fixes #6470 