### PR TITLE
Add image template tag to /dell section

### DIFF
--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -23,7 +23,16 @@
         </p>
       </div>
       <div class="col-6 u-hide--small u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/82db81d1-DELL+EMC+++Ubuntu.svg" alt="" width="226" height="195">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/82db81d1-DELL+EMC+++Ubuntu.svg",
+            alt="",
+            width="226",
+            height="195",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -55,7 +64,16 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/40d4f11a-servers.svg" width="250" height="172" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/40d4f11a-servers.svg",
+          alt="",
+          width="250",
+          height="172",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -65,7 +83,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg" width="173" height="233" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg",
+          alt="",
+          width="173",
+          height="233",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h3>
@@ -143,7 +170,17 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/c00eea7b-2C-Enterprise+management.svg" width="306" height="183" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c00eea7b-2C-Enterprise+management.svg",
+          alt="",
+          width="306",
+          height="183",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": ""},
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -167,7 +204,17 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/2fc45f60-laptop.png?w=900" width="450" height="267" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/2fc45f60-laptop.png?w=900",
+          alt="",
+          width="450",
+          height="267",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": ""},
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -177,7 +224,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/0ba3e83b-machine-learning-family.png?w=345" width="345" height="288" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/0ba3e83b-machine-learning-family.png?w=345",
+          alt="",
+          width="345",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h3>
@@ -211,7 +267,17 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" class="u-hide--small" width="250" height="178" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          width="250",
+          height="178",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
     </div>
   </div>
 </section>

--- a/templates/dell/thank-you.html
+++ b/templates/dell/thank-you.html
@@ -12,7 +12,16 @@
       <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
     </div>
     <div class="col-5  u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+          alt="",
+          width="200",
+          height="200",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Added the image template tag to all images in the /dell section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/dell
- http://0.0.0.0:8001/dell/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load properly
