### PR TITLE
Add image template to openstack consulting

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -32,7 +32,16 @@
         <p>Once you are certain OpenStack is the right choice we can deliver your cloud in two weeks. Only then do you need to commit the devops talent required to run your cloud, or <a href="/openstack/managed">outsource that to Canonical</a> as well.</p>
       </div>
       <div class="col-4 u-hide--small u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg" width="240" alt="" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg",
+            alt="",
+            height="155",
+            width="240",
+            hi_def=True,
+            loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
     <div class="u-fixed-width">
@@ -105,17 +114,53 @@
 
     <div class="row u-equal-height">
       <div class="col-4 p-card u-align--center">
-        <a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });"><img class="p-card__icon u-no-margin--bottom" src="https://assets.ubuntu.com/v1/e8568793-contact+us.svg" width="32" alt="Talk to us" /></a>
+        <a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/e8568793-contact+us.svg",
+              alt="Talk to us",
+              height="32",
+              width="32",
+              hi_def=True,
+              attrs={"class": "p-card__icon u-no-margin--bottom"},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
         <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
 
       <div class="col-4 p-card u-align--center">
-        <a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf"><img class="p-card__icon u-no-margin--bottom" src="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg" width="32" alt="Read the datasheet" /></a>
+        <a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+              alt="Read the datasheet",
+              height="32",
+              width="32",
+              hi_def=True,
+              attrs={"class": "p-card__icon u-no-margin--bottom"},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
         <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
 
       <div class="col-4 p-card u-align--center">
-        <a href="https://assets.ubuntu.com/v1/193373c7-canonical-foundation-cloud-requirements-2018-07-18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });"><img class="p-card__icon u-no-margin--bottom" src="https://assets.ubuntu.com/v1/0b6436ab-hardware+requirements+double.svg" width="32" alt="Hardware requirements" /></a>
+        <a href="https://assets.ubuntu.com/v1/193373c7-canonical-foundation-cloud-requirements-2018-07-18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/0b6436ab-hardware+requirements+double.svg",
+              alt="Hardware requirements",
+              height="32",
+              width="32",
+              hi_def=True,
+              attrs={"class": "p-card__icon u-no-margin--bottom"},
+              loading="lazy",
+            ) | safe
+          }}
+        </a>
         <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/193373c7-canonical-foundation-cloud-requirements-2018-07-18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });">Hardware&nbsp;requirements&nbsp;&rsaquo;</a></h4>
       </div>
     </div>
@@ -183,37 +228,147 @@
       <h2 class="p-muted-heading u-align--center">Companies using OpenStack with Canonical</h2>
       <ul class="p-inline-images">
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/9ca791fd-Sky_Logo_seit_Dezember_2015.png?w=124" width="124" alt="Sky" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/9ca791fd-Sky_Logo_seit_Dezember_2015.png",
+              alt="Sky",
+              height="87",
+              width="124",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5af38159-etisalat_logo.svg" width="108" alt="Etisalat" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5af38159-etisalat_logo.svg",
+              alt="Etisalat",
+              height="41",
+              width="108",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/25de1877-Tele2.svg" width="144" alt="Tele2" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/25de1877-Tele2.svg",
+              alt="Tele2",
+              height="57",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d0b7aa28-logo-deutsche-telekom.png?w=96" width="96" alt="Deutsche Telekom" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/d0b7aa28-logo-deutsche-telekom.png",
+              alt="Deutsche Telekom",
+              height="48",
+              width="96",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5482b658-liveperson-logo.jpg?w=144" width="144" alt="Liveperson" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5482b658-liveperson-logo.jpg",
+              alt="Liveperson",
+              height="33",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" width="144" alt="Cisco" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
+              alt="Cisco",
+              height="76",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg" width="144" alt="Bloomberg" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+              alt="Bloomberg",
+              height="28",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg" width="144" alt="ebay" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg",
+              alt="eBay",
+              height="55",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg" width="144" alt="Rabobank" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg",
+              alt="Rabobank",
+              height="26",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg" width="144" alt="Tesco" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg",
+              alt="Tesco",
+              height="38",
+              width="144",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5a9dfd45-Liberty-Global-Logo.png?w=88" width="88" alt="Liberty Global" />
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/5a9dfd45-Liberty-Global-Logo.png",
+              alt="Liberty Global",
+              height="88",
+              width="88",
+              hi_def=True,
+              attrs={"class": "p-inline-images__logo"},
+              loading="lazy",
+            ) | safe
+          }}
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Add image template to /openstack/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images load