### PR TITLE
Add image template to iot gateways

### DIFF
--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -289,7 +289,17 @@
       <a class="p-link--external" href="https://snapcraft.io/aws-iot-greengrass">AWS Greengrass in the Snap store</a>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://dashboard.snapcraft.io/site_media/appmedia/2019/04/product-icon_AWS-Greengrass_icon_squid_ink_125.png?w=120" width="120" alt="">
+      {{
+        image(
+          url="https://dashboard.snapcraft.io/site_media/appmedia/2019/04/product-icon_AWS-Greengrass_icon_squid_ink_125.png",
+          alt="",
+          height="120",
+          width="120",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -299,7 +309,17 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/07/icon_8BAXEYq.png?w=120" width="120" alt="">
+      {{
+        image(
+          url="https://dashboard.snapcraft.io/site_media/appmedia/2018/07/icon_8BAXEYq.png",
+          alt="",
+          height="120",
+          width="120",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <p class="p-heading--three">Eclipse Kura</p>
@@ -319,7 +339,17 @@
       <a class="p-link--external" href="https://snapcraft.io/edgexfoundry">EdgeX in the Snap store</a>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_Hx6IyH0.png?w=120" width="120" alt="">
+      {{
+        image(
+          url="https://dashboard.snapcraft.io/site_media/appmedia/2018/12/icon_Hx6IyH0.png",
+          alt="",
+          height="120",
+          width="120",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -329,7 +359,17 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://dashboard.snapcraft.io/site_media/appmedia/2017/03/thinger_256.png?w=120" width="120" alt="">
+      {{
+        image(
+          url="https://dashboard.snapcraft.io/site_media/appmedia/2017/03/thinger_256.png",
+          alt="",
+          height="120",
+          width="120",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <p class="p-heading--three">Thinger.io</p>


### PR DESCRIPTION
## Done

Add image template to /internet-of-things/gateways

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/gateways
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load