### PR TITLE
Add image_template to /download/server/thank-you-s390x

### DIFF
--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -30,7 +30,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="" />
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+                alt="",
+                width="32",
+                height="28",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+          }}
           <h4 class="p-heading-icon__title">eBook</h4>
         </div>
       </div>
@@ -40,7 +50,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="" />
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+                alt="",
+                width="32",
+                height="28",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+          }}
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>
@@ -50,7 +70,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="" />
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+                alt="",
+                width="32",
+                height="28",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+          }}
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/thank-you-s390x
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
