### PR TITLE
Add image template to desktop statistics

### DIFF
--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -349,7 +349,17 @@ Ubuntu 18.04 LTS.{% endblock %}
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
-      <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/f3f53a95-ubuntu-18.04-survey-metrics.png?w=411" width="411" alt="User survey report">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f3f53a95-ubuntu-18.04-survey-metrics.png",
+          alt="User survey report",
+          height="251",
+          width="411",
+          hi_def=True,
+          attrs={"class": "p-image--bordered"},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h3>Want to know more?</h3>


### PR DESCRIPTION
## Done

Add image template to /desktop/statistics

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/statistics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load