### PR TITLE
Add image template to cyberdyne template

### DIFF
--- a/templates/engage/cyberdyne.md
+++ b/templates/engage/cyberdyne.md
@@ -8,6 +8,8 @@ context:
   header_title: "Cyberdyne keeps cleaning robots up to date in the field with snaps"
   header_title_class: 'u-no-margin--bottom'
   header_image: https://assets.ubuntu.com/v1/470ca6c0-logo_cyberdyne.png
+  header_image_width: 250
+  header_image_height: 149
   header_url: '#register-section'
   header_cta: Register for the webinar
   header_class: p-engage-banner--dark


### PR DESCRIPTION
## Done

Add image template to /engage/cyberdyne

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/cyberdyne
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads