### PR TITLE
Add image_template to the /kubernetes/features page

### DIFF
--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -1,8 +1,9 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
-
 {% block title %}Charmed Kubernetes features{% endblock %}
+
 {% block meta_description %}Ubuntu K8s gives you the flexibility to place your services exactly where you want them while sharing operational code with a large community.{% endblock meta_description %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -17,9 +18,17 @@
       <p><a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-features">Talk to us</a></p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img
-      src="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg"
-      width="173" alt="Kubernetes Certified Service Provider" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/96d35aa4-certified-kubernetes-logo.svg",
+        alt="Kubernetes Certified Service Provider",
+        width="173",
+        height="233",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+
     </div>
   </div>
 </section>
@@ -114,7 +123,16 @@
       <p>Kubernetes uses Container Network Interface (CNI) as an interface between network providers and Kubernetes networking. CNI is a library definition and a set of tools, under the umbrella of the Cloud Native Computing Foundation project.</p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/9afbad2b-Networking.svg" width="290" alt="">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9afbad2b-Networking.svg",
+        alt="",
+        width="290",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
   <div class="u-fixed-width">
@@ -137,7 +155,16 @@
       <p>For assistance with your private cloud network underlay, leverage Canonical&lsquo;s work with hyperscale public clouds such as Google Cloud, Microsoft Azure, and Amazon Web Services, with deep insight into the dynamics of cloud network performance and security best practices for large-scale multi-tenanted operations.</p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/e022b8d2-cni-logo.svg" width="168" alt="">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/e022b8d2-cni-logo.svg",
+        alt="",
+        width="168",
+        height="74",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -157,7 +184,16 @@
       </ul>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/6baffb0b-Storage.svg" width="290" alt="">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/6baffb0b-Storage.svg",
+        alt="",
+        width="290",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
   <div class="u-fixed-width">
@@ -168,7 +204,16 @@
       <p>To improve the extensibility of the storage feature set and plugin ecosystem, Kubernetes has announced a new initiative &mdash; the Container Storage Interface (CSI) &mdash; which is currently in Beta. CSI enables storage plugins to be developed independent from the Kubernetes GitHub tree, containerized, deployed via standard Kubernetes primitives, and consumed through the Kubernetes storage primitives users know and love (<a class="p-link--external" href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims"><code>PersistentVolumeClaims</code></a>, <a class="p-link--external" href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/"><code>PersistentVolumes</code></a>, <a class="p-link--external" href="https://kubernetes.io/docs/concepts/storage/storage-classes/"><code>StorageClasses</code></a>). The next dot release of Charmed Kubernetes will provide early access to CSI.</p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/e3fc2551-csi.png" width="323" alt="">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/e3fc2551-csi.png",
+        alt="",
+        width="323",
+        height="108",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -177,7 +222,20 @@
   <div class="u-fixed-width">
     <h2>Logging and monitoring</h2>
     <p>Operations in highly coherent large-scale distributed clusters require a new level of operational monitoring and observability. Charmed Kubernetes provides a standardised set of open source log aggregation and systems monitoring dashboards with every cloud, using Prometheus, the Elasticsearch and Kibana stack (ELK), and Nagios.</p>
-    <div><img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040" width="1040" alt=""></div>
+
+    <div>
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040",
+        alt="",
+        width="1040",
+        height="585",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+
     <cite>These dashboards can be customised or integrated into existing monitoring systems at your business.</cite>
   </div>
 </section>
@@ -190,7 +248,16 @@
       <p><a href="/kubernetes/contact-us" class="p-button--positive js-invoke-modal">Contact Canonical about Kubernetes</a></p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" width="281" alt="">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        width="281",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -200,7 +267,5 @@
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-
 
 {% endblock content %}


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
