### PR TITLE
Remove the shared/_trusted-managed-service-provider.html partial

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -312,10 +312,6 @@
     </div>
   </section>
 
-  <section class="p-strip is-bordered">
-    {% include "shared/_trusted-managed-service-provider.html" %}
-  </section>
-
   <section class="p-strip--light is-bordered">
     <div class="row">
       <div class="col-8">

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -343,10 +343,6 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
-  {% include "shared/_trusted-managed-service-provider.html" %}
-</section>
-
 <section class="p-strip--light is-deep is-bordered">
   <div class="u-fixed-width">
     <h2>Count on Canonical’s OpenStack expertise</h2>


### PR DESCRIPTION
## Done

Remove the shared/_trusted-managed-service-provider.html partial from /kubernetes/managed and /openstack/managed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/managed and http://0.0.0.0:8001/openstack/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the section has been removed per comments in the [copy doc](https://docs.google.com/document/d/1Qv379nYnod9e4jMrsdDND8D7mbPyqELi2lowjkfD-gU/edit?ts=5e2efd6b#heading=h.fghanvvlxzai)

@anasereijo should I change the strips background?
