### PR TITLE
Add image_template to the /legal/ubuntu-advantage page

### DIFF
--- a/templates/legal/ubuntu-advantage/index.html
+++ b/templates/legal/ubuntu-advantage/index.html
@@ -1,10 +1,10 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Ubuntu Advantage service description{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1p-xlkejIG5ZZhOfGrYnq6rmIpTpaX46yW4HArDtPX1s/edit{% endblock meta_copydoc %}
 
 {% block content %}
-
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
@@ -14,7 +14,17 @@
     </div>
     <div class="col-4">
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/4e72de34-image-document-ubuntuassurance.svg" width="166" alt="Ubuntu Advantage" class="u-hide--small" />
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/4e72de34-image-document-ubuntuassurance.svg",
+          alt="Ubuntu Advantage",
+          width="166",
+          height="200",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -30,7 +40,7 @@
     <div class="col-6 p-card">
       <h3>Ubuntu Assurance</h3>
       <p>The Ubuntu Advantage Assurance Programme provides indemnification from Canonical against claims of intellectual property infringement support customers might face as a result of using Ubuntu. This agreement is part of all Canonical support contracts.
-        </p>
+      </p>
       <p><a href="/legal/ubuntu-advantage-assurance">View Ubuntu Advantage Assurance&nbsp;&rsaquo;</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/ubuntu-advantage- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
