### PR TITLE
Fix linkchecker errors

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -28,7 +28,7 @@
     <div class="col-5 col-start-large-8 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?w=420",
+          url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
           alt="",
           height="268",
           width="420",

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -11,7 +11,7 @@
         <small>Or follow this tutorial to learn <a class="p-link--external" href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
     </span>
-  </span>, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you" class="p-link--external">help on installing</a>.
+  </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you" class="p-link--external">help on installing</a>{% endif %}.
 </p>
 
 <script>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -11,7 +11,7 @@
         <small>Or follow this tutorial to learn <a class="p-link--external" href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
     </span>
-  </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you" class="p-link--external">help on installing</a>{% endif %}.
+  </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.
 </p>
 
 <script>


### PR DESCRIPTION
## Done

- Until RPi tutorials are published on /tutorials, hide the link to them on the RPi download thank you page.
- Removed external link icon on the same link.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select any version of Raspberry Pi, see that you are taken to a thank you page (cancel the download), and see that there is no link to an installation tutorial ("help on installing") next to "verify your download".
- Visit /download/desktop/thank-you?version=19.10&architecture=amd64 (or any other download thank you page that isn't RPi related), see that the link is there, doesn't have the external link icon, and doesn't lead to a 404.


## Issue / Card

Fixes #6597 
