### PR TITLE
Update hero of openstack/managed

### DIFF
--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<section class="p-strip--light is-deep is-bordered">
+<section class="p-strip--suru-topped is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>Fully managed OpenStack private cloud. Half the cost of VMware.</h1>


### PR DESCRIPTION
## Done

Added suru to the top of the openstack/managed hero

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the hero has the suru at the top of it


## Issue / Card

Fixes #6498 