### PR TITLE
Add image_template to the /shared/pricing includes

### DIFF
--- a/templates/shared/pricing/_kubernetes-enterprise-support.html
+++ b/templates/shared/pricing/_kubernetes-enterprise-support.html
@@ -47,66 +47,66 @@
         </tr>
         <tr>
           <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju, LXD)</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Deploy, run, scale, upgrade K8s</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Monitoring and logging</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Landscape Management</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Livepatch</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Knowledge Base</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>High availability support</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day, every day</td>
           <td>&nbsp;</td>
           <td class="p-table__cell--highlight">&nbsp;</td>
           <td class="p-table__cell--highlight">&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Disaster recovery</td>
           <td>&nbsp;</td>
           <td class="p-table__cell--highlight">&nbsp;</td>
           <td class="p-table__cell--highlight">&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
       </tbody>
     </table>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -24,39 +24,39 @@
     <tr>
       <th>Industry-leading cloud operations tooling<br />
       (Ubuntu, MAAS, Juju, LXD)</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Deploy, run, scale, upgrade K8s</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Monitoring and logging</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Landscape management</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Livepatch</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Knowledge Base</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>High availability (HA) support</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Remote operations, smart alerts and proactive monitoring by Canonical&rsquo;s cloud experts 24 hours a day, every day</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <th>Disaster recovery</th>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/pricing/_landscape.html
+++ b/templates/shared/pricing/_landscape.html
@@ -12,39 +12,39 @@
     </tr>
     <tr>
       <td>Private instance, on-prem or in a public cloud</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Automated package updates</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Remote package installation, update, and rollback</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Security compliance and audit reports</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Scale out system monitoring</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Hardware inventory control</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Role-based access controls</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>High availability support</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Phone and ticket support for Landscape 24 hours a day, every day</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/pricing/_maas-pricing.html
+++ b/templates/shared/pricing/_maas-pricing.html
@@ -36,21 +36,21 @@
         </tr>
         <tr>
           <td>Knowledge base access</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Role based access controls (RBAC)</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>High availability</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
       </tbody>
     </table>

--- a/templates/shared/pricing/_maas-support.html
+++ b/templates/shared/pricing/_maas-support.html
@@ -41,46 +41,46 @@
 
       <tr>
         <td>Ubuntu and CentOS deployment</td>
-        <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
 
       <tr>
         <td>Landscape management<br />
         (for the MAAS servers)</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
 
       <tr>
         <td>Livepatch<br />
         (for the MAAS servers)</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
 
       <tr>
         <td>Knowledge Base</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
 
       <tr>
         <td>Windows, RHEL, and custom image<br /> creation and deployment</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
 
       <tr>
         <td>High availability (HA) support</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
 
       <tr>

--- a/templates/shared/pricing/_storage-support.html
+++ b/templates/shared/pricing/_storage-support.html
@@ -32,27 +32,27 @@
     </tr>
     <tr>
       <td>Industry-leading cloud operations tooling (Ubuntu, MAAS, Juju)</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Deploy, run, scale, upgrade</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Landscape management</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Livepatch</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Knowledge Base</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
     <tr>
       <td>Production grade monitoring</td>
-      <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+      <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/pricing/_ua-desktop-support.html
+++ b/templates/shared/pricing/_ua-desktop-support.html
@@ -29,33 +29,33 @@
         </tr>
         <tr>
           <td>Download, install, run, use, update, secure, upgrade</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Landscape management</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Kernel Livepatch</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Knowledge Base</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Ubuntu Legal Assurance programme</td>
           <td>&nbsp;</td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-          <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
       </tbody>
     </table>

--- a/templates/shared/pricing/_ua-for-infrastructure-ja.html
+++ b/templates/shared/pricing/_ua-for-infrastructure-ja.html
@@ -66,45 +66,45 @@
         </tr>
         <tr>
           <td><a href="/esm">拡張セキュリティメンテナンス</a> (ESM)</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>カーネルライブパッチ (再起動が不要なカーネルバージョンの更新サービス)</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>ランドスケープ (オンプレミスシステム管理)</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>ナレッジベースへのアクセス</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>KVM Windowsゲスト用認定ドライバ</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td><a href="/security/certifications#fips">FIPS 140-2 レベル 1</a> 認証済暗号モジュール</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td><a href="/security/certifications#common-criteria">共通基準EAL（評価保証レベル）2</a></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>OpenStack</td>
@@ -127,8 +127,8 @@
         <tr>
           <td>法的保証プログラム</td>
           <td class="u-align--center">-</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Ceph/Swift用ストレージサポートの提供</td>

--- a/templates/shared/pricing/_ua-for-infrastructure-physical.html
+++ b/templates/shared/pricing/_ua-for-infrastructure-physical.html
@@ -26,86 +26,86 @@
 
         <tr>
           <td>Download, install, run, use, update, secure, upgrade</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Landscape management</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Kernel Livepatch</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Extended Security Maintenance</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Knowledge Base</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Certified VirtIO Drivers for Windows</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Ubuntu Legal Assurance programme</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>FIPS - certified cryptographic modules</td>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Storage Allowance for Ceph/Swift <a href="#fn-ua-i-storage"><sup>*</sup></a></td>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>High availability support (Kubernetes and OpenStack)</td>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>24/7 OpenStack Support</td>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>24/7 Kubernetes Support</td>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
       </tbody>
       <thead>

--- a/templates/shared/pricing/_ua-for-infrastructure-virtual.html
+++ b/templates/shared/pricing/_ua-for-infrastructure-virtual.html
@@ -27,57 +27,57 @@
 
         <tr>
           <td>Download, install, run, use, update, secure, upgrade</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Landscape management</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Kernel Livepatch</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Extended Security Maintenance</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Knowledge Base</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /> </td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }} </td>
         </tr>
 
         <tr>
           <td>Certified VirtIO Drivers for Windows</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
 
         <tr>
           <td>Ubuntu Legal Assurance programme</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>FIPS - certified cryptographic modules</td>
           <td>&nbsp;</td>
           <td>&nbsp;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
       </tbody>
     </table>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -66,45 +66,45 @@
         </tr>
         <tr>
           <td><a href="/esm">Extended Security Maintenance</a> (ESM)</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td><a href="/livepatch">Kernel Livepatch</a> service to avoid reboots</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td><a href="https://landscape.canonical.com/" class="p-link--external">Landscape</a> on-prem systems management</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Knowledge base access</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Certified Windows drivers for KVM guests</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td><a href="/security/certifications#fips">FIPS 140-2 Level 1</a> certified crypto modules</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td><a href="/security/certifications#common-criteria">Common Criteria EAL2</a></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>OpenStack</td>
@@ -133,8 +133,8 @@
         <tr>
           <td>Legal assurance program</td>
           <td class="u-align--center">&ndash;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes" /></td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
           <td>Ceph/Swift raw storage support included</td>

--- a/templates/shared/pricing/_ua-server-support.html
+++ b/templates/shared/pricing/_ua-server-support.html
@@ -38,73 +38,73 @@
       </tr>
       <tr>
         <td>Download, install, run, use,<br />update, secure, upgrade</td>
-        <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Landscape management</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Kernel Livepatch</td>
         <td></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Extended Security Maintenance</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Knowledge Base</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Certified VirtIO Drivers for Windows</td>
         <td>&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Ubuntu Legal Assurance programme</td>
         <td>&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Unlimited Ubuntu LXD guest support</td>
         <td>&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>Unlimited Ubuntu guest support</td>
         <td>&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
       <tr>
         <td>FIPS-certified cryptographic modules</td>
         <td>&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
         <td class="p-table__cell--highlight">&nbsp;</td>
-        <td class="p-table__cell--highlight u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" width="16" height="16" alt="Yes"></td>
+        <td class="p-table__cell--highlight u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Done

Replaced images with the image_template module, mostly the aubergine ticks

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/infra to see most of them
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
