### PR TITLE
Trigger the build when submitting /core/build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ static/js/build
 .webcache_blog/
 .webcache
 webapp/snapcraft_api/
+.dotrun.json
+.venv/
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.image-template==1.0.0
 canonicalwebteam.discourse-docs==0.11.0
 canonicalwebteam.store-api==1.0.5
+canonicalwebteam.launchpad==0.2.0
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedparser==5.2.1

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -5,6 +5,16 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1Hw_8dWAAUpHHm5Z_XNUVJaSVE5k5i2Vt6WANcJYUZvY/edit{% endblock meta_copydoc %}
 
 {% block content %}
+
+{% if build_info %}
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <h1>Build started</h1>
+    <p>We've kicked off <a href="{{ build_info.web_link }}">your build</a>.</p>
+    <pre>{{ build_info | tojson }}</pre>
+  </div>
+</section>
+{% else %}
 <section class="p-strip--suru-topped">
   <div class="row">
     <div class="col-7">
@@ -167,7 +177,12 @@
           <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
           <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
         </p>
-        <p><button class="p-button--positive js-build-button" aria-disabled="true" disabled="">Build image</button></p>
+        <form method="POST">
+          <input type="hidden" name="board" value="cm3" />
+          <input type="hidden" name="system" value="core16" />
+          <input type="hidden" name="snaps" value="toto,code,toto-fran" />
+          <p><button class="p-button--positive js-build-button">Build image</button></p>
+        </form>
       </div>
     </div>
   </section>
@@ -178,7 +193,8 @@
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
 
-</div>
+{% endif %}
 
 {% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -36,6 +36,7 @@ from webapp.views import (
     blog_custom_topic,
     blog_press_centre,
     download_thank_you,
+    post_build,
     releasenotes_redirect,
     search_snaps,
     build_tutorials_index,
@@ -135,6 +136,7 @@ app.add_url_rule("/logout", view_func=logout)
 template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/snaps", view_func=search_snaps)
+app.add_url_rule("/core/build", view_func=post_build, methods=["POST"])
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 url_prefix = "/server/docs"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -12,6 +12,7 @@ import talisker.requests
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
 from canonicalwebteam.store_api.stores.snapcraft import SnapcraftStoreApi
+from canonicalwebteam.launchpad import Launchpad
 from geolite2 import geolite2
 from requests.exceptions import HTTPError
 
@@ -90,6 +91,35 @@ def releasenotes_redirect():
         return flask.redirect(f"https://wiki.ubuntu.com/{ver}/ReleaseNotes")
     else:
         return flask.redirect(f"https://wiki.ubuntu.com/Releases")
+
+
+def post_build():
+    """
+    Once they submit the build form on /core/build,
+    kick off the build with launchpad
+    """
+
+    if not is_authenticated(flask.session):
+        flask.abort(401)
+
+    launchpad = Launchpad(
+        username="image.build",
+        token=os.environ["LAUNCHPAD_TOKEN"],
+        secret=os.environ["LAUNCHPAD_SECRET"],
+        session=session,
+    )
+
+    response = launchpad.build_image(
+        board=flask.request.values.get("board"),
+        system=flask.request.values.get("system"),
+        snaps=flask.request.values.get("snaps", "").split(","),
+    )
+
+    build_response = launchpad.session.get(response.headers["Location"])
+
+    return flask.render_template(
+        "core/build.html", build_info=build_response.json()
+    )
 
 
 def search_snaps():


### PR DESCRIPTION
I've bastardised the markup in `templates/core/build.html` just to
illustrate how to POST the form to my view function. So
@anthonydillon please fix it up.

This makes use of the brand spanking new
[canonicalwebteam.launchpad](https://github.com/canonical-web-and-design/canonicalwebteam.launchpad)
module, where I mostly copied the code from snapcraft.io.

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2375

QA
--

You need the `LAUNCHPAD_TOKEN` and `LAUNCHPAD_SECRET` environment variables defined in `.env.local` file. You can find the values for this in the shared Lastpass folder.

Then do `./run`.

Go to `/core/build` and click "Build image". Hopefully a horribly
garish success page.