### PR TITLE
Add lazy load to /public-cloud

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -51,7 +51,7 @@
           <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
         </ul>
       </p>
-      
+
       <p>
         <a class="p-link--external" href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf">Get the Ubuntu Pro datasheet</a>
       </p>
@@ -79,6 +79,7 @@
             height="208",
             width="504",
             hi_def=True,
+            loading="lazy",
           ) | safe
         }}
       </div>
@@ -95,6 +96,7 @@
             height="208",
             width="371",
             hi_def=True,
+            loading="lazy",
           ) | safe
         }}
       </div>
@@ -119,6 +121,7 @@
           height="272",
           width="540",
           hi_def=True,
+          loading="lazy",
         ) | safe
       }}
     </div>
@@ -148,6 +151,7 @@
           height="125",
           width="210",
           hi_def=True,
+          loading="lazy",
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

- Added lazy load config

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
