### PR TITLE
Add image_template to the /kubeflow overview page

### DIFF
--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -143,9 +143,29 @@
     </div>
     <div class="col-4 u-align--center u-vertically-center">
       <div>
-        <p><img style="max-width: 220px;" src="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg" width="134" alt=""></p>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
+          alt="",
+          width="134",
+          height="31",
+          hi_def=True,
+          loading="auto",
+          attrs={"style": "max-width: 220px;"},
+          ) | safe
+        }}
         <p>in partnership with</p>
-        <p><img style="max-width: 100px; position: relative; top: 1px;" src="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg" width="100" alt=""></p>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
+          alt="",
+          width="100",
+          height="34",
+          hi_def=True,
+          loading="lazy",
+          attrs={"style": "max-width: 100px; position: relative; top: 1px;"},
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -166,7 +186,20 @@
     <h2>IoT and Edge AI</h2>
     <h3>Train in the cloud. Act at the edge.</h3>
     <p>Cameras, music systems, cars, even firewalls and CPE are becoming smarter. From natural language processing to image recognition, from real-time high-speed autonomous navigation to network intrusion detection. Ubuntu gives you a seamless operational framework for development, training and inference all the way out to the edge.</p>
-    <div><img src="https://assets.ubuntu.com/v1/4b936f4c-cloud-to-edge_AW.svg" width="750" alt=""></div>
+
+    <div>
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/4b936f4c-cloud-to-edge_AW.svg",
+        alt="",
+        width="750",
+        height="500",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+
   </div>
 </section>
 
@@ -175,25 +208,95 @@
     <h2 class="p-muted-heading u-align--center">Leaders in artificial intelligence choose Ubuntu</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/bac02008-Amazon.com-Logo.svg" width="144" alt="Amazon">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/bac02008-Amazon.com-Logo.svg",
+          alt="Amazon",
+          width="144",
+          height="29",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg" width="144" alt="Google">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
+          alt="Google",
+          width="144",
+          height="49",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/3528a12f-logo-microsoft-160.png" width="144" alt="Microsoft">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/3528a12f-logo-microsoft-160.png",
+          alt="Microsoft",
+          width="144",
+          height="72",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/1095d3bc-Tesla_logo_silver.png" width="144" alt="Tesla">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/1095d3bc-Tesla_logo_silver.png",
+          alt="Tesla",
+          width="144",
+          height="19",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/0be38ed7-OpenAI_Logo.svg" width="127" alt="OpenAI">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/0be38ed7-OpenAI_Logo.svg",
+          alt="OpenAI",
+          width="127",
+          height="88",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/ee23142d-logo-ibm-large.png" width="110" alt="IBM">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/ee23142d-logo-ibm-large.png",
+          alt="IBM",
+          width="110",
+          height="50",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/79974738-facebook-1.svg" width="144" alt="Facebook">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/79974738-facebook-1.svg",
+          alt="Facebook",
+          width="144",
+          height="54",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -219,7 +322,17 @@
       </blockquote>
     </div>
     <div class="col-4 u-vertically-center u-align--center">
-      <p><img style="max-width: 200px;" src="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg" width="200" alt=""></p>
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
+        alt="",
+        width="200",
+        height="147",
+        hi_def=True,
+        loading="lazy",
+        attrs={"style": "max-width: 200px;"},
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -230,30 +343,42 @@
     <p>It takes an open ecosystem to solve the diverse challenges of AI infrastructure across every sector and in every region. Our partners ensure that you have the widest range of capabilities available for automated integration in your cloud, and that you can get insight and support locally.</p>
     <p>To learn more about our partners or becoming a Canonical AI partner, please contact us today.</p>
     <p><a class="p-button--positive" href="https://partners.ubuntu.com/contact-us"><span class="p-link--external">Get in touch</span></a> or <a class="p-link--external" href="https://partners.ubuntu.com/partnering-with-us">learn more about partnering with us</a>
-  </div>
-</section>
-
-{% include "kubeflow/shared/_learn-more.html" %}
-
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Get started with AI and Machine learning today.</h2>
-      <p><a class="p-button--positive" href="/kubeflow/install">Test drive Kubeflow now</a></p>
-      <p>Or <a class="js-invoke-modal" href="/kubeflow/contact-us?product=ai-index">contact our experts</a> to get started with consulting, training or outsourced operations.</p>
     </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="280" alt="">
+  </section>
+
+  {% include "kubeflow/shared/_learn-more.html" %}
+
+  <section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-7">
+        <h2>Get started with AI and Machine learning today.</h2>
+        <p><a class="p-button--positive" href="/kubeflow/install">Test drive Kubeflow now</a></p>
+        <p>Or <a class="js-invoke-modal" href="/kubeflow/contact-us?product=ai-index">contact our experts</a> to get started with consulting, training or outsourced operations.</p>
+      </div>
+      <div class="col-5 u-vertically-center u-align--center u-hide--small">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          width="280",
+          height="199",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </div>
     </div>
+  </section>
+
+  {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
-</section>
-
-{% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/kubeflow/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
 
 
 
-{% endblock content %}
+  {% endblock content %}
+
+
+  Done.

--- a/templates/kubeflow/shared/_learn-more.html
+++ b/templates/kubeflow/shared/_learn-more.html
@@ -1,3 +1,5 @@
+
+
 <section class="p-strip is-bordered">
   <div class="row">
     <h3>
@@ -8,7 +10,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Webinars</h4>
         </div>
       </div>
@@ -31,7 +43,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Articles</h4>
         </div>
       </div>
@@ -55,8 +77,8 @@
           </a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--external" href="https://www.comparethecloud.net/articles/automating-the-future-workplace/">
-            Automating the Future of the Workplace
+          <a class="p-link--external" href="https://www.comparethecloud.net/articles/lazymating-the-future-workplace/">
+            lazymating the Future of the Workplace
           </a>
         </li>
       </ul>
@@ -64,7 +86,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>

--- a/templates/kubeflow/shared/_learn-more.html
+++ b/templates/kubeflow/shared/_learn-more.html
@@ -77,8 +77,8 @@
           </a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--external" href="https://www.comparethecloud.net/articles/lazymating-the-future-workplace/">
-            lazymating the Future of the Workplace
+          <a class="p-link--external" href="https://www.comparethecloud.net/articles/automating-the-future-workplace/">
+            Automating the Future of the Workplace
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
