### PR TITLE
Add robotics to IoT sub nav and sub nav to robotics page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -369,6 +369,8 @@ iot:
       path: /internet-of-things
     - title: Digital signage
       path: /internet-of-things/digital-signage
+    - title: Robotics
+      path: /robotics
     - title: Gateways
       path: /internet-of-things/gateways
     - title: App store


### PR DESCRIPTION
## Done

- Added /robotics to IoT sub nav
- Added IoT sub nav to /robotics

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that /robotics is in the sub nav
- Go to /robotics
- Check that the sub nav from /internet-of-things is on the page


## Issue / Card

Fixes #2256