### PR TITLE
Restyle the snap selection section

### DIFF
--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -67,7 +67,7 @@
       addButton.addEventListener('click', e => {
         e.preventDefault();
         const button = (e.target.classList.contains('js-add-snap'))?e.target:e.target.closest('.js-add-snap');
-        if (!lookup(snapSearchResults[button.dataset.index].package_name, 'package_name', STATE.snaps)) {
+        if (lookup(snapSearchResults[button.dataset.index].package_name, 'package_name', STATE.snaps) === false) {
           const selectedSnapContainer = button.closest('.js-snap-search-container');
           if (selectedSnapContainer) {
             selectedSnapContainer.classList.add('u-disable');
@@ -221,7 +221,7 @@
   function lookup(name, key, arr) {
     for (var i = 0, len = arr.length; i < len; i++) {
       if (arr[i][key] === name) {
-        return true;
+        return i;
       }
     }
     return false;

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -111,7 +111,7 @@
         </span>`:'';
           results.insertAdjacentHTML('beforeend',
             `<div class="row js-snap-search-container" data-container-index="${index}">
-              <div class="col-5">
+              <div class="col-5 col-medium-5 col-small-3">
                 <div class="p-media-object u-no-margin--bottom" data-container-index="${index}">
                   <img src="${item.icon_url}" alt="" class="p-media-object__image">
                   <div class="p-media-object__details">
@@ -122,7 +122,7 @@
                   </div>
                 </div>
               </div>
-              <div class="col-1">
+              <div class="col-1 col-medium-1 col-small-1">
                 <a href="" class="p-button--base js-${buttonText.toLowerCase()}-snap" data-index="${index}"><i class="p-icon--${buttonIcon}">${buttonText}</i></a>
               </div>
             </div>

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -57,8 +57,7 @@
   }, 250);
 
   function clearSearch() {
-    changeState('snaps', []);
-    renderSnapList(STATE.snaps, snapResults, 'Add');
+    renderSnapList([], snapResults, 'Add');
   }
 
   function addSnapHandler() {
@@ -87,11 +86,13 @@
       removeButton.addEventListener('click', e => {
         e.preventDefault();
         const button = (e.target.classList.contains('js-remove-snap'))?e.target:e.target.closest('.js-remove-snap');
-        const searchIndex = lookup(STATE.snaps[button.dataset.index].package_name, 'package_name', snapSearchResults)
-        const revealItem = snapResults.querySelector(`[data-container-index="${searchIndex}"]`)
-        if (revealItem) {
-          revealItem.classList.remove('u-disable');
-          e.target.disabled = false;
+        if (STATE.snaps[button.dataset.index]) {
+          const searchIndex = lookup(STATE.snaps[button.dataset.index].package_name, 'package_name', snapSearchResults)
+          const revealItem = snapResults.querySelector(`[data-container-index="${searchIndex}"]`)
+          if (revealItem) {
+            revealItem.classList.remove('u-disable');
+            e.target.disabled = false;
+          }
         }
         STATE.snaps.splice(button.dataset.index, 1);
         renderSnapList(STATE.snaps, preinstallResults, 'Remove');
@@ -133,7 +134,7 @@
         });
         render();
       } else {
-        results.innerHTML = '<p>No matching snaps</p>';
+        results.innerHTML = (buttonText == 'Add')?'<p>No matching snaps</p>':'<p>None</p>';
       }
     }
   }

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -219,7 +219,7 @@
   function lookup(name, key, arr) {
     for (var i = 0, len = arr.length; i < len; i++) {
       if (arr[i][key] === name) {
-        return i;
+        return true;
       }
     }
     return false;

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -26,8 +26,11 @@
   function searchHandler() {
     if (snapSearch) {
       snapSearch.addEventListener('keyup', e => {
-        e.preventDefault();
-        triggerSearch();
+        // Only trigger is the key press changes a character
+        if ((e.which >= 46 && e.which <= 90) || e.which == 8) {
+          e.preventDefault();
+          triggerSearch();
+        }
       });
       snapSearch.addEventListener('submit', e => {
         e.preventDefault();
@@ -40,7 +43,7 @@
   }
 
   let triggerSearch = debounce(function() {
-    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i> &nbsp;Loading snaps</p>';
+    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i></p>';
     const searchInput = snapSearch.querySelector('.p-search-box__input');
     if (searchInput) {
       const searchValue = encodeURI(searchInput.value);
@@ -57,7 +60,7 @@
   }, 250);
 
   function clearSearch() {
-    renderSnapList([], snapResults, 'Add');
+    snapResults.innerHTML = '';
   }
 
   function addSnapHandler() {
@@ -106,6 +109,10 @@
       results.innerHTML = '';
       if (Object.entries(responce).length !== 0) {
         responce.forEach((item, index) => {
+          let disable = '';
+          if (lookup(item.package_name, 'package_name', STATE.snaps) !== false && buttonText === 'Add') {
+            disable = 'u-disable';
+          }
           buttonIcon = (buttonText === 'Add')?'plus':'minus';
           item.icon_url = (item.icon_url)?item.icon_url:'https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg';
           item.validation_icon = (item.developer_validation === 'verified')?`<span class="p-tooltip p-tooltip--top-center" aria-describedby="${item.package_name}-tooltip">
@@ -113,7 +120,7 @@
           <span class="p-tooltip__message u-align--center" role="tooltip" id="${item.package_name}-tooltip">Verified account</span>
         </span>`:'';
           results.insertAdjacentHTML('beforeend',
-            `<div class="row js-snap-search-container" data-container-index="${index}">
+            `<div class="row js-snap-search-container ${disable}" data-container-index="${index}">
               <div class="col-5 col-medium-5 col-small-3">
                 <div class="p-media-object u-no-margin--bottom" data-container-index="${index}">
                   <img src="${item.icon_url}" alt="" class="p-media-object__image">

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -40,7 +40,7 @@
   }
 
   let triggerSearch = debounce(function() {
-    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i> &nbsp;LoadingLoading snaps</p>';
+    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i> &nbsp;Loading snaps</p>';
     const searchInput = snapSearch.querySelector('.p-search-box__input');
     if (searchInput) {
       const searchValue = encodeURI(searchInput.value);

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -33,10 +33,14 @@
         e.preventDefault();
         triggerSearch();
       });
+      snapSearch.addEventListener('reset', e => {
+        clearSearch();
+      });
     }
   }
 
   let triggerSearch = debounce(function() {
+    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i> Loading snaps</p>';
     const searchInput = snapSearch.querySelector('.p-search-box__input');
     if (searchInput) {
       const searchValue = encodeURI(searchInput.value);
@@ -51,6 +55,11 @@
         });
     }
   }, 250);
+
+  function clearSearch() {
+    changeState('snaps', []);
+    renderSnapList(STATE.snaps, snapResults, 'Add');
+  }
 
   function addSnapHandler() {
     const snapAddButtons = snapResults.querySelectorAll('.js-add-snap');
@@ -121,6 +130,8 @@
           );
         });
         render();
+      } else {
+        results.innerHTML = '<p>No matching snaps</p>';
       }
     }
   }

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -40,7 +40,7 @@
   }
 
   let triggerSearch = debounce(function() {
-    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i> Loading snaps</p>';
+    snapResults.innerHTML = '<p><i class="p-icon--spinner u-animation--spin"></i> &nbsp;LoadingLoading snaps</p>';
     const searchInput = snapSearch.querySelector('.p-search-box__input');
     if (searchInput) {
       const searchValue = encodeURI(searchInput.value);
@@ -71,6 +71,7 @@
           const selectedSnapContainer = button.closest('.js-snap-search-container');
           if (selectedSnapContainer) {
             selectedSnapContainer.classList.add('u-disable');
+            e.target.disabled = true;
           }
           STATE.snaps.push(snapSearchResults[button.dataset.index]);
           renderSnapList(STATE.snaps, preinstallResults, 'Remove');
@@ -90,6 +91,7 @@
         const revealItem = snapResults.querySelector(`[data-container-index="${searchIndex}"]`)
         if (revealItem) {
           revealItem.classList.remove('u-disable');
+          e.target.disabled = false;
         }
         STATE.snaps.splice(button.dataset.index, 1);
         renderSnapList(STATE.snaps, preinstallResults, 'Remove');
@@ -123,7 +125,7 @@
                 </div>
               </div>
               <div class="col-1 col-medium-1 col-small-1">
-                <a href="" class="p-button--base js-${buttonText.toLowerCase()}-snap" data-index="${index}"><i class="p-icon--${buttonIcon}">${buttonText}</i></a>
+                <button class="p-button--base js-${buttonText.toLowerCase()}-snap" data-index="${index}"><i class="p-icon--${buttonIcon}">${buttonText}</i></button>
               </div>
             </div>
             <hr />`

--- a/static/js/imageBuilder.js
+++ b/static/js/imageBuilder.js
@@ -57,12 +57,13 @@
     snapAddButtons.forEach(addButton => {
       addButton.addEventListener('click', e => {
         e.preventDefault();
-        if (!lookup(snapSearchResults[e.target.dataset.index].snap_id, 'snap_id', STATE.snaps)) {
-          const selectedSnapContainer = e.target.closest('.p-media-object');
+        const button = (e.target.classList.contains('js-add-snap'))?e.target:e.target.closest('.js-add-snap');
+        if (!lookup(snapSearchResults[button.dataset.index].package_name, 'package_name', STATE.snaps)) {
+          const selectedSnapContainer = button.closest('.js-snap-search-container');
           if (selectedSnapContainer) {
-            selectedSnapContainer.classList.add('u-hide');
+            selectedSnapContainer.classList.add('u-disable');
           }
-          STATE.snaps.push(snapSearchResults[e.target.dataset.index]);
+          STATE.snaps.push(snapSearchResults[button.dataset.index]);
           renderSnapList(STATE.snaps, preinstallResults, 'Remove');
           removeSnapHandler();
         }
@@ -75,12 +76,13 @@
     snapRemoveButtons.forEach(removeButton => {
       removeButton.addEventListener('click', e => {
         e.preventDefault();
-        searchIndex = lookup(STATE.snaps[e.target.dataset.index].snap_id, 'snap_id', snapSearchResults)
+        const button = (e.target.classList.contains('js-remove-snap'))?e.target:e.target.closest('.js-remove-snap');
+        const searchIndex = lookup(STATE.snaps[button.dataset.index].package_name, 'package_name', snapSearchResults)
         const revealItem = snapResults.querySelector(`[data-container-index="${searchIndex}"]`)
         if (revealItem) {
-          revealItem.classList.remove('u-hide');
+          revealItem.classList.remove('u-disable');
         }
-        STATE.snaps.splice(e.target.dataset.index, 1);
+        STATE.snaps.splice(button.dataset.index, 1);
         renderSnapList(STATE.snaps, preinstallResults, 'Remove');
         removeSnapHandler();
       });
@@ -92,22 +94,30 @@
       results.innerHTML = '';
       if (Object.entries(responce).length !== 0) {
         responce.forEach((item, index) => {
+          buttonIcon = (buttonText === 'Add')?'plus':'minus';
           item.icon_url = (item.icon_url)?item.icon_url:'https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg';
           item.validation_icon = (item.developer_validation === 'verified')?`<span class="p-tooltip p-tooltip--top-center" aria-describedby="${item.package_name}-tooltip">
           <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
           <span class="p-tooltip__message u-align--center" role="tooltip" id="${item.package_name}-tooltip">Verified account</span>
         </span>`:'';
           results.insertAdjacentHTML('beforeend',
-            `<div class="p-media-object" data-container-index="${index}">
-              <img src="${item.icon_url}" alt="" class="p-media-object__image">
-              <div class="p-media-object__details">
-                <h1 class="p-media-object__title">${item.title}</h1>
-                <p class="p-media-object__content">
-                  ${item.publisher} ${item.validation_icon}
-                </p>
-                <a href="" class="p-button--neutral js-${buttonText.toLowerCase()}-snap" data-index="${index}">${buttonText}</a>
+            `<div class="row js-snap-search-container" data-container-index="${index}">
+              <div class="col-5">
+                <div class="p-media-object u-no-margin--bottom" data-container-index="${index}">
+                  <img src="${item.icon_url}" alt="" class="p-media-object__image">
+                  <div class="p-media-object__details">
+                    <h1 class="p-media-object__title" style="line-height: 1.4rem">${item.title}</h1>
+                    <p class="p-media-object__content">
+                      ${item.publisher} ${item.validation_icon}
+                    </p>
+                  </div>
+                </div>
               </div>
-            </div>`
+              <div class="col-1">
+                <a href="" class="p-button--base js-${buttonText.toLowerCase()}-snap" data-index="${index}"><i class="p-icon--${buttonIcon}">${buttonText}</i></a>
+              </div>
+            </div>
+            <hr />`
           );
         });
         render();

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -22,4 +22,16 @@
   .p-card.is-selected {
     @extend %p-card--highlighted;
   }
+
+  .p-card.has-limited-height {
+    @media only screen and (min-width: $breakpoint-medium) {
+      height: 20rem;
+    }
+  }
+
+  .p-card.has-limited-height--large {
+    @media only screen and (min-width: $breakpoint-medium) {
+      height: 23.5rem;
+    }
+  }
 }

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -24,14 +24,10 @@
   }
 
   .p-card.has-limited-height {
-    @media only screen and (min-width: $breakpoint-medium) {
-      height: 20rem;
-    }
+    height: 20rem;
   }
 
   .p-card.has-limited-height--large {
-    @media only screen and (min-width: $breakpoint-medium) {
-      height: 23.5rem;
-    }
+    height: 23.5rem;
   }
 }

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -133,7 +133,7 @@
       <div class="col-6">
         <h4>Available snaps:</h4>
         <form class="p-search-box js-snap-search">
-          <input type="search" class="p-search-box__input" name="search" placeholder="Search for snaps" required="">
+          <input type="search" class="p-search-box__input" name="search" required="">
           <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
           <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
         </form>

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -129,19 +129,28 @@
         <p>Select the applications that will be pre-installed on the device. For Ubuntu Core this will be snaps, for Ubuntu Classic it will be snaps or packages.</p>
       </div>
     </div>
-    <div class="row p-divider">
-      <div class="col-6 p-divider__block">
+    <div class="row">
+      <div class="col-6">
+        <h4>Available snaps:</h4>
         <form class="p-search-box js-snap-search">
           <input type="search" class="p-search-box__input" name="search" placeholder="Search for snaps" required="">
           <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
           <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
         </form>
-        <div class="js-snap-results"></div>
+        <div class="p-card has-limited-height">
+          <div class="js-snap-results"></div>
+        </div>
       </div>
-      <div class="col-6 p-divider__block">
-        <h4 class="p-muted-heading">Pre-installed snaps</h4>
-        <hr class="u-sv1">
-        <div class="js-preinstalled-snaps-list"></div>
+      <div class="col-6">
+        <h4>Your chosen snaps:</h4>
+        <div class="p-card has-limited-height--large">
+          <div class="js-preinstalled-snaps-list"></div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-8">
+        <p>Got an app that isn’t in the Snap Store? Learn how to <a href="https://snapcraft.io/">publish it as a snap</a>.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done
Restyle the snap selection section

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/core/build
- Select your board and OS
- Check the snap selection functions by searching then adding and removing some snaps
- Check it matches [the design](https://app.zeplin.io/project/5e33f5075368883e5da9d0bf/screen/5e4fe76ec1b203753a5fa78b)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/2402

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/75193589-7201af00-574e-11ea-967d-3d9da7068bee.png)

