### PR TITLE
Update the 19.10 Rasp Pi image

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -41,6 +41,7 @@
   </div>
 </section>
 
+{# lts row #}
 <section class="p-strip--light is-shallow u-no-padding--bottom">
   <div class="row u-equal-height">
     <div class="col-3">
@@ -81,6 +82,7 @@
 </div>
 </section>
 
+{# latest row #}
 <section class="p-strip is-bordered is-shallow u-no-padding--bottom">
   <div class="row u-equal-height">
     <div class="col-3">
@@ -90,7 +92,7 @@
     <div class="col-3">
       <p class="u-hide--small u-sv2">&nbsp;</p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi2" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
         Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
       </a>
     </p>


### PR DESCRIPTION
## Done

- Updated the 19.10 pi 2 image to the pi 3 iso

> You'll want the target to be:
> 
> http://cdimage.ubuntu.com/releases/19.10.1/release/ubuntu-19.10.1-preinstalled-server-armhf+raspi3.img.xz
> 
> Which will also work on the Raspberry Pi 2.
> 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the correct image is downloaded on the thank-you page


## Issue / Card

Fixes #6594
