### PR TITLE
[Image module] /engage pt1

### DIFF
--- a/templates/engage/14-04-esm.html
+++ b/templates/engage/14-04-esm.html
@@ -10,7 +10,18 @@
 
 <section class="p-strip--image is-deep js-takeover is-dark p-takeover--compliance">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
+    <a href="/">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+          alt="Ubuntu",
+          height="32",
+          width="143",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </a>
   </div>
   <div class="row u-vertically-center">
     <div class="col-7">
@@ -23,7 +34,17 @@
       </p>
     </div>
     <div class="col-4 u-hide--small prefix-1">
-      <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" alt="Compliance Webinar" class="p-compliance-icon">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/2217d1c8-Security.svg",
+          alt="",
+          height="154",
+          width="154",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "p-compliance-icon"}
+        ) | safe
+      }}
     </div>
   </div>
   <style>

--- a/templates/engage/14-04-esm.html
+++ b/templates/engage/14-04-esm.html
@@ -33,7 +33,7 @@
         </a>
       </p>
     </div>
-    <div class="col-4 u-hide--small prefix-1">
+    <div class="col-4 u-hide--small u-vertically-center u-align--center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/2217d1c8-Security.svg",

--- a/templates/engage/14-04-esm.html
+++ b/templates/engage/14-04-esm.html
@@ -41,8 +41,7 @@
           height="154",
           width="154",
           hi_def=True,
-          loading="auto",
-          attrs={"class": "p-compliance-icon"}
+          loading="auto"
         ) | safe
       }}
     </div>

--- a/templates/engage/14-04-esm.html
+++ b/templates/engage/14-04-esm.html
@@ -23,7 +23,7 @@
       }}
     </a>
   </div>
-  <div class="row u-vertically-center">
+  <div class="row">
     <div class="col-7">
       <h1>Still running Ubuntu 14.04?</h1>
       <p class="u-no-padding--top p-heading--four">Learn how to maintain ongoing security compliance for your 14.04 systems.</p>

--- a/templates/engage/19-10-webinar.md
+++ b/templates/engage/19-10-webinar.md
@@ -8,6 +8,8 @@ context:
    header_title: "What’s new in Ubuntu 19.10"
    header_subtitle: "Ubuntu 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train live-migration extensions for easier infrastructure deployments and more."
    header_image: "https://assets.ubuntu.com/v1/76095fd7-1910-eoan-ermine-mascot-white.svg"
+   header_image_width: "250"
+   header_image_height: "250"
    header_url: '#register-section'
    header_cta: Register for the webinar
    header_class: p-engage-banner--grad

--- a/templates/engage/451-automotive.html
+++ b/templates/engage/451-automotive.html
@@ -10,7 +10,18 @@
 
 <section class="p-strip--dark p-takeover--451">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
+    <a href="/">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+          alt="Ubuntu",
+          height="32",
+          width="143",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </a>
   </div>
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">
@@ -31,7 +42,17 @@
       </div>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img class="p-takeover__image" src="https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg" width="311" alt="451 Research" >
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg",
+          alt="451 Research",
+          height="116",
+          width="311",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "p-takeover__image"}
+        ) | safe
+      }}
     </div>
   </div>
 </section>

--- a/templates/engage/451-automotive.html
+++ b/templates/engage/451-automotive.html
@@ -49,8 +49,7 @@
           height="116",
           width="311",
           hi_def=True,
-          loading="auto",
-          attrs={"class": "p-takeover__image"}
+          loading="auto"
         ) | safe
       }}
     </div>

--- a/templates/engage/casestudy-rocketchat.html
+++ b/templates/engage/casestudy-rocketchat.html
@@ -8,7 +8,14 @@
 
 {% block content %}
 
-{% with title="Rocket.Chat communication platform enables simplicity through snaps", header_image="1ad274f9-rocket-chat.svg", url="#the-form", cta="Download the case study" %}{% include "engage/shared/_header.html" %}{% endwith %}
+{% with 
+  title="Rocket.Chat communication platform enables simplicity through snaps",
+  header_image="1ad274f9-rocket-chat.svg",
+  header_image_height="214",
+  header_image_width="250",
+  url="#the-form",
+  cta="Download the case study" 
+%}{% include "engage/shared/_header.html" %}{% endwith %}
 
 <section class="p-strip is-shallow">
   <div class="row">

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -63,21 +63,20 @@
         {% set image_url = header_image %}
       {% endif %}
 
-      {% if not header_image_width %}
-        {% set header_image_height = "250" %}
-        {% set header_image_width = "250" %}
+      {% if header_image_width %}
+        {{
+          image(
+            url=image_url,
+            alt="",
+            height=header_image_height,
+            width=header_image_width,
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
+      {% else %}
+        <img src="{% image_url %}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
       {% endif %}
-
-      {{
-        image(
-          url=image_url,
-          alt="",
-          height=header_image_height,
-          width=header_image_width,
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
     </div>{% endif %}
   </div>
 </section>

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -6,11 +6,33 @@
 <section {% if lang %}lang="{{ lang }}"{% endif %} class="{% if class %}p-strip {{ class }}{% else %}p-strip--light{% endif %}">
   {% if class %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" width="143" height="auto" alt="Ubuntu"></a>
+    <a href="/">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+          alt="Ubuntu",
+          height="32",
+          width="143",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </a>
   </div>
   {% else %}
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
+    <a href="/">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
+          alt="Ubuntu",
+          height="32",
+          width="143",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </a>
   </div>
   {% endif %}
   <div class="row u-equal-height">
@@ -34,7 +56,24 @@
       </div>
     </div>
     {% if header_image %}<div class="col-5 u-hide--small u-align--center u-vertically-center">
-      <img src="{% if 'http' not in header_image %}https://assets.ubuntu.com/v1/{% endif %}{{ header_image }}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
+
+      {% if 'http' not in header_image %}
+        {% set image_url = "https://assets.ubuntu.com/v1/" + header_image %}
+      {% else %}
+        {% set image_url = header_image %}
+      {% endif %}
+
+      {{
+        image(
+          url=image_url,
+          alt="",
+          height="353",
+          width="413",
+          hi_def=True,
+          loading="auto",
+          attrs={"style": "max-height: 410px; max-width: 250px;"}
+        ) | safe
+      }}
     </div>{% endif %}
   </div>
 </section>

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -75,7 +75,7 @@
           ) | safe
         }}
       {% else %}
-        <img src="{% image_url %}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
+        <img src="{{ image_url }}" width="413" style="max-height: 410px; max-width: 250px;" alt="" >
       {% endif %}
     </div>{% endif %}
   </div>

--- a/templates/engage/shared/_header.html
+++ b/templates/engage/shared/_header.html
@@ -63,15 +63,19 @@
         {% set image_url = header_image %}
       {% endif %}
 
+      {% if not header_image_width %}
+        {% set header_image_height = "250" %}
+        {% set header_image_width = "250" %}
+      {% endif %}
+
       {{
         image(
           url=image_url,
           alt="",
-          height="353",
-          width="413",
+          height=header_image_height,
+          width=header_image_width,
           hi_def=True,
-          loading="auto",
-          attrs={"style": "max-height: 410px; max-width: 250px;"}
+          loading="auto"
         ) | safe
       }}
     </div>{% endif %}


### PR DESCRIPTION
## Done

- Updated shared header partial to use image template
- Updated: 
  - /engage/14-04-esm
  - /engage/casestudy-rocketchat (this is good for testing the partial)
  - /engage/19-10-webinar
  - /engage/451-automotive

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/14-04-esm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that images are still present in the header
- Repeat for the other three pages in the list above
