### PR TITLE
ES & DE VMware to OpenStack takeover & engage pages

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -62,80 +62,88 @@
     <div class="{% if form_id %}col-7{% else %}col-8{% endif %}">
       {{ content | safe }}
     </div>
-    {% if form_id %}
+    {% if form_id %}      
     <div class="col-5" id="register-section">
-      <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ form_id }}">
-        <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
-          <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">First Name:</label>
-              <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
-                aria-label="First Name">
-            </li>
-            <li class="mktFormReq mktField">
-              <label for="LastName" class="mktoLabel ">Last Name:</label>
-              <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
-                aria-label="Last Name">
-            </li>
-            <li class="mktFormReq mktField">
-              <label for="Email" class="mktoLabel ">Work email:</label>
-              <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
-                aria-label="Email">
-            </li>
-            <li class="mktFormReq mktField">
-              <label for="Company" class="mktoLabel ">Company Name:</label>
-              <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
-                aria-label="Company Name">
-            </li>
-            <li class="mktFormReq mktField">
-              <label for="Title" class="mktoLabel ">Job Title:</label>
-              <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
-            </li>
-            <li class="mktFormReq mktField">
-              <label for="Phone" class="mktoLabel ">Phone Number:</label>
-              <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
-                aria-label="Phone Number">
-            </li>
-            <li class="mktField">
-              <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
-                type="hidden">
-            </li>
-            <li class="mktField">
-              <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
-            </li>
-            <li class="mktField">
-              <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
-            </li>
-            <li class="mktField">
-              <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
-                class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">I agree to receive
-                information about Canonical’s products and services.</label>
-            </li>
-            <li class="mktField">
-              <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
-                <input name="RichText" aria-label="RichText" type="hidden">
-              </p>
-            </li>
-            <li class="mktField">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
-            </li>
-            <li class="mktField">
-              <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
-            </li>
-            <li class="mktField">
-              <button type="submit" class="mktoButton u-no-margin--bottom">{% if form_cta %}{{ form_cta }}{% else %}Download the whitepaper{% endif %}</button>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input name="formid" aria-label="formid" class="mktoField" value="{{ form_id }}" type="hidden">
-              <input name="formVid" aria-label="formid" class="mktoField" value="{{ form_id }}" type="hidden">
-              <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ form_return_url }}" />
-              <input type="hidden" name="retURL" aria-label="retURL" value="{{ form_return_url }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{ form_return_url }}" />
-            </li>
-          </ul>
-        </fieldset>
-      </form>
-      <!-- /MARKETO FORM -->
+      {% if form_include %}
+        {% set form = "engage/shared/_" + form_include + "_engage_form.html" %}
+
+        {% with id = form_id, returnURL = form_return_url %}
+          {% include form %}
+        {% endwith %}
+      {% else %}
+        <!-- MARKETO FORM -->
+        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ form_id }}">
+          <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First Name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+                  aria-label="First Name">
+              </li>
+              <li class="mktFormReq mktField">
+                <label for="LastName" class="mktoLabel ">Last Name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+                  aria-label="Last Name">
+              </li>
+              <li class="mktFormReq mktField">
+                <label for="Email" class="mktoLabel ">Work email:</label>
+                <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+                  aria-label="Email">
+              </li>
+              <li class="mktFormReq mktField">
+                <label for="Company" class="mktoLabel ">Company Name:</label>
+                <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+                  aria-label="Company Name">
+              </li>
+              <li class="mktFormReq mktField">
+                <label for="Title" class="mktoLabel ">Job Title:</label>
+                <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+              </li>
+              <li class="mktFormReq mktField">
+                <label for="Phone" class="mktoLabel ">Phone Number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+                  aria-label="Phone Number">
+              </li>
+              <li class="mktField">
+                <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+                  type="hidden">
+              </li>
+              <li class="mktField">
+                <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+              </li>
+              <li class="mktField">
+                <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+              </li>
+              <li class="mktField">
+                <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
+                  class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">I agree to receive
+                  information about Canonical’s products and services.</label>
+              </li>
+              <li class="mktField">
+                <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+                  <input name="RichText" aria-label="RichText" type="hidden">
+                </p>
+              </li>
+              <li class="mktField">
+                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              </li>
+              <li class="mktField">
+                <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+              </li>
+              <li class="mktField">
+                <button type="submit" class="mktoButton u-no-margin--bottom">{% if form_cta %}{{ form_cta }}{% else %}Download the whitepaper{% endif %}</button>
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+                <input name="formid" aria-label="formid" class="mktoField" value="{{ form_id }}" type="hidden">
+                <input name="formVid" aria-label="formid" class="mktoField" value="{{ form_id }}" type="hidden">
+                <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ form_return_url }}" />
+                <input type="hidden" name="retURL" aria-label="retURL" value="{{ form_return_url }}" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{ form_return_url }}" />
+              </li>
+            </ul>
+          </fieldset>
+        </form>
+        <!-- /MARKETO FORM -->
+      {% endif %}
     </div>
     {% endif %}
   </div>

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -152,7 +152,7 @@
 {% if webinar_code %}
 <!-- webinar -->
 <section class="p-strip is-shallow" id="register-section">
-  <div class="row" id="register-section">
+  <div class="row" id="webinar">
     {{ webinar_code | safe }}
   </div>
 </section>

--- a/templates/engage/de/migration-von-vmware-zu-openstack.md
+++ b/templates/engage/de/migration-von-vmware-zu-openstack.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Migration von VMware zu OpenStack"
+     meta_description: "Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann."
+     meta_image: https://assets.ubuntu.com/v1/86829a92-Meta+data+img.jpg
+     meta_copydoc: https://docs.google.com/document/d/1_8SmEU9ESXbl1kGSTvivr1mj0JzV8rSSZe_jPSgLNLk/edit
+     header_title: "Migration von VMware zu OpenStack"
+     header_subtitle: "Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann"
+     header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_url:
+     header_cta:
+     header_class: p-engage-banner--dark
+     header_supplemental: '<br /><p><a href="#register-section" class="p-button--positive">White Paper lesen</a> <a href="#webinar" class="p-button--neutral">Webinar ansehen</a></p>'
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #FFFFFF;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17086, "language": "de-de", "commId" : 384086, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     form_include: de
+     form_id: 3507
+     form_return_url: "https://pages.ubuntu.com/VMwaretoOpenStack_DE.html"
+---
+
+Aufgrund der Kosten für Lizenzen, Support und Beratung von VMware erreichen viele nicht ihr primäres Ziel - deutlich reduzierte Gesamtkosten. Auf der Suche nach Alternativen betrachten deshalb immer mehr Unternehmen andere Plattformen wie OpenStack genauer.
+ 
+Dieses White Paper und Webinar:
+
+<ul class="p-list">
+     <li class="p-list__item is-ticked">Vergleicht die Virtualisierungsangebote von VMware mit einem Open Source-Ansatz, Charmed OpenStack von Canonical.</li>
+     <li class="p-list__item is-ticked">Zeigt die ökonomischen und Effizienzvorteile eines Open Source Ansatzes auf.</li>
+     <li class="p-list__item is-ticked">Liefert eine detaillierte Kostenanalyse, die die Einsparpotenziale für Unternehmen aufzeigt, die von VMware zu OpenStack migrieren. </li>
+</ul>

--- a/templates/engage/de/migration-von-vmware-zu-openstack.md
+++ b/templates/engage/de/migration-von-vmware-zu-openstack.md
@@ -28,3 +28,5 @@ Dieses White Paper und Webinar:
      <li class="p-list__item is-ticked">Zeigt die ökonomischen und Effizienzvorteile eines Open Source Ansatzes auf.</li>
      <li class="p-list__item is-ticked">Liefert eine detaillierte Kostenanalyse, die die Einsparpotenziale für Unternehmen aufzeigt, die von VMware zu OpenStack migrieren. </li>
 </ul>
+
+Zudem sollten Sie das Webinar "Von VMware zu Charmed OpenStack" ansehen, um in einer Demonstration zu erfahren, wie eine IT Workload mit Hilfe von Hystax von VMware zu Charmed OpenStack migriert wird.

--- a/templates/engage/de/migration-von-vmware-zu-openstack.md
+++ b/templates/engage/de/migration-von-vmware-zu-openstack.md
@@ -12,10 +12,10 @@ context:
      header_cta:
      header_class: p-engage-banner--dark
      header_supplemental: '<br /><p><a href="#register-section" class="p-button--positive">White Paper lesen</a> <a href="#webinar" class="p-button--neutral">Webinar ansehen</a></p>'
-     header_lang: en
+     header_lang: de
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #FFFFFF;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 17086, "language": "de-de", "commId" : 384086, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include: de
-     form_id: 3507
+     form_id: 3509
      form_return_url: "https://pages.ubuntu.com/VMwaretoOpenStack_DE.html"
 ---
 

--- a/templates/engage/de/migration-von-vmware-zu-openstack.md
+++ b/templates/engage/de/migration-von-vmware-zu-openstack.md
@@ -4,7 +4,7 @@ context:
      title: "Migration von VMware zu OpenStack"
      meta_description: "Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann."
      meta_image: https://assets.ubuntu.com/v1/86829a92-Meta+data+img.jpg
-     meta_copydoc: https://docs.google.com/document/d/1_8SmEU9ESXbl1kGSTvivr1mj0JzV8rSSZe_jPSgLNLk/edit
+     meta_copydoc: https://docs.google.com/document/d/15ipwZJaEZhW9tMe6ISsRfEebrjaw1U5Pznfm5SQqY5k/edit
      header_title: "Migration von VMware zu OpenStack"
      header_subtitle: "Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann"
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"

--- a/templates/engage/es/vmware-a-charmed-openstack.md
+++ b/templates/engage/es/vmware-a-charmed-openstack.md
@@ -12,7 +12,7 @@ context:
      header_cta:
      header_class: p-engage-banner--dark
      header_supplemental: '<br /><p><a href="#register-section" class="p-button--positive">Lea el documento técnico</a> <a href="#webinar" class="p-button--neutral">Vea el webinar</a></p>'
-     header_lang: en
+     header_lang: es
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #FFFFFF;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 385592, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
      form_include: es
      form_id: 3509

--- a/templates/engage/es/vmware-a-charmed-openstack.md
+++ b/templates/engage/es/vmware-a-charmed-openstack.md
@@ -28,3 +28,5 @@ Este documento y webinar:
      <li class="p-list__item is-ticked">Presenta los beneficios económicos y de eficiencia de adoptar un enfoque de código abierto.</li>
      <li class="p-list__item is-ticked">Proporciona un análisis de coste detallado que destaca los ahorros que una organización puede realizar al migrar de VMware a Charmed OpenStack.</li>
 </ul>
+
+Este webinar también proporciona una demostración que muestra cómo migrar una carga de trabajo de TI de VMware a Charmed OpenStack utilizando la herramienta de migración de la nube como servicio de Hystax.

--- a/templates/engage/es/vmware-a-charmed-openstack.md
+++ b/templates/engage/es/vmware-a-charmed-openstack.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "De VMware a Charmed OpenStack"
+     meta_description: "Migra de VMware a Charmed OpenStack para reducir costes e incrementar la eficiencia de la infraestructura."
+     meta_image: https://assets.ubuntu.com/v1/86829a92-Meta+data+img.jpg
+     meta_copydoc: https://docs.google.com/document/d/1_8SmEU9ESXbl1kGSTvivr1mj0JzV8rSSZe_jPSgLNLk/edit
+     header_title: "De VMware a Charmed OpenStack"
+     header_subtitle: "Cómo la migración a Charmed OpenStack puede reducir significativamente el TCO"
+     header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_url:
+     header_cta:
+     header_class: p-engage-banner--dark
+     header_supplemental: '<br /><p><a href="#register-section" class="p-button--positive">Lea el documento técnico</a> <a href="#webinar" class="p-button--neutral">Vea el webinar</a></p>'
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #FFFFFF;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 385592, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     form_include: es
+     form_id: 3509
+     form_return_url: "https://pages.ubuntu.com/VMwaretoOpenStack_ES.html"
+---
+
+Debido a los costes asociados a las licencias, el soporte y los servicios profesionales de VMware, muchos no pueden cumplir su objetivo principal: reducir significativamente el TCO. En busca de soluciones alternativas, las organizaciones han empezado recientemente a explorar otras plataformas de código abierto como OpenStack.
+ 
+Este documento y webinar:
+
+<ul class="p-list">
+     <li class="p-list__item is-ticked">Compara las ofertas de virtualización propietaria de VMware con un enfoque de código abierto, el Charmed OpenStack de Canonical.</li>
+     <li class="p-list__item is-ticked">Presenta los beneficios económicos y de eficiencia de adoptar un enfoque de código abierto.</li>
+     <li class="p-list__item is-ticked">Proporciona un análisis de coste detallado que destaca los ahorros que una organización puede realizar al migrar de VMware a Charmed OpenStack.</li>
+</ul>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -839,6 +839,24 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Migration von VMware zu OpenStack",
+      description="Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann.",
+      slug="de/migration-von-vmware-zu-openstack",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
+
+  <div class="row u-equal-height u-clearfix">
+    {% with title="De VMware a Charmed OpenStack",
+      description="Migra de VMware a Charmed OpenStack para reducir costes e incrementar la eficiencia de la infraestructura.",
+      slug="es/vmware-a-charmed-openstack",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}" style="margin-top:-1em;">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list u-no-margin--bottom">
       <li class="mktFormReq mktField p-list__item">
@@ -57,6 +57,7 @@
         <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="returnURL">
         <input type="hidden" name="retURL" value="{{ returnURL }}" aria-label="retURL">
         <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="return_url">
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,0 +1,71 @@
+<!-- MARKETO FORM -->
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <ul class="p-list">
+      <li class="mktFormReq mktField p-list__item">
+        <label for="FirstName" class="mktoLabel">Nombre:</label>
+        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+          aria-label="Nombre">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="LastName" class="mktoLabel ">Appelido:</label>
+        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+          aria-label="Appelido">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Email" class="mktoLabel ">E-mail de trabajo:</label>
+        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+          aria-label="E-mail de trabajo">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Company" class="mktoLabel ">Nombre de la compañía:</label>
+        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+          aria-label="Nombre de la compañía">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Title" class="mktoLabel ">Título del puesto de trabajo:</label>
+        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Título del puesto de trabajo">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Phone" class="mktoLabel ">Número de teléfono:</label>
+        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+          aria-label="Número de teléfono">
+      </li>
+      <li class="mktField">
+        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+          type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
+          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">Acepto recibir información sobre los productos y servicios de Canonical</label>
+      </li>
+      <li class="mktField">
+        <p>Al enviar este formulario, confirmo que he leído y acepto el <a href="/legal/data-privacy/contact">Aviso de Privacidad</a> y la <a href="/legal/data-privacy">Política de Privacidad</a> de Canonical.
+          <input name="RichText" aria-label="RichText" type="hidden">
+        </p>
+      </li>
+      <li class="mktField">
+        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+      </li>
+      <li class="mktField">
+        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      </li>
+      <li class="mktField">
+        <button type="submit" class="mktoButton u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descargar el documento técnico{% endif %}</button>
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+        <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+        <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
+        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+      </li>
+    </ul>
+  </fieldset>
+</form>
+<!-- /MARKETO FORM -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,9 +22,12 @@
     <section class="p-strip js-takeover"></section> <!-- For all languages -->
     <section lang="de" class="p-strip js-takeover"></section> <!-- For german languages only -->
     <section lang="fr" class="p-strip js-takeover"></section> <!-- For french languages only -->
+    <section lang="es" class="p-strip js-takeover"></section> <!-- For spanish languages only -->
 #}
 
 {% block takeover_content %}
+  {# SPANISH #}
+  {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
   {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,8 @@
 #}
 
 {% block takeover_content %}
+  {# GERMAN #}
+  {% include "takeovers/_vmware-to-charmed-openstack_german.html" %}
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}

--- a/templates/takeovers/_vmware-to-charmed-openstack_german.html
+++ b/templates/takeovers/_vmware-to-charmed-openstack_german.html
@@ -1,0 +1,15 @@
+{% with title="Migration von VMware zu OpenStack",
+subtitle="Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+image_style="width: 300px;",
+image_hide_small="",
+equal_cols="true",
+primary_url="/engage/de/migration-von-vmware-zu-openstack?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001G3e8",
+primary_cta="Webinar ansehen",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="de" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_vmware-to-charmed-openstack_spanish.html
+++ b/templates/takeovers/_vmware-to-charmed-openstack_spanish.html
@@ -1,0 +1,16 @@
+{% with title="De VMware a Charmed OpenStack",
+subtitle="Cómo la migración a Charmed OpenStack puede reducir significativamente el TCO",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+image_style="width: 300px;",
+image_hide_small="",
+equal_cols="true",
+primary_url="/engage/es/vmware-a-charmed-openstack?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001G307",
+primary_cta="Vea el webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="es",
+locale="en_ES" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -100,5 +100,8 @@
 {% include "takeovers/_451-microk8s.html" %}
 <p>21 Jan 2020</p>
 {% include "takeovers/_anbox-takeover.html" %}
+<p>5 Feb 2020</p>
+{% include "takeovers/_vmware-to-charmed-openstack_german.html" %}
+{% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
 {% endblock %}
 


### PR DESCRIPTION
## Done

- Added German and Spanish versions of the VMWare To Charmed OpenStack takeover and engage pages.
  - Also added a Spanish version of the engage form

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Set your browser language to German and refresh the page until you see a takeover with the title "Migration von VMware zu OpenStack". See that it matches the [brief](https://docs.google.com/spreadsheets/d/17rhx6XrSyrr3lUA0HUwIww3xz0cgrdKry1VoCVJchjg/edit#gid=2113339190)
- Follow the CTA on the takeover to the engage page. See that it matches the [copy doc](https://docs.google.com/document/d/15ipwZJaEZhW9tMe6ISsRfEebrjaw1U5Pznfm5SQqY5k/edit).
- Test the page on https://cards-dev.twitter.com/validator, see that the card displays the correct title, description and image.
- Complete and submit the form, see that you are returned to https://pages.ubuntu.com/VMwaretoOpenStack_DE.html
- Visit the homepage again, set your browser's language to Spanish and repeat the process.
  - The takeover should have the title "De VMware a Charmed OpenStack", and match [this brief](https://docs.google.com/spreadsheets/d/1KzOTpN3grKr86V6CLjMYxlkqYjIscjvUKzAAuZKQVgk/edit#gid=877682240)
  - The engage page should match [this copy doc](https://docs.google.com/document/d/1_8SmEU9ESXbl1kGSTvivr1mj0JzV8rSSZe_jPSgLNLk/edit), and the form should return you to https://pages.ubuntu.com/VMwaretoOpenStack_ES.html
- Visit /engage and see that both engage pages are listed.
- Visit /takeovers and see that both takeovers are listed.


## Issue / Card

Fixes #6543 & #6544 
