### PR TITLE
Add image template to desktop features

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -41,8 +41,17 @@
         <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu</a></p>
       </div>
       <div class="col-6 u-vertically-center u-hide--small u-align--center">
-        <img class="u-hide--small u-hide--medium u-image-position--top" src="https://assets.ubuntu.com/v1/01600134-XPS-touch-notebook.png?w=380" alt="" style="" width="380" />
-        <img class="u-hide--large" src="https://assets.ubuntu.com/v1/01600134-XPS-touch-notebook.png?w=380" width="380" alt="" style="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/01600134-XPS-touch-notebook.png",
+            alt="",
+            height="233",
+            width="380",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="auto",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -58,63 +67,144 @@
   <div class="u-fixed-width">
     <ul class="p-matrix is-trisected">
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c9be8d47-Spotify_logo_without_text.svg" width="48" alt="Spotify icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c9be8d47-Spotify_logo_without_text.svg",
+            alt="Spotify icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/spotify">Spotify</a></h3>
           <p class="p-matrix__desc">Play and stream your favorite songs, playlists and albums for free with Spotify.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3d6245f8-skype-icon.svg" width="48" alt="Skype icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3d6245f8-skype-icon.svg",
+            alt="Skype icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/skype">Skype</a></h3>
           <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
         </div>
       </li>
       <li class="p-matrix__item last-row">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/33f5e395-vlc.svg" width="48" alt="VLC icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/33f5e395-vlc.svg",
+            alt="VLC icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/vlc">VLC player</a></h3>
           <p class="p-matrix__desc">No other video player is compatible with as many different file formats.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/a45d30aa-vf.io-firefox.svg" width="48" alt="Firefox icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a45d30aa-vf.io-firefox.svg",
+            alt="Firefox icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/firefox">Firefox</a></h3>
           <p class="p-matrix__desc">Firefox Quantum is now 2x faster and 30% lighter than Chrome.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg" width="48" alt="Slack">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg",
+            alt="Slack icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/slack">Slack</a></h3>
           <p class="p-matrix__desc">Team communication and collaboration in one place so you can get more done.</p>
         </div>
       </li>
       <li class="p-matrix__item last-row">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/ccb8872b-Icon_Atom.svg" width="48" alt="Atom icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/ccb8872b-Icon_Atom.svg",
+            alt="Atom icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/atom">Atom</a></h3>
           <p class="p-matrix__desc">A hackable text editor for the 21st Century.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/171fcf42-Chromium_11_Logo.svg" width="48" alt="Chromium icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/171fcf42-Chromium_11_Logo.svg",
+            alt="Chromium icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/chromium">Chromium</a></h3>
           <p class="p-matrix__desc">A fast, simple and secure web browser, built for the modern web.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/4ecb4f50-PyCharm_Logo.svg" width="48" alt="PyCharm" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/4ecb4f50-PyCharm_Logo.svg",
+            alt="PyCharm",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/pycharm-community">PyCharm</a></h3>
           <p class="p-matrix__desc">PyCharm provides all the tools you need for productive Python coding.</p>
         </div>
       </li>
       <li class="p-matrix__item last-row">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3f3a15ef-logo-telegram.svg" width="48" alt="Telegram icon" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3f3a15ef-logo-telegram.svg",
+            alt="Telegram icon",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"}
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title"><a href="https://snapcraft.io/telegram-desktop">Telegram</a></h3>
           <p class="p-matrix__desc">A fast and secure desktop messaging app, perfectly synced with your mobile phone.</p>
@@ -132,7 +222,17 @@
       <p>Create professional documents, spreadsheets and presentations on Ubuntu with LibreOffice, the open source office suite that&rsquo;s compatible with Microsoft Office.   That means you can open and edit files like Word documents, Excel spreadsheets and PowerPoint presentations and share them with other users quickly and easily. You can also use Google docs directly from your desktop.</p>
     </div>
     <div class="col-7 col-start-large-6">
-      <img src="https://assets.ubuntu.com/v1/c1471906-libreoffice.jpg?w=556" height="414" width="556" alt="Office Apps" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c1471906-libreoffice.jpg",
+          alt="",
+          height="414",
+          width="556",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -140,7 +240,17 @@
 <section class="p-strip--image is-dark is-deep" style="background-image:url('https://assets.ubuntu.com/v1/0a98afcd-screenshot_desktop.jpg')">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
-      <img src="https://assets.ubuntu.com/v1/849e20c6-news.png?w=500" class="u-hide--small" width="500" alt="" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/849e20c6-news.png",
+          alt="",
+          height="390",
+          width="500",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-5 col-start-large-8">
       <div class="p-card--overlay">
@@ -158,7 +268,17 @@
       <p>Ubuntu comes with Thunderbird, Mozilla&rsquo;s popular email application, so you&rsquo;ll have fast desktop access to your email. No matter which email services you use; Microsoft Exchange, Gmail, Hotmail, POP or IMAP, email just works.</p>
     </div>
     <div class="col-6 col-start-large-7 u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/04339b8f-emaill+screenshot.jpg?w=520"  alt="" height="398" width="520" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/04339b8f-emaill+screenshot.jpg",
+          alt="",
+          height="398",
+          width="520",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -178,7 +298,17 @@
 <section class="p-strip is-bordered is-deep">
   <div class="row p-divider">
     <div class="col-8 p-divider__block">
-      <img src="https://assets.ubuntu.com/v1/5ef3d6ca-photogallery.jpg?w=531" alt="Stockwell screenshot" width="531" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/5ef3d6ca-photogallery.jpg",
+          alt="Shotwell screenshot",
+          height="379",
+          width="531",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
       <h2>Organise your photos</h2>
       <p>With Shotwell, you can quickly and easily import, organise, edit and view your pictures. And you can share your favourite snaps on all popular photo sites and social networks.</p>
     </div>
@@ -187,16 +317,56 @@
       <p>Edit your photos or create professional illustrations and designs with tools like Gimp and Inkscape, available in the Ubuntu Software Centre.</p>
       <ul class="p-inline-list">
         <li class="p-inline-list__item">
-          <img src="https://assets.ubuntu.com/v1/833323dc-Inkscape.svg" width="36" alt="Inkscape icon" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/833323dc-Inkscape.svg",
+              alt="Inkscape icon",
+              height="36",
+              width="36",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-list__item">
-          <img src="https://assets.ubuntu.com/v1/4d47a674-gimp-60x43.svg" width="60" alt="Gimp icon" width="60" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/4d47a674-gimp-60x43.svg",
+              alt="",
+              height="36",
+              width="36",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-list__item">
-          <img src="https://assets.ubuntu.com/v1/51ebf780-lightworks.svg" width="36" alt="Lightworks icon" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/51ebf780-lightworks.svg",
+              alt="Lightworks icon",
+              height="36",
+              width="36",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-list__item">
-          <img src="https://assets.ubuntu.com/v1/786ed546-blender.svg" width="45" alt="Blender icon" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/786ed546-blender.svg",
+              alt="Blender icon",
+              height="36",
+              width="36",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
       </ul>
     </div>
@@ -210,7 +380,17 @@
       <p>Watch all your favourite content on Ubuntu with apps for playing, managing and sharing your videos. Edit your movies with PiTiVi and then watch them in Movie Player &mdash; or add VLC and OpenShot from the Ubuntu Software Centre, for compatibility with even more file formats.</p>
     </div>
     <div class="col-7 col-start-large-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/d4f0c4b1-movie.png?w=542" width="542" alt="" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d4f0c4b1-movie.png",
+          alt="",
+          height="336",
+          width="542",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /desktop/features

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load
