### PR TITLE
Add image template to financial services

### DIFF
--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -21,19 +21,69 @@
     <h2 class="p-muted-heading u-align--center">Ubuntu is used by</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+            alt="Bloomberg",
+            height="32",
+            width="167",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logo"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/7699c137-city-network.svg" alt="City Network" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/7699c137-city-network.svg",
+            alt="City Network",
+            height="26",
+            width="144",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logo"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" width="144" alt="PayPal" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
+            alt="PayPal",
+            height="38",
+            width="150",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logo"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/df117255-R3.svg" width="65" alt="R3" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/df117255-R3.svg",
+            alt="R3",
+            height="35",
+            width="46",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logo"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1a223327-Grey_AG_logo.svg" width="65" alt="Allan Gray" style="height:50px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/1a223327-Grey_AG_logo.svg",
+            alt="Allan Gray",
+            height="50",
+            width="162",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logo"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -46,7 +96,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Whitepaper</h4>
           </div>
         </div>
@@ -55,7 +115,16 @@
         <p><a href="https://ubuntu.com/engage/finserv-multi-cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Find out why 60% of financial services turn to multi-cloud', 'eventLabel' : 'Multi-cloud fundamental to financial services transformation ', 'eventValue' : undefined });">Find out why 60% of financial services turn to multi-cloud&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/a3455176-FinancialServicesPage-MultiCloud_2020.svg" width="344" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a3455176-FinancialServicesPage-MultiCloud_2020.svg",
+            alt="",
+            height="200",
+            width="344",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <hr />
@@ -63,7 +132,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
         </div>
@@ -72,7 +151,16 @@
         <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/334394" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the webinar', 'eventLabel' : 'Blockchain, AI/ML and Containers - The impact new technologies will have on Financial Services', 'eventValue' : undefined });">Watch the webinar</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/cf1b8768-FinancialServicesPage-ImpactFinServ_2020.svg" width="344" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/cf1b8768-FinancialServicesPage-ImpactFinServ_2020.svg",
+            alt="",
+            height="200",
+            width="344",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <hr />
@@ -80,7 +168,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Whitepaper</h4>
           </div>
         </div>
@@ -89,7 +187,16 @@
         <p><a href="/engage/starting-with-ai" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Getting started with AI', 'eventValue' : undefined });">Get started with AI&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/0631c9dc-FinancialServicesPage-GetStarted-AI_2020.svg" width="219" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/0631c9dc-FinancialServicesPage-GetStarted-AI_2020.svg",
+            alt="",
+            height="200",
+            width="219",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <hr />
@@ -97,7 +204,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Whitepaper</h4>
           </div>
         </div>
@@ -106,7 +223,16 @@
         <p><a href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download whitepaper', 'eventLabel' : 'Accelerate your business with containers', 'eventValue' : undefined });">Download whitepaper&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/20e8c1ce-FinancialServicesPage-Containers_2020.svg" width="245" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/20e8c1ce-FinancialServicesPage-Containers_2020.svg",
+            alt="",
+            height="200",
+            width="245",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <hr />
@@ -114,7 +240,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Article</h4>
           </div>
         </div>
@@ -123,7 +259,16 @@
         <p><a class="p-link--external" href="http://superuser.openstack.org/articles/openstack-at-bloomberg/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read article', 'eventLabel' : 'Bloomberg’s OpenStack deployment', 'eventValue' : undefined });">Read article</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" width="186" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+            alt="",
+            height="36",
+            width="186",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <hr />
@@ -131,7 +276,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg" width="32" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Case study</h4>
           </div>
         </div>
@@ -140,7 +295,16 @@
         <p><a href="/engage/k8s-allan-gray" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the case study ', 'eventLabel' : 'Allan Gray unlocks unprecedented availability and productivity with Charmed Kubernetes', 'eventValue' : undefined });">Read the case study&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/1a223327-Grey_AG_logo.svg" width="186" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/1a223327-Grey_AG_logo.svg",
+            alt="",
+            height="35",
+            width="186",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <hr />
@@ -148,7 +312,17 @@
       <div class="col-8">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img u-no-margin--top u-no-margin--bottom" src="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg" width="34" alt="" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
+                alt="",
+                height="45",
+                width="45",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img u-no-margin--top u-no-margin--bottom"},
+                loading="lazy",
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Case study</h4>
           </div>
         </div>
@@ -157,7 +331,16 @@
         <p><a class="p-link--external" href="/engage/casestudy-city-network" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Read the case study', 'eventLabel' : 'OpenStack in the financial services sector', 'eventValue' : undefined });">Read the case study&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png?w=234" width="234" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/69c2fae2-CityNetwork-Logo-Regular-2015-RGB.png",
+            alt="",
+            height="42",
+            width="234",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -250,7 +433,16 @@
       <div><a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></div>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" class="u-hide--small" width="250" height="178" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          height="178",
+          width="250",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /financial-services

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/financial-services
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load