### PR TITLE
Changes <button> alt= attributes to labels

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -53,8 +53,8 @@
       <div class="p-navigation__search" role="menuitem">
         <form action="/search" class="p-search-box" id="google-appliance-search-form">
           <input type="search" class="p-search-box__input" name="q" placeholder="Search" required="" aria-label="Search">
-          <button type="reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
-          <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+          <button type="reset" class="p-search-box__reset u-no-margin--right"><i class="p-icon--close">Clear</i></button>
+          <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
         </form>
       </div>
     </nav>


### PR DESCRIPTION
## Done

Applied valid labels to the Clear and Search buttons in the header search field.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and check that the new labels in the search field do not show up
- View the same page in a text-only browser or screenreader, and check that the search field buttons now have “Clear” and “Search” labels

## Issue / Card

Fixes #6728