### PR TITLE
Update illustrations on /download/desktop

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -4,61 +4,62 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-10">
-      <h1>Download Ubuntu Desktop</h1>
-    </div>
-  </div>
+<div class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
-    <div class="p-card--highlighted">
-      <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-      <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
-        <div class="col-8 p-divider__block">
-          <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
-          <p><a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
-          <p>Recommended system requirements:</p>
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">2 GHz dual core processor or better</li>
-            <li class="p-list__item is-ticked">4 GB system memory</li>
-            <li class="p-list__item is-ticked">25 GB of free hard drive space</li>
-            <li class="p-list__item is-ticked">Either a DVD drive or a USB port for the installer media</li>
-            <li class="p-list__item is-ticked">Internet access is helpful</li>
-          </ul>
-        </div>
-        <div class="col-4">
-          <p>
-            <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download</a>
-            <script>performance.mark("Download (Desktop) button rendered")</script>
-          </p>
-          <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
-        </div>
+    <h1>Download Ubuntu Desktop</h1>
+  </div>
+</div>
+<div class="p-strip--light is-bordered">
+  <div class="u-fixed-width">
+    <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+    <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
+      <div class="col-8 p-divider__block">
+        <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
+        <p><a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
+        <p>Recommended system requirements:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">2 GHz dual core processor or better</li>
+          <li class="p-list__item is-ticked">4 GB system memory</li>
+          <li class="p-list__item is-ticked">25 GB of free hard drive space</li>
+          <li class="p-list__item is-ticked">Either a DVD drive or a USB port for the installer media</li>
+          <li class="p-list__item is-ticked">Internet access is helpful</li>
+        </ul>
+      </div>
+      <div class="col-4">
+        <p>
+          <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download</a>
+          <script>performance.mark("Download (Desktop) button rendered")</script>
+        </p>
+        <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
       </div>
     </div>
   </div>
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
   <div class="u-fixed-width">
-    <div class="p-card--highlighted">
-      <h2>Ubuntu {{ releases.latest.full_version }}</h2>
-      <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
-        <div class="col-8 p-divider__block">
-          <p class="u-no-padding--top">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
-          <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</p>
-          <p><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
-        </div>
-        <div class="col-4">
-          <p>
-            <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download</a>
-          </p>
-          <p>
-            <small><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></small>
-          </p>
-        </div>
+    <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+    <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
+      <div class="col-8 p-divider__block">
+        <p class="u-no-padding--top">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
+        <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</p>
+        <p><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
+      </div>
+      <div class="col-4">
+        <p>
+          <a class="p-button--positive is-wide js-latest-download" href="/download/desktop/thank-you/?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download</a>
+        </p>
+        <p>
+          <small><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></small>
+        </p>
       </div>
     </div>
   </div>
 </div>
 
-<div class="p-strip is-deep is-bordered">
+<div class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>Easy ways to switch to Ubuntu</h2>
   </div>
@@ -108,7 +109,9 @@
   </div>
 </div>
 
-{% include 'download/shared/_multipass-install.html' %}
+{% with strip="light" %}
+  {% include 'download/shared/_multipass-install.html' %}
+{% endwith %}
 
 {% with first_item="_download_desktop_installation",
   first_item_class="",

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -1,4 +1,8 @@
-<section class="p-strip is-shallow">
+{% if strip == "light" %}
+<section class="p-strip--light is-shallow">
+{% else %}
+<section class="p-strip is-shallow"></section>
+{% endif %}
   <div class="row u-equal-height">
     <div class="col-7">
       <h2>Multipass for instant Ubuntu VMs</h2>
@@ -36,7 +40,7 @@
   if (navigator.appVersion.indexOf('Macintosh') != -1) { os = 'macOS' };
 
   multipassOScta.setAttribute(
-    'href', 
+    'href',
     baseInstallURL + '/installing-on-' + os.toLowerCase()
   );
   ctaSpan.innerText = 'Install on ' + os;


### PR DESCRIPTION
## Done

Update /download/desktop

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page matches [the design](https://user-images.githubusercontent.com/36884067/74351157-a66c8700-4dae-11ea-857f-f408eaac5409.png)


## Issue / Card

Fixes #6634