### PR TITLE
add smart card whitepaper engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -910,5 +910,15 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
+
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Smart card login on Ubuntu",
+      description="How to configure Ubuntu 18.04 LTS to operate with a smart card",
+      slug="smart-card-whitepaper",
+      group="internet-of-things",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 </section>
 {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -909,9 +909,7 @@
       type="case study" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
-  </div>
 
-  <div class="row u-equal-height u-clearfix">
     {% with title="Smart card login on Ubuntu",
       description="How to configure Ubuntu 18.04 LTS to operate with a smart card",
       slug="smart-card-whitepaper",

--- a/templates/engage/smart-card-whitepaper.md
+++ b/templates/engage/smart-card-whitepaper.md
@@ -1,0 +1,34 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Smart cards login on Ubuntu"
+     meta_description: "How to configure Ubuntu 18.04 LTS to operate with a smart card"
+     meta_image: "https://assets.ubuntu.com/v1/13f62d9e-Meta+data+img.jpg"
+     meta_copydoc: "https://docs.google.com/document/d/1wVIC2R2OlqKTXgS97QsIi5txwKlpXpynX4bbWTXgXxo"
+     header_title: "Smart cards login on Ubuntu"
+     header_image: "https://assets.ubuntu.com/v1/cb4837ec-security-3-white.svg"
+     header_image_width: "150"
+     header_image_height: "200"
+     header_subtitle: "Configure Ubuntu 18.04 LTS for smart card operation"
+     header_title_class: 'u-no-margin--bottom'
+     header_url: '#register-section'
+     header_cta: Download whitepaper
+     header_class: p-engage-banner--dark
+     header_lang: en
+     form_include: en
+     form_id: 3506
+     form_return_url: "https://pages.ubuntu.com/Smart_Card-TY.html"
+---
+
+Smart cards have proliferated and are now everywhere, from work ID badges to credit cards and passports. For example, the United States Federal Government uses smart cards to control access to federal facilities and information systems because they offer an extra layer of security and respond to strict government guidelines. If used in a company, these will provide identity confirmation, verification that data has not been changed, and confidentiality via encryption.
+
+This whitepaper will provide information on how to configure Ubuntu 18.04 LTS to operate with a smart card to provide multi-factor authentication when logging into the system both locally and remotely. For the purposes of this whitepaper, a PIVKey smart card is used as an example since they are readily accessible and contain a few basic credentials.
+
+Download the whitepaper to learn more including:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">The software and hardware prerequisites needed for smart card configuration.</li> 
+  <li class="p-list__item is-ticked">How to set up your smart card and configure it to support smart card logins.</li>
+  <li class="p-list__item is-ticked">How to configure SSH smart card login.</li>
+</ul>
+


### PR DESCRIPTION
## Done

Added /engage/smart-card-whitepaper


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a card at the bottom of the list with the title "Smart card login on Ubuntu".
- Follow the link to the engage page, see that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2322#issuecomment-588281479) and the [copy doc](https://docs.google.com/document/d/1wVIC2R2OlqKTXgS97QsIi5txwKlpXpynX4bbWTXgXxo/edit?ts=5e42db44)
- Test the page on https://cards-dev.twitter.com/validator, see that it pulls through a relevant title, description and image


## Issue / Card

Fixes #6645 