### PR TITLE
Add image template to /aws pages

### DIFF
--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -15,7 +15,16 @@
         <a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on AWS</a>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg" alt="" width="200">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+            alt="",
+            width="200",
+            height="119",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -27,16 +36,56 @@
       <h2 class="p-muted-heading u-align--center">UBUNTU ON AWS POWERS CLOUD LEADERS LIKE</h2>
       <ul class="p-inline-images u-no-margin--bottom">
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1d3f5d21-Netflix_2015_logo.svg" alt="Netflix" width="144">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/1d3f5d21-Netflix_2015_logo.svg",
+              alt="Netflix",
+              width="144",
+              height="39",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-inline-images__logo"},
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" alt="Paypal" width="141">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
+              alt="Paypal",
+              width="141",
+              height="36",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-inline-images__logo"},
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/2133a97d-heroku-logo+copy.svg" alt="Heroku" width="144">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/2133a97d-heroku-logo+copy.svg",
+              alt="Heroku",
+              width="144",
+              height="41",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-inline-images__logo"},
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/95b783ed-acquia.svg" alt="Acquia" width="144">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/95b783ed-acquia.svg",
+              alt="Acquia",
+              width="144",
+              height="55",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-inline-images__logo"},
+            ) | safe
+          }}
         </li>
       </ul>
     </div>

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -22,7 +22,7 @@
             width="200",
             height="119",
             hi_def=True,
-            loading="lazy",
+            loading="auto",
           ) | safe
         }}
       </div>

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -16,7 +16,16 @@
         <p><a href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg" alt="" width="200">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+            alt="",
+            width="200",
+            height="119",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+        }}
       </div>
     </div>
   </div>

--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -12,7 +12,17 @@
       <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+          alt="",
+          width="200",
+          height="200",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": ""},
+        ) | safe
+      }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Added image template to /aws pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- http://0.0.0.0:8001/aws
- http://0.0.0.0:8001/aws/pro
- http://0.0.0.0:8001/aws/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that all the images load as expected
