### PR TITLE
Update /support illustrations

### DIFF
--- a/templates/shared/_case-study-itstrategen.html
+++ b/templates/shared/_case-study-itstrategen.html
@@ -5,5 +5,5 @@
       <p>The security of customer data is of the utmost importance to ITstrategen, which is why Ubuntu is their server operating system of choice.</p>
       <a class="p-button--neutral" href="/engage/ITstrategen-case-study">Read the case study</a>
     </div>
-    <div class="col-4 u-hide--small u-align--center u-vertically-center"><img src="https://assets.ubuntu.com/v1/2128a04f-itstrategen-logo.png?w=200" width="200" alt="" />
+    <div class="col-4 u-hide--small u-align--center u-vertically-center"><img src="https://assets.ubuntu.com/v1/3e31f0f5-ITstrategen+logo.svg" width="250" alt="" />
 </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -6,9 +6,9 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--suru is-dark">
   <div class="row u-equal-height">
-    <div class="col-7">
+    <div class="col-8">
       <h1>Ubuntu Advantage</h1>
       <h4>Open Source for the enterprise</h4>
       <p>Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry. With OpenStack and Kubernetes support included, Ubuntu Advantage for Infrastructure provides everything you need to future-proof your data centre.</p>
@@ -17,32 +17,10 @@
         <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-button--neutral">Read the datasheet</a>
       </p>
     </div>
-    <div class="col-5 u-align--center u-vertically-center u-hide--small">
-      <img alt="" src="https://assets.ubuntu.com/v1/11da76f5-image-management.svg" width="288" />
-    </div>
   </div>
 </section>
 
-{% with colour="dark" %}{% include "shared/_call-sales.html" %}{% endwith %}
-
-<nav class="p-tabs p-sticky-nav">
-  <div class="u-fixed-width">
-    <ul class="p-tabs__list" role="tablist">
-      <li class="p-tabs__item" role="presentation">
-        <a class="p-tabs__link js-sticky-tab" href="#what-is-ua">What's Ubuntu Advantage</a>
-      </li>
-      <li class="p-tabs__item" role="presentation">
-        <a class="p-tabs__link js-sticky-tab" href="#stories">Customer stories</a>
-      </li>
-      <li class="p-tabs__item" role="presentation">
-        <a class="p-tabs__link js-sticky-tab" href="#solutions">Solutions</a>
-      </li>
-      <li class="p-tabs__item" role="presentation">
-        <a class="p-tabs__link js-sticky-tab" href="#get-ua">Get Ubuntu Advantage</a>
-      </li>
-    </ul>
-  </div>
-</nav>
+{% with colour="white" %}{% include "shared/_call-sales.html" %}{% endwith %}
 
 <section class="p-strip is-deep is-bordered" id="what-is-ua">
   <div class="u-fixed-width">
@@ -141,7 +119,7 @@
         <p><a href="/esm">Learn more about ESM&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 u-vertically-center u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/9e59756d-shield-ESM.svg" width="150" alt="" />
+        <img src="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg" width="150" alt="" />
       </div>
     </section>
 
@@ -215,7 +193,7 @@
           <p><a href="/support/community-support">Learn more about community support&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-4 u-hide--small u-align--center u-vertically-center">
-          <img src="https://assets.ubuntu.com/v1/039628d5-picto-community-orange.svg" width="150" alt="Community">
+          <img src="https://assets.ubuntu.com/v1/5552afb7-community-support.svg" width="150" alt="Community">
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

- Update /support illustrations
- Removed tabs
- NOTE *the call-sales strip will be white when #6549 is merged*

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit#heading=h.l3kjw0agnasv)


## Issue / Card

Fixes #6527

## Screenshots

![image](https://user-images.githubusercontent.com/441217/73748720-f665a100-4751-11ea-988e-05cba2a9ff11.png)

