### PR TITLE
Added image sizes to the /engage/private-cloud-build-webinar page

### DIFF
--- a/templates/engage/private-cloud-build-webinar.md
+++ b/templates/engage/private-cloud-build-webinar.md
@@ -8,6 +8,8 @@ context:
      header_title: "Lessons learned from 100+ private cloud builds"
      header_subtitle: "Reducing the complexities of building a private cloud on OpenStack"
      header_image: "https://assets.ubuntu.com/v1/b743ab26-Private+Cloud+Build.svg"
+     header_image_width: "250"
+     header_image_height: "161"
      header_url: '#register-section'
      header_cta: Register for the webinar
      header_cta_class: p-button--positive
@@ -15,6 +17,6 @@ context:
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 376727, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---
 
-Building a private cloud based on OpenStack has typically been a complex process with uncertain build costs based on time and materials requiring specialised expertise and low-level Linux OS knowledge. To help enterprises overcome these challenges,Canonical offers private cloud builds to provide businesses with a fully deployed OpenStack delivered in as little as two weeks at a fixed cost. 
+Building a private cloud based on OpenStack has typically been a complex process with uncertain build costs based on time and materials requiring specialised expertise and low-level Linux OS knowledge. To help enterprises overcome these challenges,Canonical offers private cloud builds to provide businesses with a fully deployed OpenStack delivered in as little as two weeks at a fixed cost.
 
 And as a result, after delivering 100’s of private cloud builds over the last 5 years we’ve learnt a thing or two. Join our webinar to hear Nicholas Dimotakis, VP, Data Center Field Engineering speak about the lessons we’ve learnt, the industry changes he expects to see over the coming years and why businesses such as BT, Tele2, Yahoo! Japan and Allan Gray choose Canonical to deploy their private clouds. In addition, Nicholas will run through the process of implementing a turnkey private cloud in its entirety whilst also providing a detailed breakdown of the costs involved.


### PR DESCRIPTION
## Done

Added height and width to engage template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/private-cloud-build-webinar
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
