### PR TITLE
Remove thinger from gateway

### DIFF
--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -352,30 +352,6 @@
       }}
     </div>
   </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row">
-    <div class="col-6 u-hide--small u-align--center">
-      {{
-        image(
-          url="https://dashboard.snapcraft.io/site_media/appmedia/2017/03/thinger_256.png",
-          alt="",
-          height="120",
-          width="120",
-          hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
-        ) | safe
-      }}
-    </div>
-    <div class="col-6">
-      <p class="p-heading--three">Thinger.io</p>
-      <p>Thinger.io is a Platform for the Internet of Things. It supports multiple features like sensing and actuating, real-time dashboards, data buckets, webhooks and more.</p>
-    </div>
-  </div>
 </section>
 
 <section class="p-strip">


### PR DESCRIPTION
## Done

- Remove thinger snap from gateway page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/gateways