### PR TITLE
add "Securing ROS robotics platforms" engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -917,6 +917,14 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+    
+    {% with title="Securing ROS robotics platforms",
+      description="The steps you need to take to maximise robotics security with Ubuntu",
+      slug="securing-ros-on-robotics-platforms-whitepaper",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/securing-ros-on-robotics-platforms-whitepaper.md
+++ b/templates/engage/securing-ros-on-robotics-platforms-whitepaper.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Securing ROS robotics platforms"
+  meta_description: "The steps you need to take to maximise robotics security with Ubuntu"
+  meta_image: "https://assets.ubuntu.com/v1/3afb18e7-Meta+data+img.jpg"
+  meta_copydoc: "https://docs.google.com/document/d/156Oa3Oz3RiUQcFLTKNqtfKXiuFtzZm0fRMsrv6XV5Wc/edit"
+  header_title: "Securing ROS robotics platforms"
+  header_subtitle: "Steps to maximise robotics security with Ubuntu"
+  header_url: '#register-section'
+  header_cta: Download whitepaper
+  header_class: p-engage-banner--grad
+  header_image: "https://assets.ubuntu.com/v1/5ee71af0-Robot+arm+-+white.svg"
+  header_lang: en
+  form_include: en
+  form_id: 3537
+  form_return_url: "https://pages.ubuntu.com/Whitepaper_ROSonrobotics_TY.html"
+---
+
+The Robot Operating System (ROS) is a popular open-source platform for advanced robotics. Its flexibility and ease-of-use make it well-suited to a wide array of robotics applications – however, these robots are not always sufficiently protected against security threats.
+
+Opportunistic attacks are by far the most prevalent, and robots with inadequate ROS security make tempting targets for bad actors. With that in mind, approaching robotics security proactively is crucial to preventing breaches and saving resources in the long run. Security starts with the underlying operating system, and building robots on Ubuntu unlocks a number of easy, yet effective, measures for maximising protection against the most dominant threats.
+
+Using the Raspberry Pi based model of TurtleBot3 as an example, this whitepaper details practical steps for securing robots on Ubuntu, including:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">How to minimise the attack surface by installing the Ubuntu Server image, and by disabling USB, IPv6, core dump, and other functionalities that are not in use.</li>
+  <li class="p-list__item is-ticked">Enabling unattended upgrades to keep automatically up-to-date with the latest security vulnerability patches.</li>
+  <li class="p-list__item is-ticked">Mitigating brute force attacks through SSH hardening and firewall configuration.</li>
+</ul>


### PR DESCRIPTION
## Done

Added "Securing ROS robotics platforms" engage page

**Can't merge until we get the PDF and it's been uploaded**
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- At the bottom of the page, see that there is a card with the title "Securing ROS robotics platforms", then follow the link to the engage page
- See that the engage page matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2325) and the [copy doc](https://docs.google.com/document/d/156Oa3Oz3RiUQcFLTKNqtfKXiuFtzZm0fRMsrv6XV5Wc/edit?pli=1).


## Issue / Card

Fixes #6646 
