### PR TITLE
Update illustrations on openstack page

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -6,8 +6,8 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
-  <div class="row">
+<section class="p-strip--suru-topped is-deep is-bordered">
+  <div class="row u-equal-height">
     <div class="col-8">
       <h1>OpenStack, Delivered</h1>
       <p>Canonical designs, builds, operates and supports OpenStack private clouds on Ubuntu. We understand the importance of certainty, stability, performance and economic efficiency for private cloud infrastructure.</p>
@@ -26,8 +26,8 @@
         </a>
       </p>
     </div>
-    <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg" width="323" alt="Canonical Openstack" class="u-hide--small" />
+    <div class="col-4 u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/669390e0-openstack-cloud.svg" width="323" alt="Canonical Openstack" class="u-hide--small" />
     </div>
   </div>
 </section>

--- a/templates/shared/_resources_openstack.html
+++ b/templates/shared/_resources_openstack.html
@@ -4,7 +4,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="" />
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
@@ -13,7 +13,7 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/26797d10-newsfeed-stripvideo-icon.svg" width="32" alt="" />
+          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="" />
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>


### PR DESCRIPTION
## Done

Update illustrations on /openstack

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the updated illustrations match those outlined in [the issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6590)


## Issue / Card

Fixes #6590
