### PR TITLE
Add image template to kubeflow page

### DIFF
--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -143,9 +143,27 @@
     </div>
     <div class="col-4 u-align--center u-vertically-center">
       <div>
-        <p><img style="max-width: 220px;" src="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg" width="134" alt=""></p>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
+            alt="",
+            height="31",
+            width="134",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
         <p>in partnership with</p>
-        <p><img style="max-width: 100px; position: relative; top: 1px;" src="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg" width="100" alt=""></p>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
+            alt="",
+            height="34",
+            width="100",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -166,7 +184,18 @@
     <h2>IoT and Edge AI</h2>
     <h3>Train in the cloud. Act at the edge.</h3>
     <p>Cameras, music systems, cars, even firewalls and CPE are becoming smarter. From natural language processing to image recognition, from real-time high-speed autonomous navigation to network intrusion detection. Ubuntu gives you a seamless operational framework for development, training and inference all the way out to the edge.</p>
-    <div><img src="https://assets.ubuntu.com/v1/4b936f4c-cloud-to-edge_AW.svg" width="750" alt=""></div>
+    <div>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/4b936f4c-cloud-to-edge_AW.svg",
+          alt="",
+          height="500",
+          width="750",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
+    </div>
   </div>
 </section>
 
@@ -175,25 +204,95 @@
     <h2 class="p-muted-heading u-align--center">Leaders in artificial intelligence choose Ubuntu</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/bac02008-Amazon.com-Logo.svg" width="144" alt="Amazon">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/bac02008-Amazon.com-Logo.svg",
+            alt="Amazon",
+            height="29",
+            width="144",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg" width="144" alt="Google">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
+            alt="Google",
+            height="49",
+            width="144",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/3528a12f-logo-microsoft-160.png" width="144" alt="Microsoft">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3528a12f-logo-microsoft-160.png",
+            alt="Microsoft",
+            height="72",
+            width="144",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/1095d3bc-Tesla_logo_silver.png" width="144" alt="Tesla">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/1095d3bc-Tesla_logo_silver.png",
+            alt="Tesla",
+            height="19",
+            width="144",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/0be38ed7-OpenAI_Logo.svg" width="127" alt="OpenAI">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/0be38ed7-OpenAI_Logo.svg",
+            alt="OpenAI",
+            height="88",
+            width="127",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/ee23142d-logo-ibm-large.png" width="110" alt="IBM">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/ee23142d-logo-ibm-large.png",
+            alt="IBM",
+            height="50",
+            width="110",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/79974738-facebook-1.svg" width="144" alt="Facebook">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/79974738-facebook-1.svg",
+            alt="Facebook",
+            height="54",
+            width="144",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -219,7 +318,16 @@
       </blockquote>
     </div>
     <div class="col-4 u-vertically-center u-align--center">
-      <p><img style="max-width: 200px;" src="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg" width="200" alt=""></p>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
+          alt="",
+          height="147",
+          width="200",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -243,7 +351,16 @@
       <p>Or <a class="js-invoke-modal" href="/kubeflow/contact-us?product=ai-index">contact our experts</a> to get started with consulting, training or outsourced operations.</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="280" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          height="199",
+          width="280",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /kubeflow

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load