### PR TITLE
Add /snaps search endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.image-template==1.0.0
 canonicalwebteam.discourse-docs==0.11.0
+canonicalwebteam.store-api==1.0.5
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -38,6 +38,7 @@ from webapp.views import (
     blog_press_centre,
     download_thank_you,
     releasenotes_redirect,
+    search_snaps,
 )
 from webapp.login import login_handler, logout
 
@@ -132,6 +133,7 @@ app.add_url_rule("/logout", view_func=logout)
 # All other routes
 template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/", view_func=template_finder_view)
+app.add_url_rule("/snaps", view_func=search_snaps)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 url_prefix = "/server/docs"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -7,8 +7,10 @@ import datetime
 # Packages
 import feedparser
 import flask
+import talisker.requests
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
+from canonicalwebteam.store_api.stores.snapcraft import SnapcraftStoreApi
 from geolite2 import geolite2
 from requests.exceptions import HTTPError
 
@@ -18,6 +20,7 @@ from webapp.api import advantage
 
 
 ip_reader = geolite2.reader()
+store_api = SnapcraftStoreApi(session=talisker.requests.get_session())
 
 
 def download_thank_you(category):
@@ -85,6 +88,24 @@ def releasenotes_redirect():
         return flask.redirect(f"https://wiki.ubuntu.com/{ver}/ReleaseNotes")
     else:
         return flask.redirect(f"https://wiki.ubuntu.com/Releases")
+
+
+def search_snaps():
+    """
+    A JSON endpoint to search the snap store API
+    """
+
+    query = flask.request.args.get("q", "")
+    arch = flask.request.args.get("arch", "amd64")
+    size = flask.request.args.get("size", "100")
+    page = flask.request.args.get("page", "1")
+
+    if not query:
+        return flask.jsonify({"error": "Query parameter 'q' empty"}), 400
+
+    return flask.jsonify(
+        store_api.search(query, size=size, page=page, arch=arch)
+    )
 
 
 def advantage_view():


### PR DESCRIPTION
This makes use of our store-api module to return results from
api.snapcraft.io/api/v1/snaps/search. It also simplifies filtering
by architecture (?arch=)

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2374

QA
--

Get the site running, then:

- Go to http://0.0.0.0:8001/snaps, see a 400 (can't be bothered to handle no query for now)
- Go to http://0.0.0.0:8001/snaps?q=toto, see 6 snaps returned
- Go to http://0.0.0.0:8001/snaps?q=toto&arch=i386, see 3 snaps returned