### PR TITLE
Add image template to what is kubeflow page

### DIFF
--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -15,7 +15,16 @@
         <p>Kubeflow works well with TensorFlow and other modern AI/ML frameworks such as PyTorch, MXNet and Chainer allowing users to enhance their existing code and setup.</p>
       </div>
       <div class="col-4 col-start-large-9 u-vertically-center u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg" alt="" width="300" height="70">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
+            alt="",
+            height="70",
+            width="300",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -32,7 +41,16 @@
   </div>
   <div class="u-fixed-width">
     <figure class="u-no-margin">
-      <img src="https://assets.ubuntu.com/v1/aa8145e8-what+is+kubeflow+-+outlined.svg" alt="" width="800" height="274">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/aa8145e8-what+is+kubeflow+-+outlined.svg",
+          alt="",
+          height="274",
+          width="800",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
       <figcaption>
         Effort scale of the different areas required to train, deploy and manage AI/ML projects. Boxes in blue are improved by Kubeflow.
       </figcaption>
@@ -54,7 +72,16 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-5 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" alt="" width="281" height="200">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          height="200",
+          width="281",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-7 u-vertically-center">
       <div>
@@ -79,22 +106,82 @@
     <h2 class="p-muted-heading u-align--center">Contributors to Kubeflow</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg" alt="Google" width="100">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
+            alt="Google",
+            height="34",
+            width="100",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="110">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
+            alt="Canonical",
+            height="15",
+            width="110",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg" alt="IBM" width="80">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg",
+            alt="IBM",
+            height="32",
+            width="80",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg" alt="Nvidia" width="100">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
+            alt="Nvidia",
+            height="19",
+            width="100",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg" alt="Intel" width="80">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
+            alt="Intel",
+            height="53",
+            width="80",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/67a4ca88-redhat.svg" alt="RedHat" width="100">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/67a4ca88-redhat.svg",
+            alt="RedHat",
+            height="32",
+            width="100",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -168,16 +255,56 @@
     <div class="col-6 u-vertically-center">
       <ul class="p-inline-images">
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/547ef405-uber.svg" alt="Uber" width="90">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/547ef405-uber.svg",
+              alt="Uber",
+              height="31",
+              width="90",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logos"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/4a1c3691-lyft.svg" alt="Lyft" width="75">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/4a1c3691-lyft.svg",
+              alt="Lyft",
+              height="53",
+              width="75",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logos"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/2400d5a7-Spotify_logo_with_text.svg" alt="Spotify" width="115">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/2400d5a7-Spotify_logo_with_text.svg",
+              alt="Spotify",
+              height="35",
+              width="115",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logos"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg" alt="PayPal" width="115">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
+              alt="PayPal",
+              height="29",
+              width="115",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logos"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Add image template to /kubeflow/what-is-kubeflow

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/what-is-kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load