### PR TITLE
Add image_template to pages under /legal/contributors/

### DIFF
--- a/templates/legal/contributors/index.html
+++ b/templates/legal/contributors/index.html
@@ -1,10 +1,10 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Contributor licence agreement{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1O7n0CijJxO60eY8NLisra3BQw03SusqMUgop0PRPx6M/edit{% endblock meta_copydoc %}
 
 {% block content %}
-
 <section class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
@@ -14,8 +14,18 @@
     </div>
     <div class="col-4">
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/7b1d9e05-image-document-canonical.svg" width="166" alt="Canonical contributor licence agreement" class="u-hide--small" />
-      </div>
+        {{
+          image(
+              url="https://assets.ubuntu.com/v1/7b1d9e05-image-document-canonical.svg",
+              alt="Canonical contributor licence agreement",
+              width="166",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              attrs={"class": "u-hide--small"},
+          ) | safe
+        }}
+	      </div>
     </div>
   </div>
 </section>

--- a/templates/legal/contributors/thank-you.html
+++ b/templates/legal/contributors/thank-you.html
@@ -1,7 +1,9 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Thank you for submitting your contributor licence agreement | Ubuntu and Canonical legal{% endblock %}
+
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1hF6GE5Ui-OzrubtSgjTE5-es2Nu10U999lddwgu2ROA/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -16,8 +18,17 @@
     </div>
     <div class="col-4">
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/6065c8e5-pictogram-smile-purple.png?w=164" width="164" alt="Smile">
-      </div>
+        {{
+          image(
+              url="https://assets.ubuntu.com/v1/6065c8e5-pictogram-smile-purple.png?w=164",
+              alt="Smile",
+              width="164",
+              height="162",
+              hi_def=True,
+              loading="auto",
+          ) | safe
+        }}
+	      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/contributors/ and http://0.0.0.0:8001/legal/contributors/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
