### PR TITLE
Add image template to openstack features

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -72,7 +72,16 @@
       </p>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
-      <img src="https://assets.ubuntu.com/v1/0714f018-VMware-migration.svg" width="234" alt="" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/0714f018-VMware-migration.svg",
+          alt="",
+          height="234",
+          width="234",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -169,7 +178,16 @@
       <p><a href="/openstack/consulting">Learn more about our consulting services&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-align--right u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg" width="234" alt="" />
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg",
+          alt="",
+          height="151",
+          width="234",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -253,13 +271,33 @@
     </div>
     <div class="col-5 col-start-large-8">
       <div class="p-card">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/4f1e16bf-image-swift.svg" alt="Swift">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/4f1e16bf-image-swift.svg",
+            alt="Swift",
+            height="32",
+            width="32",
+            hi_def=True,
+            attrs={"class": "p-card__thumbnail"},
+            loading="lazy",
+          ) | safe
+        }}
         <hr class="u-sv1">
         <h3 class="p-card__title">Swift</h3>
         <p class="p-card__content">The high performance S3-compatible object store developed and shipped with OpenStack, ideal for storing unstructured data.</p>
       </div>
       <div class="p-card">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/636b94fd-ceph.svg" alt="Ceph">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/636b94fd-ceph.svg",
+            alt="Ceph",
+            height="32",
+            width="32",
+            hi_def=True,
+            attrs={"class": "p-card__thumbnail"},
+            loading="lazy",
+          ) | safe
+        }}
         <hr class="u-sv1">
         <h3 class="p-card__title">Ceph</h3>
         <p class="p-card__content">A converged storage framework that has been designed to present object, block, and file storage from a single distributed computer cluster.</p>
@@ -296,19 +334,64 @@
     <div class="col-5">
       <ul class="p-inline-images">
         <li class="p-inline-images__item">
-          <img src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" width="144" alt="Cisco">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
+              alt="Cisco",
+              height="76",
+              width="144",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img src="https://assets.ubuntu.com/v1/a2a68c52-logo-juniper-160.png?w=144" width="144" alt="Juniper">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/a2a68c52-logo-juniper-160.png",
+              alt="Juniper",
+              height="72",
+              width="144",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img src="https://assets.ubuntu.com/v1/9a58cde9-Open_vSwitch_Logo.png?w=134" width="134" alt="Open vSwitch">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/9a58cde9-Open_vSwitch_Logo.png",
+              alt="Open vSwitch",
+              height="87",
+              width="134",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img src="https://assets.ubuntu.com/v1/52ad9297-tungsten-fabric.png?w=144" width="144" alt="Tungsten fabric">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/52ad9297-tungsten-fabric.png",
+              alt="Tungsten fabric",
+              height="68",
+              width="144",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img src="https://assets.ubuntu.com/v1/0e4869ec-cplaneai-logo.png?w=142" width="142" alt="Cplaneai">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/0e4869ec-cplaneai-logo.png",
+              alt="Cplaneai",
+              height="38",
+              width="142",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
         </li>
       </ul>
     </div>
@@ -323,7 +406,16 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <img src="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png?w=1040" width="1040" alt="OpenStack logging and monitoring" />
+    {{
+      image(
+        url="https://assets.ubuntu.com/v1/9f6916dd-k8s-prometheus-light.png",
+        alt="OpenStack logging and monitoring",
+        height="585",
+        width="1040",
+        hi_def=True,
+        loading="lazy",
+      ) | safe
+    }}
     <h6>These dashboards can be customised or integrated into existing monitoring systems at your business.</h6>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add image template to /openstack/features

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load