### PR TITLE
Add image_template to the /legal/terms-and-policies pages

### DIFF
--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -1,20 +1,30 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Terms and policies{% endblock %}
+
 {% block meta_description %}Ubuntu and Canonical Legal - legal terms and policies{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit{% endblock meta_copydoc %}
 
 {% block content %}
-
 <div class="p-strip">
   <div class="row">
     <div class="col-8">
       <h1>Terms and&nbsp;policies</h1>
-      <p>We have legal agreements for the production of our software, the way we present it on our websites and the protection of intellectual property &mdash; both yours and ours. In the sections below, you can see all the legal terms and policies for Ubuntu
-        and Canonical.</p>
+      <p>We have legal agreements for the production of our software, the way we present it on our websites and the protection of intellectual property &mdash; both yours and ours. In the sections below, you can see all the legal terms and policies for Ubuntu and Canonical.</p>
     </div>
     <div class="col-3 col-start-large-10">
-      <img src="https://assets.ubuntu.com/v1/080c0e59-image-document-ubuntuterms.svg" width="166" alt="Ubuntu terms" class="u-hide--small" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/080c0e59-image-document-ubuntuterms.svg",
+        alt="Ubuntu terms",
+        width="166",
+        height="200",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
     </div>
   </div>
 </div>

--- a/templates/legal/terms-and-policies/thank-you.html
+++ b/templates/legal/terms-and-policies/thank-you.html
@@ -1,10 +1,10 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Thank you | Terms and policies{% endblock %}
+
 {% block meta_copydoc %}https://drive.google.com/open?id=1UZrvA051Ks9eWXOA42ez3LPX9RK3iStJyAp16VtvhZk{% endblock meta_copydoc %}
 
 {% block content %}
-
 <div class="p-strip">
   <div class="row">
     <div class="col-8">
@@ -17,7 +17,16 @@
       </ul>
     </div>
     <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/6aae23e9-picto-thankyou-orange.svg" width="200" alt="Smile">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/6aae23e9-picto-thankyou-orange.svg",
+        alt="Smile",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/terms-and-policies/ and http://0.0.0.0:8001/legal/terms-and-policies/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
