### PR TITLE
Change tutorial section heading sizes

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -87,8 +87,20 @@
       display: block;
     }
 
+    h2 {
+      @extend .p-heading--three;
+    }
+
     h3 {
+      @extend .p-heading--four;
+    }
+
+    h4 {
       @extend .p-heading--five;
+    }
+
+    h5 {
+      @extend .p-heading--six;
     }
   }
 

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -40,7 +40,7 @@
   <div class="l-tutorial__content">
     {% for section in document.sections %}
     <section class="l-tutorial-section" id="{{ loop.index }}-{{ section['slug']}}">
-      <h2 class="p-heading--four">{{ loop.index }}. {{ section["title"]}}</h2>
+      <h2 class="p-heading--three">{{ loop.index }}. {{ section["title"]}}</h2>
 
       <article class="l-tutorial-section__content">
         {{ section.content | safe }}


### PR DESCRIPTION
## Done

Bumped each heading level down one in tutorials sections to fix hierarchy issues

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial, change heading tags in the browser console to see that each heading uses the style of the heading level below it


## Issue / Card

Fixes #6480 
