### PR TITLE
Add GA to tutorial poll

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.image-template==1.0.0
-canonicalwebteam.discourse-docs==0.10.2
+canonicalwebteam.discourse-docs==0.11.0
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -208,4 +208,31 @@
     window.location.hash == "#welcome";
   }
 </script>
+
+<script>
+  (function() {
+    var polls = document.querySelectorAll('.poll');
+
+    polls.forEach(function(poll) {
+      var answers = poll.querySelectorAll('[type="radio"]');
+      var pollId = poll.getAttribute('data-poll-name');
+
+      answers.forEach(function(answer) {
+        answer.addEventListener('change', function(e) {
+          var answerLabel = document.querySelector('label[for="' + e.target.id + '"]');
+          var eventLabel = answerLabel.innerText;
+          var eventAction = document.getElementById(pollId).innerText;
+
+          dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'survey',
+            'eventAction' : eventAction,
+            'eventLabel' : eventLabel,
+            'eventValue' : undefined
+          });
+        });
+      });
+    });
+  })();
+</script>
 {% endblock %}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -133,7 +133,7 @@
   }
 
   function setActiveLink(navigationItems) {
-    navigationItems.forEach(function(item) {
+    [].forEach.call(navigationItems, function(item) {
       var link = item.querySelector('.l-tutorial__nav-link');
       if (link.getAttribute('href') === window.location.hash) {
         item.classList.add('is-active');
@@ -150,7 +150,7 @@
 
   setActiveLink(navigationItems);
 
-  navigationItems.forEach(function(item) {
+  [].forEach.call(navigationItems, function(item) {
     var link = item.querySelector('.l-tutorial__nav-link');
     link.addEventListener('click', toggleTutorialNavigation);
   });
@@ -160,10 +160,12 @@
     setActiveLink(navigationItems);
   });
 
-  sectionIds = []
-  document.querySelectorAll('.l-tutorial__content section').forEach(
-    function(section) {sectionIds.push(section.id)}
-  )
+  sectionIds = [];
+
+  var tutorialSections = document.querySelectorAll('.l-tutorial__content section');
+  [].forEach.call(tutorialSections, function(section) {
+    sectionIds.push(section.id);
+  });
 
   // Navigate to first tutorial step on load if no URL hash
   if (!window.location.hash) {
@@ -185,7 +187,7 @@
   var tutorialFeedbackIcons = document.querySelectorAll('.l-tutorial__feedback-icon');
   var tutorialFeedbackResult = document.querySelector('.l-tutorial__feedback-result');
 
-  tutorialFeedbackIcons.forEach(function(icon) {
+  [].forEach.call(tutorialFeedbackIcons, function(icon) {
     icon.addEventListener('click', function(e) {
       var feedbackValue = e.target.getAttribute('data-feedback-value');
       dataLayer.push({
@@ -213,11 +215,11 @@
   (function() {
     var polls = document.querySelectorAll('.poll');
 
-    polls.forEach(function(poll) {
+    [].forEach.call(polls, function(poll) {
       var answers = poll.querySelectorAll('[type="radio"]');
       var pollId = poll.getAttribute('data-poll-name');
 
-      answers.forEach(function(answer) {
+      [].forEach.call(answers, function(answer) {
         answer.addEventListener('change', function(e) {
           var answerLabel = document.querySelector('label[for="' + e.target.id + '"]');
           var eventLabel = answerLabel.innerText;


### PR DESCRIPTION
## Done

Add GA events to tutorial poll

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorial/basic-snap-usage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- At the bottom of the first section there is a poll
- Install the Google Analytics debugger browser extenstion [Chrome](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) or [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/ga-debugger/)
- Choose answers for each poll and check that a GA event is despatched with the following data:

**eventCategory:** survey
**eventAction:** The title of the poll e.g. How will you use this tutorial?
**eventLabel:** The text of the option you have chosen


## Issue / Card

Fixes #6569 