### PR TITLE
Update kubernetes install illustrations

### DIFF
--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -5,7 +5,7 @@
 
   <div class="row">
     <div class="col-6">
-      <p class="u-hide--small"><img class="p-image--shadowed" src="https://assets.ubuntu.com/v1/daf4f278-k8s-ebook-cover-crop.jpg?w=502" width="502" alt="Cover of whitepaper"></p>
+      <p class="u-hide--small"><img class="p-image--shadowed" src="https://assets.ubuntu.com/v1/daf4f278-k8s-ebook-cover-crop.jpg?w=400" width="400" alt="Cover of whitepaper"></p>
       <h3>The no-nonsense way to accelerate your business with containers</h3>
       <p>Download this whitepaper to learn:</p>
       <ul class="p-list">

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -300,10 +300,10 @@ $ kubectl cluster-info</code></pre>
 
 <section class="p-strip">
   <div class="row u-equal-height">
-    <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1f1d581a-picto-quote-orange.svg" width="200" alt="" />
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="280" alt="" />
     </div>
-    <div class="col-7 col-start-large-6 u-vertically-center">
+    <div class="col-7 u-vertically-center">
       <h2>Need more help?</h2>
       <p>Let our cloud experts help you take the next step.</p>
       <p><a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-install">Contact us</a></p>


### PR DESCRIPTION
## Done

Update illustrations on /kubernetes/install page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the illustrations on the page are the same as in the [copy doc](https://docs.google.com/document/d/1oiD6UUomf2daZitS3UOosujYBXPbiOMzPtXVZBq-ph0/edit#heading=h.mj4mzhhwhrtm)


## Issue / Card

Fixes #6457 