### PR TITLE
Add image template to /contact-us section

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -75,7 +75,16 @@
       </ul>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="" class="" width="200"/>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg",
+          alt="",
+          width="200",
+          height="200",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Added image template tag to the contact us page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/contact-us
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the canonical logo is loaded
