### PR TITLE
Fix up links to tutorials

### DIFF
--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -116,7 +116,7 @@
           <a href="https://snapcraft.io">snapcraft.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://tutorials.ubuntu.com">tutorials.ubuntu.com</a>
+          <a href="/tutorials">/tutorials</a>
         </li>
         <li class="p-list__item">
           <a href="https://ubuntuforums.org">ubuntuforums.org</a>

--- a/templates/templates/_navigation-community-h.html
+++ b/templates/templates/_navigation-community-h.html
@@ -7,7 +7,7 @@
           <h4 class="p-muted-heading u-hide--medium u-hide--large">Learn</h4>
           <p class="p-p--small u-hide--small">Tutorials cover a wide range of topics. Learn or teach something new to Ubuntu users.</p>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="http://tutorials.ubuntu.com/">Ubuntu Tutorials</a></li>
+            <li class="p-list__item"><a href="/tutorials/">Ubuntu Tutorials</a></li>
             <li class="p-list__item"><a href="https://help.ubuntu.com/">Ubuntu documentation</a></li>
             <li class="p-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Ubuntu events on Youtube</a></li>
             <li class="p-list__item"><a href="https://www.youtube.com/channel/UCSsoSZBAZ3Ivlbt_fxyjIkw">The Juju Cloud Operations Show</a></li>

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -9,7 +9,7 @@
         ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',
         'ubuntu.com', 'insights.ubuntu.com', 'developer.ubuntu.com', 'cn.ubuntu.com',
         'design.ubuntu.com', 'maas.io', 'canonical.com', 'landscape.canonical.com',
-        'pages.ubuntu.com', 'tutorials.ubuntu.com', 'docs.ubuntu.com']);
+        'pages.ubuntu.com', '/tutorials', 'docs.ubuntu.com']);
         </script>
         <!-- End Google Analytics and Google Optimize -->
 


### PR DESCRIPTION
## Done

Fix up links to tutorials

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
-  Sanity check link changes

