### PR TITLE
Add image template to dell k8s

### DIFF
--- a/templates/engage/deeptech.md
+++ b/templates/engage/deeptech.md
@@ -8,6 +8,8 @@ context:
      header_title: "Accelerating deep tech <br class='u-hide--small' />with Ubuntu"
      header_title_class: 'u-no-margin--bottom'
      header_image: "https://assets.ubuntu.com/v1/3f8c22da-Deep+tech+ubuntu+-+light.svg"
+     header_image_width: 250
+     header_image_height: 168
      header_url: '#register-section'
      header_cta: Register for the webinar
      header_class: p-engage-banner--aqua

--- a/templates/engage/dell-k8s-reference-architecture.md
+++ b/templates/engage/dell-k8s-reference-architecture.md
@@ -8,6 +8,8 @@ context:
      header_title: "Charmed Kubernetes reference architecture"
      header_subtitle: "With VxFlex OS delivered by Dell EMC and Canonical"
      header_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
+     header_image_width: 250
+     header_image_height: 216
      header_url: '#register-section'
      header_cta: Download the pdf
      header_class: p-engage-banner--dark


### PR DESCRIPTION
## Done

Add image template to /engage/dell-k8s-reference-architecture

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/dell-k8s-reference-architecture
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads