### PR TITLE
update /automotive illustrations

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -39,10 +39,10 @@
       <div class="col-6 u-vertically-center u-align--center u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/c7274075-compliance.svg",
+            url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
             alt="",
             height="300",
-            width="430",
+            width="350",
             hi_def=True,
           ) | safe
         }}

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -8,18 +8,18 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
-    <div class="col-8">
+    <div class="col-7">
       <h1>Secure Linux for the automotive sector</h1>
       <p>Leverage the most popular open source operating system to accelerate time to market for your connected vehicles. Ubuntu is the choice platform to develop cockpit infotainment, edge connectivity, mixed-criticality and AI for automotive applications. What&rsquo;s more, Ubuntu Core is designed to enhance functional safety for critical embedded systems. Canonical brings 15 years of experience, enabling and supporting Linux to the automotive sector.</p>
       <p>Tell us about your moonshot.</p>
       <p><a href="/internet-of-things/contact-us?product=automotive" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{
         image(
           url="https://assets.ubuntu.com/v1/580f3ae7-automotive.svg",
           alt="",
-          width="320",
+          width="350",
           height="250",
           hi_def=True,
         ) | safe
@@ -37,7 +37,15 @@
         <p><a class="p-link--external" href="https://assets.ubuntu.com/v1/66fcd858-ubuntu-core-security-whitepaper.pdf">Read the Ubuntu Core security whitepaper</a></p>
       </div>
       <div class="col-6 u-vertically-center u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/2697f642-Compliance.svg" alt="" width="335" height="200">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c7274075-compliance.svg",
+            alt="",
+            height="300",
+            width="430",
+            hi_def=True,
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -47,7 +55,15 @@
   <div class="p-strip is-shallow u-no-padding--bottom">
     <div class="row u-equal-height">
       <div class="col-6 u-vertically-center u-align-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/c53664cd-Security_updates.svg" alt="" width="335" height="200">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/aa1dc625-10+Year+shield+trio_AW.svg",
+            alt="",
+            height="200",
+            width="350",
+            hi_def=True,
+          ) | safe
+        }}
       </div>
       <div class="col-6">
         <h2>Long-term software updates for cars in the field</h2>


### PR DESCRIPTION
## Done

Updated /automotive illustrations according to [brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6687)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/automotive
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the items in the [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6687) have been properly addressed


## Issue / Card

Fixes #6687 
