### PR TITLE
Remove asset server resizing to increase screenshot legibility

### DIFF
--- a/templates/kubeflow/features.html
+++ b/templates/kubeflow/features.html
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="u-fixed-width">
-        <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" alt="" width="1040" />
+        <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1200&fmt=jpg" alt="" width="1040" />
       </div>
     </section>
 

--- a/templates/kubeflow/features.html
+++ b/templates/kubeflow/features.html
@@ -83,7 +83,7 @@
       </div>
       <div class="col-4 u-hide--small u-vertically-center">
         <figure class="u-no-margin">
-          <img src="https://assets.ubuntu.com/v1/710ddd41-mnist_tensorboard.png?w=323" width="323" class="p-image--shadowed" alt="" />
+          <img src="https://assets.ubuntu.com/v1/710ddd41-mnist_tensorboard.png" width="323" class="p-image--shadowed" alt="" />
           <figcaption>Tensorflow from Google is officially published for Ubuntu</figcaption>
         </figure>
       </div>
@@ -93,7 +93,7 @@
   <section class="p-strip is-bordered u-image-position">
     <div class="row">
       <div class="col-6 u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/3df02300-jupyterpreview.png?w=500" alt="" style="width: 45vw; max-width: 500px;" width="500" class="u-image-position--bottom u-hide--small"/>
+        <img src="https://assets.ubuntu.com/v1/3df02300-jupyterpreview.png" alt="" style="width: 45vw; max-width: 500px;" width="500" class="u-image-position--bottom u-hide--small"/>
       </div>
       <div class="col-6">
         <h2>JupyterHub</h2>
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="u-fixed-width">
-        <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040" alt="" width="1040" />
+        <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png" alt="" width="1040" />
       </div>
     </section>
 


### PR DESCRIPTION
## Done

- Remove asset server resizing to increase screenshot legibility

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to live and see that the screenshots are a bit clearer

## Issue / Card

Fixes #6466

