### PR TITLE
remove vmware to charmed openstack (en) takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,6 @@
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
   {% include "takeovers/_anbox-takeover.html" %}
-  {% include "takeovers/_vmware-to-charmed-openstack.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_ai-edge-webinar.html" %}
   {% include "takeovers/_dell-kubernetes-webinar.html" %}


### PR DESCRIPTION
## Done

- removed "From VMware to Charmed OpenStack" takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh at least five times, see that none of the takeovers in rotation have the title "From VMware to Charmed OpenStack"


## Issue / Card

Fixes #6609 
