### PR TITLE
update /iot/networking illustrations

### DIFF
--- a/templates/internet-of-things/networking.html
+++ b/templates/internet-of-things/networking.html
@@ -119,10 +119,10 @@
     <div class="col-6 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c00eea7b-2C-Enterprise+management.svg",
+          url="https://assets.ubuntu.com/v1/3db02edd-enterprise+management+.svg",
           alt="",
-          width="300",
-          height="200",
+          width="375",
+          height="240",
           hi_def=True,
         ) | safe
       }}
@@ -144,9 +144,9 @@
     <div class="col-6 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/1e7ead79-2B-app-store.svg",
+          url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
           alt="",
-          width="300",
+          width="200",
           height="200",
           hi_def=True,
         ) | safe


### PR DESCRIPTION
## Done

Updated /internet-of-things/networking illustrations according to [brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6688)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/networking
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the points in [the issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6688) have been properly addressed


## Issue / Card

Fixes #6688 
