### PR TITLE
Add image_template to /training

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -1,7 +1,9 @@
 {% extends "training/_base_training.html" %}
 
 {% block title %}Training{% endblock %}
+
 {% block meta_description %}Canonical run OpenStack, Kubernetes, MAAS and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
 
 {% block outer_content %}
@@ -14,7 +16,17 @@
       <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
     </div>
     <div class="col-6 u-hide--small" style="position: relative; margin-top: -6rem;">
-      <img class="u-image-position--top u-image-position--right u-hide--small u-no-margin--top" alt="" src="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg" width="460" style="width: 460px;" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg",
+        alt="",
+        width="460",
+        height="263",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-image-position--top u-image-position--right u-hide--small u-no-margin--top", "style": "width: 460px;"},
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -239,7 +251,6 @@
   </div>
 </section>
 
-
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
@@ -248,7 +259,16 @@
       <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/9b170f06-picto-help-orange.svg" width="135" alt="" />
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9b170f06-picto-help-orange.svg",
+        alt="",
+        width="135",
+        height="135",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
