### PR TITLE
Remove anchor on /advatage link on livepatch page

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -50,7 +50,7 @@
       <p><a class="p-button--positive"  href="https://auth.livepatch.canonical.com/">Get Livepatch</a></p>
       <h2>Part of Ubuntu Advantage</h2>
       <p>Buy as part of Ubuntu Advantage from Canonical. Buy online.</p>
-      <p><a class="p-button--positive"  href="/advantage#livepatch">Get Ubuntu Advantage</a></p>
+      <p><a class="p-button--positive"  href="/advantage">Get Ubuntu Advantage</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Remove anchor on /advatage link on livepatch page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/livepatch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the button 'Get Ubuntu Advantage' no longer has a anchor


## Issue / Card

Fixes #6110
