### PR TITLE
add interana case study

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -31,7 +31,7 @@
   <div class="row u-equal-height">
     <div class="{% if header_image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
       <div>
-        <h1 {% if not header_subtitle and not header_date %}class="u-no-margin--bottom"{% endif %}>
+        <h1 {% if not header_subtitle and not header_date %}class="u-no-margin--bottom{% if title_class %} {{ title_class }}{% endif %}"{% endif %}>
           {{ header_title | safe }}
         </h1>
         {% if header_subtitle %}<h4>

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -31,7 +31,7 @@
   <div class="row u-equal-height">
     <div class="{% if header_image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
       <div>
-        <h1 {% if not header_subtitle and not header_date %}class="u-no-margin--bottom{% if title_class %} {{ title_class }}{% endif %}"{% endif %}>
+        <h1 {% if header_title_class %}class="{{ header_title_class }}"{% endif %}>
           {{ header_title | safe }}
         </h1>
         {% if header_subtitle %}<h4>

--- a/templates/engage/build-smart-devices-with-mir-whitepaper.md
+++ b/templates/engage/build-smart-devices-with-mir-whitepaper.md
@@ -6,6 +6,7 @@ context:
      meta_image: "https://assets.ubuntu.com/v1/8b2a5baf-61620202-4f636100-ac68-11e9-9c88-ffdccb58ecdf.jpg"
      meta_copydoc: "https://docs.google.com/document/d/11E9O_mVN_U63ZLsZOvwsdXAyNtpRv0aF8_VWBDfrnRc"
      header_title: "Build smart display devices with Mir: fast to production, secure, open-source"
+     header_title_class: 'u-no-margin--bottom'
      header_url: '#register-section'
      header_cta: Build your smart display device
      header_class: p-engage-banner--dark

--- a/templates/engage/case-study-acuris.md
+++ b/templates/engage/case-study-acuris.md
@@ -6,6 +6,7 @@ context:
     meta_image: "https://assets.ubuntu.com/v1/9f33421e-acuris-case-study-social-media.jpg"
     meta_copydoc: "https://docs.google.com/document/d/1rKM8TyZFZipp0NL_QbsIyJ6cn5oPFmN_cD5XDCL003s/edit"
     header_title: "TIM ensures system security and client confidence with ESM"
+    header_title_class: 'u-no-margin--bottom'
     header_image: "https://assets.ubuntu.com/v1/e7043d2c-TIM_Logo_white.png"
     header_url: '#register-section'
     header_cta: Download case study

--- a/templates/engage/cyberdyne.md
+++ b/templates/engage/cyberdyne.md
@@ -6,7 +6,7 @@ context:
   meta_image: "https://assets.ubuntu.com/v1/3bca057e-Meta+data+img.jpg"
   meta_copydoc: "https://docs.google.com/document/d/17JI-RzetZYq5GZF9COAuh-uHG2yHI2pGy25ePdfA9Qk/edit"
   header_title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
-  header_subtitle: 
+  header_title_class: 'u-no-margin--bottom'
   header_image: https://assets.ubuntu.com/v1/470ca6c0-logo_cyberdyne.png
   header_url: '#register-section'
   header_cta: Register for the webinar

--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -6,7 +6,7 @@ context:
      meta_image: https://assets.ubuntu.com/v1/e93f66b3-deeptech.jpg
      meta_copydoc: "https://docs.google.com/document/d/1guBMZs8ymlZ2sk5R84hYFLhQBIDhKKll9lsg9rHS854/edit"
      header_title: "Accelerating deep tech <br class='u-hide--small' />with Ubuntu"
-     header_subtitle: ""
+     header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/3f8c22da-Deep+tech+ubuntu+-+light.svg"
      header_url: '#register-section'
      header_cta: Register for the webinar

--- a/templates/engage/dell-kubernetes-webinar.md
+++ b/templates/engage/dell-kubernetes-webinar.md
@@ -6,7 +6,7 @@ context:
      meta_image: "https://assets.ubuntu.com/v1/f0d09455-Meta+data+img.jpg"
      meta_copydoc: "https://docs.google.com/document/d/1wtlW9L69Y_3mexwQ38x4ENxOa65X-XUZNUb1bOWpaOI/edit"
      header_title: "A decision maker's guide to Kubernetes deployments"
-     header_subtitle: ""
+     header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg"
      header_image_width: "200"
      header_url: '#register-section'

--- a/templates/engage/developing-android-on-ubuntu.md
+++ b/templates/engage/developing-android-on-ubuntu.md
@@ -6,7 +6,7 @@ context:
      meta_image: dab160e2-anroid_on_ubuntu-social.png
      meta_copydoc: https://docs.google.com/document/d/10w-f6FEEYGPGcrFFPiZmWioZnfC3lfvfjqx_tMsi1nE/edit
      header_title: A guide to developing Android apps on Ubuntu
-     header_subtitle:
+     header_title_class: 'u-no-margin--bottom'
      header_image: 30f461a5-android-on-ubuntu.svg
      header_url: '#register-section'
      header_cta: Download the whitepaper

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -874,5 +874,15 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
+
+  <div class="row u-equal-height u-clearfix">
+    {% with title="ESM maintains Interana's system security while upgrading",
+      description="How Ubuntu helps Interana provide their customers with some of the fastest analytics capabilities on the market and why they turned to ESM to maintain system security while upgrading.",
+      slug="interana-casestudy",
+      group="case-study",
+      type="case study" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 </section>
 {% endblock content %}

--- a/templates/engage/interana-casestudy.md
+++ b/templates/engage/interana-casestudy.md
@@ -6,7 +6,7 @@ context:
      meta_image: https://assets.ubuntu.com/v1/863b2860-Meta+data+img.jpg
      meta_copydoc: "https://docs.google.com/document/d/1FCaFi5ZuP_pPMF2POu3ySaB00yt60Qo-nrNJZ9jwhFw/edit"
      header_title: "Interana uses ESM to maintain system security while upgrading its customers to Ubuntu 18.04 LTS across public clouds"
-     title_class: p-heading--two
+     header_title_class: 'p-heading--two'
      header_image: "https://assets.ubuntu.com/v1/0026bea9-logo-interana.svg"
      header_url: '#register-section'
      header_cta: Download our case study

--- a/templates/engage/interana-casestudy.md
+++ b/templates/engage/interana-casestudy.md
@@ -1,0 +1,38 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "ESM maintains Interana's system security while upgrading"
+     meta_description: "How Ubuntu helps Interana provide their customers with some of the fastest analytics capabilities on the market and why they turned to ESM to maintain system security while upgrading."
+     meta_image: https://assets.ubuntu.com/v1/863b2860-Meta+data+img.jpg
+     meta_copydoc: "https://docs.google.com/document/d/1FCaFi5ZuP_pPMF2POu3ySaB00yt60Qo-nrNJZ9jwhFw/edit"
+     header_title: "Interana uses ESM to maintain system security while upgrading its customers to Ubuntu 18.04 LTS across public clouds"
+     title_class: p-heading--two
+     header_image: "https://assets.ubuntu.com/v1/0026bea9-logo-interana.svg"
+     header_url: '#register-section'
+     header_cta: Download our case study
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--dark
+     header_lang: en
+     form_include: en
+     form_id: 3536
+     form_return_url: https://pages.ubuntu.com/CStudy_Interana_TY.html
+---
+
+Interana, an analytics software provider, enables users to run advanced big data queries on raw customer data and delivers answers in seconds. Their customers include Microsoft, Comcast and Salesforce. 
+ 
+Interana’s leading-edge platform is based on Ubuntu and deployed directly inside customers’ public cloud environments. This empowers users with some of the fastest analytics capabilities on the market. However, this also means that they have to schedule large-scale data migrations with each client.
+ 
+Due to the large amounts of customer data that Interana handles, ensuring that security was tight was a priority. Rather than rush the upgrade from Ubuntu 14.04LTS, which would have been a major inconvenience for both Interana and its customers, Interana turned to Canonical and ESM. This ensured that their upgrade rollout was secured and controlled.
+ 
+<blockquote class="p-pull-quote">
+  <p class="p-pull-quote__quote">ESM literally saved our lives. It’s allowing us to upgrade from 14.04 LTS at our own pace.</p>
+  <cite class="p-pull-quote__citation">Zivago Lee, Director of DevOps Engineering, Interana</cite>
+</blockquote>
+ 
+Download the case study to learn:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Why Interana relies on Ubuntu as the foundation for its flagship analytics platform</li>
+  <li class="p-list__item is-ticked">How ESM eliminates security concerns while Interana migrates its customers from Ubuntu 14.04 LTS to 18.04 LTS</li>
+  <li class="p-list__item is-ticked">How ESM is enabling a staggered Ubuntu 18.04 LTS rollout that coincides with upgrades to the new Interana V4 release.</li>
+</ul>

--- a/templates/engage/interana-casestudy.md
+++ b/templates/engage/interana-casestudy.md
@@ -13,7 +13,7 @@ context:
      header_cta_class: p-button--positive
      header_class: p-engage-banner--dark
      header_lang: en
-     form_include: en
+     form_cta: Download the case study
      form_id: 3536
      form_return_url: https://pages.ubuntu.com/CStudy_Interana_TY.html
 ---

--- a/templates/engage/kata-containers-webinar.md
+++ b/templates/engage/kata-containers-webinar.md
@@ -7,6 +7,7 @@ context:
      meta_image: https://assets.ubuntu.com/v1/48c73e93-Meta+data+img.jpg
      meta_copydoc: "https://docs.google.com/document/d/1KeCbhYudWJuKW2cMuNfsClvQXnyrpz0q2I-ILuwhfcY/edit?ts=5d6de4ad"
      header_title: "Ensuring security and isolation in Kubernetes with Kata Containers"
+     header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/4cbd0535-kata+containers+kubernetes.svg"
      header_url: '#register-section'
      header_cta: Watch the webinar

--- a/templates/engage/sbi-casestudy.md
+++ b/templates/engage/sbi-casestudy.md
@@ -6,6 +6,7 @@ context:
      meta_image: "https://assets.ubuntu.com/v1/41c9663c-Embedded+social+media+banner+.jpg"
      meta_copydoc: "https://docs.google.com/document/d/1ky7FmqiSEBi_fDMo3d2p7oeIrFhvSCCCJmohd6rc6uQ"
      header_title: "SBI Group unlocks infrastructure automation with secure, on-premises OpenStack cloud"
+     header_title_class: 'u-no-margin--bottom'
      header_url: '#register-section'
      header_cta: Download case study
      header_class: p-engage-banner--dark

--- a/templates/engage/wellcome-sanger-case-study.md
+++ b/templates/engage/wellcome-sanger-case-study.md
@@ -6,6 +6,7 @@ context:
      meta_image: "https://assets.ubuntu.com/v1/7d4ae717-Meta+data+img.jpg"
      meta_copydoc: "https://docs.google.com/document/d/1Q3qm-OpMojw1f2hoK7fOW2MZGacC2BJz8d5DsuRjHyA"
      header_title: "The Wellcome Sanger Institute turns to Canonical for high level Ceph support"
+     header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/50aec8a8-sanger+++ceph.svg"
      header_url: '#register-section'
      header_cta: Download case study

--- a/templates/engage/yahoo-japan-case-study.md
+++ b/templates/engage/yahoo-japan-case-study.md
@@ -6,7 +6,7 @@ context:
      meta_image: https://assets.ubuntu.com/v1/bb29b611-yahoo-japan-case-study-social.jpg
      meta_copydoc: https://docs.google.com/document/d/1WHnbQO6m6B4puJr8Vc3WxPC9BBJ0E7pvkTXSJUKvCM0/edit
      header_title: "Yahoo! Japan builds their IaaS environment with Canonical"
-     header_subtitle:
+     header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/5d403409-2018-logo-yahoo-japan.svg"
      header_url: '#register-section'
      header_cta: Download case study


### PR DESCRIPTION
## Done

Added /engage/interana-casestudy

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/interana-casestudy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page matches the [copy doc](https://docs.google.com/document/d/1o5K--Dtnrm_3er0Ux3mRf2yGFt8vFDCizrtQZ4m4mfU/edit?ts=5e42cc49) and the [design](https://github.com/canonical-web-and-design/ubuntu.com/issues/6671#issuecomment-586937377)
- Test the engage page on https://cards-dev.twitter.com/validator, see that an appropriate title, description and image are pulled through.
- Visit /engage, see that the engage page is listed there (last entry)


## Issue / Card

Fixes #6672 
