### PR TITLE
Add two legal pages for anbox cloud and add them to the terms and policies list page

### DIFF
--- a/templates/legal/anbox-cloud-privacy-notice.html
+++ b/templates/legal/anbox-cloud-privacy-notice.html
@@ -74,7 +74,7 @@
         London, SE1 0SU<br>
         United Kingdom</p>
         <p>Alternatively, you can use the relevant contact us form.</p>
-        <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:</p>
+        <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="https://ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:</p>
         <p>Information Commissioner's Office<br>
         Wycliffe House<br>
         Water Lane<br>

--- a/templates/legal/anbox-cloud-privacy-notice.html
+++ b/templates/legal/anbox-cloud-privacy-notice.html
@@ -48,7 +48,7 @@
           <li class="p-list__item is-ticked">object to decisions being taken by automated means which produce legal effects concerning you or similarly significantly affect you;</li>
           <li class="p-list__item is-ticked">object in certain other situations to our continued processing of your personal information;</li>
           <li class="p-list__item is-ticked">otherwise restrict our processing of your personal information in certain circumstances;</li>
-          <li class="p-list__item is-ticked">claim compensation for damages caused by out breach of any data protection laws.</li>
+          <li class="p-list__item is-ticked">claim compensation for damages caused by our breach of any data protection laws.</li>
         </ul>
         <p>For further information on each of those rights, including the circumstances in which they apply, see the Guidance from the UK Information Commissioner’s Office (ICO) on individuals rights under the General Data Protection Regulation.</p>
         <p>If you would like to exercise any of those rights, please:</p>

--- a/templates/legal/anbox-cloud-privacy-notice.html
+++ b/templates/legal/anbox-cloud-privacy-notice.html
@@ -1,0 +1,90 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Privacy notice – Anbox Cloud Demo Service{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1PVV5fpGAS6mPbwmMCM7WVWJxn9MM06aC58khAFs1yII{% endblock meta_copydoc %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8 l-legal-pages">
+      <section>
+        <h1>Privacy notice – Anbox Cloud Demo Service</h1>
+        <p>This privacy notice tells you about the information collected from you when you access the Anbox Cloud Demo Service. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our <a href="/legal/data-privacy">privacy policy</a>.</p>
+      </section>
+      <section>
+        <h2 id="who-are-we">Who are we?</h2>
+        <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.</p>
+        <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
+      </section>
+      <section>
+        <h2 id="what-personal-data-do-we-collect">What personal data do we collect?</h2>
+        <p>When you register to access the Anbox Cloud Demo Service we ask you for your name, your email address, job title and related information.</p>
+      </section>
+      <section>
+        <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+        <p>We will use your information for user and product research purposes. We ask for your consent to do this and will only contact you for this purpose for as long as you continue to consent.</p>
+        <p>If relevant, we may share your information with third parties Ampere Computing LLC with a registered office at 4655 Great America Pkwy Suite 601 Santa Clara, CA 95054, United States and Packet Host Inc., with a registered office in 30 Vesey Street, New York, 10007 NY, United States, or use your information to send you other news and product updates from Canonical. This may involve us calling you, where we have your phone number in order to do so.</p>
+      </section>
+      <section>
+        <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+        <p>Your information is stored in our database and may be processed outside of the European Economic Area. It is shared with the third parties only as reasonably required for Canonical to process and store your data in accordance with this notice.</p>
+        <p>Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection similar to those which apply to the United Kingdom and EEA, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of you personal information. If you would like further information please contact us (see “Your right to complain” below). We will not otherwise transfer your personal data outside of the EEA.</p>
+      </section>
+      <section>
+        <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+        <p>Your information is kept for as long as you continue to consent and for so long as reasonably required thereafter in accordance with our record retention policy.</p>
+      </section>
+      <section>
+        <h2 id="your-rights-over-your-information">Your rights over your information</h2>
+        <p>You have a number of important rights under data protection laws. In summary, those include rights to:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">fair processing of information and transparency over how we use your personal information;</li>
+          <li class="p-list__item is-ticked">access to your personal information and to certain other supplementary information that this Privacy Notice is already designed to address;</li>
+          <li class="p-list__item is-ticked">require us to correct any mistakes in your information which we hold;</li>
+          <li class="p-list__item is-ticked">require the erasure of personal information concerning you in certain situations;</li>
+          <li class="p-list__item is-ticked">receive the personal information concerning you which you have provided to us, in a structured, commonly used and machine-readable format and have the right to transmit that data to a third party in certain situations;</li>
+          <li class="p-list__item is-ticked">object at any time to processing of personal information concerning you for direct marketing;</li>
+          <li class="p-list__item is-ticked">object to decisions being taken by automated means which produce legal effects concerning you or similarly significantly affect you;</li>
+          <li class="p-list__item is-ticked">object in certain other situations to our continued processing of your personal information;</li>
+          <li class="p-list__item is-ticked">otherwise restrict our processing of your personal information in certain circumstances;</li>
+          <li class="p-list__item is-ticked">claim compensation for damages caused by out breach of any data protection laws.</li>
+        </ul>
+        <p>For further information on each of those rights, including the circumstances in which they apply, see the Guidance from the UK Information Commissioner’s Office (ICO) on individuals rights under the General Data Protection Regulation.</p>
+        <p>If you would like to exercise any of those rights, please:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">email, call or write to us, please see “Your right to complain” section below;</li>
+          <li class="p-list__item is-ticked">let us have enough information to identify you;</li>
+          <li class="p-list__item is-ticked">let us have proof of your identity and address (a copy of your driving licence or passport and a recent utility or credit card bill); and</li>
+          <li class="p-list__item is-ticked">let us know the information to which your request relates.</li>
+        </ul>
+        <p>If you would like to unsubscribe from any email you can also click on the “unsubscribe” button at the bottom of the email. Please note that this is not automatic, but will be implemented once confirmed.</p>
+      </section>
+      <section>
+        <h2 id="keeping-your-personal-information-secure">Keeping your personal information secure</h2>
+        <p>We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorised way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorised manner and are subject to a duty of confidentiality.</p>
+        <p>We also have procedures in place to deal with any suspected data security breach. We will notify you and any applicable regulator of a suspected data breach where we are legally required to do so.</p>
+      </section>
+      <section>
+        <h2 id="your-right-to-complain">Your right to complain</h2>
+        <p>We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy notice or any other related matter are welcomed and should be addressed to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> or to the address below:</p>
+        <p>Legal, Canonical<br>
+        5th Floor, Blue Fin Building<br>
+        110 Southwark Street<br>
+        London, SE1 0SU<br>
+        United Kingdom</p>
+        <p>Alternatively, you can use the relevant contact us form.</p>
+        <p>If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:</p>
+        <p>Information Commissioner's Office<br>
+        Wycliffe House<br>
+        Water Lane<br>
+        Wilmslow<br>
+        Cheshire<br>
+        SK9 5AF<br>
+        United Kingdom</p>
+      </section>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/anbox-cloud-terms-of-service.html
+++ b/templates/legal/anbox-cloud-terms-of-service.html
@@ -1,0 +1,92 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Terms of service – Anbox Cloud Demo Service{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1EPBkBdDHLpg8IR15miZXb_HaaDHtdGQPEgSlbPwySic{% endblock meta_copydoc %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-12">
+      <h4 class="p-muted-heading">Version - January 2020</h4>
+      <hr style="margin-bottom: 2rem;">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8 l-legal-pages">
+      <h1>Terms of service</h1>
+      <section>
+        <h2 id="introduction">1. Introduction</h2>
+        <p>These Terms of Service cover your access to the Anbox Cloud Demo Service (“<strong>Anbox Cloud Demo</strong>”) made available by Canonical Group Limited ("<strong>Canonical</strong>", "<strong>us</strong>", "<strong>our</strong>" or "<strong>we</strong>") to you ("<strong>you</strong>" or "<strong>your</strong>") subject to and in accordance with these Terms of Service (the “<strong>Service</strong>”).</p>
+        <p>Please read these Terms of Service carefully before you use the Services. By using Services, you agree to become bound by these Terms of Service. You may not use the Service for illegal or unauthorised purposes or otherwise in accordance with these Terms of Service.</p>
+        <p>If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Service through the account, to these Terms of Service. “you” and “your” shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.</p>
+        <p>You must be at least 13 years old to use the Service. If you are between age 13 and 18, we require your parent's or legal guardian's consent to use of the Services, please contact us at legal@canonical.com.</p>
+        <p>Any change or update to the Services or Terms of Service will be made in accordance with section 6 below.</p>
+      </section>
+      <section>
+        <h2 id="services">2. Services</h2>
+        <p>The Service enables you to access a demo of Anbox Cloud (<a href="https://anbox-cloud.io" class="p-link--external">https://anbox-cloud.io</a>) which includes streaming an Android system from the cloud.</p>
+      </section>
+      <section>
+        <h2 id="account">3. Account</h2>
+        <p>You will need an account to access and use the Service. We reserve the right to reject your request for an account or to immediately cancel or suspend your account and your use of the Services at any time if you do not comply with the following requirements. You must not attempt to create an account or use the Service if doing so would violate these Terms of Service. You must:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">have a Service account</li>
+          <li class="p-list__item is-ticked">not use the Service for illegal or unauthorised purposes (or which encourage or permit illegal or authorised purposes), in infringement of a third party's’ rights or otherwise in accordance with these Terms of Service</li>
+          <li class="p-list__item is-ticked">not take any action or use the Service in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Service</li>
+          <li class="p-list__item is-ticked">not use the Service in any manner that might be libellous or defamatory, that contains threats or incites violence towards individuals or entities, or that violates the privacy rights of any third party</li>
+          <li class="p-list__item is-ticked">not be located in or use the Services in an OFAC/EAR embargoed or sanctioned country or be on the U.S. Commerce Department’s Denied Persons List, Entity List, or Unverified List</li>
+        </ul>
+        <p>In order to access the Anbox Cloud Demo you will require an invitation code and a Single Sign On account with Canonical. The invitation code in conjunction with your Single Sign On account will create an Anbox Cloud Demo account which will enable you to access the Anbox Cloud Demo.</p>
+      </section>
+      <section>
+        <h2 id="end-of-service">4. End of Service</h2>
+        <p>We look forward to providing you with the Service for a limited trial period only. The trial period will be specified on the invitation code and may differ from user to user. However, there are also some circumstances under which the Service may be suspended or terminated:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">We cease to make the Service (or any part thereof) available</li>
+          <li class="p-list__item is-ticked">By us at any time as described in Section 3 above</li>
+        </ul>
+        <p>We may also cease to offer the Services for any other reason, in which case we will provide you with notice on your account page.</p>
+      </section>
+      <section>
+        <h2 id="changes">6. Changes</h2>
+        <p>We aim to continually improve the delivery and content of the Service and accordingly may make changes to the Service throughout the trial.</p>
+        <p>This Service is offered on a trial basis, and your use of this Service  will be limited to the period of your trial. New features may be added, but we may also modify or discontinue (temporarily or permanently) part of the Service, in part or in whole before the end of the trial period.</p>
+        <p>In the event of a material change to the Service, we will notify you on your account page. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment.</p>
+        <p>Similarly, we may occasionally make changes to these Terms of Service and will notify you of material changes either by email or on your account page. If Canonical does make changes to these Terms of Service, all changes will go into effect at the time we post the updated Terms of Service on your account page or as otherwise notified at that time.</p>
+      </section>
+      <section>
+        <h2 id="intellectual-property">7. Intellectual property</h2>
+        <p>You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Services for such time as it is made available by us strictly in accordance with these Terms of Service.</p>
+        <p>You will not acquire any rights to the Service (or the intellectual property rights contained therein) from your use of the Service, other than as set out in these Terms of Service.</p>
+      </section>
+      <section>
+        <h2 id="personal-data">8. Personal data</h2>
+        <p>In order to provide the Service to you, you will be required to provide information about yourself such as your name, address, job title and company. Any such information you provide to Canonical must always be accurate, correct and up to date.</p>
+        <p>Our <a href="/legal/anbox-cloud-privacy-notice">Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a> explain how we treat your personal data and protect your privacy when using the Services and our services in general. Canonical may provide limited personal data, such as your name, email address and related information, to third parties Ampere Computing LLC with a registered office at 4655 Great America Pkwy Suite 601 Santa Clara, CA 95054, United States and Packet Host Inc., with a registered office in 30 Vesey Street, New York, 10007 NY, United States. By accessing the Anbox Cloud Demo you are agreeing to the use of your personal data in this way.</p>
+        <p>We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.</p>
+        <p>Canonical may disclose any or all personal data and contents you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of your personal data is subject to the Privacy Policy.</p>
+      </section>
+      <section>
+        <h2 id="liability">9. Liability</h2>
+        <p>Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis without warranty of any kind.</p>
+        <p>In the case of the Service provided by Canonical, the Service is provided “as is” and, other than as expressly set out in these Terms of Service, all warranties (whether express, implied, statutory or otherwise) in respect of the Services are expressly excluded to the maximum extent permitted by law.</p>
+        <p>Canonical will provide the Services with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Services, but makes no guarantee that the Services will be available without interruption or will be error-free.</p>
+        <p>Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical’s total liability in contract, tort or otherwise for any claims is limited to £10.</p>
+        <p>Nothing in these Terms of Service will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.</p>
+      </section>
+      <section>
+        <h2 id="general">9. General</h2>
+        <p>These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.</p>
+        <p>Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.</p>
+        <p>Any notices should be sent by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> or by registered post to:</p>
+        <p>Canonical Group Limited,<br>
+        5th Floor, Blue Fin Building,<br>
+        110 Southwark Street,<br>
+        London, SE1 0SU.</p>
+      </section>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/anbox-cloud-terms-of-service.html
+++ b/templates/legal/anbox-cloud-terms-of-service.html
@@ -83,7 +83,7 @@
         <p>Canonical Group Limited,<br>
         5th Floor, Blue Fin Building,<br>
         110 Southwark Street,<br>
-        London, SE1 0SU.</p>
+        London, SE1 0SU</p>
       </section>
     </div>
   </div>

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -104,6 +104,19 @@
       <p>Terms and conditions governing use of Canonical's Partner Portal.</p>
       <p><a href="/legal/partner-portal-terms">View Partner Portal terms&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-6 p-card">
+      <h3>Anbox Cloud Demo terms of service</h3>
+      <p>The terms of our Anbox Cloud service.</p>
+      <p><a href="/legal/anbox-cloud-terms-of-service">View Anbox Cloud terms&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3>Anbox Cloud Demo privacy notice</h3>
+      <p>This privacy notice tells you about the information collected from you when you access the Anbox Cloud Demo Service.</p>
+      <p><a href="/legal/anbox-cloud-privacy-notice">View Anbox Cloud Demo privacy notice&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Added terms page
- Added privacy notice page
- Updated terms list

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
  - http://0.0.0.0:8001/legal/terms-and-policies
  - http://0.0.0.0:8001/legal/anbox-cloud-terms-of-service
  - http://0.0.0.0:8001/legal/anbox-cloud-privacy-notice
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6605
