### PR TITLE
Add image template to deep tech engage page

### DIFF
--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -8,6 +8,8 @@ context:
      header_title: "Accelerating deep tech <br class='u-hide--small' />with Ubuntu"
      header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/3f8c22da-Deep+tech+ubuntu+-+light.svg"
+     header_image_width: 250
+     header_image_height: 168
      header_url: '#register-section'
      header_cta: Register for the webinar
      header_class: p-engage-banner--aqua


### PR DESCRIPTION
## Done

Add image template to /engage/deeptech

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/deeptech
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads