### PR TITLE
Add image_template to /containers page

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -9,24 +9,24 @@
   <div class="row">
     <div class="col-7">
       <h1>Why is Ubuntu the #1 OS for Containers?</h1>
-      <p>From Docker to Kubernetes, the experts choose Ubuntu for container operations. The single most important driver of quality, security and performance is the kernel version, and Canonical ensures that Ubuntu always has the very latest kernels with the latest security capabilities. That’s why the world’s biggest cloud operators and the world’s most sophisticated IT operations have chosen Ubuntu for containers.<p>
-        <p><a class="js-invoke-modal" href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-5 u-hide--small">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/a9aff224-Containers-illustration.svg",
-          alt="",
-          width="350",
-          height="318",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "u-float-right", "id": ""},
-          ) | safe
-        }}
-      </div>
+      <p>From Docker to Kubernetes, the experts choose Ubuntu for container operations. The single most important driver of quality, security and performance is the kernel version, and Canonical ensures that Ubuntu always has the very latest kernels with the latest security capabilities. That’s why the world’s biggest cloud operators and the world’s most sophisticated IT operations have chosen Ubuntu for containers.</p>
+      <p><a class="js-invoke-modal" href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/a9aff224-Containers-illustration.svg",
+        alt="",
+        width="350",
+        height="318",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-float-right", "id": ""},
+        ) | safe
+      }}
     </div>
   </div>
+</div>
 </div>
 
 <div class="p-strip--light">

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -93,7 +93,7 @@
         width="275",
         height="275",
         hi_def=True,
-        loading="auto",
+        loading="lazy",
         attrs={"class": "", "id": ""},
         ) | safe
       }}

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -10,10 +10,20 @@
     <div class="col-7">
       <h1>Why is Ubuntu the #1 OS for Containers?</h1>
       <p>From Docker to Kubernetes, the experts choose Ubuntu for container operations. The single most important driver of quality, security and performance is the kernel version, and Canonical ensures that Ubuntu always has the very latest kernels with the latest security capabilities. That’s why the world’s biggest cloud operators and the world’s most sophisticated IT operations have chosen Ubuntu for containers.<p>
-      <p><a class="js-invoke-modal" href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
+        <p><a class="js-invoke-modal" href="/containers/contact-us?product=containers-overview">Talk to us about your container strategy&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-hide--small">
-        <img class="u-float-right" src="https://assets.ubuntu.com/v1/a9aff224-Containers-illustration.svg" width="350" alt="" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/a9aff224-Containers-illustration.svg",
+          alt="",
+          width="350",
+          height="318",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-float-right", "id": ""},
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -22,11 +32,21 @@
 <div class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-5 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg?w=275" alt="" width="275" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg",
+        alt="",
+        width="275",
+        height="267",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "", "id": ""},
+        ) | safe
+      }}
     </div>
     <div class="col-7">
       <h2>Kubernetes &mdash; the multi-cloud operations layer for next-gen apps</h2>
-      <p class="p-heading--four">Kubernetes on Ubuntu supports VMware, Openstack, bare metal and every public cloud.</h2>
+      <p class="p-heading--four">Kubernetes on Ubuntu supports VMware, Openstack, bare metal and every public cloud.</p>
       <p>The new wave of cloud-native applications are being designed for Kubernetes operations. With high performance auto-scaling, healing, service meshes and built-in primitives for CI/CD, K8s is the most significant change in IT operations since the emergence of public cloud in 2009.</p>
       <p><a href="/kubernetes">Learn more about Kubernetes on Ubuntu&nbsp;&rsaquo;</a></p>
     </div>
@@ -66,7 +86,17 @@
 <div class="p-strip">
   <div class="row u-equal-height">
     <div class="col-5 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/9b153e96-lxd.svg" alt="" width="275px">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9b153e96-lxd.svg",
+        alt="",
+        width="275",
+        height="275",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "", "id": ""},
+        ) | safe
+      }}
     </div>
     <div class="col-7">
       <h2>VM-style containers for legacy applications with LXD</h2>
@@ -111,7 +141,7 @@
       <ul class="p-inline-list">
         <li class="p-inline-list__item"><a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Visit the Ubuntu Advantage store</span></a></li>
         <li class="p-inline-list__item">or <a href="/containers/contact-us?product=containers-overview" class="js-invoke-modal">contact us&nbsp;&rsaquo;</a></li>
-        </ul>
+      </ul>
     </div>
   </div>
 </div>

--- a/templates/containers/shared/_whitepaper.html
+++ b/templates/containers/shared/_whitepaper.html
@@ -13,7 +13,7 @@
             width="175",
             height="175",
             hi_def=True,
-            loading="auto",
+            loading="lazy",
             attrs={"class": "", "id": ""},
           ) | safe
       }}

--- a/templates/containers/shared/_whitepaper.html
+++ b/templates/containers/shared/_whitepaper.html
@@ -6,7 +6,17 @@
       <p><a class="p-button--neutral" href="https://pages.ubuntu.com/container-whitepaper.html" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Container whitepaper: {{ level_1 }} {{ level_2 }}', 'eventLabel' : 'Download the white paper', 'eventValue' : undefined });"><span class="p-link--external">Download the white paper</span></a></p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/3aa7e9a6-picto-articles-white.svg" width="175" alt="" />
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/3aa7e9a6-picto-articles-white.svg",
+            alt="",
+            width="175",
+            height="175",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "", "id": ""},
+          ) | safe
+      }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/containers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
