### PR TITLE
Add image_template to the /server/hyperscale page

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -8,14 +8,23 @@
 {% block content %}
 <div class="p-strip is-deep is-bordered">
   <div class="row u-equal-height">
-    <div class="col-8">
+    <div class="col-8 u-vertically-center">
       <h1>Ubuntu leads in hyperscale</h1>
       <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and Arm processors.</p>
       <p><a class="p-button--positive" href="/download/server">Download Ubuntu Server</a></p>
       <p><a href="/download/arm">Download Ubuntu for ARM &nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/ab812f69-image-server-hyperscale.svg" width="323" alt="" />
+    <div class="col-4 u-align--center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/ab812f69-image-server-hyperscale.svg",
+        alt="",
+        width="323",
+        height="258",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
     </div>
   </div>
 </div>
@@ -152,7 +161,16 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/f38c9ed1-hpe_pri_grn_pos_rgb.svg"  width="200" alt="Hewlett Packard Enterprise" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/f38c9ed1-hpe_pri_grn_pos_rgb.svg",
+          alt="Hewlett Packard Enterprise",
+          width="200",
+          height="133",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Canonical has been involved in the development of Moonshot, Hewlett Packard Enterprise&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
@@ -160,7 +178,16 @@
     </div>
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg" width="150" height="45" alt="Arm" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg",
+          alt="Arm",
+          width="150",
+          height="45",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Arm and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
@@ -171,7 +198,16 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/d0e5bf77-partners-logo-cavium.png",
+          alt="Cavium",
+          width="150",
+          height="34",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
@@ -179,7 +215,16 @@
     </div>
     <div class="col-6 p-card">
       <div class="u-align--center u-vertically-center u-hide--small" style="min-height: 8rem;">
-        <img src="https://assets.ubuntu.com/v1/ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/ca664713-partners-logo-apm.svg",
+          alt="Applied Micro Circuits Corporation",
+          width="150",
+          height="50",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
       </div>
       <div class="u-sv2 u-hide--medium u-hide--large"></div>
       <p class="p-card__content">Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/server/hyperscale
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
