### PR TITLE
Add image template to desktop index page

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -24,7 +24,16 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-8 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/3a05fc34-Dell_XPS_Laptop_Front-news.png?w=681" width="681" alt="The Guardian website on Firefox in 16.04 LTS" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/3a05fc34-Dell_XPS_Laptop_Front-news.png",
+          alt="The Guardian website on Firefox in 16.04 LTS",
+          height="343",
+          width="681",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-4">
       <h2>Complete</h2>
@@ -55,7 +64,16 @@
   <section class="p-strip is-bordered">
     <div class="row u-equal-height">
       <div class="col-7">
-        <img src="https://assets.ubuntu.com/v1/d4f0c4b1-movie.png?w=592" width="592" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/d4f0c4b1-movie.png",
+            alt="",
+            height="367",
+            width="592",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="col-4 col-start-large-9 u-vertically-center">
         <div>
@@ -77,7 +95,16 @@
         <p><a href="https://partners.ubuntu.com/programmes" class="p-link--external">Find out more about our partners</a></p>
       </div>
       <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=413" width="413" alt="Photo of laptop running Ubuntu" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/d9105909-Dell_XPS_Laptop_Left-Desktop.png",
+            alt="Photo of laptop running Ubuntu",
+            height="256",
+            width="413",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Add image template to desktop index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images below the fold are lazy loaded