### PR TITLE
Add image template to what is openstack

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -19,7 +19,16 @@
 
 <section class="p-strip is-bordered">
   <div class="u-fixed-width">
-    <img src="https://assets.ubuntu.com/v1/2d2a0b2a-what+is+open+stack+diagram.svg" width="850" alt="What is OpenStack?" />
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/2d2a0b2a-what+is+open+stack+diagram.svg",
+        alt="What is OpenStack?",
+        height="250",
+        width="850",
+        hi_def=True,
+        loading="auto",
+      ) | safe
+    }}
   </div>
 </section>
 
@@ -55,22 +64,76 @@
   </div>
   <ul class="row">
     <li class="col-2 col-small-2 col-medium-2">
-      <img src="https://assets.ubuntu.com/v1/403148e0-2018-logo-canonical.svg" width="144" alt="Canonical">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/403148e0-2018-logo-canonical.svg",
+          alt="Canonical",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="col-2 col-small-2 col-medium-2">
-      <img src="https://assets.ubuntu.com/v1/9b1fe97b-2018-logo-IBM.svg" width="144" alt="IBM">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9b1fe97b-2018-logo-IBM.svg",
+          alt="IBM",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="col-2 col-small-2 col-medium-2">
-      <img src="https://assets.ubuntu.com/v1/64277a51-2018-logo-redhat.svg" width="144" alt="RedHat">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/64277a51-2018-logo-redhat.svg",
+          alt="RedHat",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="col-2 col-small-2 col-medium-2">
-      <img src="https://assets.ubuntu.com/v1/7dd7bfaf-2018-logo-huawei.svg" width="144" alt="Huawei">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/7dd7bfaf-2018-logo-huawei.svg",
+          alt="Huawei",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="col-2 col-small-2 col-medium-2">
-      <img src="https://assets.ubuntu.com/v1/c4c720c6-suse.png?w=145" width="144" alt="SUSE">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4c720c6-suse.png",
+          alt="SUSE",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </li>
     <li class="col-2 col-small-2 col-medium-2">
-      <img src="https://assets.ubuntu.com/v1/a1e6f331-2018-logo-rackspace.svg" width="144" alt="Rackspace">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a1e6f331-2018-logo-rackspace.svg",
+          alt="Rackspace",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </li>
   </ul>
 </section>


### PR DESCRIPTION
## Done

Add image template to /openstack/what-is-openstack

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/what-is-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load