### PR TITLE
Remove link to thinger in the snapstore, fixed meta info

### DIFF
--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -1,32 +1,32 @@
 {% extends "internet-of-things/base_things.html" %}
 
+{% block title %}Ubuntu on Edge and Industrial Gateways{% endblock %}
 
-{% block title %}Gateways | Ubuntu for the Internet of Things {% endblock %}
-{% block meta_description %}Ubuntu Core is the perfect robust, reliable and secure OS host for the edge gateways and it&rsquo;s deployment.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1hQon1vuYPDg_GojABIwbp2gFBkE2WApZTZJGT3yUdLU/edit{% endblock meta_copydoc %}
+{% block meta_description %}Leveraging virtualisation on industrial gateways at the edge is easiest with Ubuntu. Orchestrate any type of application containers the most secure way with Ubuntu.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/18ffTcNolrtJS9AvjMfa8KW94uLfC0KzmHtTe-jMYmlo/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 
 <section class="p-strip is-deep u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-topped">
     <div class="row u-vertically-center">
-        <div class="col-6">
-          <h1>Virtualisation on edge gateways</h1>
-          <p class="p-heading--four">Edge gateways provide key infrastructure for the digital transformation industrial operations</p>
-          <p class="u-sv3">Ubuntu delivers long-term security, along with the flexibility to deploy various types of applications, platforms and protocols to the edge though virtualisation.</p>
-        </div>
-        <div class="u-vertically-center col-5 col-start-large-8 u-align--center u-hide--small">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/d40fc8b9-Internet+of+Things_digital-gateways.svg",
-              alt="",
-              height="280",
-              width="300",
-              hi_def=True,
-              attrs={"class": "row-hero__image"},
-            ) | safe
-          }}
-        </div>
+      <div class="col-6">
+        <h1>Virtualisation on edge gateways</h1>
+        <p class="p-heading--four">Edge gateways provide key infrastructure for the digital transformation industrial operations</p>
+        <p class="u-sv3">Ubuntu delivers long-term security, along with the flexibility to deploy various types of applications, platforms and protocols to the edge though virtualisation.</p>
+      </div>
+      <div class="u-vertically-center col-5 col-start-large-8 u-align--center u-hide--small">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/d40fc8b9-Internet+of+Things_digital-gateways.svg",
+          alt="",
+          height="280",
+          width="300",
+          hi_def=True,
+          attrs={"class": "row-hero__image"},
+          ) | safe
+        }}
       </div>
     </div>
   </div>
@@ -58,11 +58,11 @@
     <div class="col-6 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
+        alt="",
+        height="200",
+        width="350",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -76,11 +76,11 @@
     <div class="col-6 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
+        alt="",
+        height="200",
+        width="350",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -102,11 +102,11 @@
     <div class="col-6 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
-          alt="",
-          height="185",
-          width="185",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
+        alt="",
+        height="185",
+        width="185",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -164,11 +164,11 @@
     <div class="col-6 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
+        alt="",
+        height="200",
+        width="350",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -182,11 +182,11 @@
     <div class="col-6 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/fad662b3-faster+cheaper.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/fad662b3-faster+cheaper.svg",
+        alt="",
+        height="200",
+        width="350",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -333,8 +333,7 @@
     </div>
     <div class="col-6">
       <p class="p-heading--three">Thinger.io</p>
-      <p>Thinger.io is a Platform for the Internet of Things. It supports multiple features like sensing and actuating, real-time dashboards, data buckets, webhooks, etc...</p>
-      <a class="p-link--external" href="https://snapcraft.io/thinger-maker-server">Thinger in the Snap store</a>
+      <p>Thinger.io is a Platform for the Internet of Things. It supports multiple features like sensing and actuating, real-time dashboards, data buckets, webhooks and more.</p>
     </div>
   </div>
 </section>
@@ -344,11 +343,11 @@
     <div class="col-4 u-align--left u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-          alt="",
-          height="280",
-          width="280",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        height="280",
+        width="280",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -367,7 +366,5 @@
 <!-- Set default Marketo information for contact form below -->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=gateways" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Updated the meta data
- Moved the copy docs around - note, lots of updates not approved
- Removed link to thinger on the snapstore

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/gateways
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the link to thinger has been removed

## Issue / Card

Fixes #6564 

