### PR TITLE
Add image template to desktop partners

### DIFF
--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -15,13 +15,43 @@
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       <ul class="p-inline-images">
         <li class="p-inline-images__item u-no-margin--right">
-          <img src="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg" alt="" class="p-inline-images__logo" width="150">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
+              alt="",
+              height="31",
+              width="162",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="auto",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item u-no-margin--right">
-          <img src="https://assets.ubuntu.com/v1/5e92614c-amd-logo.svg" width="95" alt="" class="p-inline-images__logo">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5e92614c-amd-logo.svg",
+              alt="",
+              height="22",
+              width="95",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="auto",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item u-no-margin--right">
-          <img src="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg" alt="" class="p-inline-images__logo" width="100">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
+              alt="",
+              height="99",
+              width="99",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="auto",
+            ) | safe
+          }}
         </li>
       </ul>
     </div>
@@ -87,7 +117,17 @@
       <p><a class="p-link--external" href="https://certification.ubuntu.com/certification/">Learn more about Ubuntu Certified hardware</a></p>
     </div>
     <div class="col-6 u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/d9105909-Dell_XPS_Laptop_Left-Desktop.png?w=502" width="502" alt="Photo of laptop running Ubuntu" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d9105909-Dell_XPS_Laptop_Left-Desktop.png",
+          alt="Photo of a laptop running Ubuntu",
+          height="311",
+          width="502",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /desktop/partners

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/partners
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the image loads
