### PR TITLE
[Image module] /blog

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -113,7 +113,16 @@
         </div>
 
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
-          <img width="100" src="https://assets.ubuntu.com/v1/39ebd977-robot.svg" alt="" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/39ebd977-robot.svg",
+              alt="",
+              height="157",
+              width="100",
+              hi_def=True,
+              loading="lazy"
+            ) | safe
+          }}
         </div>
       </div>
     </section>

--- a/templates/blog/blog-card-upcoming.html
+++ b/templates/blog/blog-card-upcoming.html
@@ -7,12 +7,16 @@
     {% if article.image %}
       <div class="u-crop--16-9">
         <a href="/blog/{{ article.slug }}">
-          <img
-            src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}"
-            srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w"
-            sizes="(min-width: 1031px) 460px, (max-width: 1030px) and (min-width: 876px) 460px, (max-width: 875px) and (min-width: 621px) 875px, (max-width: 620px) and (min-width: 461px) 620px, (max-width: 460px) 460px"
-            alt=""
-          />
+          {{
+            image(
+              url=article.image.source_url,
+              alt="",
+              height="165",
+              width="293",
+              hi_def=True,
+              loading="lazy"
+            ) | safe
+          }}
         </a>
       </div>
     {% endif %}

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -5,18 +5,7 @@
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">
       <a href="/blog/{{ article.slug }}">
-        <img
-          src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}"
-          srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w,
-                                                                                         https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w,
-                                                                                                       https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w"
-          sizes="(min-width: 1031px) 460px,
-                                                                                                     (max-width: 1030px) and (min-width: 876px) 460px,
-                                                                                                                   (max-width: 875px) and (min-width: 621px) 875px,
-                                                                                                                                 (max-width: 620px) and (min-width: 461px) 620px,
-                                                                                                                                               (max-width: 460px) 460px"
-          alt=""
-        />
+        <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}" srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w" sizes="(min-width: 1031px) 460px, (max-width: 1030px) and (min-width: 876px) 460px, (max-width: 875px) and (min-width: 621px) 875px, (max-width: 620px) and (min-width: 461px) 620px, (max-width: 460px) 460px" alt="" loading="lazy" />
       </a>
     </div>
     {% endif %}
@@ -26,13 +15,9 @@
     </h3>
 
     <p>
-      <em
-        >by
-        <a href="/blog/author/{{article.author.slug}}"
-          >{{ article.author.name }}</a
-        >
-        on {{ article.date }}</em
-      >
+      <em>by
+        <a href="/blog/author/{{article.author.slug}}">{{ article.author.name }}</a>
+        on {{ article.date }}</em>
     </p>
 
     {% if summary_visible or not article.image.source_url %}

--- a/templates/blog/internet-of-things.html
+++ b/templates/blog/internet-of-things.html
@@ -19,7 +19,17 @@
       </div>
 
       <div class="col-5 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/a3c4eaae-Internet+of+Things_digital-drone-white.svg" class="u-hide--small" alt="" width="200" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a3c4eaae-Internet+of+Things_digital-drone-white.svg",
+            alt="",
+            height="166",
+            width="200",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "u-hide--small"}
+          ) | safe
+        }}
       </div>
 
       <div id="rtp-banner" class="rtp-banner"></div>

--- a/templates/blog/topics/juju.html
+++ b/templates/blog/topics/juju.html
@@ -9,7 +9,17 @@
   <section class="p-strip--suru-blog-header">
     <div class="u-fixed-width">
       <p>
-        <img class="p-blog-heading__icon" src="https://assets.ubuntu.com/v1/67057b2c-product-page-juju-logo.svg" alt="" width="140" height="50" style="height: 50px;"/>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/67057b2c-product-page-juju-logo.svg",
+            alt="",
+            height="50",
+            width="140",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-blog-heading__icon", "style": "height: 50px;"}
+          ) | safe
+        }}
       </p>
       <h2 class="p-heading--four">All the latest news on Juju &ndash; the open source application <br class="u-hide u-show--large" />modelling tool for public and private clouds.</h2>
       <p>

--- a/templates/blog/topics/maas.html
+++ b/templates/blog/topics/maas.html
@@ -8,7 +8,18 @@
 
   <section class="p-strip--suru-blog-header">
     <div class="u-fixed-width">
-      <h1><img src="https://assets.ubuntu.com/v1/4fac1d52-MAAS-Logo.svg" alt="" width="200" height="50"></h1>
+      <h1>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/4fac1d52-MAAS-Logo.svg",
+            alt="MAAS",
+            height="50",
+            width="200",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
+      </h1>
       <h2 class="p-heading--four">All the latest news on MAAS<br>&ndash; the smartest way to manage bare metal.</h2>
       <p>
         <a class="p-link--external p-link--inverted" href="https://maas.io">Learn more about MAAS</a>

--- a/templates/blog/topics/robotics.html
+++ b/templates/blog/topics/robotics.html
@@ -20,7 +20,17 @@
       </div>
 
       <div class="col-5 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/5ee71af0-Robot+arm+-+white.svg" class="u-hide--small" alt="" width="200" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/5ee71af0-Robot+arm+-+white.svg",
+            alt="",
+            height="201",
+            width="200",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "u-hide--small"}
+          ) | safe
+        }}
       </div>
     </div>
   </section>

--- a/templates/blog/topics/snapcraft.html
+++ b/templates/blog/topics/snapcraft.html
@@ -9,8 +9,17 @@
   <section class="p-strip--suru-blog-header">
     <div class="u-fixed-width">
       <p>
-        <img class="p-blog-heading__icon" src="https://assets.ubuntu.com/v1/b46c8d7d-snapcraft-logo-hor-white.svg" alt=""
-        width="272" height="62" style="height: 62px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/b46c8d7d-snapcraft-logo-hor-white.svg",
+            alt="Snapcraft",
+            height="62",
+            width="272",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-blog-heading__icon", "style": "height: 62px;"}
+          ) | safe
+        }}
       </p>
       <h2 class="p-heading--four">All the latest from the Snappy team &ndash; articles on application<br class="u-hide u-show--large">architecture, prototyping, packaging paradigms and more.</h2>
       <p>


### PR DESCRIPTION
## Done

- updated /blog pages with image_template module where possible:
  - /blog
  - /blog/the-state-of-robotics-january-2020 (includes a robotics illustration below the post)
  - /blog/internet-of-things
  - /blog/topics/maas
  - /blog/topics/juju
  - /blog/topics/robotics
  - /blog/topics/snapcraft
- on blog cards, images aren't always a uniform size, but they already use a cloudinary URL, so have just added the loading attribute to those images in the partial

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images load, repeat for all the pages listed above