### PR TITLE
Add image_template to /download/desktop

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -68,7 +68,17 @@
     <div class="col-4 p-card">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/cb3ecebb-picto-ubuntu.svg" width="60" alt="" />
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/cb3ecebb-picto-ubuntu.svg",
+                alt="",
+                width="60",
+                height="60",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img"},
+              ) | safe
+          }}
           <h3 class="p-heading-icon__title">From an older version</h3>
         </div>
       </div>
@@ -82,7 +92,17 @@
     <div class="col-4 p-card">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/08563efa-picto-windows.svg" width="60"  alt="" />
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/08563efa-picto-windows.svg",
+                alt="",
+                width="60",
+                height="60",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img"},
+                ) | safe
+          }}
           <h3 class="p-heading-icon__title">From Windows</h3>
         </div>
       </div>
@@ -96,7 +116,17 @@
     <div class="col-4 p-card">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/4239507e-picto-mac.svg" width="60"  alt="" />
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/4239507e-picto-mac.svg",
+                alt="",
+                width="60",
+                height="60",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img"},
+              ) | safe
+          }}
           <h3 class="p-heading-icon__title">From macOS</h3>
         </div>
       </div>

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -17,7 +17,16 @@
       </p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/4e0ff71e-Multipass+logo_thin_rgb.svg" alt="" width="320">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/4e0ff71e-Multipass+logo_thin_rgb.svg",
+            alt="",
+            width="320",
+            height="61",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
