### PR TITLE
Add image template to embedded

### DIFF
--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -18,7 +18,17 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--right">
-      <img src="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="auto",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -42,7 +52,17 @@
 <section class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-5 u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/fad662b3-faster+cheaper.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/fad662b3-faster+cheaper.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-7">
       <h2>Faster, cheaper, better. Pick any 3.</h2>
@@ -109,7 +129,17 @@
       <!-- rtp section left start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/b061c401-White+paper.svg' width="32" alt='' />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+              alt="",
+              height="32",
+              width="36",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy",
+            ) | safe
+          }}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
@@ -120,7 +150,17 @@
       <!-- rtp section center start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/6e184942-Webinar.svg' width="32" alt='' />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+              alt="",
+              height="32",
+              width="36",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy",
+            ) | safe
+          }}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
@@ -131,7 +171,17 @@
       <!-- rtp section right start -->
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
-          <img class='p-heading-icon__img p-heading-icon__img--small' src='https://assets.ubuntu.com/v1/b061c401-White+paper.svg' width="32" alt='' />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+              alt="",
+              height="32",
+              width="36",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy",
+            ) | safe
+          }}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
@@ -148,7 +198,17 @@
       <p class="p-heading--four">Give them the platform they love.</p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/f7c1457a-drive+success.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f7c1457a-drive+success.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -207,7 +267,17 @@
       <p>The new Ubuntu Core is an appliance platform with immutable packages.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/759b19ec-server+or+core.svg" alt="" width="350px" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/759b19ec-server+or+core.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
   <div class="row p-divider" style="margin-top: 3rem;">
@@ -236,7 +306,17 @@
       <p>Any compromise of your device puts your reputation on the line.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/aa1dc625-10+Year+shield+trio_AW.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/aa1dc625-10+Year+shield+trio_AW.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -291,7 +371,17 @@
       <p>Automatic tracking of Ubuntu component licenses and monitoring for  your packages help you and your customers meet obligations.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/c7274075-compliance.svg" alt="" width="350px" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c7274075-compliance.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -326,7 +416,17 @@
       <p class="p-heading--four">Develop, deploy, iterate and improve. With Ubuntu and snapcraft, your embedded app teams run at cloud speeds.</p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/22f88d02-apps.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/22f88d02-apps.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -361,7 +461,17 @@
       <p><a href="https://snapcraft.io/build" class="p-link--external p-button--positive">Build a snap</a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/22007291-DevOps.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/22007291-DevOps.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -377,14 +487,34 @@
 
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/944b8760-snapcraft-logo-bird.svg" alt="" style="max-height: 4rem;">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/944b8760-snapcraft-logo-bird.svg",
+          alt="",
+          height="72",
+          width="75",
+          hi_def=True,
+          attrs={"class": "p-card__thumbnail"},
+          loading="lazy",
+        ) | safe
+      }}
       <hr class="u-sv1">
       <h3 class="p-card__title">Snaps</h3>
       <p class="p-card__content">App containers with transactional updates for system software.</p>
       <p><a class="p-link--external" href="https://snapcraft.io/first-snap">Build a snap</a></p>
     </div>
     <div class="col-6 p-card">
-      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/66b7000f-logo-docker.png" alt="" style="max-height: 4rem;">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/66b7000f-logo-docker.png",
+          alt="",
+          height="72",
+          width="105",
+          hi_def=True,
+          attrs={"class": "p-card__thumbnail"},
+          loading="lazy",
+        ) | safe
+      }}
       <hr class="u-sv1">
       <h4>Docker</h4>
       <p>Bring your cloud containers and CI/CD tooling to the edge.</p>
@@ -403,14 +533,34 @@
 
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="" style="max-height: 4rem;">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg",
+          alt="",
+          height="72",
+          width="74",
+          hi_def=True,
+          attrs={"class": "p-card__thumbnail"},
+          loading="lazy",
+        ) | safe
+      }}
       <hr class="u-sv1">
       <h4>Kubernetes</h4>
       <p>Enable microk8s for secure container orchestration.</p>
       <p><a class="p-link--external" href="https://microk8s.io/">Explore microk8s</a></p>
     </div>
     <div class="col-6 p-card">
-      <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d85ef015-image-lxd.svg" alt="" style="max-height: 4rem;">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d85ef015-image-lxd.svg",
+          alt="",
+          height="72",
+          width="78",
+          hi_def=True,
+          attrs={"class": "p-card__thumbnail"},
+          loading="lazy",
+        ) | safe
+      }}
       <hr class="u-sv1">
       <h4>LXD</h4>
       <p>Machine containers create full independent OS workspaces.</p>
@@ -427,7 +577,17 @@
       <h3>Ultra-reliable updates</h3>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/c711b814-reliable_updates.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c711b814-reliable_updates.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -481,7 +641,17 @@
       <p class="p-heading--four u-no-max-width">We certify the major platforms so you are ready to roll.<br />Fixed-price enablement and certification of related boards.</p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg" alt="" width="350px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -520,7 +690,17 @@
       <p>Have a custom board? Let us deliver a standard Linux for your developers.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/642b4ee3-unleash_hardware.svg" alt="" width="350px" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/642b4ee3-unleash_hardware.svg",
+          alt="",
+          height="200",
+          width="350",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -574,7 +754,17 @@
       <p class="p-heading--four">Long term support, defined and delivered. We’ll get you from POC to MVP and shipping in record time.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" width="150" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg",
+          alt="",
+          height="150",
+          width="150",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /embedded

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/embedded
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load