### PR TITLE
Update illustrations on kubernetes partners page

### DIFF
--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -6,7 +6,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-bottomed is-deep is-bordered">
+<section class="p-strip--suru-bottomed is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>Charmed Kubernetes partners</h1>

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -32,6 +32,9 @@
       <img style="max-width: 210px;" src="https://assets.ubuntu.com/v1/8f878ba0-rancher-logo-stacked-color.svg" width="210" alt="">
     </div>
   </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
   <div class="row u-vertically-spaced u-equal-height">
     <div class="col-8">
       <h3>In partnership with Google</h3>
@@ -42,6 +45,9 @@
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       <img style="max-width: 250px;" src="https://assets.ubuntu.com/v1/ba70dd8a-gce.png?w=250" width="250" alt="">
     </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator">
   </div>
   <div class="row u-vertically-spaced u-equal-height">
     <div class="col-8">
@@ -56,11 +62,14 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
+  <div class="row u-equal-height">
+    <div class="col-7">
       <h2>Become a cloud partner</h2>
       <p>To learn more about becoming a Charmed Kubernetes partner, please contact us today.</p>
       <p><a class="p-button--positive" href="https://partners.ubuntu.com/contact-us">Get in touch</a> or <a href="https://partners.ubuntu.com/partnering-with-us">learn more about partnering with us&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="281" alt="">
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Update illustrations on /kubernetes/partners

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/partners
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the illustrations on the page are the same as the [copy doc](https://docs.google.com/document/d/1vRlHxWr7pxstx5pOtqXWrIviXtdPvW2gd3-mNeYQKp0/edit#heading=h.oqi22mc8fijl)


## Issue / Card

Fixes #6458 