### PR TITLE
Add image template tag to support pages

### DIFF
--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -12,7 +12,17 @@
       <p>You can find support from a variety of sources. Take a look &ndash; you&rsquo;re likely to find an answer to every question. If you can&rsquo;t find an answer, just ask the people in our active forums.</p>
     </div>
     <div class="col-4 col-start-large-9 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/5552afb7-community-support.svg" width="200" alt="Community">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+            alt="Community",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "", "id": ""},
+        ) | safe
+      }}
     </div>
   </div>
 </div>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -137,7 +137,17 @@
         <p><a href="/esm">Learn more about ESM&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 u-vertically-center u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg" width="150" alt="" />
+        {{
+          image(
+              url="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg",
+              alt="",
+              width="150",
+              height="150",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "", "id": ""},
+          ) | safe
+        }}
       </div>
     </section>
 
@@ -172,31 +182,121 @@
         <h2 class="p-muted-heading u-align--center">A selection of Ubuntu Advantage customers</h2>
         <ul class="p-inline-images">
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1a062141-logo-bloomberg.svg" width="187" alt="Bloomberg">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/1a062141-logo-bloomberg.svg",
+                  alt="Bloomberg",
+                  width="187",
+                  height="28",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&amp;T">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
+                  alt="AT&amp;T",
+                  width="145",
+                  height="145",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/3161e6ba-logo-walmart.svg" width="210" alt="Walmart">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/3161e6ba-logo-walmart.svg",
+                  alt="Walmart",
+                  width="210",
+                  height="34",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg" width="242" alt="Deutsche Telekom">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
+                  alt="Deutsche Telekom",
+                  width="242",
+                  height="32",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg" width="170" alt="Ebay">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg",
+                  alt="Ebay",
+                  width="170",
+                  height="55",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg" width="156" alt="Cisco">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg",
+                  alt="Cisco",
+                  width="156",
+                  height="76",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ddb0f9d6-logo-ntt.svg" width="71" alt="NTT">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/ddb0f9d6-logo-ntt.svg",
+                  alt="NTT",
+                  width="88",
+                  height="66",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg" width="144" alt="Best Buy">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg",
+                  alt="Best Buy",
+                  width="144",
+                  height="86",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" width="166" alt="Paypal">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
+                  alt="Paypal",
+                  width="166",
+                  height="36",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "p-inline-images__logo", "id": ""},
+              ) | safe
+            }}
           </li>
         </ul>
       </div>
@@ -211,7 +311,17 @@
           <p><a href="/support/community-support">Learn more about community support&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-4 u-hide--small u-align--center u-vertically-center">
-          <img src="https://assets.ubuntu.com/v1/5552afb7-community-support.svg" width="150" alt="Community">
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+                alt="Community",
+                width="150",
+                height="150",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "", "id": ""},
+            ) | safe
+          }}
         </div>
       </div>
     </section>

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -14,7 +14,17 @@
       <p class="p-heading--four">A member of our team will be in touch within one working day or you can <a class="p-link--external" href="https://buy.ubuntu.com">visit our store</a> to purchase UA Infrastructure.</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+            alt="smile",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "", "id": ""},
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Added image template tag to support

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- http://0.0.0.0:8001/support
- http://0.0.0.0:8001/support/community-support
- http://0.0.0.0:8001/support/thank-you
