### PR TITLE
Add image sizes to /engage/yahoo-japan-case-study

### DIFF
--- a/templates/engage/yahoo-japan-case-study.md
+++ b/templates/engage/yahoo-japan-case-study.md
@@ -8,6 +8,8 @@ context:
      header_title: "Yahoo! Japan builds their IaaS environment with Canonical"
      header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/5d403409-2018-logo-yahoo-japan.svg"
+     header_image_width: "250"
+     header_image_height: "63"     
      header_url: '#register-section'
      header_cta: Download case study
      header_class: p-engage-banner--dark


### PR DESCRIPTION
## Done

Added height and width to engage template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/yahoo-japan-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
