### PR TITLE
Add suru banner to /pricing/consulting

### DIFF
--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -1,13 +1,12 @@
 {% extends "pricing/base_pricing.html" %}
 
-
 {% block title %}Consulting{% endblock %}
 {% block meta_description %}Open Infrastructure training and consulting on openstack, kubernetes and kubeflow. Learn how to design, deploy and operate open infrastructure at scale.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY{% endblock meta_copydoc %}
 
 {% block content %}
 
-  <section class="p-strip">
+  <section class="p-strip--suru-topped">
     <div class="row">
       <div class="col-8">
         <h1>Open Infrastructure consulting &amp; training</h1>


### PR DESCRIPTION
## Done

- Add suru banner to /pricing/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve the comment in the [copy doc](https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY/edit#heading=h.bf26y8ax9nwu)


## Issue / Card

Fixes #6530

