### PR TITLE
Update tutorial links

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -71,10 +71,10 @@
           <h3 class="p-heading-icon__title">From an older version</h3>
         </div>
       </div>
-      <p>If you&rsquo;re already running Ubuntu, you can upgrade in a few clicks from <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Software Updater</a>.</p>
+      <p>If you&rsquo;re already running Ubuntu, you can upgrade in a few clicks from <a href="/tutorials/tutorial-upgrading-ubuntu-desktop">Software Updater</a>.</p>
       <ul class="p-list">
-        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu</a></li>
-        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">How to create a bootable USB stick on Ubuntu</a></li>
+        <li class="p-list__item"><a href="/tutorials/tutorial-burn-a-dvd-on-ubuntu">How to burn a DVD on Ubuntu&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">How to create a bootable USB stick on Ubuntu&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
 
@@ -87,8 +87,8 @@
       </div>
       <p>If you&rsquo;re using Windows 8 or any computer with a 64-bit processor, we recommend the 64-bit download.</p>
       <ul class="p-list">
-        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows">How to burn a DVD on Windows</a></li>
-        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">How to create a bootable USB stick on Windows</a></li>
+        <li class="p-list__item"><a href="/tutorials/tutorial-burn-a-dvd-on-windows">How to burn a DVD on Windows&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/tutorials/tutorial-create-a-usb-stick-on-windows">How to create a bootable USB stick on Windows&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
 
@@ -101,8 +101,8 @@
       </div>
       <p>Most Macs with Intel processors will work with either 64-bit or Mac images. If the 64-bit image doesn't work, try the Mac image.</p>
       <ul class="p-list">
-        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos">How to burn a DVD on macOS</a></li>
-        <li class="p-list__item"><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">How to create a bootable USB stick on macOS</a></li>
+        <li class="p-list__item"><a href="/tutorials/tutorial-burn-a-dvd-on-macos">How to burn a DVD on macOS&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/tutorials/tutorial-create-a-usb-stick-on-macos">How to create a bootable USB stick on macOS&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
   </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -519,12 +519,12 @@
       <div class="col-4 p-card--highlighted">
         <h3>Learn how to try Ubuntu before you install</h3>
         <p class="p-card__content">Run Ubuntu directly from either a USB stick or a DVD for a quick and easy way to experience how Ubuntu works.</p>
-        <p class="p-card__content"><a class="p-link--external"  href="https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install">Follow our simple guide</a></p>
+        <p class="p-card__content"><a href="/tutorials/try-ubuntu-before-you-install">Follow our simple guide&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 p-card--highlighted">
         <h3>Do you want to upgrade your OS?</h3>
         <p class="p-card__content">If you are already running Ubuntu, you can upgrade with the Software Updater.</p>
-        <p class="p-card__content"><a href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop" class="p-link--external">How to upgrade</a></p>
+        <p class="p-card__content"><a href="/tutorials/tutorial-upgrading-ubuntu-desktop">How to upgrade&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 p-card--highlighted">
         <h3>Let’s connect</h3>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -26,7 +26,7 @@
         Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or macOS, or run Ubuntu alongside it.
       </p>
       <p>
-        <strong>Do you want to upgrade?</strong> <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
+        <strong>Do you want to upgrade?</strong> <a href="/tutorials/tutorial-upgrading-ubuntu-desktop">Follow our simple guide&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">

--- a/templates/download/intel-iei-tank-870.html
+++ b/templates/download/intel-iei-tank-870.html
@@ -53,7 +53,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <ol class="u-no-margin--left">
-            <li>Download and flash an <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">macOS</a>.</li>
+            <li>Download and flash an <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a href="/tutorials/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a href="/tutorials/tutorial-create-a-usb-stick-on-macos">macOS</a>.</li>
             <li>Copy the Ubuntu Core image file to the second USB flash drive.</li>
           </ol>
         </div>

--- a/templates/download/intel-joule.html
+++ b/templates/download/intel-joule.html
@@ -63,7 +63,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <ol class="u-no-margin--left">
-            <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
+            <li>Download and copy the <a href="/download/desktop">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a href="/tutorials/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a href="/tutorials/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
             <li>Download the Ubuntu Core image for Intel Joule and copy the file on the second USB drive.</li>
           </ol>
         </div>

--- a/templates/download/intel-nuc-desktop.html
+++ b/templates/download/intel-nuc-desktop.html
@@ -40,7 +40,7 @@
     <ol class="p-stepped-list--detailed">
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Download Ubuntu Desktop
         </h3>
         <div class="p-stepped-list__content">
@@ -53,16 +53,16 @@
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Flash the USB drive
         </h3>
         <div class="p-stepped-list__content">
-          <p>Copy the image on a USB drive by following the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions</a>.</p>
+          <p>Copy the image on a USB drive by following the <a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">installation media instructions&nbsp;&rsaquo;</a>.</p>
         </div>
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Install Ubuntu Desktop
         </h3>
         <div class="p-stepped-list__content">

--- a/templates/download/intel-nuc.html
+++ b/templates/download/intel-nuc.html
@@ -62,7 +62,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <ol class="u-no-margin--left">
-            <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
+            <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a href="/tutorials/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a href="/tutorials/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
             <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
           </ol>
         </div>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -8,10 +8,10 @@
         <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
         <small>You should get the following output:</small><br />
         <code style="display: block; margin-top: 1rem;">ubuntu-{{ version }}-{{ system }}-{{ architecture }}.iso: OK</code><br />
-        <small>Or follow this tutorial to learn <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
+        <small>Or follow this tutorial to learn <a href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads&nbsp;&rsaquo;</a></small>
       </span>
     </span>
-  </span>, or get <a href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you" class="p-link--external">help on installing</a>.
+  </span>, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you" class="p-link--external">help on installing&nbsp;&rsaquo;</a>.
 </p>
 
 <script>

--- a/templates/download/up-squared-iot-grove-server.html
+++ b/templates/download/up-squared-iot-grove-server.html
@@ -36,20 +36,20 @@
     <ol class="p-stepped-list--detailed">
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Download Ubuntu Server
         </h3>
         <div class="p-stepped-list__content">
           <p>Get the correct Ubuntu Server image for your board:</p>
           <ul class="u-no-margin--left">
             <li>Intel provides a modified Ubuntu Server 16.04.3 LTS image shipped with a custom 4.10 kernel and the Intel IoT Developer Kit.</li>
-            <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
+            <li>Download and copy the <a class="p-link--external" href="https://downloads.up-community.org/download/up-squared-iot-grove-development-kit-ubuntu-16-04-server-image/">Ubuntu Server 16.04 LTS</a> image on a USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a href="/tutorials/tutorial-create-a-usb-stick-on-windows">Windows</a>, or <a href="/tutorials/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
           </ul>
         </div>
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Install Ubuntu Server
         </h3>
         <div class="p-stepped-list__content">
@@ -57,7 +57,7 @@
           <ol class="u-no-margin--left">
             <li>Insert the USB flash drive in the Up<sup>2</sup> board.</li>
             <li>Power on the board.</li>
-            <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
+            <li>The installer will start automatically. Follow the prompts to install Ubuntu Server on the on-board eMMC disk. You can refer to <a class="p-link--external" href="/tutorials/tutorial-install-ubuntu-server#4">this tutorial</a> for complete Ubuntu Server installation guidance.</li>
           </ol>
         </div>
       </li>
@@ -73,7 +73,7 @@
     <div class="col-8">
       <h3>Install and develop snaps</h3>
       <p>Your {{ board or "board" }} is now ready to have snaps installed — <a class="p-link--external" href="http://snapcraft.io/docs/core/usage">get started with the <code>snap</code> command</a></p>
-      <p>Your board is ready to develop and run snaps, secured application packages tailored for IoT, this tutorial will show you <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/create-your-first-snap">how to create your first snap</a>.</p>
+      <p>Your board is ready to develop and run snaps, secured application packages tailored for IoT, this tutorial will show you <a class="p-link--external" href="/tutorials/create-your-first-snap">how to create your first snap</a>.</p>
     </div>
   </div>
 </section>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -185,7 +185,7 @@
           <h3 class="p-stepped-list__title">Next Steps</h3>
           <div class="p-stepped-list__content">
             <p>
-              To get more information on this install process, including screen shots of the process, please visit the <a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/get-started-kubeflow">Getting Started with Kubeflow tutorial</a>.
+              To get more information on this install process, including screen shots of the process, please visit the <a href="/tutorials/get-started-kubeflow">Getting Started with Kubeflow tutorial&nbsp;&rsaquo;</a>.
             </p>
             <p>
               More recommended reading:

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -28,7 +28,7 @@ Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because 
     </div>
     <div class="col-4 p-divider__block">
       <h3>Tutorials</h3>
-      <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/get-started-kubeflow#0">Get started with Kubeflow</a></p>
+      <p><a href="/tutorials/get-started-kubeflow">Get started with Kubeflow&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -116,9 +116,6 @@
           <a href="https://snapcraft.io">snapcraft.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://tutorials.ubuntu.com">tutorials.ubuntu.com</a>
-        </li>
-        <li class="p-list__item">
           <a href="https://ubuntuforums.org">ubuntuforums.org</a>
         </li>
         <li class="p-list__item">

--- a/templates/shared/contextual_footers/_download_all_installation.html
+++ b/templates/shared/contextual_footers/_download_all_installation.html
@@ -2,8 +2,8 @@
   <h3 class="p-heading--four">Installation guides</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
-      <li><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install desktop guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Desktop</a></li>
-      <li><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install server guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Server</a></li>
+      <li><a href="/tutorials/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install desktop guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Desktop&nbsp;&rsaquo;</a></li>
+      <li><a href="/tutorials/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install server guide', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installing Ubuntu Server&nbsp;&rsaquo;</a></li>
       <li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install openstack', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Install OpenStack&nbsp;&rsaquo;</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_download_desktop_installation.html
+++ b/templates/shared/contextual_footers/_download_desktop_installation.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Installation guide</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guide.</p>
-  <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install-ubuntu-desktop', 'eventLabel' : 'Installation guide', 'eventValue' : undefined });">Read the installation instructions</a></p>
+  <p><a href="/tutorials/tutorial-install-ubuntu-desktop" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install-ubuntu-desktop', 'eventLabel' : 'Installation guide', 'eventValue' : undefined });">Read the installation instructions&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_documentation.html
+++ b/templates/shared/contextual_footers/_download_documentation.html
@@ -4,6 +4,6 @@
   <ul class="p-list">
     <li><a href="/server/docs"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Ubuntu Server docs&nbsp;&rsaquo;</a></li>
 
-    <li><a href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download</a></li>
+    <li><a href="/tutorials/tutorial-how-to-verify-ubuntu" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'how to verify', 'eventLabel' : 'Detailed docs', 'eventValue' : undefined });">Verify your download&nbsp;&rsaquo;</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_download_server_installation.html
+++ b/templates/shared/contextual_footers/_download_server_installation.html
@@ -2,7 +2,7 @@
   <h3 class="p-heading--four">Installation guides</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
-      <li><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu Server</a></li><li>
+      <li><a href="/tutorials/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu Server&nbsp;&rsaquo;</a></li><li>
       </li><li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu OpenStack&nbsp;&rsaquo;</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_download_try_desktop.html
+++ b/templates/shared/contextual_footers/_download_try_desktop.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Try before you install</h3>
   <p>There&rsquo;s no need to replace your operating system to try Ubuntu.</p>
-  <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'try before you install instructions', 'eventLabel' : 'Try before you instlal', 'eventValue' : undefined });">Run Ubuntu from a USB or DVD</a></p>
+  <p><a href="/tutorials/try-ubuntu-before-you-install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'try before you install instructions', 'eventLabel' : 'Try before you instlal', 'eventValue' : undefined });">Run Ubuntu from a USB or DVD&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_verify_your_download.html
+++ b/templates/shared/contextual_footers/_download_verify_your_download.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Verify your download</h3>
   <p>If you want to verify the  data integrity and authenticity of your Ubuntu download, follow our guide.</p>
-  <p><a class="p-link--external" href="https://tutorials.ubuntu.com/tutorial/tutorial-how-to-verify-ubuntu" class="p-link--external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'verify instructions', 'eventLabel' : 'Verify your download', 'eventValue' : undefined });">Learn how to verify</a></p>
+  <p><a href="/tutorials/tutorial-how-to-verify-ubuntu" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'verify instructions', 'eventLabel' : 'Verify your download', 'eventValue' : undefined });">Learn how to verify&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -7,7 +7,7 @@
           <h4 class="p-muted-heading u-hide--medium u-hide--large">Learn</h4>
           <p class="p-p--small u-hide--small">Tutorials cover a wide range of topics. Learn or teach something new to Ubuntu users.</p>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="http://tutorials.ubuntu.com/">Ubuntu Tutorials</a></li>
+            <li class="p-list__item"><a href="/tutorials/">Ubuntu Tutorials</a></li>
             <li class="p-list__item"><a href="https://help.ubuntu.com/">Ubuntu documentation</a></li>
             <li class="p-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Ubuntu events on Youtube</a></li>
             <li class="p-list__item"><a href="https://www.youtube.com/channel/UCSsoSZBAZ3Ivlbt_fxyjIkw">The Juju Cloud Operations Show</a></li>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -111,7 +111,7 @@
               <a href="/internet-of-things/gateways">Industrial gateways and controllers&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="https://tutorials.ubuntu.com/tutorial/graphical-snaps">Build a secure Ubuntu based kiosk&nbsp;&rsaquo;</a>
+              <a href="/tutorials/graphical-snaps">Build a secure Ubuntu based kiosk&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
               <a href="/internet-of-things/digital-signage">The leading OS for digital signage&nbsp;&rsaquo;</a>
@@ -190,12 +190,12 @@
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading"><a href="https://tutorials.ubuntu.com/">Tutorials&nbsp;&rsaquo;</a></h4>
+          <h4 class="p-muted-heading"><a href="/tutorials/">Tutorials&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">
               <li class="p-list__item">
-                <a href="https://tutorials.ubuntu.com/tutorial/tutorial-guidelines">How to write a tutorial&nbsp;&rsaquo;</a>
+                <a href="/tutorials/tutorial-guidelines">How to write a tutorial&nbsp;&rsaquo;</a>
               </li>
             </ul>
           </div>
@@ -244,7 +244,7 @@
             <a href="https://ubuntuforums.org/">Forum</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://tutorials.ubuntu.com/">Tutorials</a>
+            <a href="/tutorials/">Tutorials</a>
           </li>
           <li class="p-inline-list__item">
             <a href="https://www.youtube.com/user/celebrateubuntu">Videos</a>

--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -79,10 +79,10 @@
     <div class="row">
       <div class="col-3">
         <h4 class="p-muted-heading--small">Tutorials</h4>
-        <p class="p-p--small">If you are already running Ubuntu - you can <a href='https://tutorials.ubuntu.com/tutorial/tutorial-upgrading-ubuntu-desktop'>upgrade</a> with the Software Updater</p>
-        <p class="p-p--small">Burn a DVD on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-macos'>macOS</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-burn-a-dvd-on-windows'>Windows</a>. Create a bootable USB stick on <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos'>macOS</a>, or <a href='https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
-        <p class="p-p--small">Installation guides for <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop'>Ubuntu Desktop</a> and <a href='https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-server'>Ubuntu Server</a></p>
-        <p class="p-p--small">You can learn how to <a href='https://tutorials.ubuntu.com/tutorial/try-ubuntu-before-you-install'>try Ubuntu before you install</a></p>
+        <p class="p-p--small">If you are already running Ubuntu - you can <a href='/tutorials/tutorial-upgrading-ubuntu-desktop'>upgrade</a> with the Software Updater</p>
+        <p class="p-p--small">Burn a DVD on <a href='/tutorials/tutorial-burn-a-dvd-on-ubuntu'>Ubuntu</a>, <a href='/tutorials/tutorial-burn-a-dvd-on-macos'>macOS</a>, or <a href='/tutorials/tutorial-burn-a-dvd-on-windows'>Windows</a>. Create a bootable USB stick on <a href='/tutorials/tutorial-create-a-usb-stick-on-ubuntu'>Ubuntu</a>, <a href='/tutorials/tutorial-create-a-usb-stick-on-macos'>macOS</a>, or <a href='/tutorials/tutorial-create-a-usb-stick-on-windows'>Windows</a></p>
+        <p class="p-p--small">Installation guides for <a href='/tutorials/tutorial-install-ubuntu-desktop'>Ubuntu Desktop</a> and <a href='/tutorials/tutorial-install-ubuntu-server'>Ubuntu Server</a></p>
+        <p class="p-p--small">You can learn how to <a href='/tutorials/try-ubuntu-before-you-install'>try Ubuntu before you install</a></p>
       </div>
       <div class="col-3">
         <h4 class="p-muted-heading--small">Read the docs</h4>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -200,7 +200,7 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/blog?category=webinars#posts-list">Webinars</a></li>
-          <li class="p-inline-list__item"><a href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
+          <li class="p-inline-list__item"><a href="/tutorials/" title="Visit the Tutorials">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
           <li class="p-inline-list__item"><a href="/blog?category=case-studies#posts-list">Case studies</a></li>
           <li class="p-inline-list__item"><a href="/blog?category=white-papers#posts-list">White papers</a></li>

--- a/templates/templates/global-nav.html
+++ b/templates/templates/global-nav.html
@@ -150,7 +150,7 @@
           <h5 class="p-muted-heading p-footer__title">Resources</h5>
           <ul class="p-list is-split second-level-nav">
             <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
-            <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
+            <li class="p-list__item"><a class="p-link" href="/tutorials/" title="Visit the Tutorials">Tutorials</a></li>
             <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
             <li class="p-list__item"><a class="p-link" href="/blog/archives?category=case-studies" title="Visit the Case studies">Case studies</a></li>
             <li class="p-list__item"><a class="p-link" href="/blog/archives?category=white-papers" title="Visit the White papers">White papers</a></li>
@@ -286,7 +286,7 @@
             <h5 class="p-muted-heading">Resources</h5>
             <ul class="p-list is-split">
               <li class="p-list__item"><a class="p-link" href="https://www.brighttalk.com/search?q=Canonical" title="Visit the Webinars - external site">Webinars</a></li>
-              <li class="p-list__item"><a class="p-link" href="https://tutorials.ubuntu.com/" title="Visit the Tutorials - external site">Tutorials</a></li>
+              <li class="p-list__item"><a class="p-link" href="/tutorials/" title="Visit the Tutorials">Tutorials</a></li>
               <li class="p-list__item"><a class="p-link" href="/resources?content=videos" title="Visit the Videos">Videos</a></li>
               <li class="p-list__item"><a class="p-link" href="/blog/archives?category=case-studies" title="Visit the Case studies">Case studies</a></li>
               <li class="p-list__item"><a class="p-link" href="/blog/archives?category=white-papers" title="Visit the White papers">White papers</a></li>


### PR DESCRIPTION
## Done

Update all links for tutorials.ubuntu.com to /tutorials

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the tutorial links on the following pages all work
   - /download/desktop
    - /download/
    - /kubeflow/insall
    - /download/desktop/thank-you
    - /download/intel-iei-tank-870
    - /download/intel-joule
    - /download/intel-nuc-desktop
    - /download/intel-nuc
    - /download/up-squared-iot-grove-server
    - /kubernetes/docs



## Issue / Card

Fixes #6382 