### PR TITLE
Changes “cis/?” to “cis-audit/?”

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -128,7 +128,7 @@ category/product/ubuntu-advantage/?: /support
 category/product/ubuntu-light/?: http://lubuntu.net/
 cc/?: "/security/certifications"
 cc-eal/?: "/security/certifications"
-cis/?: "/security/certifications"
+cis-audit/?: "/security/certifications"
 cloud/?: "/public-cloud"
 cloud/awsome/?: "https://launchpad.net/awsome"
 cloud/azure/?: "/public-cloud"


### PR DESCRIPTION
`ua help` refers to https://ubuntu.com/cis-audit, which does not exist. But `/fips`, `/cc-eal`, and `/cis` all redirect to `/security/certifications`. So it looks like the `/cis` redirect was mistaken.

Discovered while investigating #6710.