### PR TITLE
Rename CDK to Charmed Kubernetes

### DIFF
--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -13,7 +13,7 @@
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes' %}
-{% with h1="Contact us about The Charmed Distribution of Kubernetes",
+{% with h1="Contact us about Charmed Kubernetes",
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="2243",
   lpId="4986",

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 {% if product == 'containers-kubernetes' %}
-  {% with thanks_context="enquiring about the Charmed Distribution of Kubernetes" %}{% include "shared/_thank_you.html" %}{% endwith %}
+  {% with thanks_context="enquiring about Charmed Kubernetes" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% elif product == 'containers-kubernetes-foundation' %}
     {% with thanks_context="enquiring about the Enterprise Kubernetes Packages" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {%  else %}

--- a/templates/engage/ai-ml-ubuntu.html
+++ b/templates/engage/ai-ml-ubuntu.html
@@ -52,7 +52,7 @@
         <li>The key concepts in Machine Learning</li>
         <li>How AI applications and their development are reshaping company’s IT</li>
         <li>How enterprises are applying devops practices to their ML infrastructure and workflows</li>
-        <li>How Canonical’s AI / ML portfolio from Ubuntu to the Charmed Distribution of Kubernetes and and how to get started
+        <li>How Canonical’s AI / ML portfolio from Ubuntu to Charmed Kubernetes and and how to get started
           quickly with your project</li>
       </ul>
       <h3>Other questions answered</h3>

--- a/templates/kubeflow/features.html
+++ b/templates/kubeflow/features.html
@@ -119,7 +119,7 @@
     <div class="row">
       <div class="col-8">
         <h2>Artificial Intelligence infrastructure architecture</h2>
-        <p class="u-sv3">To get the most out of Kubeflow, you&rsquo;ll want to run it on an effective supporting stack. Minimally, leveraging the Charmed Distribution of Kubernetes (CDK) gives you the benefits of perfect portability between your private data-center and the public cloud.  CDK on Canonical Openstack unlocks further benefits, as described below.</p>
+        <p class="u-sv3">To get the most out of Kubeflow, you&rsquo;ll want to run it on an effective supporting stack. Minimally, leveraging Charmed Kubernetes gives you the benefits of perfect portability between your private data-center and the public cloud.  Charmed Kubernetes on Canonical Openstack unlocks further benefits, as described below.</p>
       </div>
     </div>
     <div class="row u-equal-height">

--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -2,7 +2,7 @@
 
 
 {% block title %}Kubeflow: AI and Machine Learning on Ubuntu{% endblock %}
-{% block meta_description %}The default platform for Tensorflow and other AI/ML frameworks, with automatic hardware GPGPU acceleration on Ubuntu. Canonical provides training and K8s-based ML expertise.{% endblock %}
+{% block meta_description %}Charmed Kubeflow is the default platform for Tensorflow, PyTorch and other AI/ML frameworks, with automatic hardware GPGPU acceleration on Ubuntu. Canonical provides training and access to machine learning experts.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1mJq8PxH8FVRVF9i1Xzh0f6M73eyjqZE4NaKYHRcRAKM/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -207,7 +207,7 @@
     </p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">NVIDIA DGX servers optimised for machine learning come with Ubuntu and support from Canonical included</li>
-      <li class="p-list__item is-ticked">NVIDIA Kubernetes extensions for hardware acceleration are enabled in the Canonical Distribution of Kubernetes</li>
+      <li class="p-list__item is-ticked">NVIDIA Kubernetes extensions for hardware acceleration are enabled in Charmed Kubernetes</li>
       <li class="p-list__item is-ticked">NVIDIA Tegra and Drive PX2 ship with Ubuntu for Edge AI</li>
     </ul>
   </div>

--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -100,13 +100,13 @@ As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infra
         2. Support for guest instances other than [Cloud Guests](#term-cloud-guests).
   2. Support for Kubernetes
     1. Full Stack support requirements:
-        1. [Deployment](#term-deployment) of [Charmed Distribution of Kubernetes](#term-cdk) (CDK) in at least the minimum deployment configuration, or a kubeadm-deployed cluster of unmodified upstream Kubernetes binaries as published by the CNCF deployed on Ubuntu as base OS.
-        2. Highly-Available control plane either deployed using Charms in the CDK reference architecture or in a similar fashion using kubeadm.
+        1. [Deployment](#term-deployment) of [Charmed Kubernetes](#term-cdk) in at least the minimum deployment configuration, or a kubeadm-deployed cluster of unmodified upstream Kubernetes binaries as published by the CNCF deployed on Ubuntu as base OS.
+        2. Highly-Available control plane either deployed using Charms in the Charmed Kubernetes reference architecture or in a similar fashion using kubeadm.
         3. Support must be purchased for all nodes in the supported Kubernetes cluster.
         4. Supported versions of Kubernetes include the current stable minor release and the two most recent minor releases in the stable release channel. Additional information can be found at: [https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions](https://github.com/juju-solutions/bundle-canonical-kubernetes/wiki/Supported-Kubernetes-Versions)
-        5. For any deployment of the Charmed Distribution of Kubernetes carried out by Canonical while under contract for a deployment, which result in the customisation of any Charms, the customisation will be supported for 90 days after completion of the deployment.
+        5. For any deployment of Charmed Kubernetes carried out by Canonical while under contract for a deployment, which result in the customisation of any Charms, the customisation will be supported for 90 days after completion of the deployment.
     2. Unless Full-Stack Support requirements are met, support is limited to:
-        1. The software packages and Charms necessary for running the Charmed Distribution of Kubernetes.
+        1. The software packages and Charms necessary for running Charmed Kubernetes.
         2. Kubernetes clusters deployed using kubeadm utilising the software packages available from apt.kubernetes.io.
         3. Bug-fix support in the supplied software artefacts by Canonical.
 3. Ubuntu Legal Assurance programme. The customer is entitled to participate in the Ubuntu Assurance Programme, subject to its terms and conditions. Canonical may update the Assurance Programme and its terms periodically. The current Ubuntu Assurance Programme and its IP indemnification terms are available at Canonical’s Ubuntu Assurance page:[ http://www.ubuntu.com/legal/ubuntu-advantage/assurance](http://www.ubuntu.com/legal/ubuntu-advantage/assurance)
@@ -356,7 +356,7 @@ Add-Ons constitute additional support services available separately on a per-Nod
 - <strong id="term-cluster">Cluster</strong> means the deployment of the Kubernetes computing environment to be managed by Canonical.
 - <strong id="term-container-instance">Container Instance</strong> means a container instance running in the Cluster.
 - <strong id="term-hypervisor">Covered Hypervisor</strong> means any of: KVM | Qemu | Bochs, VMWare ESXi, LXD | LXC, Xen, Hyper-V, VirtualBox, z/VM, Docker.
-- <strong id="term-deployment">Deployment</strong> means the process of deploying the Charmed Distribution of Kubernetes or Kubernetes using kubeadm. A deployment is considered successful once Juju reports all applications in a “started” state.
+- <strong id="term-deployment">Deployment</strong> means the process of deploying Charmed Kubernetes or Kubernetes using kubeadm. A deployment is considered successful once Juju reports all applications in a “started” state.
 - <strong id="term-dse">DSE</strong> means a Canonical dedicated support engineer dedicated to work full-time for a single customer acting as an extension of the customer’s support organization with a primary focus on integrating and supporting Canonicals offerings within the customer’s environment.
 - <strong id="term-dtam">DTAM</strong> means a Canonical support engineer dedicated to work full-time remotely for a single customer.
 - <strong id="term-environment">Environment</strong> means a Cloud or Cluster, as applicable to the particular service offering.

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -164,7 +164,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Financial services</h3>
           <p class="p-matrix__desc">
-            Marquee financial institutions the world over trust Canonical OpenStack and Charmed Kubernetes (CDK) for secure private and public cloud infrastructure services to host their mission-critical applications.
+            Marquee financial institutions the world over trust Canonical OpenStack and Charmed Kubernetes for secure private and public cloud infrastructure services to host their mission-critical applications.
           </p>
         </div>
       </li>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -109,7 +109,7 @@
         <input type="hidden" name="_mkt_disp" value="return"/>
         <input type="hidden" name="_mkt_trk" value=""/>
       </form>
-    
+
     <!-- /MARKETO FORM -->
   </div>
 </div>
@@ -164,7 +164,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Financial services</h3>
           <p class="p-matrix__desc">
-            Marquee financial institutions the world over trust Canonical OpenStack and the Charmed Distribution of Kubernetes (CDK) for secure private and public cloud infrastructure services to host their mission-critical applications.
+            Marquee financial institutions the world over trust Canonical OpenStack and Charmed Kubernetes (CDK) for secure private and public cloud infrastructure services to host their mission-critical applications.
           </p>
         </div>
       </li>

--- a/templates/takeovers/takeunders/_ubuntu-product-month.html
+++ b/templates/takeovers/takeunders/_ubuntu-product-month.html
@@ -5,7 +5,7 @@
     </div>
     <div class="col-4 u-no-margin--top">
       <h3><a href="https://pages.ubuntu.com/kubernetes-month.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Ubuntu Product Month takeunder', 'eventLabel' : 'Watch our Kubernetes webinars', 'eventValue' : undefined });">Watch our Kubernetes webinars&nbsp;&rsaquo;</a></h3>
-      <p>A series of on-demand webinars to learn more about Charmed&rsquo;s Distribution of Kubernetes.</p>
+      <p>A series of on-demand webinars to learn more about Charmed Kubernetes.</p>
     </div>
   </div>
 </div>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -77,7 +77,7 @@
               <a href="https://jaas.ai/">Juju for standardised operations&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="/kubernetes">Charmed Distribution of Kubernetes&nbsp;&rsaquo;</a>
+              <a href="/kubernetes">Charmed Kubernetes&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
               <a href="https://microk8s.io/">MicroK8s - single node k8s for devs&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Rename 'the Charmed Distribution of Kubernetes' or 'the Canonical Distribution of Kubernetes' or 'CDK' to Charmed Kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at:
    - https://ubuntu.com/containers/thank-you - not in copy doc, logic in code
    - https://ubuntu.com/containers/contact-us - not in copy doc, logic in code
    - [Developer mega menu](https://ubuntu.com/#developer) - [copy doc](https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit)
    - https://ubuntu.com/engage/ai-ml-ubuntu  - [copy doc](https://docs.google.com/document/d/1YVPlQYT3jvxb6Yp5OShSiUsmKBPOYOm_fNLJHNsQ6tQ/edit)
    - https://ubuntu.com/rfp  - [copy doc](https://docs.google.com/document/d/1OA_Eg1200fHpt7YYkE4qubiWfxL_U5fnlA0OObRe2n8/edit)
    - https://ubuntu.com/kubeflow/features - [copy doc](https://docs.google.com/document/d/1DT5nCRSJH-OkvDmlyKh6vVhofeHPHZJHTTBDNu44wCY/edit)
    - https://ubuntu.com/legal/ubuntu-advantage-service-description - [copy     doc](https://docs.google.com/document/d/1vQNdVmpsB3iQP7SnJHxT3A8rbD5jSAzTEoYUOepR-SM/edit#)
    - https://ubuntu.com/kubeflow - [copy doc](https://docs.google.com/document/d/1mJq8PxH8FVRVF9i1Xzh0f6M73eyjqZE4NaKYHRcRAKM/edit#heading=h.ut5vkcuyk8sv)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all instances and the copy docs have been updated


## Issue / Card

Fixes #6522

