### PR TITLE
Add image template to kubeflow install page

### DIFF
--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -13,7 +13,16 @@
       <p>Create and train machine learning models on your laptop, in your data center, or in the cloud.</p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/a1317807-Install+Kubeflow.svg" width="290" alt="Install Kubernetes" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a1317807-Install+Kubeflow.svg",
+          alt="Install Kubernetes",
+          height="200",
+          width="290",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -224,7 +233,16 @@
 <div class="p-strip is-deep">
   <div class="row u-equal-height">
     <div class="col-4 u-align--center u-hide--small u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="280" alt="" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          height="199",
+          width="280",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-7 col-start-large-6 u-vertically-center">
       <h2>Need more help?</h2>

--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -20,7 +20,7 @@
           height="200",
           width="290",
           hi_def=True,
-          loading="lazy",
+          loading="auto",
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

Add image template to /kubeflow/install

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load