### PR TITLE
Remove cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@canonical/global-nav": "2.4.0",
     "@canonical/cookie-policy": "2.0.3",
-    "cypress": "4.0.2",
     "vanilla-framework": "2.6.0"
   },
   "resolutions": {


### PR DESCRIPTION
Removing cypresss from dependencies. Since it downloads a lot of stuff that we don't need when deploying.