### PR TITLE
Update banner illustration on /embedded page

### DIFF
--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -18,7 +18,7 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--right">
-      <img src="https://assets.ubuntu.com/v1/4e2131b0-3B-Embedded+Linux.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg" alt="" width="335px">
     </div>
   </div>
 </section>

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -18,7 +18,7 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--right">
-      <img src="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg" alt="" width="350px">
     </div>
   </div>
 </section>
@@ -42,7 +42,7 @@
 <section class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-5 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/682f351e-Faster_cheaper.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/fad662b3-faster+cheaper.svg" alt="" width="350px">
     </div>
     <div class="col-7">
       <h2>Faster, cheaper, better. Pick any 3.</h2>
@@ -109,7 +109,7 @@
       <!-- rtp section left start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/5cf7bd32-news-feed-strip-case-study.svg' width="32" alt='' />
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/b061c401-White+paper.svg' width="32" alt='' />
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
@@ -120,7 +120,7 @@
       <!-- rtp section center start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg' width="32" alt='' />
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/6e184942-Webinar.svg' width="32" alt='' />
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
@@ -131,7 +131,7 @@
       <!-- rtp section right start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/cc61684f-case-study-icon.svg' width="32" alt='' />
+          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/b061c401-White+paper.svg' width="32" alt='' />
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
@@ -148,7 +148,7 @@
       <p class="p-heading--four">Give them the platform they love.</p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/6b057d20-Drive_success.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/f7c1457a-drive+success.svg" alt="" width="350px">
     </div>
   </div>
 </section>
@@ -207,7 +207,7 @@
       <p>The new Ubuntu Core is an appliance platform with immutable packages.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/7dc80491-Server_or_Core.svg" alt="" width="335px" />
+      <img src="https://assets.ubuntu.com/v1/759b19ec-server+or+core.svg" alt="" width="350px" />
     </div>
   </div>
   <div class="row p-divider" style="margin-top: 3rem;">
@@ -236,7 +236,7 @@
       <p>Any compromise of your device puts your reputation on the line.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/c53664cd-Security_updates.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/aa1dc625-10+Year+shield+trio_AW.svg" alt="" width="350px">
     </div>
   </div>
 
@@ -291,7 +291,7 @@
       <p>Automatic tracking of Ubuntu component licenses and monitoring for  your packages help you and your customers meet obligations.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/2697f642-Compliance.svg" alt="" width="335px" />
+      <img src="https://assets.ubuntu.com/v1/c7274075-compliance.svg" alt="" width="350px" />
     </div>
   </div>
 
@@ -326,7 +326,7 @@
       <p class="p-heading--four">Develop, deploy, iterate and improve. With Ubuntu and snapcraft, your embedded app teams run at cloud speeds.</p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/6cef8858-Apps.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/22f88d02-apps.svg" alt="" width="350px">
     </div>
   </div>
 </section>
@@ -361,7 +361,7 @@
       <p><a href="https://snapcraft.io/build" class="p-link--external p-button--positive">Build a snap</a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/0df476e6-DevOps.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/22007291-DevOps.svg" alt="" width="350px">
     </div>
   </div>
 
@@ -427,7 +427,7 @@
       <h3>Ultra-reliable updates</h3>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/77faea7a-Reliable_updates.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/c711b814-reliable_updates.svg" alt="" width="350px">
     </div>
   </div>
 
@@ -481,7 +481,7 @@
       <p class="p-heading--four u-no-max-width">We certify the major platforms so you are ready to roll.<br />Fixed-price enablement and certification of related boards.</p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/9cb01800-Hardware_Easy.svg" alt="" width="335px">
+      <img src="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg" alt="" width="350px">
     </div>
   </div>
 </section>
@@ -520,7 +520,7 @@
       <p>Have a custom board? Let us deliver a standard Linux for your developers.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/122d89aa-Unleash_hardware.svg" alt="" width="335px" />
+      <img src="https://assets.ubuntu.com/v1/642b4ee3-unleash_hardware.svg" alt="" width="350px" />
     </div>
   </div>
 

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -610,7 +610,7 @@
       <li class="p-matrix__item">
         <div>
           <h4 class="p-matrix__title">Global support</h4>
-          <p class="p-matrix__desc">No matter where you ship, no matter where your customers, we can be there when you need us.</p>
+          <p class="p-matrix__desc">No matter where you ship, no matter where your customers are, we can be there when you need us.</p>
         </div>
       </li>
       <li class="p-matrix__item">


### PR DESCRIPTION
## Done

- Update banner illustration on /embedded page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/embedded
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the illustrations has been updated per the [copy doc](https://docs.google.com/document/d/15Tz87YRg4SnX4DWGOSl2TDTHLSStJoma879xHnF0nuo/edit#) and accept them please


## Issue / Card

Fixes #6513 
