### PR TITLE
Add image testing pages

### DIFF
--- a/templates/_image-testing/index.html
+++ b/templates/_image-testing/index.html
@@ -1,0 +1,39 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Image testing{% endblock %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+<section class="p-strip--suru is-dark is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1>Image testing</h1>
+      <p>
+        Viewing images in isolation for testing purposes.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <ul class="row">
+    <ul>
+      <li><a href="/_image-testing/jpg/">Jpeg (Native)</a></li>
+      <li><a href="/_image-testing/jpg/index-lazy">Jpeg (With image module)</a></li>
+    </ul>
+    <ul>
+      <li><a href="/_image-testing/png/">Png (Native)</a></li>
+      <li><a href="/_image-testing/png/index-lazy">Png (With image module)</a></li>
+    </ul>
+    <ul>
+      <li><a href="/_image-testing/svg/">SVG (Native)</a></li>
+      <li><a href="/_image-testing/svg/index-lazy">SVG (With image module)</a></li>
+    </ul>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/_image-testing/jpg/index-lazy.html
+++ b/templates/_image-testing/jpg/index-lazy.html
@@ -1,0 +1,51 @@
+{% extends "templates/image-testing_base.html" %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+{{
+  image(
+    url="https://assets.ubuntu.com/v1/c1471906-libreoffice.jpg",
+    alt="",
+    height="414",
+    width="500",
+    hi_def=True,
+    loading="auto",
+  ) | safe
+}}
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+{{
+  image(
+    url="https://assets.ubuntu.com/v1/e820660a-small-robot-company-logo.jpg",
+    alt="",
+    height="350",
+    width="350",
+    hi_def=True,
+    loading="lazy"
+  ) | safe
+}}
+
+{% endblock content %}

--- a/templates/_image-testing/jpg/index.html
+++ b/templates/_image-testing/jpg/index.html
@@ -1,0 +1,33 @@
+{% extends "templates/image-testing_base.html" %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+<img width="500" height="414" src="https://assets.ubuntu.com/v1/c1471906-libreoffice.jpg" alt="">
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Abreiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<img width="350" height="350" src="https://assets.ubuntu.com/v1/e820660a-small-robot-company-logo.jpg" alt="" />
+
+{% endblock content %}

--- a/templates/_image-testing/png/index-lazy.html
+++ b/templates/_image-testing/png/index-lazy.html
@@ -1,0 +1,43 @@
+{% extends "templates/image-testing_base.html" %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+{{
+  image(
+    url="https://assets.ubuntu.com/v1/3a05fc34-Dell_XPS_Laptop_Front-news.png",
+    alt="",
+    height="353",
+    width="700",
+    hi_def=True,
+    loading="auto",
+  ) | safe
+}}
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Abreiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+{{
+  image(
+    url="https://assets.ubuntu.com/v1/971aa15e-QXLkLsa.png",
+    alt="",
+    width="138",
+    height="52",
+    hi_def=True,
+    loading="lazy",
+  ) | safe
+}}
+
+{% endblock content %}

--- a/templates/_image-testing/png/index.html
+++ b/templates/_image-testing/png/index.html
@@ -1,0 +1,41 @@
+{% extends "templates/image-testing_base.html" %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+<img src="https://assets.ubuntu.com/v1/3a05fc34-Dell_XPS_Laptop_Front-news.png" width="700" height="353" alt="">
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<img width="138" height="52" src="https://assets.ubuntu.com/v1/971aa15e-QXLkLsa.png" alt="">
+
+{% endblock content %}

--- a/templates/_image-testing/svg/index-lazy.html
+++ b/templates/_image-testing/svg/index-lazy.html
@@ -1,0 +1,67 @@
+{% extends "templates/image-testing_base.html" %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+{{
+  image(
+    url="https://assets.ubuntu.com/v1/580f3ae7-automotive.svg",
+    alt="",
+    width="350",
+    height="250",
+    hi_def=True,
+    loading="auto",
+  ) | safe
+}}
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+{{
+  image(
+    url="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg",
+    alt="",
+    height="365",
+    width="360",
+    hi_def=True,
+    loading="lazy"
+  ) | safe
+}}
+
+{% endblock content %}

--- a/templates/_image-testing/svg/index.html
+++ b/templates/_image-testing/svg/index.html
@@ -1,0 +1,33 @@
+{% extends "templates/image-testing_base.html" %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block content %}
+
+<img width="350" height="250" src="https://assets.ubuntu.com/v1/580f3ae7-automotive.svg" alt="">
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias.Abreiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Aliquid maxime voluptate accusantium dolor hic molestias. Ab reiciendis eius adipisci non dolorem, quia, animi dolore sit nisi iusto porro. Modi, voluptatibus!</p>
+
+<img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg" width="360" height="365" alt="">
+
+{% endblock content %}

--- a/templates/templates/image-testing_base.html
+++ b/templates/templates/image-testing_base.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html prefix="og: http://ogp.me/ns#" lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex" />
+  <title>Testing images | Ubuntu</title>
+  <link rel="preconnect" href="https://res.cloudinary.com">
+  <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
+</head>
+<body>
+  {% block content %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
## Done

Add image testing pages to run tests comparing native image tags versus using the image template module.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check pages at /_image-testing
- Sanity check code
