### PR TITLE
Remove smooth scroll when changing tutorial steps

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -489,10 +489,6 @@ summary {
   margin-top: 2rem;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 .u-text-light {
   color: $color-mid-dark;
 }

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -122,7 +122,6 @@
   </div>
 </div>
 
-<!-- <script src="/static/js/tutorials.js"></script> -->
 <script>
 (function() {
   function toggleTutorialNavigation() {
@@ -142,17 +141,7 @@
         item.classList.remove('is-active');
       }
     });
-    scrollToTop();
   };
-
-  function scrollToTop() {
-    // Wrap in setTimeout so runs at end of event loop
-    // This is so the scroll happens after the hashchange
-    // which prevents the page from jumping
-    window.setTimeout(function() {
-      window.scrollTo(0, 0);
-    }, 0);
-  }
 
   var navigationItems = document.querySelectorAll('.l-tutorial__nav-item');
   var toggleButton = document.querySelector('.l-tutorial__nav-toggle');
@@ -169,7 +158,6 @@
   window.addEventListener('hashchange', function(e) {
     e.preventDefault();
     setActiveLink(navigationItems);
-    scrollToTop();
   });
 
   sectionIds = []
@@ -181,7 +169,6 @@
   if (!window.location.hash) {
     var firstSectionLink = document.querySelector('.l-tutorial__nav-link');
     window.location.hash = firstSectionLink.getAttribute('href');
-    scrollToTop();
   } else {
     // Redirect #0, #1 etc. to the correct section
     match = window.location.hash.match(/^#(\d+)$/);


### PR DESCRIPTION
## Done

- Remove scroll to top behaviour when changing tutorial steps

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through to a tutorial
- See that the page jumps straight to the first section of the tutorial
- Click through the steps of the tutorial and see that each one jumps to that section in the browser



## Issue / Card

Fixes #6554 
