### PR TITLE
Update search to fix error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask_base==0.3.3
 canonicalwebteam.http==1.0.1
 canonicalwebteam.blog==4.0.2
-canonicalwebteam.search==0.2.0
+canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.image-template==1.0.0
 canonicalwebteam.discourse-docs==0.10.2


### PR DESCRIPTION
Fixes #6566

QA
--

Make sure `SEARCH_API_KEY` is in `.env.local`. If you don't have the key, get it from https://console.cloud.google.com/apis/credentials?project=ubuntu-search-1530889417216. Ask @nottrobin for access.

Now `./run`, go to http://0.0.0.0:8001/search?q=kernel, experience success.