### PR TITLE
Add image template to desktop developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -20,6 +20,7 @@
             width="380",
             hi_def=True,
             attrs={"class": "col-6 u-vertically-center u-align--center u-hide--small"},
+            loading="auto",
           ) | safe
         }}
       </div>
@@ -42,7 +43,17 @@
   <section class="p-strip is-bordered">
     <div class="row">
       <div class="col-6">
-        <img src="https://assets.ubuntu.com/v1/a9948f53-desktop_graph.png?w=439" width="439" alt="17% use Ubuntu over 3% for Debian" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a9948f53-desktop_graph.png",
+            alt="17% use Ubuntu over 3% for Debian",
+            height="380",
+            width="439",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="lazy",
+          ) | safe
+        }}
         <p><small>Source: Eclipse Community survey, 2014, Stackoverflow annual survey 2016</small></p>
         <p><small>* This graph excludes non-Linux OSs</small></p>
       </div>
@@ -106,7 +117,17 @@
         <p><a href="https://snapcraft.io">Learn more about publishing with Snapcraft&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 u-hide--small u-align--center">
-        <img src="https://assets.ubuntu.com/v1/24b49062-LOGOS.png?w=290" width="290" alt="">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/24b49062-LOGOS.png",
+            alt="",
+            height="209",
+            width="290",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </section>
@@ -131,7 +152,17 @@
         <p><a class="p-link--external" href="https://snapcraft.io/">Find out more about snaps</a></p>
       </div>
       <div class="col-5 col-start-large-7 u-vertically-center">
-        <img class="u-hide--small" src="https://assets.ubuntu.com/v1/bb7f0c54-snaps-hero%403x.png?w=400" width="400" alt="Snap icons">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/bb7f0c54-snaps-hero%403x.png",
+            alt="",
+            height="223",
+            width="400",
+            hi_def=True,
+            attrs={"class": "u-hide--small"},
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </section>
@@ -200,7 +231,17 @@
         <p><a class="p-link--external" href="https://certification.ubuntu.com/desktop">See all Ubuntu certified PCs</a></p>
       </div>
       <div class="col-5 u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/89abf289-Dell_XPS_Laptop_Left-Developer.png?w=413" width="413" alt="Developer laptop" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/89abf289-Dell_XPS_Laptop_Left-Developer.png",
+            alt="",
+            height="256",
+            width="413",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </section>
@@ -220,7 +261,17 @@
   <section class="p-strip is-bordered">
     <div class="row u-equal-height u-vertically-center">
       <div class="col-5">
-        <img src="https://assets.ubuntu.com/v1/bda34a6e-wordpress-apache-mysql-bundle-trans.svg" width="442" height="394" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/bda34a6e-wordpress-apache-mysql-bundle-trans.svg",
+            alt="",
+            height="394",
+            width="442",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="col-6 col-start-large-7">
         <h2>Deployment made easy</h2>
@@ -239,7 +290,17 @@
         <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 col-start-large-8 u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/4125e046-landscape_activity.png?w=413" width="413" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/4125e046-landscape_activity.png",
+            alt="",
+            height="288",
+            width="413",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Add image template to /desktop/developers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/developers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load
