### PR TITLE
use image module on /support screenshots

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -94,7 +94,16 @@
       </p>
     </div>
     <div class="col-7 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/b89de9f4-feature.png" width="500" alt="screenshot of Landscape" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/b89de9f4-feature.png",
+          alt="",
+          height="263",
+          width="500",
+          hi_def=True,
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -102,7 +111,16 @@
 <section class="p-strip is-bordered is-deep">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4d62c90a-applying-Livepatches.png" width="500" alt="Screenshot of applying livepatches" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/4d62c90a-applying-Livepatches.png",
+          alt="",
+          height="312",
+          width="500",
+          hi_def=True,
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h3>Apply critical kernel patches without rebooting</h3>


### PR DESCRIPTION
## Done

- switched out img elements for image module in order to provide the most appropriate resolution image for a given user

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View the page on both a standard resolution screen and a hi-res/retina screen, see that the screenshots in the "Systems management and security at scale" and "Apply critical kernel patches without rebooting" sections are of good quality.
