### PR TITLE
hide interana case study from engage index

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -874,15 +874,5 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
-
-  <div class="row u-equal-height u-clearfix">
-    {% with title="ESM maintains Interana's system security while upgrading",
-      description="How Ubuntu helps Interana provide their customers with some of the fastest analytics capabilities on the market and why they turned to ESM to maintain system security while upgrading.",
-      slug="interana-casestudy",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
-    {% endwith %}
-  </div>
 </section>
 {% endblock content %}


### PR DESCRIPTION
## Done

Hidden the Interana engage page from the engage index - I hadn't realised that [the PDF](https://github.com/canonical-web-and-design/ubuntu.com/issues/6673) for the thank you page wasn't done yet, I just noticed it when checking on staging.

## QA

Go to /engage and see that there is no mention of "interana"