### PR TITLE
Improve error handling for 401s

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,7 +31,7 @@ from webapp.context import (
     releases,
 )
 from webapp.views import (
-    advantage,
+    advantage_view,
     blog_blueprint,
     blog_custom_group,
     blog_custom_topic,
@@ -99,7 +99,7 @@ def utility_processor():
 # ===
 
 # Simple routes
-app.add_url_rule("/advantage", view_func=advantage)
+app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule(
     "/download/<regex('server|desktop|cloud'):category>/thank-you",
     view_func=download_thank_you,


### PR DESCRIPTION
- *only* catch explicitly 401s, re-raise all other `http_errors`
- limit the `try: except` block to just the bit that we think should return 401
- send a bit more data to sentry for us to debug when people do hit 401 errors

## QA

`./run`

- Go to http://0.0.0.0:8001/advantage and log in
- Switch to using staging API
- Reload http://0.0.0.0:8001/advantage
- Log in again
- Check it all works as expected