### PR TITLE
Add image_template to /engage/whitepaper-iot-security page

### DIFF
--- a/templates/engage/whitepaper-iot-security.html
+++ b/templates/engage/whitepaper-iot-security.html
@@ -47,7 +47,7 @@
         width="150",
         height="150",
         hi_def=True,
-        loading="lazy",
+        loading="auto",
         ) | safe
       }}
     </div>

--- a/templates/engage/whitepaper-iot-security.html
+++ b/templates/engage/whitepaper-iot-security.html
@@ -48,7 +48,6 @@
         height="150",
         hi_def=True,
         loading="lazy",
-        attrs={"style": "max-height: 150px; max-width: 150px;"},
         ) | safe
       }}
     </div>

--- a/templates/engage/whitepaper-iot-security.html
+++ b/templates/engage/whitepaper-iot-security.html
@@ -10,29 +10,50 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width navigation-logo-engage">
-    <a href="/"><img src="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg" width="143" height="auto" alt="Ubuntu"></a>
+    <a href="/">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
+        alt="Ubuntu",
+        width="143",
+        height="32",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </a>
   </div>
-        <div class="row u-equal-height">
-          <div class="col-7  u-vertically-center">
-            <div>
-            <h1 class="u-no-margin--bottom">
-              Taking charge of the IoT's security vulnerabilities
-            </h1>
+  <div class="row u-equal-height">
+    <div class="col-7  u-vertically-center">
+      <div>
+        <h1 class="u-no-margin--bottom">
+          Taking charge of the IoT's security vulnerabilities
+        </h1>
 
 
-            <br class="u-hide--medium u-hide--large">
-            <p class="u-hide--medium u-hide--large">
-              <a href="#the-form" class="p-button--neutral">
-                Download the whitepaper
-              </a>
-            </p>
-            </div>
-          </div>
-          <div class="col-5 u-hide--small u-align--center u-vertically-center">
-            <img src="https://assets.ubuntu.com/v1/2217d1c8-Security.svg" width="150" style="max-height: 150px; max-width: 150px;" alt="">
-          </div>
-        </div>
-      </section>
+        <br class="u-hide--medium u-hide--large">
+        <p class="u-hide--medium u-hide--large">
+          <a href="#the-form" class="p-button--neutral">
+            Download the whitepaper
+          </a>
+        </p>
+      </div>
+    </div>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/2217d1c8-Security.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy",
+        attrs={"style": "max-height: 150px; max-width: 150px;"},
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
 
 <section class="p-strip is-shallow">
   <div class="row">
@@ -47,7 +68,7 @@
       </ul>
     </div>
     <div class="col-5" id="the-form">
-    {% with id="1917", returnURL="https://pages.ubuntu.com/IoTSecurityWhitepaper-Fullreport.html", cta="Download the whitepaper" %}{% include "engage/shared/_en_engage_form.html" %}{% endwith %}
+      {% with id="1917", returnURL="https://pages.ubuntu.com/IoTSecurityWhitepaper-Fullreport.html", cta="Download the whitepaper" %}{% include "engage/shared/_en_engage_form.html" %}{% endwith %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/whitepaper-iot-security
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
