### PR TITLE
Update alternative downloads page

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -5,19 +5,16 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip is-deep is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-7">
+<div class="p-strip--suru-topped is-bordered">
+  <div class="row">
+    <div class="col-8">
       <h1>Alternative downloads</h1>
       <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases. If you don&rsquo;t specifically require any of these installers, we recommend using our <a href="/download">standard downloads</a>.</p>
-    </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/be3876ec-picto-download-warmgrey.svg" width="200" height="200" alt="" />
     </div>
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip--light is-bordered">
   <div class="row" id="network-installer">
     <div class="col-8">
       <h2 id="network-installer">Network installer</h2>
@@ -67,7 +64,7 @@
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip--light">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h2 id="alternate-ubuntu-server-installer">Alternative Ubuntu Server installer</h2>


### PR DESCRIPTION
## Done

Update /download/alternative-downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/alternative-downloads
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page matches [the design](https://user-images.githubusercontent.com/36884067/74352550-9786d400-4db0-11ea-9343-9779256152bc.png)


## Issue / Card

Fixes #6636