### PR TITLE
Add image sizes to /engage/whats-new-ubuntu-14-04-lts

### DIFF
--- a/templates/engage/whats-new-ubuntu-14-04-lts.html
+++ b/templates/engage/whats-new-ubuntu-14-04-lts.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-{% with title="Learn What's New In Ubuntu Server 14.04 LTS", header_image="9f61b97f-logo-ubuntu.svg", url="#the-form", cta="Download the whitepaper" %}{% include "engage/shared/_header.html" %}{% endwith %}
+{% with title="Learn What's New In Ubuntu Server 14.04 LTS", header_image="9f61b97f-logo-ubuntu.svg", header_image_width="250", header_image_height="56", url="#the-form", cta="Download the whitepaper" %}{% include "engage/shared/_header.html" %}{% endwith %}
 
 <section class="p-strip is-shallow">
   <div class="row">


### PR DESCRIPTION
## Done

Added height and width to engage template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/whats-new-ubuntu-14-04-lts
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images are still there (compare to ubuntu.com)
