### PR TITLE
Add image_template to /download/server/provisioning

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -92,7 +92,19 @@
             <li>Ubuntu images</li>
             <li><abbr title="Secure shell">SSH</abbr> keys (for currently logged in user)</li>
           </ul>
-          <p><a href="https://assets.ubuntu.com/v1/e0915052-initial_setup.png" title="Initial screen of the first use journey"><img class="p-image--bordered" src="https://assets.ubuntu.com/v1/e0915052-initial_setup.png?w=504" alt="First user journey screenshot" width="504" height="316"></a></p>
+          <p><a href="https://assets.ubuntu.com/v1/e0915052-initial_setup.png" title="Initial screen of the first use journey">
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/e0915052-initial_setup.png?w=504",
+                alt="First user journey screenshot",
+                width="504",
+                height="316",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-image--bordered  image--shadow"},
+              ) | safe
+          }}
+        </a></p>
         </div>
       </li>
       <li class="p-stepped-list__item">
@@ -108,7 +120,17 @@
             <li>Fill in the details for the dynamic range.</li>
           </ol>
           <p><a href="https://assets.ubuntu.com/v1/65c03778-provide_DHCP.png" title="VLAN details page in an active MAAS">
-            <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/65c03778-provide_DHCP.png?w=504" class="image--shadow" alt="VLAN details" width="504" height="316">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/65c03778-provide_DHCP.png?w=504",
+                  alt="VLAN details",
+                  width="504",
+                  height="316",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"class": "p-image--bordered image--shadow"},
+                ) | safe
+            }}
           </a></p>
         </div>
       </li>
@@ -127,7 +149,17 @@
             <li>When machines have a &ldquo;Ready&rdquo; status you can start deploying</li>
           </ol>
           <p><a href="https://assets.ubuntu.com/v1/94f90490-machine_listing.png" title="The node listing page in MAAS">
-            <img src="https://assets.ubuntu.com/v1/94f90490-machine_listing.png?w=504" class="p-image--bordered" alt="MAAS node listing" width="504" height="316">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/94f90490-machine_listing.png?w=504",
+                  alt="MAAS node listing",
+                  width="504",
+                  height="316",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-image--bordered  image--shadow"},
+                ) | safe
+            }}
           </a></p>
           <p><a class="p-link--external" href="https://docs.ubuntu.com/maas/2.3/en/">Refer to the user manual to get a more detailed guide in how to get up and running with MAAS</a></p>
         </div>

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -127,7 +127,7 @@
                   width="504",
                   height="316",
                   hi_def=True,
-                  loading="auto",
+                  loading="lazy",
                   attrs={"class": "p-image--bordered image--shadow"},
                 ) | safe
             }}

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -6,7 +6,18 @@
   </div>
   <div class="row">
     <div class="col-7">
-      <p class="u-hide--small"><img src="https://assets.ubuntu.com/v1/a3b75778-MAAS-ebook-web.svg" alt="" width="400px"></p>
+      <p class="u-hide--small">
+        {{
+          image(
+              url="https://assets.ubuntu.com/v1/a3b75778-MAAS-ebook-web.svg",
+              alt="",
+              width="400",
+              height="279",
+              hi_def=True,
+              loading="auto",
+            ) | safe
+        }}
+      </p>
       <h3>
         Server provisioning: what Network Admins and IT pros need to know
       </h3>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -14,7 +14,7 @@
               width="400",
               height="279",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
             ) | safe
         }}
       </p>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/provisioning
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
