### PR TITLE
Add image template to domotz engage

### DIFF
--- a/templates/engage/domotz-case-study.md
+++ b/templates/engage/domotz-case-study.md
@@ -8,6 +8,8 @@ context:
      header_title: "How Domotz streamlined provisioning of IoT devices"
      header_subtitle: "Learn how Ubuntu Core and snaps gives Domotz a competitive advantage"
      header_image: "https://assets.ubuntu.com/v1/b097ccfe-domotz-logo-white.svg"
+     header_image_width: 250
+     header_image_height: 52
      header_url: '#register-section'
      header_cta: Download case study
      header_class: p-engage-banner--dark


### PR DESCRIPTION
## Done

Add image template to /engage/domotz-case-study

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/domotz-case-study
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the header image loads