### PR TITLE
Add image_template to the /shared/_thank_you.html

### DIFF
--- a/templates/shared/_thank_you.html
+++ b/templates/shared/_thank_you.html
@@ -5,7 +5,16 @@
       <p class="p-heading--four">{% if thanks_message %}{{ thanks_message | safe }}{% else %}A member of our team will be in touch {{ details }}within one working day{% endif %}</p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+            alt="Smile",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+      }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/containers/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
