### PR TITLE
[Image module] /robotics

### DIFF
--- a/templates/robotics.html
+++ b/templates/robotics.html
@@ -242,21 +242,51 @@
       <h3>Raspberry Pi</h3>
       <hr class="u-sv1" />
       <div class="p-card__content">
-        <img src="https://assets.ubuntu.com/v1/37373e4d-raspberry-pi.png" alt="" style="padding-top: 1rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/37373e4d-raspberry-pi.png",
+            alt="",
+            height="202",
+            width="293",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "padding-top: 1rem;"}
+          ) | safe
+        }}
       </div>
     </div>
     <div class="p-card col-4">
       <h3>NVIDIA Jetson</h3>
       <hr class="u-sv1" />
       <div class="p-card__content">
-        <img src="https://assets.ubuntu.com/v1/ec75aaca-NVIDIA-Jetson.png" alt="" style="padding-top: 1rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/ec75aaca-NVIDIA-Jetson.png",
+            alt="",
+            height="241",
+            width="293",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "padding-top: 1rem;"}
+          ) | safe
+        }}
       </div>
     </div>
     <div class="p-card col-4">
       <h3>Dragonboard</h3>
       <hr class="u-sv1" />
       <div class="p-card__content">
-        <img src="https://assets.ubuntu.com/v1/a64b7ee2-dragonboard.png" alt="" style="padding-top: 1rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a64b7ee2-dragonboard.png",
+            alt="",
+            height="197",
+            width="293",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "padding-top: 1rem;"}
+          ) | safe
+        }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Replaced images on /robotics with image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com/robotics)
