### PR TITLE
Remove erroneous closing tag

### DIFF
--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -1,17 +1,15 @@
 {% if strip == "light" %}
 <section class="p-strip--light is-bordered">
 {% else %}
-<section class="p-strip is-bordered"></section>
+<section class="p-strip is-bordered">
 {% endif %}
   <div class="row u-equal-height">
     <div class="col-7">
       <h2>Multipass for instant Ubuntu VMs</h2>
       <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
-
       <p>
         <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
       </p>
-
       <p>
         <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>
       </p>


### PR DESCRIPTION
## Done

- Removed closing section tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the "Multipass for instant Ubuntu VMs" strip is displayed correctly


## Issue / Card

Fixes #6846 