### PR TITLE
Add image_template to modal forms, remove unused partial

### DIFF
--- a/templates/shared/forms/interactive/_aws.html
+++ b/templates/shared/forms/interactive/_aws.html
@@ -172,7 +172,16 @@
           <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
         </div>
         <div class="col-5 u-vertically-center u-align--center u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+            alt="smile",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
         </div>
       </div>
       <a class="js-close p-button--neutral" href="">Close</a>

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -363,7 +363,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -215,7 +215,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -7,7 +7,7 @@
     </header>
     <div class="js-pagination js-pagination--1">
       <p id="modal-description" class="u-no-max-width u-no-margin--bottom">Canonical certifies, secures and enables enterprise open source on Ubuntu. Tell us about your project so we bring the right team to the conversation.</p>
-        <div class="js-formfield">
+      <div class="js-formfield">
         <h3 class="p-heading--five">How would you like to make use of Ubuntu?</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
@@ -248,7 +248,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>
@@ -256,4 +265,3 @@
     </div>
   </div>
 </div>
-

--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -198,7 +198,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -279,7 +279,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_openstack.html
+++ b/templates/shared/forms/interactive/_openstack.html
@@ -365,7 +365,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_partner-dell.html
+++ b/templates/shared/forms/interactive/_partner-dell.html
@@ -264,7 +264,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -219,7 +219,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_robotics.html
+++ b/templates/shared/forms/interactive/_robotics.html
@@ -232,7 +232,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_storage.html
+++ b/templates/shared/forms/interactive/_storage.html
@@ -207,7 +207,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -692,12 +692,12 @@
                 name="Consent_to_Processing__c"
                 value="yes"
               />
-              <input 
-                type="hidden" 
-                aria-hidden="true" 
-                aria-label="hidden field" 
-                name="productContext" 
-                id="product-context" 
+              <input
+                type="hidden"
+                aria-hidden="true"
+                aria-label="hidden field"
+                name="productContext"
+                id="product-context"
                 value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
@@ -733,12 +733,16 @@
             </p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img
-              src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg"
-              alt="smile"
-              width="200"
-              height="200"
-            />
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>
@@ -746,4 +750,3 @@
     </div>
   </div>
 </div>
-  

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -218,7 +218,16 @@
             <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Replaced images with the image_template module
- Removed empty and unused _ua-support include

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/#get-in-touch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Try a few modal forms and see that it still works, I don't think the thank-you modal even shows
