### PR TITLE
Add image_template to /kubernetes view page

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,6 +1,5 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
-
 {% block title %}Multi-cloud Kubernetes on Ubuntu{% endblock %}
 
 {% block meta_description %}Ubuntu and Canonical deliver a pure upstream K8s experience, tested across a wide range of multi-cloud architectures for optimum Kubernetes performance and integrated with modern metrics and monitoring.{% endblock meta_description %}
@@ -19,7 +18,16 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg?w=275" alt="" width="264" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg?w=275",
+        alt="",
+        width="264",
+        height="256",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -96,7 +104,16 @@
       <p><a href="/pricing/infra">Learn more about UA-I&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 col-start-large-9 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg" alt="" width="200" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -106,43 +123,134 @@
     <h2 class="p-muted-heading u-align--center">On public clouds and on-premises</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logos" src="https://assets.ubuntu.com/v1/4f54c31c-Google-Cloud-Platform.png?w=144" width="144" alt="Google Cloud Platform" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/4f54c31c-Google-Cloud-Platform.png?w=144",
+          alt="Google Cloud Platform",
+          width="144",
+          height="47",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logos"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg" width="144" alt="Azure"  />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg",
+          alt="Azure",
+          width="144",
+          height="41",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d584bd83-logo-vmware.svg" width="144" alt="VMware" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/d584bd83-logo-vmware.svg",
+          alt="VMware",
+          width="144",
+          height="22",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg" width="144" alt="AWS" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg",
+          alt="AWS",
+          width="144",
+          height="54",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f7f8709c-logo-joyent.svg" width="144" alt="Joyent" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/f7f8709c-logo-joyent.svg",
+          alt="Joyent",
+          width="144",
+          height="40",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/33409c7b-logo-maas.svg" width="144" alt="MAAS" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/33409c7b-logo-maas.svg",
+          alt="MAAS",
+          width="144",
+          height="47",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/eed716e9-logo-openstack.svg" width="89" alt="OpenStack" style="max-height:90px;"/>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/eed716e9-logo-openstack.svg",
+          alt="OpenStack",
+          width="89",
+          height="90",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo", "style": "max-height:90px;"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f1d885ce-Oracle-cloud.png?w=144" width="144" alt="Oracle Cloud">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/f1d885ce-Oracle-cloud.png?w=144",
+          alt="Oracle Cloud",
+          width="144",
+          height="44",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" width="144" alt="Cisco">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
+          alt="Cisco",
+          width="144",
+          height="76",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
-
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4fabe174-local+host.svg" width="144" alt="Local host">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/4fabe174-local+host.svg",
+          alt="Local host",
+          width="144",
+          height="50",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"},
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -215,7 +323,6 @@
           <p class="p-matrix__desc">Charmed Kubernetes has consistently been the leader in K8s test suite performance and API standards conformance</p>
         </div>
       </li>
-
       <li class="p-matrix__item">
         <div class="p-matrix__content">
           <h3 class="p-matrix__title p-heading--four">Resilient</h3>
@@ -284,7 +391,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="" />
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
@@ -293,7 +410,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="" />
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
@@ -302,7 +429,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="" />
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>
@@ -311,12 +448,10 @@
   </div>
 </section>
 
-  {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-
 
 {% endblock content %}

--- a/templates/shared/_training.html
+++ b/templates/shared/_training.html
@@ -1,18 +1,27 @@
 <section class="p-strip is-bordered">
- <div class="row u-equal-height">
-   <div class="col-8">
-     <h2>
-       {% if type %}{{ type }} training{% else %}Train with Ubuntu{% endif %}
-     </h2>
-     <p>
-       Train your sysadmins and devops engineers to become Ubuntu OpenStack, Ubuntu Server or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Get the most out of your investment.
-     </p>
-     <p>
-       <a href="/training">Learn more about training&nbsp;&rsaquo;</a>
-     </p>
-   </div>
-   <div class="col-4 u-vertically-center u-align--center u-hide--small">
-     <img src="https://assets.ubuntu.com/v1/0e5f4269-questions.svg" width="200" alt="">
-   </div>
- </div>
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h2>
+        {% if type %}{{ type }} training{% else %}Train with Ubuntu{% endif %}
+      </h2>
+      <p>
+        Train your sysadmins and devops engineers to become Ubuntu OpenStack, Ubuntu Server or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Get the most out of your investment.
+      </p>
+      <p>
+        <a href="/training">Learn more about training&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/0e5f4269-questions.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
 </section>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
