### PR TITLE
Add image-module to /about

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -25,7 +25,16 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <img src="https://assets.ubuntu.com/v1/ddf53747-release-evergreen.png?w=681" width="681" alt="" />
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/ddf53747-release-evergreen.png",
+            alt="",
+            width="681",
+            height="154",
+            hi_def=True,
+            loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Add image-module to /about

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


