### PR TITLE
Add image_template to the /download/cloud page

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -44,7 +44,7 @@
                   width="211",
                   height="130",
                   hi_def=True,
-                  loading="auto",
+                  loading="lazy",
                   attrs={"style": "lign-self: center; max-height: 10rem;"},
                 ) | safe
             }}
@@ -68,7 +68,7 @@
                   width="160",
                   height="60",
                   hi_def=True,
-                  loading="auto",
+                  loading="lazy",
                   attrs={"style": "align-self: center;max-height: 10rem; max-width:10rem;"},
                 ) | safe
             }}
@@ -92,7 +92,7 @@
                   width="184",
                   height="53",
                   hi_def=True,
-                  loading="auto",
+                  loading="lazy",
                   attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
                 ) | safe
             }}
@@ -118,7 +118,7 @@
                  width="192",
                  height="45",
                  hi_def=True,
-                 loading="auto",
+                 loading="lazy",
                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
                ) | safe
             }}
@@ -140,7 +140,7 @@
                   width="192",
                   height="56",
                   hi_def=True,
-                  loading="auto",
+                  loading="lazy",
                   attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
                 ) | safe
             }}
@@ -162,7 +162,7 @@
                   width="192",
                   height="27",
                   hi_def=True,
-                  loading="auto",
+                  loading="lazy",
                   attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
                 ) | safe
             }}
@@ -186,7 +186,7 @@
             width="600",
             height="307",
             hi_def=True,
-            loading="auto",
+            loading="lazy",
           ) | safe
       }}
     </div>

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -37,7 +37,17 @@
       <div class="p-card__content">
         <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-            <img src="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=211" width="211" alt="Google Cloud Platform" style="align-self: center;max-height: 10rem;">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=211",
+                  alt="Google Cloud Platform",
+                  width="211",
+                  height="130",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"style": "lign-self: center; max-height: 10rem;"},
+                ) | safe
+            }}
           </a>
         </h4>
         <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
@@ -51,7 +61,17 @@
       <div class="p-card__content">
         <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="http://cloud-images.ubuntu.com/locator/ec2/">
-            <img src="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg" width="160" alt="Amazon Web Services" style="align-self: center;max-height: 10rem; max-width:10rem;">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg",
+                  alt="Amazon Web Services",
+                  width="160",
+                  height="60",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"style": "align-self: center;max-height: 10rem; max-width:10rem;"},
+                ) | safe
+            }}
           </a>
         </h4>
         <p>Amazon Web Services offers reliable, scalable, and inexpensive cloud computing services.</p>
@@ -65,7 +85,17 @@
       <div class="p-card__content">
         <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer">
-            <img src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="184" alt="Microsoft Azure" style="align-self: center;max-height: 10rem; max-width:12rem;">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg",
+                  alt="Microsoft Azure",
+                  width="184",
+                  height="53",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
+                ) | safe
+            }}
           </a>
         </h4>
         <p>Microsoft Azure is an open, flexible, enterprise-grade cloud computing platform.</p>
@@ -81,7 +111,17 @@
       <div class="p-card__content">
         <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.ibm.com/cloud/">
-            <img src="https://assets.ubuntu.com/v1/5e91ff73-ibm-cloud-logo.svg" width="192" alt="IBM Cloud" style="align-self: center;max-height: 10rem; max-width:12rem;">
+            {{
+             image(
+                 url="https://assets.ubuntu.com/v1/5e91ff73-ibm-cloud-logo.svg",
+                 alt="IBM Cloud",
+                 width="192",
+                 height="45",
+                 hi_def=True,
+                 loading="auto",
+                 attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
+               ) | safe
+            }}
           </a>
         </h4>
       </div>
@@ -93,7 +133,17 @@
       <div class="p-card__content">
         <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.rackspace.com/managed-hosting">
-            <img src="https://assets.ubuntu.com/v1/ff936628-rackspace.svg" width="192" alt="Rackspace" style="align-self: center;max-height: 10rem; max-width:12rem;">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/ff936628-rackspace.svg",
+                  alt="Rackspace",
+                  width="192",
+                  height="56",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
+                ) | safe
+            }}
           </a>
         </h4>
       </div>
@@ -105,7 +155,17 @@
       <div class="p-card__content">
         <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://docs.oracle.com/en/cloud/get-started/index.html">
-            <img src="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg" width="192" alt="Oracle" style="align-self: center;max-height: 10rem; max-width:12rem;">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg",
+                  alt="Oracle",
+                  width="192",
+                  height="27",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
+                ) | safe
+            }}
           </a>
         </h4>
       </div>
@@ -119,7 +179,16 @@
 <section class="p-strip--light is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-6 u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/2e62cdb4-desktop-developer-hero.png?w=600" width="600" alt="Ubuntu cloud">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/2e62cdb4-desktop-developer-hero.png?w=600",
+            alt="Ubuntu cloud",
+            width="600",
+            height="307",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+      }}
     </div>
     <div class="col-6">
       <h2>Develop with Ubuntu cloud images</h2>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
