### PR TITLE
Show tutorial next to logo on tutorial page

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -123,3 +123,19 @@ This is then used in `webapp.context_processors.navigation` in `webapp/context_p
 - `nav_sections`: A direct representation of the `NAV_SECTIONS` setting
 
 These are then used in the `templates/templates/base.html` and `templates/templates/footer.html` templates to build the markup for the top navigation, the breadcrumb navigation and the footer navigation.
+
+### Mobile nav header
+
+On mobile we have a pattern of showing the section title next to the logo, e.g.
+
+![Section title example](https://assets.ubuntu.com/v1/bb50217a-Screenshot+from+2020-02-04+15-29-36.png)
+
+For the most part this will happen automatically as long as the subpages (/kubeflow/what-is-kubeflow) are in `navigtation.yml` as children. In some cases this isn't possible due to dynamically created content such as tutorials. In this case you can set the `section_title` and `section_path` variables in the template e.g.
+
+```
+{% set section_title="Tutorials" %}
+{% set section_path="/tutorials" %}
+
+{% block content %}
+{% endblock %}
+```

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -75,7 +75,6 @@ server:
 tutorials:
   title: Tutorials
   path: /tutorials
-  persist: True
 
   children:
     - title: Overview

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -75,6 +75,7 @@ server:
 tutorials:
   title: Tutorials
   path: /tutorials
+  persist: True
 
   children:
     - title: Overview

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -17,6 +17,14 @@
           </a>
         </h5>
         {% endif %}
+
+        {% if section_title and section_path %}
+        <h5 class="p-navigation--secondary__logo u-hide--nav-threshold-up">
+          <a class="p-navigation--secondary__banner" href="{{ section_path }}">
+            {{ section_title }}
+          </a>
+        </h5>
+        {% endif %}
       </div>
     </div>
     <nav class="p-navigation__nav">

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -2,6 +2,9 @@
 
 {% set small_footer=True %}
 
+{% set section_title="Tutorials" %}
+{% set section_path="/tutorials" %}
+
 {% block title %}{{ document["title"] }}{% endblock %}
 {% block meta_image %}https://assets.ubuntu.com/v1/ebdfffbf-Aubergine_suru_background.png{% endblock %}
 


### PR DESCRIPTION
## Done

Show the title "Tutorials" next to the Ubuntu logo on a tutorial page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Resize to a mobile viewport width (320px)
- Check that the orange nav with the Ubuntu logo has the text "Tutorials" next to it (see screenshot)
- Click through to a tutorial
- Check that the same text is present in the orange nav (see screenshot)
- Check on desktop view and make sure the breadcrumb nav isn't duplicated


## Issue / Card

Fixes #6553

## Screenshots

https://user-images.githubusercontent.com/501889/73737022-b8f51980-4739-11ea-80bf-78b2a8e7b5e8.png
