### PR TITLE
Update engage template to use image_template

### DIFF
--- a/templates/_docs/engage_pages.html
+++ b/templates/_docs/engage_pages.html
@@ -33,7 +33,17 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+            alt="",
+            width="250",
+            height="160",
+            hi_def=True,
+            loading="auto",
+            attrs={"style": "max-height: 410px; max-width: 250px;"},
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -67,6 +77,8 @@ context:
      header_title: "From VMware to Charmed&nbsp;OpenStack"
      header_subtitle:
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_image_width="250"
+     header_image_height="160"
      header_url: '#register-section'
      header_cta: Register for the webinar
      header_class: p-engage-banner--dark
@@ -100,6 +112,8 @@ This is some more text.
         <li class="p-list__item"><strong>header_title</strong> - text for the &lt;h1> of the pages</li>
         <li class="p-list__item"><strong>header_subtitle</strong> - <em>optional</em> - text for the &lt;h4> subtitle</li>
         <li class="p-list__item"><strong>header_image:</strong> - <em>optional</em> - url of the image to be on the right of the banner</li>
+        <li class="p-list__item"><strong>header_image_width</strong> - <em>required</em> the width of the header image in pixels</li>
+        <li class="p-list__item"><strong>  header_image_height</strong> <em>required</em> - the height of the header image in pixels</li>
         <li class="p-list__item"><strong>header_url</strong> - the url or anchor for the mobile view CTA - usually '#register-section'</li>
         <li class="p-list__item"><strong>header_cta</strong> - text for the mobile view CTA - usually 'Register for the webinar' or 'Download the whitepaper'</li>
         <li class="p-list__item"><strong>header_class</strong> - the class of the engage banner you want to use - usually one of: p-engage-banner--dark, p-engage-banner--grad, p-engage-banner--k8s, p-engage-banner--openstack, p-engage-banner--aqua, p-engage-banner--snapcraft</li>

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -21,12 +21,34 @@
 <section {% if header_lang %}lang="{{ header_lang }}"{% endif %} class="{% if header_class %}p-strip {{ header_class }}{% else %}p-strip--light{% endif %}">
   {% if header_class %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
+    <a href="/">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            alt="Ubuntu",
+            width="143",
+            height="32",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </a>
   </div>
   {% else %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
-  </div>
+    <a href="/">
+    {{
+      image(
+          url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
+          alt="Ubuntu",
+          width="143",
+          height="32",
+          hi_def=True,
+          loading="auto",
+      ) | safe
+    }}
+    </a>
+</div>
   {% endif %}
   <div class="row u-equal-height">
     <div class="{% if header_image %}col-7 {% else %}col-8{% endif %} u-vertically-center">
@@ -52,7 +74,21 @@
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if "http" not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="{% if header_image_width %}{{ header_image_width }}{% else %}413{% endif %}" style="max-height: 410px; max-width: 250px;" alt="" >
+      {% if header_image_width %}
+      {{
+        image(
+            url=header_image,
+            alt="",
+            width=header_image_width,
+            height=header_image_height,
+            hi_def=True,
+            loading="auto",
+            attrs={"style": "max-height: 410px; max-width: 250px;"},
+        ) | safe
+      }}
+      {% else %}
+        <img src="{{ header_image }}" alt="" style="max-height: 410px; max-width: 250px;" width="413">
+      {% endif %}
     </div>{% endif %}
   </div>
 </section>
@@ -62,7 +98,7 @@
     <div class="{% if form_id %}col-7{% else %}col-8{% endif %}">
       {{ content | safe }}
     </div>
-    {% if form_id %}      
+    {% if form_id %}
     <div class="col-5" id="register-section">
       {% if form_include %}
         {% set form = "engage/shared/_" + form_include + "_engage_form.html" %}

--- a/templates/engage/anbox-cloud-gaming-whitepaper.md
+++ b/templates/engage/anbox-cloud-gaming-whitepaper.md
@@ -8,6 +8,8 @@ context:
      header_title: "Cloud gaming for Android"
      header_subtitle: "Building a high performing and scalable platform"
      header_image: "https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg"
+     header_image_width: "250"
+     header_image_height: "182"
      header_url: '#register-section'
      header_cta: Download whitepaper
      header_cta_class: p-button--positive

--- a/templates/engage/de/migration-von-vmware-zu-openstack.md
+++ b/templates/engage/de/migration-von-vmware-zu-openstack.md
@@ -8,6 +8,8 @@ context:
      header_title: "Migration von VMware zu OpenStack"
      header_subtitle: "Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann"
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_image_width: "250"
+     header_image_height: "160"
      header_url:
      header_cta:
      header_class: p-engage-banner--dark
@@ -20,7 +22,7 @@ context:
 ---
 
 Aufgrund der Kosten für Lizenzen, Support und Beratung von VMware erreichen viele nicht ihr primäres Ziel - deutlich reduzierte Gesamtkosten. Auf der Suche nach Alternativen betrachten deshalb immer mehr Unternehmen andere Plattformen wie OpenStack genauer.
- 
+
 Dieses White Paper und Webinar:
 
 <ul class="p-list">

--- a/templates/engage/dell-kubernetes-webinar.md
+++ b/templates/engage/dell-kubernetes-webinar.md
@@ -9,6 +9,7 @@ context:
      header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg"
      header_image_width: "200"
+     header_image_height: "195"
      header_url: '#register-section'
      header_cta: Watch the webinar
      header_class: p-engage-banner--k8s

--- a/templates/engage/es/vmware-a-charmed-openstack.md
+++ b/templates/engage/es/vmware-a-charmed-openstack.md
@@ -8,6 +8,8 @@ context:
      header_title: "De VMware a Charmed OpenStack"
      header_subtitle: "Cómo la migración a Charmed OpenStack puede reducir significativamente el TCO"
      header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_image_width: "250"
+     header_image_height: "160"
      header_url:
      header_cta:
      header_class: p-engage-banner--dark
@@ -20,7 +22,7 @@ context:
 ---
 
 Debido a los costes asociados a las licencias, el soporte y los servicios profesionales de VMware, muchos no pueden cumplir su objetivo principal: reducir significativamente el TCO. En busca de soluciones alternativas, las organizaciones han empezado recientemente a explorar otras plataformas de código abierto como OpenStack.
- 
+
 Este documento y webinar:
 
 <ul class="p-list">

--- a/templates/engage/microk8s-451research.md
+++ b/templates/engage/microk8s-451research.md
@@ -8,8 +8,10 @@ context:
      header_title: "Kubernetes: a secure, flexible and automated edge for IoT developers"
      header_subtitle: "The factors for implementing Kubernetes successfully at the edge"
      header_image: https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg
+     header_image_width: "250"
+     header_image_height: "93"
      header_url: '#register-section'
-     header_cta: Download the report by 451 Research 
+     header_cta: Download the report by 451 Research
      header_class: p-engage-banner--grad
      header_lang: en
      form_include: en


### PR DESCRIPTION
## Done

- Replaced images with the image_template module
- Added `heaeder_image_width` and `header_image_height` to the yaml
- Updated the [docs](http://0.0.0.0:8001/_docs/engage_pages)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Try the engage pages from the homepage and see they are using the image template (inspect them)
- Try an older engage page from /engage and see that this work the old way
