### PR TITLE
Add image_template to the /livechat page

### DIFF
--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -33,7 +33,7 @@
     <div class="col-3 u-vertically-center">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/0326ac7d-dena-logo.png?w=144",
+        url="https://assets.ubuntu.com/v1/0326ac7d-dena-logo.png",
         alt="Dena",
         width="144",
         height="59",

--- a/templates/livepatch/index.html
+++ b/templates/livepatch/index.html
@@ -1,7 +1,9 @@
 {% extends "livepatch/base_livepatch.html" %}
 
 {% block title %}Canonical Livepatch Service{% endblock %}
+
 {% block meta_description %}Automatic Linux kernel updates for Ubuntu 16.04 and 18.04 LTS. Apply critical patches without rebooting and keep your systems secure and compliant.{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1Ofw9bQ4I40gy9hDIjuDMApz6sDK8qSdHI03-oY7xs-A/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -9,7 +11,7 @@
   <div class="p-strip--suru-half-and-half">
     <div class="row u-equal-height">
       <div class="col-7">
-          <h1>Canonical Livepatch Service</h1>
+        <h1>Canonical Livepatch Service</h1>
         <h2 class="p-heading--four">Apply critical kernel patches without rebooting.</h2>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Fixes are applied automatically, without restarting your system</li>
@@ -29,7 +31,16 @@
 <section class="p-strip--light is-deep">
   <div class="row u-equal-height">
     <div class="col-3 u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/0326ac7d-dena-logo.png?w=144" width="144" alt="Dena" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/0326ac7d-dena-logo.png?w=144",
+        alt="Dena",
+        width="144",
+        height="59",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
     </div>
     <div class="col-8 col-start-large-5">
       <blockquote class="p-pull-quote">
@@ -63,15 +74,123 @@
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-align-text--center">Livepatch is used by</h2>
     <div class="p-fluid-grid--centered">
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/9ae8ff55-2018-logo-bloomberg.svg" width="145" alt="Bloomberg" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&T" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/ff209af1-2018-logo-walmart.svg" width="145" alt="Walmart" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/d199354d-2018-logo-deutsche-telekom.svg" width="145" alt="Deutcshe Telecom" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/675af314-2018-logo-eBay.svg" width="145" alt="eBay" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/8a4d26de-2018-logo-cisco.svg" width="145" alt="Cisco" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/94da9f2a-2018-logo-NTT.svg" width="145" alt="NTT" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/dcde7628-2018-logo-best-buy.svg" width="145" alt="Best Buy" /></span>
-      <span class="p-logo-image p-fluid-grid__item--small u-align--center"><img src="https://assets.ubuntu.com/v1/9f7bc2d4-2018-logo-paypal.svg" width="145" alt="PayPal" /></span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/9ae8ff55-2018-logo-bloomberg.svg",
+          alt="Bloomberg",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
+          alt="AT&T",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/ff209af1-2018-logo-walmart.svg",
+          alt="Walmart",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/d199354d-2018-logo-deutsche-telekom.svg",
+          alt="Deutcshe Telecom",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/675af314-2018-logo-eBay.svg",
+          alt="eBay",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/8a4d26de-2018-logo-cisco.svg",
+          alt="Cisco",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/94da9f2a-2018-logo-NTT.svg",
+          alt="NTT",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/dcde7628-2018-logo-best-buy.svg",
+          alt="Best Buy",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
+      <span class="p-logo-image p-fluid-grid__item--small u-align--center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/9f7bc2d4-2018-logo-paypal.svg",
+          alt="PayPal",
+          width="145",
+          height="145",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-image p-fluid-grid__item--small u-align--center"},
+          ) | safe
+        }}
+      </span>
     </div>
   </div>
 </section>
@@ -117,7 +236,17 @@
       <div class="p-card">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img p-heading-icon__img--small" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="" />
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
             <h4 class="p-heading-icon__title">Datasheet</h4>
           </div>
         </div>
@@ -136,19 +265,28 @@
 </section>
 
 <section class="p-strip">
-    <div class="row u-equal-height">
-      <div class="col-5 u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg" style="height:200px" alt="">
-      </div>
-      <div class="col-7 u-vertically-center">
-        <div>
-          <h2>Get started with Livepatch today</h2>
-          <p>Livepatch is free to use on your own PC or server. To discuss whether Livepatch is right for your business, talk to our team.</p>
-          <p class="u-no-margin--bottom"><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
-        </div>
+  <div class="row u-equal-height">
+    <div class="col-5 u-align--center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        width="281",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-7 u-vertically-center">
+      <div>
+        <h2>Get started with Livepatch today</h2>
+        <p>Livepatch is free to use on your own PC or server. To discuss whether Livepatch is right for your business, talk to our team.</p>
+        <p class="u-no-margin--bottom"><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
       </div>
     </div>
-  </section>
+  </div>
+</section>
 
 {% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -2,39 +2,58 @@
 
 <div class="p-strip--accent is-dark is-bordered is-x-shallow" style="background-blend-mode: color;
 background-image: linear-gradient(-45deg, #5E2750 0%, #2C001E 100%);">
-  <div class="row u-vertically-center">
-    <div class="col-1 u-vertically-center u-hide--small">
-      <img src="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Epath4185%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-131 -719)' fill='%23FFFFFF'%3E%3Cg transform='translate(-15 697)'%3E%3Cg transform='translate(157 34) scale(-1 1) translate(-17 -18)'%3E%3Cg transform='translate(.27856 .15983)'%3E%3Cg transform='translate(16.286 17.834) rotate(-90) translate(-17 -16)'%3E%3Cg transform='translate(17.282 16) scale(-1 1) translate(-16.5 -16)'%3E%3Cg transform='translate(16.641 16) scale(-1 1) translate(-16 -16)'%3E%3Cpath transform='translate(13.652 13.564) scale(1 -1) translate(-13.652 -13.564)' d='m27.303 5.8745c-0.574-2.5209-1.428-6.83-5.29-5.6848-4.907 1.4556-9.373 5.5584-12.791 8.9531v-1e-4c-0.0033 0.0034-0.0068 0.0067-0.0102 0.0101-0.0032 0.0034-0.0068 0.0067-0.0102 0.0101l1e-4 1e-4c-3.4165 3.396-7.5458 7.833-9.0107 12.709-1.1526 3.837 3.1842 4.686 5.7214 5.256l3.6037-8.142-1.7315-3.191c0.7581-1.18 2.6604-3.219 3.9284-4.48 1.269-1.26 3.321-3.1499 4.509-3.9032l2.886 2.0434 8.195-3.5807z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A" width="28" alt="" />
-    </div>
+<div class="row u-vertically-center">
+  <div class="col-1 u-vertically-center u-hide--small">
 
-{% elif colour == 'white' %}
+    <img src="data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Epath4185%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-131 -719)' fill='%23FFFFFF'%3E%3Cg transform='translate(-15 697)'%3E%3Cg transform='translate(157 34) scale(-1 1) translate(-17 -18)'%3E%3Cg transform='translate(.27856 .15983)'%3E%3Cg transform='translate(16.286 17.834) rotate(-90) translate(-17 -16)'%3E%3Cg transform='translate(17.282 16) scale(-1 1) translate(-16.5 -16)'%3E%3Cg transform='translate(16.641 16) scale(-1 1) translate(-16 -16)'%3E%3Cpath transform='translate(13.652 13.564) scale(1 -1) translate(-13.652 -13.564)' d='m27.303 5.8745c-0.574-2.5209-1.428-6.83-5.29-5.6848-4.907 1.4556-9.373 5.5584-12.791 8.9531v-1e-4c-0.0033 0.0034-0.0068 0.0067-0.0102 0.0101-0.0032 0.0034-0.0068 0.0067-0.0102 0.0101l1e-4 1e-4c-3.4165 3.396-7.5458 7.833-9.0107 12.709-1.1526 3.837 3.1842 4.686 5.7214 5.256l3.6037-8.142-1.7315-3.191c0.7581-1.18 2.6604-3.219 3.9284-4.48 1.269-1.26 3.321-3.1499 4.509-3.9032l2.886 2.0434 8.195-3.5807z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A" width="28" >
 
-<div class="p-strip is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">
-  <div class="row u-vertically-center">
-    <div class="col-1 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg" width="100" alt="" />
-    </div>
+  </div>
+
+  {% elif colour == 'white' %}
+
+  <div class="p-strip is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">
+    <div class="row u-vertically-center">
+      <div class="col-1 u-align--center u-hide--small">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg",
+          alt="",
+          width="100",
+          height="100",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </div>
 
 {% else %}
 
-  <div class="p-strip--light is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">
-    <div class="row u-vertically-center">
-      <div class="col-1 u-align--center u-hide--small">
-        <img src="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg" width="100" alt="" />
-      </div>
+<div class="p-strip--light is-x-shallow {% if bordered == 'true' %}is-bordered{% endif %}">
+<div class="row u-vertically-center">
+  <div class="col-1 u-align--center u-hide--small">
+    {{
+      image(
+      url="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg",
+      alt="",
+      width="100",
+      height="100",
+      hi_def=True,
+      loading="lazy",
 
-{% endif %}
+      ) | safe
+    }}
+  </div>
+  {% endif %}
 
-
-    <div class="col-11 u-no-margin--left u-no-margin--bottom">
-      <h4 style="margin-bottom: 0.5rem;">Any questions?</h4>
-      <p class="u-no-margin--bottom u-no-max-width">
-        <span style="margin-right: 0.25rem;">
-          Call us <tel href="+17372040291">+1&nbsp;737&nbsp;204&nbsp;0291</tel>&nbsp;(Americas),
-          <tel href="+442036565291">+44&nbsp;203&nbsp;656&nbsp;5291</tel>&nbsp;(RoW) or
-        </span>
-        <br class="u-hide--large u-hide--medium" /><br class="u-hide--large u-hide--medium" />
-        <a href="/support/contact-us" class="p-button--neutral js-invoke-modal">contact us online</a></p>
+  <div class="col-11 u-no-margin--left u-no-margin--bottom">
+    <h4 style="margin-bottom: 0.5rem;">Any questions?</h4>
+    <p class="u-no-margin--bottom u-no-max-width">
+      <span style="margin-right: 0.25rem;">
+        Call us <tel href="+17372040291">+1&nbsp;737&nbsp;204&nbsp;0291</tel>&nbsp;(Americas),
+        <tel href="+442036565291">+44&nbsp;203&nbsp;656&nbsp;5291</tel>&nbsp;(RoW) or
+      </span>
+      <br class="u-hide--large u-hide--medium" /><br class="u-hide--large u-hide--medium" />
+      <a href="/support/contact-us" class="p-button--neutral js-invoke-modal">contact us online</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/livepatch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
