### PR TITLE
update ebook layouts

### DIFF
--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -1,34 +1,37 @@
-<section class="p-strip--accent is-deep">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2>Before you start, get your IoT security story straight</h2>
+      <h2 class="p-heading--three">Before you start, get your IoT security story straight</h2>
     </div>
   </div>
   <div class="row">
-    <div class="col-7 suffix-1">
+    <div class="col-7">
       <p>A recent Canonical survey of 2,000 consumers suggests that a shockingly high percentage of connected devices may be vulnerable to botnets, hackers and cyber attacks:</p>
-      <ul>
-        <li>Only 31% of consumers update the firmware on their connected devices as soon as updates become available.</li>
-        <li>40% of consumers have never performed firmware updates on their connected devices</li>
-        <li>40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Only 31% of consumers update the firmware on their connected devices as soon as updates become available.</li>
+        <li class="p-list__item is-ticked">40% of consumers have never performed firmware updates on their connected devices</li>
+        <li class="p-list__item is-ticked">40% of consumers believe that performing firmware updates on their connected devices is the responsibility of either software developers or the device manufacturer</li>
       </ul>
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/783e1354-iot-business-model-takeover.svg",
-          alt="",
-          height="382",
-          width="440",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "u-hide--small"}
-        ) | safe
-      }}
+
+      <div class="p-card--highlighted u-hide--small" style="display: inline-block;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/33792cb9-IoTSecurityWhitepaper-cover.jpg",
+            alt="",
+            height="357",
+            width="504",
+            hi_def=True,
+            loading="lazy",
+            attrs={ "style": "display: block;" }
+          ) | safe
+        }}
+      </div>
     </div>
 
-    <div class="col-5">
+    <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1917" class="marketo-form">
-        <fieldset>
+        <fieldset style="border: 0;">
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
               <label for="firstName" class="mktoLabel">First name:</label>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -1,23 +1,8 @@
-<div class="p-strip--accent is-deep">
-  <div class="row">
-    <div class="col-12">
-      <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
-    </div>
-  </div>
+<div class="p-strip--light is-deep">
   <div class="row">
     <div class="col-7">
-      <p class="u-hide--small">
-        {{
-          image(
-              url="https://assets.ubuntu.com/v1/a3b75778-MAAS-ebook-web.svg",
-              alt="",
-              width="400",
-              height="279",
-              hi_def=True,
-              loading="lazy",
-            ) | safe
-        }}
-      </p>
+      <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
+
       <h3>
         Server provisioning: what Network Admins and IT pros need to know
       </h3>
@@ -27,11 +12,22 @@
       <p>
         Canonical’s MAAS helps organisations to take full advantage of existing hardware investments by maximising hardware efficiency, and a pathway to leverage the performance and security of hardware based solutions with the economics and efficiencies of the cloud.
       </p>
+
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/eb104826-MAAS-ebook.png",
+          alt="",
+          width="417",
+          height="303",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
     <div class="col-5">
       <!-- MARKETO FORM -->
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1862" class="marketo-form">
-        <fieldset>
+        <fieldset style="border: 0;">
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
               <label for="1-FirstName" class="mktoLabel">First name:</label>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -1,7 +1,7 @@
 <div class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-heading--three">Before you start, get your IoT security story straight</h2>
+      <h2 class="p-heading--three">Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
     </div>
   </div>
 

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -1,9 +1,13 @@
-<div class="p-strip--light is-deep">
+<div class="p-strip--light">
   <div class="row">
-    <div class="col-7">
-      <h2>Before you start, you&rsquo;ll want this&nbsp;eBook</h2>
+    <div class="col-12">
+      <h2 class="p-heading--three">Before you start, get your IoT security story straight</h2>
+    </div>
+  </div>
 
-      <h3>
+  <div class="row">
+    <div class="col-6">
+      <h3 class="p-heading--four">
         Server provisioning: what Network Admins and IT pros need to know
       </h3>
       <p>
@@ -13,18 +17,22 @@
         Canonical’s MAAS helps organisations to take full advantage of existing hardware investments by maximising hardware efficiency, and a pathway to leverage the performance and security of hardware based solutions with the economics and efficiencies of the cloud.
       </p>
 
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/eb104826-MAAS-ebook.png",
-          alt="",
-          width="417",
-          height="303",
-          hi_def=True,
-          loading="lazy",
-        ) | safe
-      }}
+      <div class="p-card--highlighted" style="display: inline-block;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a7595f5e-network-admin-ebook.png",
+            alt="",
+            width="504",
+            height="338",
+            hi_def=True,
+            loading="lazy",
+            attrs={ "style": "display: block;" }
+          ) | safe
+        }}
+      </div>
     </div>
-    <div class="col-5">
+
+    <div class="col-5 col-start-large-8">
       <!-- MARKETO FORM -->
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1862" class="marketo-form">
         <fieldset style="border: 0;">

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -6,7 +6,7 @@
   </div>
 
   <div class="row">
-    <div class="col-6">
+    <div class="col-7">
       <h3 class="p-heading--four">
         Server provisioning: what Network Admins and IT pros need to know
       </h3>
@@ -32,7 +32,7 @@
       </div>
     </div>
 
-    <div class="col-5 col-start-large-8">
+    <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1862" class="marketo-form">
         <fieldset style="border: 0;">


### PR DESCRIPTION
## Done

Updated the layout of two ebook strip partials

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/provisioning
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the layout looks OK and complies with the [brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6676)
- Visit /download/intel-iei-tank-870
- See that the layout looks OK and complies with the [brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6676)


## Issue / Card

Fixes #6676 

## Screenshots
Before:
![FireShot Capture 026 - Get MAAS to run your physical cloud - Download - Ubuntu - Ubuntu - localhost](https://user-images.githubusercontent.com/2376968/75232970-04866a80-57b0-11ea-8eeb-3ab60cbc23b5.png)

![FireShot Capture 027 - Install Ubuntu Core on an Intel IEI TANK 870 - Ubuntu - localhost](https://user-images.githubusercontent.com/2376968/75232989-094b1e80-57b0-11ea-8593-e51f47ad64e7.png)

After:
![FireShot Capture 024 - Install Ubuntu Core on an Intel IEI TANK 870 - Ubuntu - localhost](https://user-images.githubusercontent.com/2376968/75233009-10722c80-57b0-11ea-84b9-9a5a91769c97.png)

![FireShot Capture 025 - Get MAAS to run your physical cloud - Download - Ubuntu - Ubuntu - localhost](https://user-images.githubusercontent.com/2376968/75233016-12d48680-57b0-11ea-8e71-4a68802a6208.png)





