### PR TITLE
Update tutorial links on /download/intel-nuc

### DIFF
--- a/templates/download/intel-nuc.html
+++ b/templates/download/intel-nuc.html
@@ -62,7 +62,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <ol class="u-no-margin--left">
-            <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="p-link--external" href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a class="p-link--external" href="/tutorials/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a class="p-link--external" href="/tutorials/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
+            <li>Download and copy the <a href="/download/desktop">Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a> image on the first USB flash drive by following the live USB Ubuntu Desktop tutorial for <a href="/tutorials/tutorial-create-a-usb-stick-on-ubuntu">Ubuntu</a>, <a  href="/tutorials/tutorial-create-a-usb-stick-on-windows">Windows</a>, or  <a href="/tutorials/tutorial-create-a-usb-stick-on-macos">macOS</a></li>
             <li>Copy the Ubuntu Core image for Intel NUC on the second USB flash drive</li>
           </ol>
         </div>
@@ -114,7 +114,6 @@
         {% with number=8 %}{% include "download/iot/_login.html" %}{% endwith %}
       </ol>
     </div>
-  </div>
 </section>
 
 {% with strip="p-strip--light" %}{% include "download/iot/_boot-tips-strip.html" %}{% endwith %}


### PR DESCRIPTION
## Done

Fixed links to the, now local, tutorials

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/intel-nuc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the links for creating media work

## Issue / Card

Fixes #6663
