### PR TITLE
Add image size attributes to intro to microk8s engage page

### DIFF
--- a/templates/engage/intro-to-microk8s-webinar.md
+++ b/templates/engage/intro-to-microk8s-webinar.md
@@ -8,6 +8,8 @@ context:
      header_title: "An intro to MicroK8s"
      header_subtitle: "Reliable, fast, small and upstream Kubernetes"
      header_image: "https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg"
+     header_image_height: 250
+     header_image_width: 250
      header_url: '#register-section'
      header_cta: Watch the webinar
      header_class: p-engage-banner--dark
@@ -20,7 +22,7 @@ context:
 
 MicroK8s is a single package that enables developers to get a fully featured, conformant and secure Kubernetes system running in under 60 seconds.  Designed for local development, IoT appliances, CI/CD, and use at the edge, MicroK8s is available as a snap and available on Linux, Windows and Mac.
 
-Join our upcoming webinar to learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started. Learn more about the add-ons available including Kubeflow for AI/ML, Istio, Grafana and Prometheus for monitoring, Kubernetes dashboard and more. 
+Join our upcoming webinar to learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started. Learn more about the add-ons available including Kubeflow for AI/ML, Istio, Grafana and Prometheus for monitoring, Kubernetes dashboard and more.
 
 <blockquote class="p-pull-quote">
   <p class="p-pull-quote__quote">Canonical might have assembled the easiest way to provision a single node Kubernetes cluster</p>


### PR DESCRIPTION
## Done

- Add image size attributes to intro to microk8s engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- http://localhost:8001/engage/intro-to-microk8s-webinar
