### PR TITLE
[Image module] /download/raspberry-pi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -16,7 +16,16 @@
       <p>Running Ubuntu Server on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your pi and away you go.</p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg" width="100" alt="Raspberry Pi">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
+          alt="",
+          height="123",
+          width="100",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -27,15 +36,48 @@
       <h2 class="u-no-margin--bottom">Download your Ubuntu Pi image</h2>
     </div>
     <div class="col-3">
-      <div><img src="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png" alt="A photo the the Raspberry Pi 2"></div>
+      <div>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png",
+            alt="",
+            height="156",
+            width="236",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
+      </div>
       <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 2</h3>
     </div>
     <div class="col-3">
-      <div><img src="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png" alt="A photo the the Raspberry Pi 3"></div>
+      <div>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
+            alt="",
+            height="151",
+            width="236",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
+      </div>
       <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 3</h3>
     </div>
     <div class="col-3">
-      <div><img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png" alt="A photo the the Raspberry Pi 4"></div>
+      <div>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+            alt="",
+            height="151",
+            width="236",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
+      </div>
       <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 4</h3>
     </div>
   </div>
@@ -52,34 +94,35 @@
       <p class="u-hide--small u-sv2">&nbsp;</p>
       <p>
         <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=armhf+raspi2" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-        Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
-      </a>
-    </p>
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-3">
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
+        </a>
+      </p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-3">
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
+        </a>
+      </p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
+        </a>
+      </p>
+    </div>
   </div>
-  <div class="col-3">
-    <p>
-      <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-      Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
-    </a>
-  </p>
-  <p>
-    <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-    Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span></a>
-  </p>
-</div>
-<div class="col-3">
-  <p>
-    <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-    Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
-  </a>
-</p>
-<p>
-  <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-  Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
-</a>
-</p>
-</div>
-</div>
 </section>
 
 {# latest row #}
@@ -93,35 +136,35 @@
       <p class="u-hide--small u-sv2">&nbsp;</p>
       <p>
         <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-        Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
-      </a>
-    </p>
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-3">
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
+        </a>
+      </p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-3">
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
+        </a>
+      </p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
+        </a>
+      </p>
+    </div>
   </div>
-  <div class="col-3">
-    <p>
-      <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-      Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
-    </a>
-  </p>
-  <p>
-    <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-    Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
-  </a>
-</p>
-</div>
-<div class="col-3">
-  <p>
-    <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-      Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
-    </a>
-  </p>
-  <p>
-    <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-      Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
-    </a>
-  </p>
-</div>
-</div>
 </section>
 
 <section class="p-strip">

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -31,7 +31,16 @@
       {% endif %}
     </div>
     <div class="col-5 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg" alt="" width="350">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg",
+          alt="",
+          height="227",
+          width="350",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -90,7 +99,16 @@
       <p>Here are a few things you can do now that you have your Raspberry Pi running Ubuntu.</p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/a46ea917-3+-+Leverage+snaps+to+build+a+lean+custom+production+image.svg" alt="" width="350">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a46ea917-3+-+Leverage+snaps+to+build+a+lean+custom+production+image.svg",
+          alt="",
+          height="227",
+          width="350",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Replaced images with the image_template module on:
- /download/raspberry-pi
- /download/raspberry-pi/thank-you

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com/download/raspberry-pi)
- Repeat for /download/raspberry-pi/thank-you
