### PR TITLE
Add image template to apparmor engage page

### DIFF
--- a/templates/engage/apparmor-intro.html
+++ b/templates/engage/apparmor-intro.html
@@ -10,6 +10,8 @@
 
 {% with title="An introduction to AppArmor",
   header_image="bf810a68-AppArmor_logo.svg",
+  header_image_width="250",
+  header_image_height="250",
   subtitle="An explanation of AppArmor and its key features.",
   url="#register-section",
   cta="Read the whitepaper" %}


### PR DESCRIPTION
## Done

Add image template to /engage/apparmor-intro

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/apparmor-intro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads