### PR TITLE
Add image template to kubeflow shared

### DIFF
--- a/templates/kubeflow/shared/_learn-more.html
+++ b/templates/kubeflow/shared/_learn-more.html
@@ -8,7 +8,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/6e184942-Webinar.svg" width="32" alt="">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+              alt="",
+              height="28",
+              width="32",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy",
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Webinars</h4>
         </div>
       </div>
@@ -31,7 +41,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+              alt="",
+              height="28",
+              width="32",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy",
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Articles</h4>
         </div>
       </div>
@@ -64,7 +84,17 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/b061c401-White+paper.svg" width="32" alt="">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+              alt="",
+              height="28",
+              width="32",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy",
+            ) | safe
+          }}
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>


### PR DESCRIPTION
## Done

Add image template to kubeflow shared partial

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the icons in the "Learn more about AI/ML and Kubeflow" section load