### PR TITLE
Community page: Blog migrated from external site to internal display

### DIFF
--- a/templates/community/index.html
+++ b/templates/community/index.html
@@ -53,7 +53,7 @@
           <p>Discover community generated how-to’s, tips, tricks and hacks on the <a href="https://help.ubuntu.com/community/CommunityHelpWiki" class="p-link--external">community help wiki</a>.</p>
         </li>
         <li>
-          <p>Get the latest Ubuntu news and resources on our <a href="https://blog.ubuntu.com/" class="p-link--external">insights blog</a>.</p>
+          <p>Get the latest Ubuntu news and resources on our <a href="/blog">blog</a>.</p>
         </li>
       </ul>
       <h3>Connect</h3>


### PR DESCRIPTION
## Done

- Remove a reference to the old “Insights” name
- Remove external link class

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

N/A