### PR TITLE
Fix /download/rpi-compute-module-3 images

### DIFF
--- a/templates/download/raspberry-pi-compute-module-3.html
+++ b/templates/download/raspberry-pi-compute-module-3.html
@@ -91,33 +91,13 @@ sudo ./rpiboot</code></pre>
             <li>
               <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
               <p>
-                {{
-                  image(
-                    url="https://assets.ubuntu.com/v1/55329e6f-CM3_J4.jpg",
-                    alt="",
-                    height="368",
-                    width="300",
-                    hi_def=True,
-                    loading="lazy",
-                    attrs={"class": "p-image--bordered"}
-                  ) | safe
-                }}
+                <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4">
               </p>
             </li>
             <li>
               <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
               <p>
-                {{
-                  image(
-                    url="https://assets.ubuntu.com/v1/2073d0aa-CM3_J15.jpg",
-                    alt="",
-                    height="",
-                    width="300",
-                    hi_def=True,
-                    loading="lazy",
-                    attrs={"class": "p-image--bordered"}
-                  ) | safe
-                }}
+                <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15">
               </p>
             </li>
             <li>With the second micro USB to USB cable, power on the IO board.</li>

--- a/templates/download/raspberry-pi-compute-module-3.html
+++ b/templates/download/raspberry-pi-compute-module-3.html
@@ -91,7 +91,7 @@ sudo ./rpiboot</code></pre>
             <li>
               <p>Ensure the <code>J4</code> switch (<code>USB SLAVE BOOT ENABLE</code>) on the IO board is in the EN position.</p>
               <p>
-                <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4">
+                <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/55329e6f-CM3_J4.JPG?w=300" width="300" alt="J4"  loading="lazy">
               </p>
             </li>
             <li>

--- a/templates/download/raspberry-pi-compute-module-3.html
+++ b/templates/download/raspberry-pi-compute-module-3.html
@@ -97,7 +97,7 @@ sudo ./rpiboot</code></pre>
             <li>
               <p>With the first micro USB to USB cable, plug the host machine into the IO Board USB slave port (<code>J15</code>).</p>
               <p>
-                <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15">
+                <img class="p-image--bordered" src="https://assets.ubuntu.com/v1/2073d0aa-CM3_J15.JPG?w=300" width="300" alt="J15"  loading="lazy">
               </p>
             </li>
             <li>With the second micro USB to USB cable, power on the IO board.</li>


### PR DESCRIPTION
…module-3

## Done

For some reason, the image_template module doesn't work with the two photos embedded in the install guide, so have reverted them back to image tags.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi-compute-module-3
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the two photos in the guide are there
