### PR TITLE
[Image module] /download

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -23,14 +23,34 @@
     <div class="col-12">
       <ul class="p-matrix is-trisected">
         <li class="p-matrix__item" style="border-top: none;">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/267e8693-Kubuntu_logo.svg" width="48" alt="Kubuntu icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/267e8693-Kubuntu_logo.svg",
+              alt="Kubuntu icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://www.kubuntu.org/">Kubuntu</a></h3>
             <p class="p-matrix__desc">Kubuntu offers the KDE Plasma Workspace experience, a good-looking system for home and office use.</p>
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/6ac4ba34-lubuntu-logo.svg" width="48" alt="Lubuntu icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/6ac4ba34-lubuntu-logo.svg",
+              alt="Lubuntu icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://lubuntu.me/">Lubuntu</a></h3>
             <p class="p-matrix__desc">Lubuntu is a light, fast, and modern Ubuntu flavor using LXQt as its default desktop environment. Lubuntu used to use LXDE as its default desktop environment.</p>
@@ -38,21 +58,51 @@
         </li>
 
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/49e647f4-budgie-remix-logo-medium.svg" width="48" alt="Budgie icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/49e647f4-budgie-remix-logo-medium.svg",
+              alt="Budgie icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://ubuntubudgie.org/">Ubuntu Budgie</a></h3>
             <p class="p-matrix__desc">Ubuntu Budgie provides the Budgie desktop environment which focuses on simplicity and elegance. It provides a traditional desktop metaphor based interface utilising a customisable panel based menu driven system.</p>
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/a9914e3f-ubuntu-kylin.svg" width="48" alt="Ubuntu Kylin icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/a9914e3f-ubuntu-kylin.svg",
+              alt="Kylin icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://www.ubuntukylin.com/index.php?lang=en">Ubuntu Kylin</a></h3>
             <p class="p-matrix__desc">The Ubuntu Kylin project is tuned to the needs of Chinese users, providing a thoughtful and elegant Chinese experience out-of-the-box.</p>
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b89d0c93-mate.svg" width="48" alt="Ubuntu MATE icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/b89d0c93-mate.svg",
+              alt="MATE icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://ubuntu-mate.org/">Ubuntu MATE</a></h3>
             <p class="p-matrix__desc">Ubuntu MATE expresses the simplicity of a classic desktop environment. Ubuntu MATE is the continuation of the GNOME 2 desktop  which was Ubuntu's default desktop until October 2010.</p>
@@ -60,14 +110,34 @@
         </li>
 
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/4a512076-ubuntustudio.svg" width="48" alt="Ubuntu Studio icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/4a512076-ubuntustudio.svg",
+              alt="Studio icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://ubuntustudio.org/">Ubuntu Studio</a></h3>
             <p class="p-matrix__desc">Ubuntu Studio is a multimedia content creation flavor of Ubuntu, aimed at the audio, video and graphic enthusiast or professional.</p>
           </div>
         </li>
         <li class="p-matrix__item">
-          <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/36e8f12b-Xubuntu_logo.svg" width="48" alt="Xbuntu icon">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/36e8f12b-Xubuntu_logo.svg",
+              alt="Xbuntu icon",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-matrix__img"}
+            ) | safe
+          }}
           <div class="p-matrix__content">
             <h3 class="p-matrix__title"><a class="p-link--external" href="https://xubuntu.org/">Xubuntu</a></h3>
             <p class="p-matrix__desc">Xubuntu is an elegant and easy to use operating system. Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment.</p>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -30,7 +30,16 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/f11985a2-Eoan+Ermine-gradient-outline.svg" width="250" alt="Eoan Ermine pictogram" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f11985a2-Eoan+Ermine-gradient-outline.svg",
+          alt="",
+          height="250",
+          width="250",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>

--- a/templates/download/iot/_install-snaps-strip.html
+++ b/templates/download/iot/_install-snaps-strip.html
@@ -6,7 +6,16 @@
       <p>The <a href="https://snapcraft.io/store" class="p-link--external">Snap Store</a> is where you can find the best Linux apps packaged as snaps to install on your Ubuntu device and get started with your secure IoT journey.</p>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/bd695c08-app+store.svg" alt="" width="150">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
+          alt="",
+          height="150",
+          width="150",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </section>

--- a/templates/download/raspberry-pi-compute-module-3.html
+++ b/templates/download/raspberry-pi-compute-module-3.html
@@ -90,11 +90,35 @@ sudo ./rpiboot</code></pre>
             <li>Attach the USB hub, RJ45 adaptor, keyboard and monitor (HDMI) to the board.</li>
             <li>
               <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
-              <p><img class="p-image--bordered" src="https://assets.ubuntu.com/v1/55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"></p>
+              <p>
+                {{
+                  image(
+                    url="https://assets.ubuntu.com/v1/55329e6f-CM3_J4.jpg",
+                    alt="",
+                    height="368",
+                    width="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image--bordered"}
+                  ) | safe
+                }}
+              </p>
             </li>
             <li>
               <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
-              <p><img class="p-image--bordered" src="https://assets.ubuntu.com/v1/2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"></p>
+              <p>
+                {{
+                  image(
+                    url="https://assets.ubuntu.com/v1/2073d0aa-CM3_J15.jpg",
+                    alt="",
+                    height="",
+                    width="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image--bordered"}
+                  ) | safe
+                }}
+              </p>
             </li>
             <li>With the second micro USB to USB cable, power on the IO board.</li>
           </ol>
@@ -102,7 +126,6 @@ sudo ./rpiboot</code></pre>
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-
           Flash the board from your host system
         </h3>
         <div class="p-stepped-list__content">

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -12,7 +12,17 @@
         <li>40% of consumers have never performed firmware updates on their connected devices</li>
         <li>40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
       </ul>
-      <img class="u-hide--small" src="https://assets.ubuntu.com/v1/783e1354-iot-business-model-takeover.svg" alt="" width="440" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/783e1354-iot-business-model-takeover.svg",
+          alt="",
+          height="382",
+          width="440",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "u-hide--small"}
+        ) | safe
+      }}
     </div>
 
     <div class="col-5">

--- a/templates/download/up-squared-iot-grove-server.html
+++ b/templates/download/up-squared-iot-grove-server.html
@@ -68,7 +68,16 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/0c16085c-network-equipment_2px.svg" alt="" width="150">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/0c16085c-network-equipment_2px.svg",
+          alt="",
+          height="125",
+          width="142",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-8">
       <h3>Install and develop snaps</h3>


### PR DESCRIPTION
## Done

Replaced images with the image_template module on:
- /download
- /download/flavours
- /download/raspberry-pi-2-3-core
- /download/raspberry-pi-compute-module-3

This PR covers a lot of pages, because the following ones all use one or both of the `download/shared/_get-ebook-security.html` and `download/iot/_install-snaps-strip.html` partials, which contain the only images on those pages:

- /download/intel-iei-tank-870
- /download/intel-nuc-desktop
- /download/intel-nuc
- /download/kvm
- /download/orange-pi-zero
- /download/qualcom-dragonboard-410c
- /download/up-squared-iot-grove-server

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com/ceph)
- Repeat for the other pages
