### PR TITLE
Remove the summary section

### DIFF
--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -6,9 +6,6 @@
   };
   const boardSelection = document.querySelectorAll('.js-boards .js-selection');
   const osSelection = document.querySelectorAll('.js-os .js-selection');
-  const summaryBoard = document.querySelector('.js-summary-board');
-  const summaryOS = document.querySelector('.js-summary-os');
-  const summarySnaps = document.querySelector('.js-summary-snaps');
   const snapSearch = document.querySelector('.js-snap-search');
   const snapResults = document.querySelector('.js-snap-results');
   const preinstallResults = document.querySelector('.js-preinstalled-snaps-list');
@@ -165,16 +162,6 @@
   }
 
   function renderSummary() {
-    if (summaryBoard) {
-      summaryBoard.innerText = STATE.board;
-    }
-    if (summaryOS) {
-      summaryOS.innerText = STATE.os;
-    }
-    if (summarySnaps) {
-      summarySnaps.innerText = STATE.snaps.length;
-    }
-
     if (STATE.board != '' && STATE.os != '') {
       buildButton.setAttribute('aria-disabled', 'false');
       buildButton.disabled = false;

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -149,12 +149,12 @@
   <section class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
+        <p>We’ll email you at {{ openid.email }} once the build is ready.</p>
         <p>
           <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
           <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
         </p>
         <p><button class="p-button--positive js-build-button" aria-disabled="true" disabled="">Build image</button></p>
-        <p>We’ll mail you at {{ openid.email }} once the build is ready.</p>
       </div>
     </div>
   </section>

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -148,26 +148,13 @@
 
   <section class="p-strip--light is-shallow">
     <div class="row">
-      <h2>Summary</h2>
-    </div>
-    <div class="row p-divider">
-      <div class="col-6 p-divider__block">
-        <dl>
-          <dt>Board</dt>
-          <dd class="js-summary-board"></dd>
-          <dt>Operating system</dt>
-          <dd class="js-summary-os"></dd>
-          <dt>Packages</dt>
-          <dd><span class="js-summary-snaps">0</span> pre-installed packages</dd>
-        </dl>
-      </div>
-      <div class="col-6 p-divider__block">
-        <p>This will trigger a build in Launchpad to create your image. Once the image has been built we will contact you via email on <strong>{{ openid.email }}</strong>. This build will only be available for a few days so please do not rely on Launchpad for future downloads</p>
+      <div class="col-8">
         <p>
           <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
           <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
         </p>
         <p><button class="p-button--positive js-build-button" aria-disabled="true" disabled="">Build image</button></p>
+        <p>We’ll mail you at {{ openid.email }} once the build is ready.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done
Remove the summary section

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/core/build
- Make a section and see there is no summary at the bottom
- Check it matched [the copy doc](https://docs.google.com/document/d/1Hw_8dWAAUpHHm5Z_XNUVJaSVE5k5i2Vt6WANcJYUZvY/edit#)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/2401

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/75165515-6ac0ae00-571a-11ea-96fc-435a114dc734.png)

