### PR TITLE
[Image module] /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -14,7 +14,16 @@
       <p class="p-heading--four u-sv3">Everything you love about Ubuntu, locked down for security. Helping you make safer things &ndash; because we&rsquo;re all connected.</p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg" width="400" alt="Ubuntu Core 18">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg",
+          alt="",
+          height="390",
+          width="400",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
   <style>
@@ -34,14 +43,58 @@
     <div class="row p-divider">
       <div class="col-6 p-divider__block">
         <div class="row u-equal-height u-no-margin--bottom">
-          <div class="col-3 col-small-2 col-medium-3 col-2 col-start-large-3 u-align--center"><img src="https://assets.ubuntu.com/v1/94ea495b-2018-logo-Intel.svg" alt="Intel" width="143" /></div>
-          <div class="col-3 col-small-2 col-medium-3 col-2 u-align--center"><img src="https://assets.ubuntu.com/v1/b1767848-2018-logo-raspberry-pi.svg" alt="Raspberry Pi" width="143" /></div>
+          <div class="col-3 col-small-2 col-medium-3 col-2 col-start-large-3 u-align--center">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/94ea495b-2018-logo-Intel.svg",
+                alt="Intel",
+                height="142",
+                width="143",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
+          </div>
+          <div class="col-3 col-small-2 col-medium-3 col-2 u-align--center">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/b1767848-2018-logo-raspberry-pi.svg",
+                alt="Raspberry Pi",
+                height="143",
+                width="143",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
+          </div>
         </div>
       </div>
       <div class="col-6 p-divider__block">
         <div class="row u-equal-height u-no-margin--bottom">
-          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center"><img src="https://assets.ubuntu.com/v1/0970d532-2018-logo-dell.svg" alt="Dell" width="143" /></div>
-          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center"><img src="https://assets.ubuntu.com/v1/a6d7f650-Rigado-logo.svg" alt="Rigado" width="143" /></div>
+          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/0970d532-2018-logo-dell.svg",
+                alt="Dell",
+                height="143",
+                width="143",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
+          </div>
+          <div class="p-list__item col-2 col-medium-3 col-small-2 u-vertically-center u-align--center">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/a6d7f650-Rigado-logo.svg",
+                alt="Rigado",
+                height="143",
+                width="143",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
+          </div>
         </div>
       </div>
     </div>
@@ -77,6 +130,16 @@
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       <img src="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -86,7 +149,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/9c80823b-confinement.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Strict confinement everywhere</h4>
@@ -107,7 +179,16 @@
       <p>No other embedded Linux comes close.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/ceb481d1-10+years.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ceb481d1-10+years.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -117,7 +198,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/3505cd01-GRAPHIC_os_image_size.svg" width="335" alt="Ubuntu Core: 260 MB. Red Hat coreOS: 807 MB.">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/3505cd01-GRAPHIC_os_image_size.svg",
+          alt="Ubuntu Core: 260 MB. Red Hat coreOS: 807 MB.",
+          height="195",
+          width="335",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Minimal core, minimal risk, minimal bugs</h4>
@@ -141,7 +231,16 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/7e5a3ee1-scan.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/7e5a3ee1-scan.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -163,7 +262,16 @@
       <p>As a device manufacturer or a snap publisher, you decide which updates are signed, certified and delivered to your devices.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -173,7 +281,16 @@
 
   <div class="row u-equal-height">
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/bd695c08-app+store.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>App store included</h4>
@@ -195,7 +312,16 @@
       <p>You decide when updates happen. You decide which versions, too.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/3db02edd-enterprise+management+.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/3db02edd-enterprise+management+.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -205,7 +331,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/69aaa876-compliance.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/69aaa876-compliance.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>License compliance</h4>
@@ -226,7 +361,17 @@
       <p><a class="p-button--neutral is-inline" href="https://snapcraft.io/store" style="margin-left: 0;"><span class="p-link--external">Visit the Snap Store</span></a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/26e55529-snapstore.png" width="477" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/26e55529-snapstore.png",
+          alt="",
+          height="255",
+          width="477",
+          hi_def=True,
+          loading="auto|lazy",
+          attrs={"class": "p-image--bordered"}
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -236,7 +381,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/4e20332d-mission+critical+support.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/4e20332d-mission+critical+support.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Mission critical support</h4>
@@ -276,7 +430,16 @@
       <p><a class="p-button--neutral" href="https://snapcraft.io/"><span class="p-link--external">Build your IoT application with Snapcraft</span></a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
+          alt="",
+          height="230",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -286,7 +449,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Embedded Linux is easy on Ubuntu</h4>
@@ -309,7 +481,16 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -319,7 +500,16 @@
 
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg",
+          alt="",
+          height="54",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Harness all things open source</h4>
@@ -349,7 +539,16 @@
       <p>Your power supply may not be reliable. Your devices will be. Resilience to adversity saves money and reputations. Bank on Ubuntu Core to deliver your updates safely.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/fc3ca86d-bullet+proof.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/fc3ca86d-bullet+proof.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -359,7 +558,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Backup boot paths</h4>
@@ -380,7 +588,16 @@
       <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/7de21966-snapshot.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/7de21966-snapshot.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -403,7 +620,16 @@
       <p>Shipping and updating apps adds up to a lot of traffic. Control costs with automatic compression and delta composition.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/58e11dd2-delta+updates.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/58e11dd2-delta+updates.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -413,7 +639,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/aec863e2-Off+the+shelf.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/aec863e2-Off+the+shelf.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Off-the-shelf board support by Canonical</h4>
@@ -435,7 +670,16 @@
       <p>Get the best deal when you’re ready to ship.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/47ced1e2-right+size.svg" width="350" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/47ced1e2-right+size.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -445,7 +689,16 @@
 
   <div class="row u-equal-height">
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/de23ae0e-logos.svg" width="270" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/de23ae0e-logos.svg",
+          alt="",
+          height="156",
+          width="270",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>Choice of ARM or x86</h4>
@@ -468,7 +721,17 @@
       <!-- rtp section left start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg' width="32" alt='' />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
+              alt="",
+              height="28",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+            ) | safe
+          }}
           <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>
@@ -479,7 +742,17 @@
       <!-- rtp section center start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/b061c401-White+paper.svg' width="32" alt='' />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+              alt="",
+              height="28",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+            ) | safe
+          }}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
@@ -490,7 +763,17 @@
       <!-- rtp section right start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg' width="32" alt='' />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
+              alt="",
+              height="28",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+            ) | safe
+          }}
           <h4 class='p-heading-icon__title'>Case study</h4>
         </div>
       </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -129,7 +129,6 @@
       <p>Immutable packages and persistent digital signatures mean Ubuntu Core can verify any software component at any time.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg" width="200" alt="">
       {{
         image(
           url="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg",

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -12,7 +12,16 @@
       <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Replaced images on /core and /core/thank-you with image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com/core)
- Visit /core/thank-you and see that the smile image is still there
