### PR TITLE
Build AI edge webinar takeover and engage page

### DIFF
--- a/templates/engage/ai-edge-webinar.md
+++ b/templates/engage/ai-edge-webinar.md
@@ -1,0 +1,24 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Edge AI in a 5G world"
+     meta_description: "Reduce costs through lower hardware complexity and compute resource sharing by allowing AI/ML models to be executed at the edge."
+     meta_image: "https://assets.ubuntu.com/v1/de422801-Social+media+banner.jpg"
+     meta_copydoc: "https://docs.google.com/document/d/1edSyC9pffQ6zF8GJrehQWtSGVTqkuLNjXhrqPhmdXbc/edit"
+     header_title: "Artificial Intelligence at the edge in a 5G world"
+     header_subtitle: "Deploying AI/ML solutions in latency-sensitive environments requires a new solution architecture approach"
+     header_image: "https://assets.ubuntu.com/v1/f0bce376-AI_lrg_white.svg"
+     header_url: "#register-section"
+     header_cta: "Watch the webinar"
+     header_class: p-engage-banner--dark
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 385097, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Deploying AI/ML solutions in latency-sensitive use cases requires a new solution architecture approach for many businesses.
+
+Fast computational units (i.e. GPUs) and low-latency connections (i.e. 5G) allow for AI/ML models to be executed outside the sensors/actuators (e.g. cameras & robotic arms). This reduces costs through lower hardware complexity as well as compute resource sharing amongst the IoT fleet.
+
+Strict AI responsiveness requirements that before required IoT AI model embedding can now be met with co-located GPUs (e.g. on the same factory building) as the sensors and actuators. An example of this is the robot &lsquo;dummification&rsquo; trend that is currently being observed for factory robotics with a view to reducing robot unit costs and fleet management.
+
+In this webinar we will explore some real-life scenarios in which GPUs and low-latency connectivity can unlock previously prohibitively expensive solutions now available for businesses to put in place and lead the 4th industrial revolution.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -857,6 +857,14 @@
       type="webinar" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Artificial Intelligence at the edge in a 5G world",
+      description="Deploying AI/ML solutions in latency-sensitive environments requires a new solution architecture approach",
+      slug="ai-edge-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,11 +31,10 @@
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
-  {% include "takeovers/_ai-edge-webinar.html" %}
   {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_451-microk8s.html" %}
-  {% include "takeovers/_ubuntu-masters-takeover.html" %}
+  {% include "takeovers/_ai-edge-webinar.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
+  {% include "takeovers/_ai-edge-webinar.html" %}
   {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_451-microk8s.html" %}

--- a/templates/takeovers/_ai-edge-webinar.html
+++ b/templates/takeovers/_ai-edge-webinar.html
@@ -1,0 +1,14 @@
+{% with title="Artificial Intelligence at the edge in a 5G world",
+subtitle="Deploying AI/ML solutions in latency-sensitive environments requires a new solution architecture approach",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/f0bce376-AI_lrg_white.svg",
+image_style="width: 250px;",
+image_hide_small="true",
+equal_cols="true",
+primary_url="/engage/ai-edge-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_IOT_Edge_AI_WBN",
+primary_cta="Watch the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -103,5 +103,6 @@
 <p>5 Feb 2020</p>
 {% include "takeovers/_vmware-to-charmed-openstack_german.html" %}
 {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
+<p>7 Feb 2020</p>
+{% include "takeovers/_ai-edge-webinar.html" %}
 {% endblock %}
-


### PR DESCRIPTION
## Done

- Build AI edge webinar engage page
- Add AI edge engage webinar page to /engage
- Build AI edge webinar takeover
- Add AI edge webinar takeover to /takeovers
- Add AI edge webinar takeover to homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh until you see the takeover titled "Artificial Intelligence at the edge in a 5G world"
- Check that the takeover matches the [brief](https://docs.google.com/spreadsheets/d/11RDq5vNUpgdy3UU_51d-QtGiptq5Fgz_tdOFbgx3zec/edit?ts=5e3d4646#gid=2113339190)
- Go to /takeovers
- Check that the "Artificial Intelligence at the edge in a 5G world" takeover is at the bottom of the page
- Click the CTA link in the takeover matches [the brief](https://docs.google.com/spreadsheets/d/11RDq5vNUpgdy3UU_51d-QtGiptq5Fgz_tdOFbgx3zec/edit?ts=5e3d4646#gid=1271849439) and [the copy doc](https://docs.google.com/document/d/1edSyC9pffQ6zF8GJrehQWtSGVTqkuLNjXhrqPhmdXbc/edit)
- Go to /engage
- Check that the AI edge webinar engage card is shown at the bottom of the page
- 


## Issue / Card

Fixes #6555