### PR TITLE
Add empty col between content on download s390x

### DIFF
--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -6,13 +6,14 @@
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-<div class="p-strip is-deep">
+<div class="p-strip--suru-topped is-bordered">
   <div class="row">
     <div class="col-12">
       <h1>Ubuntu Server for IBM LinuxONE and IBM Z</h1>
     </div>
   </div>
-
+</div>
+<div class="p-strip">
   <div class="row">
     <div class="col-6">
       <h2>Ubuntu Server</h2>
@@ -21,7 +22,7 @@
       <p>Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p>
       <p>For questions about Ubuntu Advantage for IBM Z and LinuxONE, please call us <tel href="+442036565291">+44&nbsp;(0)&nbsp;203&nbsp;656&nbsp;5291</tel> or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
     </div>
-    <div class="col-6">
+    <div class="col-5 col-start-large-8">
 
       <!-- MARKETO FORM -->
       <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">


### PR DESCRIPTION
## Done

Add empty column between content on /download/server/s390x

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/s390x
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that there is an empty column between the main content and form


## Issue / Card

Fixes #6625 