### PR TITLE
Add image template to kubeflow consulting

### DIFF
--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -19,14 +19,8 @@
         Our data science consulting partners bring machine learning and deep learning expertise to the AI mix and Canonical delivers optimised infrastructure for multi-cloud AI with Ubuntu, GPGPUs, Kubernetes and Kubeflow. Assess data readiness, empower developers and accelerate your machine learning processing - on-premises or in the cloud.
       </p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/kubeflow/contact-us?product=ai-index"
-          >Speak to the experts</a
-        >
-        <a
-          class="p-link--external"
-          href="/engage/starting-with-ai?utm_source=bubble&utm_campaign=CY19_DC_AI_Whitepaper_AIConsulting"
-          >Download the Getting started with AI whitepaper</a
-        >
+        <a class="p-button--positive js-invoke-modal" href="/kubeflow/contact-us?product=ai-index">Speak to the experts</a>
+        <a class="p-link--external" href="/engage/starting-with-ai?utm_source=bubble&utm_campaign=CY19_DC_AI_Whitepaper_AIConsulting">Download the Getting started with AI whitepaper</a>
       </p>
     </div>
   </div>
@@ -66,16 +60,28 @@
       <h5 class="p-muted-heading u-sv3">Our consulting partners</h5>
       <ul class="row">
         <li class="col-2 col-small-2 col-medium-2">
-          <img
-            src="https://assets.ubuntu.com/v1/e9e4d429-Manceps.png"
-            alt="Manceps"
-          />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/e9e4d429-Manceps.png",
+              alt="",
+              height="31",
+              width="147",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="col-2 col-small-2 col-medium-2">
-          <img
-            src="https://assets.ubuntu.com/v1/99d8f79e-deepsense.png"
-            alt="Deepsense AI"
-          />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/99d8f79e-deepsense.png",
+              alt="",
+              height="27",
+              width="147",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
       </ul>
     </div>
@@ -100,7 +106,16 @@
   </div>
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/e68fd355-1+discovery_AW.svg" alt="" width="335px"/>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/e68fd355-1+discovery_AW.svg",
+          alt="",
+          height="191",
+          width="335",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>1 - Discovery</h4>
@@ -130,7 +145,16 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/146a6eba-2+assessment_AW.svg" alt="" width="335px"/>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/146a6eba-2+assessment_AW.svg",
+          alt="",
+          height="191",
+          width="335",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -140,7 +164,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/455740b4-3+design_AW.svg" alt="" width="335px"/>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/455740b4-3+design_AW.svg",
+          alt="",
+          height="191",
+          width="335",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>3 - Design</h4>
@@ -162,7 +195,16 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/ae0d7b33-4+implementation_AW.svg" alt="" width="335px"/>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ae0d7b33-4+implementation_AW.svg",
+          alt="",
+          height="191",
+          width="335",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -172,11 +214,16 @@
 
   <div class="row">
     <div class="col-6 u-hide--small u-align--center">
-      <img
-        src="https://assets.ubuntu.com/v1/70227781-5+operation+and+feedback_AW.svg"
-        alt=""
-        width="335px"
-      />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/70227781-5+operation+and+feedback_AW.svg",
+          alt="",
+          height="191",
+          width="335",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-6">
       <h4>5 - Operation and Feedback</h4>
@@ -219,7 +266,16 @@
       </a>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/da5a7c9e-Kubeflow-Logo.svg" alt="" width="180px">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/da5a7c9e-Kubeflow-Logo.svg",
+          alt="",
+          height="178",
+          width="180",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /kubeflow/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load