### PR TITLE
Add suru to openstack features page

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -6,7 +6,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip is-deep is-bordered">
+<section class="p-strip--suru-image is-deep is-bordered">
   <div class="row">
     <div class="col-8">
       <h1>Flexible, open, fast and reliable</h1>


### PR DESCRIPTION
## Done

Add suru to top of /openstack/features

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the is a suru at the top of the page


## Issue / Card

Fixes #6499