### PR TITLE
Add image template to IoT digital signage

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -21,7 +21,17 @@
         </div>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/2c3ad93c-digital-signage-2.png"/>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/2c3ad93c-digital-signage-2.png",
+            alt="",
+            height="295",
+            width="466",
+            hi_def=True,
+            attrs={"class": ""},
+            loading="auto",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -149,7 +159,19 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.screenly.io/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/5917a214-logo-screenly.png?h=65" height="65" alt="Screenly" /></a>
+        <a href="https://www.screenly.io/">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5917a214-logo-screenly.png",
+              alt="Screenly",
+              height="65",
+              width="133",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Screenly</h3>
@@ -158,7 +180,19 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.4yousee.com.br/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/391ea778-logo-4yousee.png?h=65" height="65" alt="4YouSee" /></a>
+        <a href="https://www.4yousee.com.br/">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/391ea778-logo-4yousee.png",
+              alt="4YouSee",
+              height="65",
+              width="238",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">4YouSee</h3>
@@ -168,7 +202,19 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg" height="65" alt="Intel® NUC" /></a>
+        <a href="https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
+              alt="Intel® NUC",
+              height="65",
+              width="98",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Intel<sup>®</sup> NUC</h3>
@@ -176,7 +222,19 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="https://www.risevision.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/f2396b21-logo-risevision.png?h=65" height="65" alt="Rise Vision" /></a>
+        <a href="https://www.risevision.com/">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/f2396b21-logo-risevision.png",
+              alt="Rise Vision",
+              height="65",
+              width="171",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Rise Vision</h3>
@@ -195,7 +253,19 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="http://www.boldmind.co.uk/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/d4e5daf4-logo-boldmind.png?h=65" height="65" alt="Boldmind" /></a>
+        <a href="http://www.boldmind.co.uk/">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/d4e5daf4-logo-boldmind.png",
+              alt="Boldmind",
+              height="65",
+              width="108",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Boldmind</h3>
@@ -204,7 +274,19 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="http://www.limemicro.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/5e68dad7-logo-lime-microsystems.png?h=65" height="65" alt="Lime Micro" /></a>
+        <a href="http://www.limemicro.com/">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5e68dad7-logo-lime-microsystems.png",
+              alt="Lime Micro",
+              height="65",
+              width="154",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Lime Micro</h3>
@@ -215,7 +297,19 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">
-        <a href="http://www.hoxtonanalytics.com/"><img style="max-height: 65px; height: 65px;" src="https://assets.ubuntu.com/v1/d4ae60aa-logo-hoxton-analytics.svg" height="65" alt="Hoxton Analytics" /></a>
+        <a href="http://www.hoxtonanalytics.com/">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/d4ae60aa-logo-hoxton-analytics.svg",
+              alt="Hoxton Analytics",
+              height="65",
+              width="148",
+              hi_def=True,
+              attrs={"class": ""},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Hoxton Analytics</h3>


### PR DESCRIPTION
## Done

Add image template to /internet-of-things/digital-signage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/digital-signage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load