### PR TITLE
Update raspi logo on /download/iot

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -15,7 +15,7 @@
     <div class="col-6">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/31bd2627-logo-raspberry-pi.svg"  alt="Raspberry Pi" style="margin-top: .5rem">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg"  alt="Raspberry Pi" style="margin-top: .5rem">
           <h2 class="p-heading-icon__title" style="line-height: 4rem;">Ubuntu for Raspberry Pi</h2>
         </div>
       </div>


### PR DESCRIPTION
## Done

Update rasberry pi logo on /download/iot

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the raspberry pi logo is correct


## Issue / Card

Fixes #6620