### PR TITLE
Update kubeflow install hero image

### DIFF
--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -13,7 +13,7 @@
       <p>Create and train machine learning models on your laptop, in your data center, or in the cloud.</p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/0822f908-kubernetes-instal.svg" width="140" alt="Install Kubernetes" />
+      <img src="https://assets.ubuntu.com/v1/a1317807-Install+Kubeflow.svg" width="290" alt="Install Kubernetes" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Update hero illustration on /kubeflow/install

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the hero illustration has been updated as per [the issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6600)


## Issue / Card

Fixes #6600