### PR TITLE
Update illustrations and minor text updates on /pricing/devices

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -57,7 +57,7 @@
   </div>
 </section>
 
-{% with colour="light" %}{% include "shared/_call-sales.html" %}{% endwith %}
+{% with colour="light", bordered="true" %}{% include "shared/_call-sales.html" %}{% endwith %}
 
 <section class="p-strip is bordered">
   <div class="u-fixed-width">

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -602,7 +602,7 @@
   </div>
 </section>
 
-{% with colour="light", bordered="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
+{% with colour="white", bordered="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-bordered">
+<section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
     <h1>Ubuntu IoT and device services</h1>
     <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge. Get ten years of security coverage and dedicated app stores for your smart connected devices.</p>
@@ -287,11 +287,9 @@
       <p class="p-heading--three">$2,000 per day</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
-        <p>On-site or remote engagement with Canonical experts in board and SoC enablement, snap development or Ubuntu
-          management.</p>
+        <p>On-site or remote engagement with Canonical experts in board and SoC enablement, snap development or Ubuntu management.</p>
 
-        <p>For pre-launch integration we recommend our SMART START package for fixed pricing and delivery schedule
-          commitments. Price per day on site or remote.</p>
+        <p>For pre-launch integration we recommend our SMART START package for fixed pricing and delivery schedule commitments. Price per day on site or remote.</p>
       </div>
     </div>
 
@@ -302,8 +300,7 @@
       <div class="p-card__content">
         <p>Get the most from your app store with our two-day in-depth training program.</p>
 
-        <p>Understand the relationship between devices, app stores, enterprise stores, and master offline operations.
-          Learn how to manage your app portfolio per model, with full control of updates. Two days full time for up to 20
+        <p>Understand the relationship between devices, app stores, enterprise stores, and master offline operations. Learn how to manage your app portfolio per model, with full control of updates. Two days full time for up to 20
           people.</p>
       </div>
     </div>
@@ -313,11 +310,9 @@
       <p class="p-heading--three">$4,000 online</p>
       <hr class="u-sv1" />
       <div class="p-card__content">
-        <p>Take control of snaps in the enterprise and on public cloud. Ensure you have full visibility of snap versions,
-          updates and security status across the estate.</p>
+        <p>Take control of snaps in the enterprise and on public cloud. Ensure you have full visibility of snap versions, updates and security status across the estate.</p>
 
-        <p>Ubuntu and Ubuntu Core raise the bar for device management and security, enabling whole-enterprise policy for
-          devices from a wide range of brands. Two days full time for up to 20 people.</p>
+        <p>Ubuntu and Ubuntu Core raise the bar for device management and security, enabling whole-enterprise policy for devices from a wide range of brands. Two days full time for up to 20 people.</p>
       </div>
     </div>
   </div>
@@ -460,7 +455,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-7">
       <h2>Ubuntu device support for enterprises</h2>
@@ -607,7 +602,7 @@
   </div>
 </section>
 
-{% with colour="dark" %}{% include "shared/_call-sales.html" %}{% endwith %}
+{% with colour="light", bordered="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -9,7 +9,7 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
 
 {% else %}
 
-  <div class="p-strip--light is-bordered is-x-shallow">
+  <div class="p-strip--light is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">
     <div class="row u-vertically-center">
       <div class="col-1 u-align--center u-hide--small">
         <img src="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg" width="100" alt="" />

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -7,6 +7,14 @@ background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
       <img src="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Epath4185%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-131 -719)' fill='%23FFFFFF'%3E%3Cg transform='translate(-15 697)'%3E%3Cg transform='translate(157 34) scale(-1 1) translate(-17 -18)'%3E%3Cg transform='translate(.27856 .15983)'%3E%3Cg transform='translate(16.286 17.834) rotate(-90) translate(-17 -16)'%3E%3Cg transform='translate(17.282 16) scale(-1 1) translate(-16.5 -16)'%3E%3Cg transform='translate(16.641 16) scale(-1 1) translate(-16 -16)'%3E%3Cpath transform='translate(13.652 13.564) scale(1 -1) translate(-13.652 -13.564)' d='m27.303 5.8745c-0.574-2.5209-1.428-6.83-5.29-5.6848-4.907 1.4556-9.373 5.5584-12.791 8.9531v-1e-4c-0.0033 0.0034-0.0068 0.0067-0.0102 0.0101-0.0032 0.0034-0.0068 0.0067-0.0102 0.0101l1e-4 1e-4c-3.4165 3.396-7.5458 7.833-9.0107 12.709-1.1526 3.837 3.1842 4.686 5.7214 5.256l3.6037-8.142-1.7315-3.191c0.7581-1.18 2.6604-3.219 3.9284-4.48 1.269-1.26 3.321-3.1499 4.509-3.9032l2.886 2.0434 8.195-3.5807z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A" width="28" alt="" />
     </div>
 
+{% elif colour == 'white' %}
+
+<div class="p-strip is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">
+  <div class="row u-vertically-center">
+    <div class="col-1 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg" width="100" alt="" />
+    </div>
+
 {% else %}
 
   <div class="p-strip--light is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">

--- a/templates/shared/pricing/_smart-start-prices.html
+++ b/templates/shared/pricing/_smart-start-prices.html
@@ -23,7 +23,7 @@
     <div class="col-7">
       <p>Time to market is crucial when establishing an IoT strategy. Canonical will validate your hardware, package your apps and prepare your device image. Free your team to focus on your solution, industrial design and business operations.</p>
 
-      <p>Choose from our extensive list of <a href="https://certification.ubuntu.com/iot" class="p-link--external">certified boards</a> and boxes with long-term security commitments.</p>
+      <p>Choose from our extensive list of <a href="https://certification.ubuntu.com/iot" class="p-link--external">certified boards and boxes</a> with long-term security commitments.</p>
 
       <p>Add-ons cover enablement and certification of alternative boards and additional chipsets. For the first year, app store and device security updates are included.</p>
     </div>
@@ -75,6 +75,6 @@
   </div>
 
   <div class="u-fixed-width">
-    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Start your embedded project</a>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update illustrations and minor text updates on /pricing/devices
- Updated call sales include to optionally have a border and fixed up /livepatch to use it

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/devices and http://0.0.0.0:8001/livepatch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit#)


## Issue / Card

Fixes #6531
