### PR TITLE
Update checksums for 18.04.4

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -7,7 +7,7 @@ latest:
 lts:
   slug: BionicBeaver
   short_version: "18.04"
-  full_version: "18.04.3"
+  full_version: "18.04.4"
   release_date: "April 2018"
   eol: April 2023
 openstack_lts:
@@ -19,15 +19,15 @@ previous_lts:
 checksums:
   desktop:
     "19.10": 96a8095001d447bbb9078925d72f7a77a3f62fbd78460093759af4394ce83d79 *ubuntu-19.10-desktop-amd64.iso
-    "18.04.3": add4614b6fe3bb8e7dddcaab0ea97c476fbd4ffe288f2a4912cb06f1a47dcfa0 *ubuntu-18.04.3-desktop-amd64.iso
+    "18.04.4": c0d025e560d54434a925b3707f8686a7f588c42a5fbc609b8ea2447f88847041 *ubuntu-18.04.4-desktop-amd64.iso
   live-server:
     "19.10": 3fe242f4b330ead8191b3c200bcf1d8d3be4243d62fe6b866a778499370c9dbb *ubuntu-19.10-live-server-amd64.iso
-    "18.04.3": b9beac143e36226aa8a0b03fc1cbb5921cff80123866e718aaeba4edb81cfa63 *ubuntu-18.04.3-live-server-amd64.iso
+    "18.04.4": 73b8d860e421000a6e35fdefbb0ec859b9385b0974cf8089f5d70a87de72f6b9 *ubuntu-18.04.4-live-server-amd64.iso
   armhf+raspi2:
-    "18.04.3": 4da845835fbfd14a2bb30f35935b2f171701d63bae9c12a1419dcc32e7f7354c *ubuntu-18.04.3-preinstalled-server-armhf+raspi2.img.xz
+    "18.04.4": 0382a2b87b6937ff645f59f546120e3480f2d5a2c2945712bf373379b9e82f51 *ubuntu-18.04.4-preinstalled-server-armhf+raspi2.img.xz
   arm64+raspi3:
     "19.10.1": 3fcae7490edebd35663cb30dcd7a6317b6b9601d0f59ed5caa3c20dfd936cbb1 *ubuntu-19.10.1-preinstalled-server-arm64+raspi3.img.xz
-    "18.04.3": b5538e526f92ce331a6ce005ea5fe0047c851aec3acb26fc9ec44cd00a499895 *ubuntu-18.04.3-preinstalled-server-arm64+raspi3.img.xz
+    "18.04.4": f270d4a11fcef7f85ea77bc0642d1c6db2666ae734e9dcc4cb875a31c9f0dc57 *ubuntu-18.04.4-preinstalled-server-arm64+raspi3.img.xz
   armhf+raspi3:
     "19.10.1": d40820ba3933554b9902dc560e8a98d20352ae49b8544e71cacc6fdcfd2c2405 *ubuntu-19.10.1-preinstalled-server-armhf+raspi3.img.xz
-    "18.04.3": 4e9c24c48414482fb709909bf79dd9c7ed494e90620d3279d55e0bfc81338900 *ubuntu-18.04.3-preinstalled-server-armhf+raspi3.img.xz
+    "18.04.4": 0382a2b87b6937ff645f59f546120e3480f2d5a2c2945712bf373379b9e82f51 *ubuntu-18.04.4-preinstalled-server-armhf+raspi3.img.xz


### PR DESCRIPTION
## Done

Swapped out 18.04.3 checksum variable for 18.04.4

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click the link to download 18.04.4, see that you are taken to a thank you page, and the download triggers
- Repeat the process for /download/raspberry-pi and /download/server


## Issue / Card

Fixes #6532 
