### PR TITLE
Add image template to openstack shared

### DIFF
--- a/templates/openstack/shared/_openstack_clients.html
+++ b/templates/openstack/shared/_openstack_clients.html
@@ -2,40 +2,160 @@
   <h2 class="p-muted-heading u-align--center">{{ heading }}</h2>
   <ul class="p-inline-images{% if size == 'smaller' %}--smaller{% endif %}">
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1ccb6d93-logo-deutschetelekom.svg" width="144" alt="Deutshe Telekom" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/1ccb6d93-logo-deutschetelekom.svg",
+          alt="Deutshe Telekom",
+          height="32",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/be345c7f-bSkyb_logo.png?w=141" width="141" alt="Sky" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/be345c7f-bSkyb_logo.png",
+          alt="Sky",
+          height="87",
+          width="141",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+          alt="Bloomberg",
+          height="28",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4ef05fb7-bestbuy.jpg?w=144" width="144" alt="Best Buy" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/4ef05fb7-bestbuy.jpg",
+          alt="Best Buy",
+          height="81",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b3315d88-walmart.svg" width="144" alt="Walmart" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
+          alt="Walmart",
+          height="34",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg" width="144" alt="NTT" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg",
+          alt="NTT",
+          height="53",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" width="144" alt="Rabobank" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg",
+          alt="Rabobank",
+          height="26",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png?w=144" width="144" alt="Astra Zeneca" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png",
+          alt="Astra Zeneca",
+          height="36",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg" width="144" alt="Tesco" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg",
+          alt="Tesco",
+          height="38",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png?w=144" width="144" alt="BNP" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png",
+          alt="BNP",
+          height="32",
+          width="144",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&amp;T" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
+          alt="AT&amp;T",
+          height="88",
+          width="145",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="p-inline-images__item">
-      <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5cba4548-logo-ebay.svg" width="80" alt="eBay" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/5cba4548-logo-ebay.svg",
+          alt="eBay",
+          height="88",
+          width="88",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+        ) | safe
+      }}
     </li>
   </ul>
 </div>


### PR DESCRIPTION
## Done

Add image template to openstack shared

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the client logo images load