### PR TITLE
Add image template to acuris engage page

### DIFF
--- a/templates/engage/case-study-acuris.md
+++ b/templates/engage/case-study-acuris.md
@@ -8,6 +8,8 @@ context:
     header_title: "TIM ensures system security and client confidence with ESM"
     header_title_class: 'u-no-margin--bottom'
     header_image: "https://assets.ubuntu.com/v1/e7043d2c-TIM_Logo_white.png"
+    header_image_width: "205"
+    header_image_height: "106"
     header_url: '#register-section'
     header_cta: Download case study
     header_class: p-engage-banner--dark


### PR DESCRIPTION
## Done

Add image template to /engage/case-study-acuris

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/case-study-acuris
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads