### PR TITLE
build Dell K8s webinar takeover and engage page

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -52,7 +52,7 @@
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if "http" not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
+      <img src="{% if "http" not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="{% if header_image_width %}{{ header_image_width }}{% else %}413{% endif %}" style="max-height: 410px; max-width: 250px;" alt="" >
     </div>{% endif %}
   </div>
 </section>

--- a/templates/engage/dell-kubernetes-webinar.md
+++ b/templates/engage/dell-kubernetes-webinar.md
@@ -8,6 +8,7 @@ context:
      header_title: "A decision maker's guide to Kubernetes deployments"
      header_subtitle: ""
      header_image: "https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg"
+     header_image_width: "200"
      header_url: '#register-section'
      header_cta: Watch the webinar
      header_class: p-engage-banner--k8s

--- a/templates/engage/dell-kubernetes-webinar.md
+++ b/templates/engage/dell-kubernetes-webinar.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Deploy Kubernetes in your data centre"
+     meta_description: "Learn what sets Kubernetes apart from other options and how you can get started"
+     meta_image: "https://assets.ubuntu.com/v1/f0d09455-Meta+data+img.jpg"
+     meta_copydoc: "https://docs.google.com/document/d/1wtlW9L69Y_3mexwQ38x4ENxOa65X-XUZNUb1bOWpaOI/edit"
+     header_title: "A decision maker's guide to Kubernetes deployments"
+     header_subtitle: ""
+     header_image: "https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg"
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_class: p-engage-banner--k8s
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 383698, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+The container landscape is based on constantly evolving technology, with Kubernetes dominating the ecosystem for automating and managing containerized applications. While a very powerful software, it’s also complex. How do you compare Kubernetes to other options, get started with containers, and maintain over the long-term?
+
+In this webinar, you will learn:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">What the container landscape looks like today, including migration from virtualisation to containerisation</li>
+  <li class="p-list__item is-ticked">Why Kubernetes is becoming the industry standard</li>
+  <li class="p-list__item is-ticked">Ease of container management with Kubernetes for developers from testing to production</li>
+  <li class="p-list__item is-ticked">Aspects of Kubernetes for managing containerized applications</li>
+  <li class="p-list__item is-ticked">Strategies for deployment</li>
+  <li class="p-list__item is-ticked">Ease of deployment and automation to easily stand up in the data centre</li>
+  <li class="p-list__item is-ticked">Ongoing management considerations</li>
+</ul>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -857,6 +857,14 @@
       type="webinar" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Deploy Kubernetes in your data centre",
+      description="Learn what sets Kubernetes apart from other options and how you can get started.",
+      slug="dell-kubernetes-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,7 @@
   {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_ubuntu-masters-takeover.html" %}
+  {% include "takeovers/_dell-kubernetes-webinar.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_dell-kubernetes-webinar.html
+++ b/templates/takeovers/_dell-kubernetes-webinar.html
@@ -1,0 +1,15 @@
+{% with title="A decision maker's guide to Kubernetes data centre deployments",
+subtitle="Learn what sets Kubernetes apart from the rest and how you can get started",
+class="p-takeover--k8s",
+header_image="https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg",
+image_style="width: 240px;",
+image_hide_small=true,
+equal_cols="true",
+primary_url="/engage/dell-kubernetes-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Kubernetes_WBN_Dell",
+primary_cta="Watch the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -103,5 +103,7 @@
 <p>5 Feb 2020</p>
 {% include "takeovers/_vmware-to-charmed-openstack_german.html" %}
 {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
+<p>7 Feb 2020</p>
+{% include "takeovers/_dell-kubernetes-webinar.html" %}
 {% endblock %}
 


### PR DESCRIPTION
## Done

Created takeover and engage page for Dell K8s webinar

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see a takeover with the title "A decision maker's guide to Kubernetes data centre deployments", see that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2302#issuecomment-583410319) and the [brief](https://docs.google.com/spreadsheets/d/1T9BEfgdYrkMuxMbJm_KZWwYoMH7eZYPq8eotk6MrUag/edit#gid=1271849439).
- Follow the CTA to the engage page, see that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2302#issuecomment-583410319) and the [copy doc](https://docs.google.com/document/d/1wtlW9L69Y_3mexwQ38x4ENxOa65X-XUZNUb1bOWpaOI/edit).
- Test the page on https://cards-dev.twitter.com/validator, see that the card preview includes a relevant title, description and image.
- Visit /takeovers, see that the takeover is listed at the bottom of the page.
- Visit /engage, see that there is a link to the engage page there.


## Issue / Card

Fixes #6571 
