### PR TITLE
Add image sizes to /engage/whitepaper-containers

### DIFF
--- a/templates/engage/whitepaper-containers.html
+++ b/templates/engage/whitepaper-containers.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-{% with title="For CTOs: the no-nonsense way to accelerate your business with containers", header_image="a9aff224-Containers-illustration.svg", url="#the-form", cta="Download the whitepaper" %}{% include "engage/shared/_header.html" %}{% endwith %}
+{% with title="For CTOs: the no-nonsense way to accelerate your business with containers", header_image="a9aff224-Containers-illustration.svg",      header_image_width="250", header_image_height="227", url="#the-form", cta="Download the whitepaper" %}{% include "engage/shared/_header.html" %}{% endwith %}
 
 <section class="p-strip is-shallow">
   <div class="row">


### PR DESCRIPTION
## Done

Added height and width to engage template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/whitepaper-containers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
