### PR TITLE
Set cache-control headers for the whole site

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask_base==0.3.3
+canonicalwebteam.flask_base==0.4.0
 canonicalwebteam.http==1.0.1
 canonicalwebteam.blog==4.0.2
 canonicalwebteam.search==0.2.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -206,3 +206,17 @@ def index():
 
 
 tutorials_docs.init_app(app)
+
+
+@app.after_request
+def cache_headers(response):
+    """
+    Set cache expiry to 60 seconds for homepage and blog page
+    """
+
+    if flask.request.path in ["/", "/blog"]:
+        response.headers[
+            "Cache-Control"
+        ] = "public, max-age=60, stale-while-revalidate=90"
+
+    return response


### PR DESCRIPTION
Set cache-control headers for the whole site

Use flask-base 0.4.0 so that all pages get 5 minute cache.

Also set homepage and blog list page to 1 minute cache.

QA
--

Check cache-control headers with curl:

``` bash
# Homepage and blog have 1 minute cache
# ==
$ curl -I https://ubuntu-com-canonical-web-and-design-pr-6661.run.demo.haus/
Cache-Control: public, max-age=60, stale-while-revalidate=90

$ curl -I https://ubuntu-com-canonical-web-and-design-pr-6661.run.demo.haus/blog
Cache-Control: public, max-age=60, stale-while-revalidate=90

# Other pages in ubuntu.com and under blog have 5 minute cache
# ==
$ curl -I https://ubuntu-com-canonical-web-and-design-pr-6661.run.demo.haus/openstack
Cache-Control: public, max-age=300, stale-while-revalidate=360

$ curl -I https://ubuntu-com-canonical-web-and-design-pr-6661.run.demo.haus/blog/topics/design
Cache-Control: public, max-age=300, stale-while-revalidate=360

# Advantage is still private
$ curl -I https://ubuntu-com-canonical-web-and-design-pr-6661.run.demo.haus/advantage
Cache-Control: private
```
