### PR TITLE
Update image sizes on /engage/get-started-with-ai-part-2 pae

### DIFF
--- a/templates/engage/get-started-with-ai-part-2.md
+++ b/templates/engage/get-started-with-ai-part-2.md
@@ -8,6 +8,8 @@ context:
      header_title: "Machine Learning Operations&nbsp;(MLOps)"
      header_subtitle: "Deploy at scale"
      header_image: "https://assets.ubuntu.com/v1/5fc06110-AI+illustration.svg"
+     header_image_width: "250"
+     header_image_height: "224"
      header_url: '#register-section'
      header_cta: Register for the webinar
      header_class: p-engage-banner--aqua


### PR DESCRIPTION
## Done

Added height and width to engage template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/get-started-with-ai-part-2
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
