### PR TITLE
Squid needs max-age > 60

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -217,6 +217,6 @@ def cache_headers(response):
     if flask.request.path in ["/", "/blog"]:
         response.headers[
             "Cache-Control"
-        ] = "public, max-age=60, stale-while-revalidate=90"
+        ] = "max-age=61, stale-while-revalidate=90"
 
     return response


### PR DESCRIPTION
This is kinda nuts, but Squid won't cache anything with max-age of 60 or less.

http://squid-web-proxy-cache.1019090.n4.nabble.com/Objects-with-values-below-60-second-for-Cache-Control-max-age-are-not-cached-td4679079.html

``` bash
$ curl -I https://ubuntu.com
HTTP/1.1 200 OK
Date: Fri, 14 Feb 2020 15:28:44 GMT
Server: openresty/1.15.8.2
Strict-Transport-Security: max-age=15768000
Content-Type: text/html; charset=utf-8
Content-Length: 61602
Vary: Accept-Encoding
Cache-Control: public, max-age=60, stale-while-revalidate=90
X-View-Name: canonicalwebteam.templatefinder.templatefinder.template_finder
X-VCS-Revision: 1581691608-619d565
X-Request-Id: 4660f9eea4ef839f99dc3a4a4249e540
Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect
X-Cache: MISS from privet.canonical.com
X-Cache-Lookup: MISS from privet.canonical.com:80
Via: 1.1 privet.canonical.com (squid/3.5.12)
```

QA
--

``` bash
$ curl -I https://ubuntu-com-canonical-web-and-design-pr-6665.run.demo.haus/
Cache-Control: max-age=61, stale-while-revalidate=90
```