### PR TITLE
Add image template to desktop organisations

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -57,63 +57,153 @@
   <div class="u-fixed-width">
     <ul class="p-matrix is-trisected">
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/be731535-Logo-libreoffice.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/be731535-Logo-libreoffice.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">LibreOffice</h3>
           <p class="p-matrix__desc">The free office productivity suite that’s compatible with Microsoft Office.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Slack</h3>
           <p class="p-matrix__desc">Team communication for the 21st century.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/09b7a2e3-wavebox-logo.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/09b7a2e3-wavebox-logo.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Wavebox</h3>
           <p class="p-matrix__desc">The web communication client that brings together Gmail, Inbox, Outlook, O365, Trello and Slack.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c9be8d47-Spotify_logo_without_text.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c9be8d47-Spotify_logo_without_text.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Spotify</h3>
           <p class="p-matrix__desc">Play and stream your favorite songs and albums for free with Spotify.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/171fcf42-Chromium_11_Logo.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/171fcf42-Chromium_11_Logo.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Chromium</h3>
           <p class="p-matrix__desc">A fast, simple and secure web browser, built for the modern web.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3d6245f8-skype-icon.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3d6245f8-skype-icon.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Skype</h3>
           <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/11d81b4e-IntelliJ_IDEA_Logo.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/11d81b4e-IntelliJ_IDEA_Logo.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Intellij</h3>
           <p class="p-matrix__desc">Capable and ergonomic Integrated Development Environment for Java.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/6e5fe7ef-logo-dropbox.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/6e5fe7ef-logo-dropbox.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Dropbox</h3>
           <p class="p-matrix__desc">The world’s favourite cloud backup and file sharing service.</p>
         </div>
       </li>
       <li class="p-matrix__item">
-        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/27848067-Ora_logo.svg" width="48" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/27848067-Ora_logo.svg",
+            alt="",
+            height="48",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-matrix__img"},
+            loading="lazy",
+          ) | safe
+        }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Ora</h3>
           <p class="p-matrix__desc">Agile task management and visual team collaboration, Ora is your team’s command center.</p>
@@ -136,7 +226,17 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?w=640" width="640" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png",
+          alt="",
+          height="285",
+          width="567",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h2>Pre-installed on certified hardware</h2>
@@ -155,7 +255,17 @@
       <p><a href="/cloud">Learn more about Ubuntu’s cloud offering&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/a64aed2d-most-popular-opensource-IOS.png?w=428" width="428" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a64aed2d-most-popular-opensource-IOS.png",
+          alt="",
+          height="368",
+          width="428",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
       <p>
         <small>
           Source: Eclipse Community survey, 2014, Stackoverflow annual survey 2016<br>
@@ -174,7 +284,17 @@
       <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4125e046-landscape_activity.png?w=502" width="502" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/4125e046-landscape_activity.png",
+          alt="",
+          height="350",
+          width="502",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /desktop/organisations

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/organisations
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load