### PR TITLE
Fix main navigation dropdowns for IE11

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -1,4 +1,4 @@
-var navDropdowns = document.querySelectorAll('.p-navigation__dropdown-link');
+var navDropdowns = [].slice.call(document.querySelectorAll('.p-navigation__dropdown-link'));
 var dropdownWindow = document.querySelector('.dropdown-window');
 var dropdownWindowOverlay = document.querySelector('.dropdown-window-overlay');
 var navigationThresholdBreakpoint = 900;
@@ -80,7 +80,7 @@ if (window.location.hash) {
 }
 
 function closeMainMenu() {
-  var navigationLinks = document.querySelectorAll('.p-navigation__dropdown-link');
+  var navigationLinks = [].slice.call(document.querySelectorAll('.p-navigation__dropdown-link'));
 
   navigationLinks.forEach(function(navLink) {
     navLink.classList.remove('is-selected');
@@ -112,12 +112,12 @@ addGANavEvents('.p-footer--secondary', 'www.ubuntu.com-nav-footer-1');
 function addGANavEvents(target, category){
   var t = document.querySelector(target);
   if (t) {
-    t.querySelectorAll('a').forEach(function(a) {
+    [].slice.call(t.querySelectorAll('a')).forEach(function(a) {
       a.addEventListener('click', function(){
         dataLayer.push({
           'event' : 'GAEvent',
           'eventCategory' : category,
-          'eventAction' : `from:${origin} to:${a.href}`,
+          'eventAction' : 'from:' + origin + ' to:' + a.href,
           'eventLabel' : a.text,
           'eventValue' : undefined
         });
@@ -131,10 +131,10 @@ addGAContentEvents('#main-content')
 function addGAContentEvents(target){
   var t = document.querySelector(target);
   if (t) {
-    t.querySelectorAll('a').forEach(function(a) {
-      if (a.className.includes('p-button--positive')) {
+    [].slice.call(t.querySelectorAll('a')).forEach(function(a) {
+      if (a.classList.contains('p-button--positive')) {
         var category = 'www.ubuntu.com-content-cta-0';
-      } else if (a.className.includes('p-button')) {
+      } else if (a.classList.contains('p-button')) {
         var category = 'www.ubuntu.com-content-cta-1';
       } else {
         var category = 'www.ubuntu.com-content-link';
@@ -144,7 +144,7 @@ function addGAContentEvents(target){
           dataLayer.push({
             'event' : 'GAEvent',
             'eventCategory' : category,
-            'eventAction' : `from:${origin} to:${a.href}`,
+            'eventAction' : 'from:' + origin + ' to:' + a.href,
             'eventLabel' : a.text,
             'eventValue' : undefined
           });
@@ -157,15 +157,15 @@ function addGAContentEvents(target){
 addGAImpressionEvents('.js-takeover')
 
 function addGAImpressionEvents(target){
-  var t = document.querySelectorAll(target);
+  var t = [].slice.call(document.querySelectorAll(target));
   if (t) {
     t.forEach(function(section) {
-      if (! section.className.includes('u-hide')){
+      if (! section.classList.contains('u-hide')){
         var a = section.querySelector("a");
         dataLayer.push({
           'event' : 'NonInteractiveGAEvent',
           'eventCategory' : "www.ubuntu.com-impression",
-          'eventAction' : `from:${origin} to:${a.href}`,
+          'eventAction' : 'from:' + origin + ' to:' + a.href,
           'eventLabel' : a.text,
           'eventValue' : undefined,
         });

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -144,17 +144,13 @@
   }
 
   function fetchDropdown(url, id) {
-    const div = document.getElementById(id);
-    fetch(url)
-    .then(function(response) {
-      return response.text();
-    })
-    .then(function(text) {
-      div.innerHTML = text;
-    })
-    .catch(function(error) {
-      console.log('Request failed', error)
-    })
+    var div = document.getElementById(id);
+    var req = new XMLHttpRequest();
+    req.open('GET', url);
+    req.send();
+    req.addEventListener('load', function() {
+      div.innerHTML = this.responseText;
+    });
   }
 </script>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -12,6 +12,8 @@
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
   <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js" defer></script>
+  <!-- Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660) -->
+  <script src="{{ versioned_static('js/navigation.js') }}" defer></script>
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
   <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
     main: [
       "./static/js/dynamic-contact-form.js",
       "./static/js/core.js",
-      "./static/js/navigation.js",
+      // Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660)
+      // "./static/js/navigation.js",
       "./static/js/formValidation.js",
       "./static/js/scratch.js"
     ],


### PR DESCRIPTION
## Done

- Hardlinked navigation JS to avoid it being blocked due to errors in the main JS bundle
- Replaced `fetch` with `XMLHttpRequest` so it works in IE 11
- Replaced `forEach` on node lists with the array slice method so it works in IE 11

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on the main navigation and check that the dropdowns are shown
- Click on the faded area beneath the dropdowns and check that it closes the dropdowns
- Load the page with a dropdown hash in the URL e.g. ubuntu.com/#download and check that the appropriate dropdown is shown


## Issue / Card

Fixes #6655 