### PR TITLE
Fix counters on tutorial steps

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -42,6 +42,24 @@
     padding-bottom: $sp-medium;
   }
 
+  .l-tutorial__nav-title {
+    &::before {
+      height: $sp-large;
+      margin-right: $sp-medium;
+      width: $sp-large;
+    }
+
+    .is-active & {
+      font-weight: 400;
+
+      &::before {
+        background-color: $color-brand;
+        color: $color-x-light;
+        font-weight: 300;
+      }
+    }
+  }
+
   .l-tutorial__nav-link {
     color: $color-dark;
 
@@ -51,22 +69,6 @@
 
     &:hover {
       text-decoration: none;
-    }
-
-    &::before {
-      height: $sp-large;
-      margin-right: $sp-medium;
-      width: $sp-large;
-    }
-
-    &.is-active {
-      font-weight: 400;
-
-      &::before {
-        background-color: $color-brand;
-        color: $color-x-light;
-        font-weight: 300;
-      }
     }
   }
 

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -30,9 +30,11 @@
     <ol class="l-tutorial__nav p-stepped-list u-hide--small">
       {% for section in document.sections %}
         <li class="p-stepped-list__item l-tutorial__nav-item">
-          <a class="p-stepped-list__title l-tutorial__nav-link" href="#{{ loop.index }}-{{ section['slug'] }}">
-            {{ section["title"]}}
-          </a>
+          <p class="p-stepped-list__title l-tutorial__nav-title u-no-margin--bottom">
+            <a class="l-tutorial__nav-link" href="#{{ loop.index }}-{{ section['slug'] }}">
+              {{ section["title"]}}
+            </a>
+          </p>
         </li>
       {% endfor %}
     </ol>
@@ -128,12 +130,13 @@
     menu.classList.toggle('u-hide--small');
   }
 
-  function setActiveLink(navigationLinks) {
-    navigationLinks.forEach(function(link) {
+  function setActiveLink(navigationItems) {
+    navigationItems.forEach(function(item) {
+      var link = item.querySelector('.l-tutorial__nav-link');
       if (link.getAttribute('href') === window.location.hash) {
-        link.classList.add('is-active');
+        item.classList.add('is-active');
       } else {
-        link.classList.remove('is-active');
+        item.classList.remove('is-active');
       }
     });
     scrollToTop();
@@ -148,20 +151,21 @@
     }, 0);
   }
 
-  var navigationLinks = document.querySelectorAll('.l-tutorial__nav-link');
+  var navigationItems = document.querySelectorAll('.l-tutorial__nav-item');
   var toggleButton = document.querySelector('.l-tutorial__nav-toggle');
 
   toggleButton.addEventListener('click', toggleTutorialNavigation);
 
-  setActiveLink(navigationLinks);
+  setActiveLink(navigationItems);
 
-  navigationLinks.forEach(function(link) {
+  navigationItems.forEach(function(item) {
+    var link = item.querySelector('.l-tutorial__nav-link');
     link.addEventListener('click', toggleTutorialNavigation);
   });
 
   window.addEventListener('hashchange', function(e) {
     e.preventDefault();
-    setActiveLink(navigationLinks);
+    setActiveLink(navigationItems);
     scrollToTop();
   });
 


### PR DESCRIPTION
## Done

Fix the appearance of tutorial step counter when section title is long

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials/tutorial-burn-a-dvd-on-windows
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the number next to section 3 in the side navigation is a circle


## Issue / Card

Fixes #6547

## Screenshots
https://user-images.githubusercontent.com/554953/73726697-9e00b600-46f5-11ea-84bb-8ef0ad8248a4.png