### PR TITLE
Build kernel variants page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -792,3 +792,5 @@ kernel:
   children:
     - title: Overview
       path: /kernel
+    - title: Variants
+      path: /kernel/variants

--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -8,7 +8,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu kernels from Canonical</h1>
-      At the core of the Ubuntu operating system is the Linux kernel, which manages and controls the hardware resources like I/O (networking, storage, graphics and various user interface devices, etc.), memory and CPU for your device or computer. It is one of the first software programs a booting device loads and runs on the central processing unit (CPU). The Linux kernel manages the system&rsquo;s hardware environment so other programs like the operating system&rsquo;s user space programs and application software programs can run well without modification on a variety of different platforms and without needing to know very much about that underlying system.
+      <p>At the core of the Ubuntu operating system is the Linux kernel, which manages and controls the hardware resources like I/O (networking, storage, graphics and various user interface devices, etc.), memory and CPU for your device or computer. It is one of the first software programs a booting device loads and runs on the central processing unit (CPU). The Linux kernel manages the system&rsquo;s hardware environment so other programs like the operating system&rsquo;s user space programs and application software programs can run well without modification on a variety of different platforms and without needing to know very much about that underlying system.</p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/3b5dc41b-Kernel_white.svg" width="280" alt="">

--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -84,6 +84,7 @@
     <p>How a kernel runs is based on what kernel modules are included and how the kernel is configured for both hardware, and the expected workloads that are run on it.</p>
     <p>Kernel modules are binary programs that extend a kernel&rsquo;s ability to control the computing system&rsquo;s hardware or add additional system capabilities like high performance networking or non-standard graphics, etc. The GA kernel that is shipped by default, with the Canonical Ubuntu Long Term Support (LTS) and Hardware Enablement (HWE) releases, are tuned for stable, reliable, secure, high-performance operation over a wide variety of hardware platforms and workloads.</p>
     <p>A kernel variant is a kernel that deviates from the generic GA kernel by changes to its configuration, and/or by having modules added and/or removed.</p>
+    <p><a href="/kernel/variants">Should my organisation use a variant kernel?&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 

--- a/templates/kernel/variants.html
+++ b/templates/kernel/variants.html
@@ -1,0 +1,157 @@
+{% extends "kernel/base_kernel.html" %}
+
+{% block title %}Ubuntu kernel variants from Canonical{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1UVxrF8raNb5Pggj05P0ar_OzV_uwhrTRHv9XRiuM4zs/{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-topped is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu kernel variants from Canonical</h1>
+      <p>A kernel variant is a kernel that deviates from the General Availability (GA) kernel by changes to its configuration and/or by having modules added and/or removed. In short, a kernel variant is an Ubuntu kernel that reports a kernel version and flavour other than what is reported with an Ubuntu LTS <code><em>-generic</em></code> kernel when you run the <code>$ uname -a</code> command. It is possible to have kernel variants for multiple releases of a kernel, which is something that will happen naturally over time to a newly-released custom kernel.</p>
+      <p>Canonical&rsquo;s Kernel Team strives to support all use cases from the generic kernel. Only where this is not possible are kernel variants created. Variants fall into four broad categories:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked"><a href="#version-specific-kernels">Version-specific</a>, where the kernel base version differs</li>
+        <li class="p-list__item is-ticked"><a href="#configuration-specific-kernels">Configuration-specific</a>, where desired kernel configurations are incompatible and the underlying features are not runtime selectable</li>
+        <li class="p-list__item is-ticked"><a href="#platform-specific-kernels">Platform-specific</a>, where a specific platform requires patches that are not currently applicable to the primary kernels</li>
+        <li class="p-list__item is-ticked"><a href="#project-specific-kernels">Project-specific</a>, where project deadlines require expedited delivery</li>
+      </ul>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2 id="version-specific-kernels">Version-specific kernels</h2>
+      <p>It is not possible to sensibly combine kernels at different upstream versions. For any Ubuntu LTS release  where we carry a General Availability (GA) kernel at one version, and a Hardware Enablement (HWE) kernel at another version, those are delivered as separate kernels. Version-specific kernels provide a consistent operating environment for Application Binary Interface (ABI)-sensitive workloads. It is not possible to combine kernels based on different upstream versions, which means maintaining a version-specific kernel is done through backporting fixes for serious/critical bugs and CVEs, which is the primary differentiator for this kernel variant. Version-specific kernels are just as rigorously maintained by Canonical as our generic kernels but Canonical ensures backport of critical/high CVE mitigation.</p>
+      <p>There is no significant additional technical consideration with a version-specific kernel variant since the work of backporting patches is a well-understood industry practice. However, there are business considerations regarding scope, cost and effort to maintain ABI compatibility over time as a version-specific kernel ages and gets further and further away from the latest upstream stable kernels, which makes backporting critical and high patches increasingly complicated and expensive.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2 id="configuration-specific-kernels">Configuration-specific kernels</h2>
+      <p>Our primary kernels are targeted to a general-purpose configuration with wide applicability. Where additional configuration combinations are needed, and cannot be runtime selected, we create use-case-specific kernels. For example, some memory management unit (MMU) page table code is build time selectable for performance reasons.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2 id="platform-specific-kernels">Platform-specific kernels</h2>
+      <p>Some platforms exhibit a very large delta to the primary kernel code base. It is common for this delta to change platform-agnostic code in ways which create risk for other platforms and are not yet accepted upstream. In these cases it is desirable to create a separate kernel for this platform to contain the risk.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2 id="project-specific-kernels">Project-specific kernels</h2>
+      <p>For some projects it might be required  to release kernels out of sync with the primary kernels, or to release fixes to those projects quicker than is possible to cycle a full suite of testing. In these cases it is desirable to create a separate kernel to release it from those constraints.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-bordered">
+  <div class="u-fixed-width">
+    <h2 id="current-variant-kernels">Current varient kernels</h2>
+    <table class="p-table--mobile-card" role="grid">
+      <thead>
+        <tr role="row">
+          <th>Name</th>
+          <th>Type</th>
+          <th width="60%;">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">Generic</td>
+          <td role="gridcell" aria-label="Type">-</td>
+          <td role="gridcell" aria-label="Description">The primary GA kernel, targeting a general-purpose configuration. It is the latest upstream kernel at the time of the release and remains on this version for the life of the release.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">lowlatency</td>
+          <td role="gridcell" aria-label="Type">configuration</td>
+          <td role="gridcell" aria-label="Description">Targets latency sensitive applications such as sound processing.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">generic-hwe</td>
+          <td role="gridcell" aria-label="Type">version</td>
+          <td role="gridcell" aria-label="Description">Targets a later version of the upstream kernel, and updates with respect to that every 6 months until it matches the GA kernel in the subsequent LTS release.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">lowlatency-hwe</td>
+          <td role="gridcell" aria-label="Type">
+            version<br>
+            configuration
+          </td>
+          <td role="gridcell" aria-label="Description">Targets latency-sensitive applications such as sound processing at the same version as the generic-hwe kernel.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">generic-hwe-edge</td>
+          <td role="gridcell" aria-label="Type">version</td>
+          <td role="gridcell" aria-label="Description">Provides early access to the next generic-hwe kernel.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">lowlatency-hwe-edge</td>
+          <td role="gridcell" aria-label="Type">
+            version<br>
+            configuration
+          </td>
+          <td role="gridcell" aria-label="Description">Provides early access to the next lowlatency-hwe kernel.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">kvm</td>
+          <td role="gridcell" aria-label="Type">configuration</td>
+          <td role="gridcell" aria-label="Description">Targeting KVM instance usage. This carries the minimum support required for a guest kernel.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">aws</td>
+          <td role="gridcell" aria-label="Type">configuration</td>
+          <td role="gridcell" aria-label="Description">Targeting the AWS cloud.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">azure</td>
+          <td role="gridcell" aria-label="Type">
+            configuration<br>
+            version
+          </td>
+          <td role="gridcell" aria-label="Description">Targeting the Azure cloud.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">gcp/gke</td>
+          <td role="gridcell" aria-label="Type">configuration</td>
+          <td role="gridcell" aria-label="Description">Targeting the Google Compute Platform/Google Kubernetes Engine.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">raspi2</td>
+          <td role="gridcell" aria-label="Type">platform</td>
+          <td role="gridcell" aria-label="Description">For the Raspberry Pi 2 ARM board.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">snapdragon</td>
+          <td role="rowheader" aria-label="Type">platform</td>
+          <td role="rowheader" aria-label="Description">For the Qualcomm Snapdragon ARM64 board.</td>
+        </tr>
+        <tr role="row">
+          <td role="rowheader" aria-label="Name">oem</td>
+          <td role="rowheader" aria-label="Type">project</td>
+          <td role="rowheader" aria-label="Description">Targeting various OEM projects. This carries early access drivers for hardware enablement. This kernel is typically used in the early phases of a project release, with a view to &ldquo;upstreaming&rdquo; any delta into the GA or HWE kernels and once this delta is incorporated the final platform is moved over to those kernels.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2 id="additional-kernel-variants">Additional kernel variants</h2>
+      <p>In addition to those kernel variants, Canonical offers FIPS/STIG kernels:</p>
+      <ul>
+        <li>FIPS &mdash; Certified 16.04 GA kernel for Ubuntu 16.04</li>
+        <li>FIPS &mdash; compliant 16.04 GA kernel with critical security and patch updates for Ubuntu 16.04</li>
+      </ul>
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Done

- Add missing paragraph tags around intro copy on /kernel
- Add /kernel/variant

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kernel/variant
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that it matches the [copy doc](https://docs.google.com/document/d/1UVxrF8raNb5Pggj05P0ar_OzV_uwhrTRHv9XRiuM4zs/edit#heading=h.atr230qlrn8h)


## Issue / Card

Fixes #5685