### PR TITLE
Update illustrations on kubeflow install page

### DIFF
--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -8,9 +8,12 @@
 {% block content %}
 <section class="p-strip--suru-topped is-deep is-bordered">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <h1>Install Kubeflow on Ubuntu</h1>
       <p>Create and train machine learning models on your laptop, in your data center, or in the cloud.</p>
+    </div>
+    <div class="col-5 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/0822f908-kubernetes-instal.svg" width="140" alt="Install Kubernetes" />
     </div>
   </div>
 </section>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -12,9 +12,6 @@
       <h1>Install Kubeflow on Ubuntu</h1>
       <p>Create and train machine learning models on your laptop, in your data center, or in the cloud.</p>
     </div>
-    <div class="col-3 col-start-large-10 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1ec1605a-kubeflow.svg?w=275" alt="" width="275" />
-    </div>
   </div>
 </section>
 
@@ -221,10 +218,10 @@
 </div>
 
 {% include "kubeflow/shared/_learn-more.html" %}
-<div class="p-strip--light is-deep">
+<div class="p-strip is-deep">
   <div class="row u-equal-height">
     <div class="col-4 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/1f1d581a-picto-quote-orange.svg" width="200" alt="" />
+      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="280" alt="" />
     </div>
     <div class="col-7 col-start-large-6 u-vertically-center">
       <h2>Need more help?</h2>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -7,8 +7,8 @@
 
 {% block content %}
 <section class="p-strip--suru-topped is-deep is-bordered">
-  <div class="row">
-    <div class="col-7">
+  <div class="row u-equal-height">
+    <div class="col-7 u-vertically-center">
       <h1>Install Kubeflow on Ubuntu</h1>
       <p>Create and train machine learning models on your laptop, in your data center, or in the cloud.</p>
     </div>


### PR DESCRIPTION
## Done

Updated the illustrations on /kubeflow/install

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the illustrations are the same as in the [copy doc](https://docs.google.com/document/d/1KVyyvZsDyrfoi5tK2m5SLWs9YuHg9hgqVz0c8cWHsf8/edit#heading=h.pt6iw0mepowo)


## Issue / Card

Fixes #6468