### PR TITLE
Add image template to dell ref engage

### DIFF
--- a/templates/engage/dell-openstack-reference-architecture.md
+++ b/templates/engage/dell-openstack-reference-architecture.md
@@ -8,6 +8,8 @@ context:
      header_title: "Charmed OpenStack reference architecture"
      header_subtitle: "With Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking and Canonical"
      header_image: "https://assets.ubuntu.com/v1/2de27236-ubuntu+plus+dell+white+version.svg"
+     header_image_width: 250
+     header_image_height: 216
      header_url: '#register-section'
      header_cta: Download the pdf
      header_class: p-engage-banner--dark


### PR DESCRIPTION
## Done

Add image template to /engage/dell-openstack-reference-architecture

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/dell-openstack-reference-architecture
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads