### PR TITLE
Update /engage/wellcome-sanger-case-study banner with image sizes

### DIFF
--- a/templates/engage/wellcome-sanger-case-study.md
+++ b/templates/engage/wellcome-sanger-case-study.md
@@ -8,6 +8,8 @@ context:
      header_title: "The Wellcome Sanger Institute turns to Canonical for high level Ceph support"
      header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/50aec8a8-sanger+++ceph.svg"
+     header_image_width: "250"
+     header_image_height: "203"
      header_url: '#register-section'
      header_cta: Download case study
      header_class: p-engage-banner--dark
@@ -18,9 +20,9 @@ context:
      form_return_url: "https://pages.ubuntu.com/CStudy_Welcome_Sange_rTY.html"
 ---
 
-The Wellcome Sanger Institute, a global centre of excellence for genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular genetics. With a need to collaborate and share data with other centres around the world, The Institute has to store, process and share vast amounts of data. 
+The Wellcome Sanger Institute, a global centre of excellence for genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular genetics. With a need to collaborate and share data with other centres around the world, The Institute has to store, process and share vast amounts of data.
 
-Following a move to an OpenStack private cloud to complement their existing batch computing infrastructure, The Institute initially opted for self-maintained Ceph storage. As capacity needs grew from 3 PB to over 20 PB, The Institute turned to Canonical for high-level Ceph support providing direct access to Canonical’s engineering teams to resolve the more complex issues. 
+Following a move to an OpenStack private cloud to complement their existing batch computing infrastructure, The Institute initially opted for self-maintained Ceph storage. As capacity needs grew from 3 PB to over 20 PB, The Institute turned to Canonical for high-level Ceph support providing direct access to Canonical’s engineering teams to resolve the more complex issues.
 
 <blockquote class="p-pull-quote">
   <p class="p-pull-quote__quote">Storage effectively holds the crown jewels of the Institute. There’s a huge amount of value held on the system. With Canonical as our trusted partner, we’re confident that we can overcome even the most complex Ceph challenges and continue to create new opportunities for our scientists and the community.</p>
@@ -29,8 +31,8 @@ Following a move to an OpenStack private cloud to complement their existing batc
 
 Utilising a reliable Ceph storage has enabled The Institute to reduce the barriers for scientists and ensure their time is focused on the research itself.
 
-Read the case study to learn how: 
+Read the case study to learn how:
 
 - With the help of Canonical support, The Institute’s latest Ceph roll out decreased from a month to just four days.
-- How the use of object store service enabled by Ceph has allowed scientists to share large volume data digitally rather than by posting physical disks. 
+- How the use of object store service enabled by Ceph has allowed scientists to share large volume data digitally rather than by posting physical disks.
 - The Institute hopes to be able to adopt new technologies quicker – such as erasure coding – with Ceph and Canonical’s support.


### PR DESCRIPTION
## Done

Replaced images with the image_template module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/wellcome-sanger-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
