### PR TITLE
use hi res screenshots on /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -94,7 +94,7 @@
       </p>
     </div>
     <div class="col-7 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/b89de9f4-feature.png?w=500" width="500" alt="screenshot of Landscape" />
+      <img src="https://assets.ubuntu.com/v1/b89de9f4-feature.png" width="500" alt="screenshot of Landscape" />
     </div>
   </div>
 </section>
@@ -102,7 +102,7 @@
 <section class="p-strip is-bordered is-deep">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4d62c90a-applying-Livepatches.png?w=500" width="500" alt="Screenshot of applying livepatches" />
+      <img src="https://assets.ubuntu.com/v1/4d62c90a-applying-Livepatches.png" width="500" alt="Screenshot of applying livepatches" />
     </div>
     <div class="col-6">
       <h3>Apply critical kernel patches without rebooting</h3>


### PR DESCRIPTION
## Done

- Removed `?w=500` from two screenshots to allow higher res versions to be displayed instead.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Inspect the screenshots in the "Systems management and security at scale" and "Apply critical kernel patches without rebooting" and see that the original size of each is a lot larger than 500px wide.


## Issue / Card

Fixes #6528 
