### PR TITLE
Update chart on /about page

### DIFF
--- a/static/js/chartData.js
+++ b/static/js/chartData.js
@@ -1,86 +1,7 @@
-export var serverAndDesktopReleases = [
-  {
-    startDate: new Date('2012-04-01T00:00:00'),
-    endDate: new Date('2014-10-01T00:00:00'),
-    taskName: 'Ubuntu 12.04 LTS',
-    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2014-10-01T00:00:00'),
-    endDate: new Date('2017-04-01T00:00:00'),
-    taskName: 'Ubuntu 12.04 LTS',
-    status: 'MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2017-04-01T00:00:00'),
-    endDate: new Date('2019-04-01T00:00:00'),
-    taskName: 'Ubuntu 12.04 LTS',
-    status: 'ESM'
-  },
-  {
-    startDate: new Date('2014-04-01T00:00:00'),
-    endDate: new Date('2016-09-01T00:00:00'),
-    taskName: 'Ubuntu 14.04 LTS',
-    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2016-09-01T00:00:00'),
-    endDate: new Date('2019-04-01T00:00:00'),
-    taskName: 'Ubuntu 14.04 LTS',
-    status: 'MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2019-04-01T00:00:00'),
-    endDate: new Date('2022-04-01T00:00:00'),
-    taskName: 'Ubuntu 14.04 LTS',
-    status: 'ESM'
-  },
-  {
-    startDate: new Date('2016-04-01T00:00:00'),
-    endDate: new Date('2018-10-01T00:00:00'),
-    taskName: 'Ubuntu 16.04 LTS',
-    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2018-10-01T00:00:00'),
-    endDate: new Date('2021-04-01T00:00:00'),
-    taskName: 'Ubuntu 16.04 LTS',
-    status: 'MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2021-04-01T00:00:00'),
-    endDate: new Date('2024-04-01T00:00:00'),
-    taskName: 'Ubuntu 16.04 LTS',
-    status: 'ESM'
-  },
-  {
-    startDate: new Date('2018-04-01T00:00:00'),
-    endDate: new Date('2020-09-01T00:00:00'),
-    taskName: 'Ubuntu 18.04 LTS',
-    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
-  },
-  {
-    startDate: new Date('2020-09-01T00:00:00'),
-    endDate: new Date('2023-04-01T00:00:00'),
-    taskName: 'Ubuntu 18.04 LTS',
-    status: 'MAINTENANCE_UPDATES'
-  },
-
-  {
-    startDate: new Date('2023-04-01T00:00:00'),
-    endDate: new Date('2028-04-01T00:00:00'),
-    taskName: 'Ubuntu 18.04 LTS',
-    status: 'ESM'
-  },
-  {
-    startDate: new Date('2019-04-01T00:00:00'),
-    endDate: new Date('2020-01-01T00:00:00'),
-    taskName: 'Ubuntu 19.04',
-    status: 'INTERIM_RELEASE'
-  },
+export var smallReleases = [
   {
     startDate: new Date('2019-10-01T00:00:00'),
-    endDate: new Date('2020-07-01T00:00:00'),
+    endDate: new Date('2020-07-06T00:00:00'),
     taskName: 'Ubuntu 19.10',
     status: 'INTERIM_RELEASE'
   },
@@ -92,7 +13,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date('2022-10-01T00:00:00'),
-    endDate: new Date('2025-04-01T00:00:00'),
+    endDate: new Date('2025-04-02T00:00:00'),
     taskName: 'Ubuntu 20.04 LTS',
     status: 'MAINTENANCE_UPDATES'
   },
@@ -104,34 +25,158 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date('2020-10-01T00:00:00'),
-    endDate: new Date('2021-07-01T00:00:00'),
+    endDate: new Date('2021-07-07T00:00:00'),
     taskName: 'Ubuntu 20.10',
     status: 'INTERIM_RELEASE'
   },
   {
-    startDate: new Date('2021-04-01T00:00:00'),
-    endDate: new Date('2022-01-01T00:00:00'),
-    taskName: 'Ubuntu 21.04',
-    status: 'INTERIM_RELEASE'
-  },
-  {
     startDate: new Date('2021-10-01T00:00:00'),
-    endDate: new Date('2022-07-01T00:00:00'),
+    endDate: new Date('2022-07-07T00:00:00'),
     taskName: 'Ubuntu 21.10',
     status: 'INTERIM_RELEASE'
   },
   {
+    startDate: new Date('2021-04-01T00:00:00'),
+    endDate: new Date('2022-01-05T00:00:00'),
+    taskName: 'Ubuntu 21.04',
+    status: 'INTERIM_RELEASE'
+  },
+  {
     startDate: new Date('2022-04-01T00:00:00'),
-    endDate: new Date('2024-09-01T00:00:00'),
+    endDate: new Date('2024-09-30T00:00:00'),
     taskName: 'Ubuntu 22.04 LTS',
     status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
   },
   {
-    startDate: new Date('2024-09-01T00:00:00'),
+    startDate: new Date('2024-09-30T00:00:00'),
     endDate: new Date('2027-04-01T00:00:00'),
     taskName: 'Ubuntu 22.04 LTS',
     status: 'MAINTENANCE_UPDATES'
-  }
+  },
+  {
+    startDate: new Date('2027-04-01T00:00:00'),
+    endDate: new Date('2032-04-09T00:00:00'),
+    taskName: 'Ubuntu 22.04 LTS',
+    status: 'ESM'
+  },
+];
+
+export var serverAndDesktopReleases = [
+  {
+    startDate: new Date('2014-04-01T00:00:00'),
+    endDate: new Date('2016-09-30T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2016-09-30T00:00:00'),
+    endDate: new Date('2019-04-02T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+
+  {
+    startDate: new Date('2019-04-02T00:00:00'),
+    endDate: new Date('2022-04-02T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS',
+    status: 'ESM'
+  },
+  {
+    startDate: new Date('2016-04-01T00:00:00'),
+    endDate: new Date('2018-10-01T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2018-10-01T00:00:00'),
+    endDate: new Date('2021-04-02T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2021-04-02T00:00:00'),
+    endDate: new Date('2024-04-02T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS',
+    status: 'ESM'
+  },
+  {
+    startDate: new Date('2018-04-01T00:00:00'),
+    endDate: new Date('2020-09-30T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2020-09-30T00:00:00'),
+    endDate: new Date('2023-04-02T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2023-04-02T00:00:00'),
+    endDate: new Date('2028-04-01T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS',
+    status: 'ESM'
+  },
+  {
+    startDate: new Date('2019-10-01T00:00:00'),
+    endDate: new Date('2020-07-06T00:00:00'),
+    taskName: 'Ubuntu 19.10',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2020-04-01T00:00:00'),
+    endDate: new Date('2022-10-01T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2022-10-01T00:00:00'),
+    endDate: new Date('2025-04-02T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2025-04-02T00:00:00'),
+    endDate: new Date('2030-04-02T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'ESM'
+  },
+  {
+    startDate: new Date('2020-10-01T00:00:00'),
+    endDate: new Date('2021-07-07T00:00:00'),
+    taskName: 'Ubuntu 20.10',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2021-10-01T00:00:00'),
+    endDate: new Date('2022-07-07T00:00:00'),
+    taskName: 'Ubuntu 21.10',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2021-04-01T00:00:00'),
+    endDate: new Date('2022-01-05T00:00:00'),
+    taskName: 'Ubuntu 21.04',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2022-04-01T00:00:00'),
+    endDate: new Date('2024-09-30T00:00:00'),
+    taskName: 'Ubuntu 22.04 LTS',
+    status: 'HARDWARE_AND_MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2024-09-30T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04 LTS',
+    status: 'MAINTENANCE_UPDATES'
+  },
+  {
+    startDate: new Date('2027-04-01T00:00:00'),
+    endDate: new Date('2032-04-09T00:00:00'),
+    taskName: 'Ubuntu 22.04 LTS',
+    status: 'ESM'
+  },
 ];
 
 export var kernelReleases = [
@@ -972,42 +1017,42 @@ export var kernelReleasesLTS = [
 ];
 
 export var kernelReleaseSchedule = [
-{
-  startDate: new Date('2014-04-21T00:00:00'),
-  endDate: new Date('2019-04-20T00:00:00'),
-  taskName: 'Ubuntu 14.04 LTS (v3.13)',
-  status: 'LTS'
-},
-{
-  startDate: new Date('2016-04-21T00:00:00'),
-  endDate: new Date('2021-04-20T00:00:00'),
-  taskName: 'Ubuntu 16.04 LTS (v4.4)',
-  status: 'LTS'
-},
-{
-  startDate: new Date('2018-04-21T00:00:00'),
-  endDate: new Date('2023-04-20T00:00:00'),
-  taskName: 'Ubuntu 18.04 LTS (v4.15)',
-  status: 'LTS'
-},
-{
-  startDate: new Date('2019-04-16T00:00:00'),
-  endDate: new Date('2020-01-20T00:00:00'),
-  taskName: 'Ubuntu 19.04 (v5.0)',
-  status: 'INTERIM_RELEASE'
-},
-{
-  startDate: new Date('2019-10-15T00:00:00'),
-  endDate: new Date('2020-07-20T00:00:00'),
-  taskName: 'Ubuntu 19.10 (v5.3)',
-  status: 'INTERIM_RELEASE'
-},
-{
-  startDate: new Date('2020-04-23T00:00:00'),
-  endDate: new Date('2025-04-22T00:00:00'),
-  taskName: 'Ubuntu 20.04 LTS',
-  status: 'LTS'
-}
+  {
+    startDate: new Date('2014-04-21T00:00:00'),
+    endDate: new Date('2019-04-20T00:00:00'),
+    taskName: 'Ubuntu 14.04 LTS (v3.13)',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2016-04-21T00:00:00'),
+    endDate: new Date('2021-04-20T00:00:00'),
+    taskName: 'Ubuntu 16.04 LTS (v4.4)',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2018-04-21T00:00:00'),
+    endDate: new Date('2023-04-20T00:00:00'),
+    taskName: 'Ubuntu 18.04 LTS (v4.15)',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2019-04-16T00:00:00'),
+    endDate: new Date('2020-01-20T00:00:00'),
+    taskName: 'Ubuntu 19.04 (v5.0)',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2019-10-15T00:00:00'),
+    endDate: new Date('2020-07-20T00:00:00'),
+    taskName: 'Ubuntu 19.10 (v5.3)',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2020-04-23T00:00:00'),
+    endDate: new Date('2025-04-22T00:00:00'),
+    taskName: 'Ubuntu 20.04 LTS',
+    status: 'LTS'
+  }
 ];
 
 export var openStackReleases = [
@@ -1181,6 +1226,15 @@ export var kubernetesStatus = {
   CHARMED_KUBERNETES_EXPIRED_SUPPORT: 'chart__bar--grey',
 };
 
+export var smallReleaseNames = [
+  'Ubuntu 22.04 LTS',
+  'Ubuntu 21.10',
+  'Ubuntu 21.04',
+  'Ubuntu 20.10',
+  'Ubuntu 20.04 LTS',
+  'Ubuntu 19.10'
+];
+
 export var desktopServerReleaseNames = [
   'Ubuntu 22.04 LTS',
   'Ubuntu 21.10',
@@ -1188,11 +1242,9 @@ export var desktopServerReleaseNames = [
   'Ubuntu 20.10',
   'Ubuntu 20.04 LTS',
   'Ubuntu 19.10',
-  'Ubuntu 19.04',
   'Ubuntu 18.04 LTS',
   'Ubuntu 16.04 LTS',
-  'Ubuntu 14.04 LTS',
-  'Ubuntu 12.04 LTS'
+  'Ubuntu 14.04 LTS'
 ];
 
 export var kernelReleaseNames = [

--- a/static/js/release-chart.js
+++ b/static/js/release-chart.js
@@ -1,5 +1,6 @@
 import {createChart} from './chart'
 import {
+  smallReleases,
   serverAndDesktopReleases,
   kernelReleases,
   kernelReleaseSchedule,
@@ -18,6 +19,7 @@ import {
   kernelStatusALL,
   openStackStatus,
   kubernetesStatus,
+  smallReleaseNames,
   desktopServerReleaseNames,
   kernelReleaseNames,
   kernelReleaseScheduleNames,
@@ -46,6 +48,9 @@ function debounce(func, wait, immediate) {
 }
 
 function buildCharts() {
+  if (document.querySelector('#small-eol')) {
+    createChart('#small-eol', smallReleaseNames, desktopServerStatus, smallReleases);
+  }
   if (document.querySelector('#server-desktop-eol')) {
     createChart('#server-desktop-eol', desktopServerReleaseNames, desktopServerStatus, serverAndDesktopReleases);
   }
@@ -82,6 +87,9 @@ function buildCharts() {
 }
 
 function clearCharts() {
+  if (document.querySelector('#small-eol')) {
+    document.querySelector('#small-eol').innerHTML = '';
+  }
   if (document.querySelector('#server-desktop-eol')) {
     document.querySelector('#server-desktop-eol').innerHTML = '';
   }

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -25,16 +25,55 @@
   </div>
   <div class="row">
     <div class="col-8">
-      {{
-        image(
-            url="https://assets.ubuntu.com/v1/ddf53747-release-evergreen.png",
-            alt="",
-            width="681",
-            height="154",
-            hi_def=True,
-            loading="lazy",
-        ) | safe
-      }}
+      <div class="u-hide--small" id="small-eol"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Extended security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Ubuntu 19.10</td>
+            <td>Oct 2019</td>
+            <td>Jul 2020</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04 LTS</strong></td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
+            <td>Apr 2030</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 20.10</td>
+            <td>Oct 2020</td>
+            <td>Jul 2021</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 21.10</td>
+            <td>Oct 2021</td>
+            <td>Jul 2022</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 21.04</td>
+            <td>Apr 2021</td>
+            <td>Jan 2022</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04 LTS</strong></td>
+            <td>Apr 2022</td>
+            <td>Apr 2027</td>
+            <td>Apr 2032</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
   <div class="row">
@@ -55,4 +94,6 @@
   </div>
 </section>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js" defer></script>
+<script src="{{ versioned_static('js/build/release-chart.min.js') }}" defer></script>
 {% endblock content %}

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -71,506 +71,505 @@
             <th scope="col">End of Life</th>
             <th scope="col">Extended security maintenance</th>
           </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Ubuntu 22.04 LTS</strong></td>
-            <td>Apr 2022</td>
-            <td>Apr 2027</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>Ubuntu 21.10</td>
-            <td>Oct 2021</td>
-            <td>Jul 2022</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>Ubuntu 21.04</td>
-            <td>Apr 2021</td>
-            <td>Jan 2022</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>Ubuntu 20.10</td>
-            <td>Oct 2020</td>
-            <td>Jul 2021</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 20.04 LTS</strong></td>
-            <td>Apr 2020</td>
-            <td>Apr 2025</td>
-            <td>Apr 2030</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 19.10</td>
-            <td>Oct 2019</td>
-            <td>Jul 2020</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>Ubuntu 19.04</td>
-            <td>Apr 2019</td>
-            <td>Jan 2020</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04 LTS</strong></td>
-            <td>Apr 2018</td>
-            <td>Apr 2023</td>
-            <td>Apr 2028</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 16.04 LTS</strong></td>
-            <td>Apr 2016</td>
-            <td>Apr 2021</td>
-            <td>Apr 2024</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 14.04 LTS</strong></td>
-            <td>Apr 2014</td>
-            <td>Apr 2019</td>
-            <td>Apr 2022</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 12.04 LTS</strong></td>
-            <td>Apr 2012</td>
-            <td>Apr 2017</td>
-            <td>Apr 2019</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <p>Interim releases will introduce new capabilities from Canonical and upstream open source projects, they serve as a proving ground for these new capabilities. Many developers run interim releases because they provide newer compilers or access to newer kernels and newer libraries, and they are often used inside rapid devops processes like CI/CD pipelines where the lifespan of an artifact is likely to be less than the support period of the interim release. Interim releases receive full security maintenance for ‘main’ during their lifespan.</p>
-  </div>
-</section>
-
-<section class="p-strip--light is-bordered ">
-  <div class="u-fixed-width">
-    <h2>Release components - debs, snaps, images, containers</h2>
-    <p>A release of Ubuntu is made through several different channels. What you consume will depend on where you are and what your interests happen to be.</p>
-    <p>The heart of Ubuntu is a collection of ‘deb’ packages which are tested and integrated so that they work well as a set. Debs are optimised for highly structured dependency management, enabling you to combine debs very richly while ensuring that the necessary software dependencies for each deb (themselves delivered as debs) are installed on your machine.</p>
-    <p>Ubuntu also supports ‘snap’ packages which are more suited for third-party applications and tools which evolve at their own speed, independently of Ubuntu. If you want to install a high-profile app like Skype or a toolchain like the latest version of Golang, you probably want the snap because it will give you fresher versions and more control of the specific major versions you want to track.</p>
-    <p>Snaps each pick a ‘base’, for example Ubuntu18 (corresponding to the set of minimal debs in Ubuntu 18.04 LTS). Nevertheless, the choice of base does not impact on your ability to use a snap on any of the supported Linux distributions or versions &mdash; it’s a choice of the publisher and should be invisible to you as a user or developer.</p>
-    <p>A snap can be strictly confined, which means that it operates in a secure box with only predefined points of access to the rest of the system. For third-party applications, this means that you will have a very high level of confidence that the app can only see appropriate data that you have provided to it. Snaps can also be ‘classic’ which means that they behave more like debs, and can see everything on your system. You should make sure you have a high level of confidence in the publisher of any classic snap you install, since a compromise or bad faith behaviour in that code is not confined to the app itself.</p>
-    <p>It is also common to consume Ubuntu as an image on a public cloud, or as a container. Ubuntu is published by Canonical on all major public clouds, and the latest image for each LTS version will always include security updates rolled up to at most two weeks ago. You may benefit from installing newer updates than that, but the base image you boot on the cloud should always be the current one from Canonical to ensure that it is broadly up to date and the number of updates needed for full security is minimal.</p>
-    <p>Canonical also publishes a set of images and containers that you can download for use with VMware or other local hypervisors and private cloud technologies. These include standard Ubuntu images on the Docker Hub, and standard images for use with LXD and MAAS. These images are also kept up to date, with publication of rolled up security updated images on a regular cadence, and you should automate your use of the latest images to ensure consistent security coverage for your users.</p>
-  </div>
-</section>
-
-<section class="p-strip is-bordered ">
-  <div class="u-fixed-width">
-    <h2>Editions, Classic and Core</h2>
-    <p>Each release of Ubuntu is available in minimal configurations which have the fewest possible packages installed: available in the installer for Server, Desktop and as separate cloud images. There are also multiple flavours of desktop Ubuntu corresponding to a number of desktop GUI preferences. All of these images are considered ‘Classic’ Ubuntu because they use debs as their base and may add snaps for specific packages or applications.</p>
-    <p>The Ubuntu Core image is an all-snap edition of Ubuntu. It is unusual in that the base operating system itself is delivered as a snap; that makes it suitable for embedded appliances where all the possible apps that might need to be installed are available as strictly confined snaps. Ubuntu Core is an appliance or embedded oriented edition of Ubuntu, not particularly comfortable for humans but highly reliable and secure for large-scale appliance deployments such as IoT and CPE in the telco world.</p>
-  </div>
-</section>
-
-<section class="p-strip--light is-bordered ">
-  <div class="u-fixed-width">
-    <h2>Maintenance and security updates</h2>
-    <p>The debs in Ubuntu are categorised by whether they are considered part of the base system (‘main’ and ‘restricted’ are in the base and ‘universe’ and ‘multiverse’ are not) and whether they are open source (‘main’ and ‘universe’ are, ‘restricted’ and ‘multiverse’ are not).</p>
-  </div>
-
-  <div class="row">
-    <div class="col-10" style="overflow: auto;">
-      <table style="margin-top: 1rem;">
-        <thead>
-          <tr>
-            <th>&nbsp;</th>
-            <th scope="col">Base Packages</th>
-            <th scope="col">Extended Packages</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Open Source</strong></td>
-            <td>main</td>
-            <td>universe</td>
-          </tr>
-          <tr>
-            <td><strong>Not Open Source</strong></td>
-            <td>restricted</td>
-            <td>multiverse</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <p>The base system receives a commitment to public maintenance for the period where it is the current LTS or interim release and for a period thereafter.</p>
-    <p>Customers of Canonical often ask for an extended security maintenance commitment, either to ‘main’ for a longer period of time, or to ‘universe’ software packages during the initial maintenance period of the LTS. This is known as '<a href="/esm">Extended Security Maintenance</a>' or ESM and is available for LTS releases since Ubuntu 12.04 LTS.</p>
-  </div>
-
-  <div class="row">
-    <div class="col-10" style="overflow: auto;">
-      <table style="margin-top: 1rem; width: auto;">
-        <thead>
-          <tr>
-            <th>LTS security maintenance</th>
-            <th scope="col">5 years initial period</th>
-            <th scope="col">Further 3 years</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>main</strong></td>
-            <td>public</td>
-            <td>ESM</td>
-          </tr>
-          <tr>
-            <td><strong>universe</strong></td>
-            <td>ESM</td>
-            <td>ESM</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-8">
-      <p>Ubuntu LTS releases transition into Extended Security Maintenance (ESM) phase as the standard, five-year public support window comes to a close. It is recommended for users and organisations to upgrade to the latest LTS release or <a href="/esm">subscribe to ESM</a> for continued security coverage.</p>
-      <p>This command will print the exact status of your system:</p>
-      <div class="p-code-copyable" style="margin-top: .5rem;">
-        <input class="p-code-copyable__input" value="ubuntu-support-status" readonly="readonly">
-        <button class="p-code-copyable__action">Copy to clipboard</button>
+          <tbody>
+            <tr>
+              <td><strong>Ubuntu 10.04 LTS</strong></td>
+              <td>Apr 2010</td>
+              <td>Apr 2015</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 12.04 LTS</strong></td>
+              <td>Apr 2012</td>
+              <td>Apr 2017</td>
+              <td>Apr 2019</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 14.04 LTS</strong></td>
+              <td>Apr 2014</td>
+              <td>Apr 2019</td>
+              <td>Apr 2022</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 16.04 LTS</strong></td>
+              <td>Apr 2016</td>
+              <td>Apr 2021</td>
+              <td>Apr 2024</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04 LTS</strong></td>
+              <td>Apr 2018</td>
+              <td>Apr 2023</td>
+              <td>Apr 2028</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 19.10</td>
+              <td>Oct 2019</td>
+              <td>Jul 2020</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.04 LTS</strong></td>
+              <td>Apr 2020</td>
+              <td>Apr 2025</td>
+              <td>Apr 2030</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 20.10</td>
+              <td>Oct 2020</td>
+              <td>Jul 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 21.10</td>
+              <td>Oct 2021</td>
+              <td>Jul 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 21.04</td>
+              <td>Apr 2021</td>
+              <td>Jan 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 22.04 LTS</strong></td>
+              <td>Apr 2022</td>
+              <td>Apr 2027</td>
+              <td>Apr 2032</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-      <p>The <a class="p-link--external" href="https://wiki.ubuntu.com/Releases">Ubuntu Releases wiki</a> has current information on previous and upcoming versions.</p>
     </div>
-  </div>
-</section>
 
-<section class="p-strip is-bordered ">
-  <div class="u-fixed-width">
-    <h2 id="ubuntu-kernel-release-cycle">Ubuntu kernel release cycle</h2>
-    <p>Canonical maintains multiple kernel packages for each LTS version of Ubuntu, which serve different purposes. Several of the kernel packages address the need for kernels with specific performance priorities, for example the low-latency kernel package. Others are focused on optimisation for a particular hypervisor, for example the kernel packages which are named after public clouds. You are recommended to use the <a class="p-link--external" href="https://wiki.ubuntu.com/Kernel">detailed Ubuntu kernel guide</a> to select the best Ubuntu kernel for your application.</p>
-    <p>In general, all of the LTS kernel packages will use the same base version of the Linux kernel, for example Ubuntu 18.04 LTS kernels typically used the 4.15 upstream Linux kernel as a base. Some cloud-specific kernels may use a newer version in order to benefit from improved mechanisms in performance or security that are material to that cloud. These kernels are all supported for the full life of their underlying LTS release.</p>
-    <p>In addition, the kernel versions from the subsequent four releases are made available on the latest LTS release of Ubuntu. So Ubuntu 16.04 LTS received the kernels from Ubuntu 16.10, 17.04, 17.10 and 18.04 LTS. These kernels use newer upstream versions and as a result offer an easy path to newer features and newer classes of hardware for many users of Ubuntu. Note however that these kernels ‘roll’ which means that they jump every six months until the next LTS. Large scale deployments that adopt these ‘hardware enablement’ or HWE kernels should manage those transitions explicitly. These newer HWE kernels are accompanied by a collection of userspace tools closely tied to the kernel and hardware, specifically X display enablement on newer graphics cards.</p>
-    <p>The Ubuntu kernel support lifecycle is as follows:</p>
-  </div>
-
-  <div class="row">
-    <div class="col-10" style="overflow: auto;">
-      <div class="u-hide--small" id="kernel-eol"></div>
-      <table class="u-hide--medium u-hide--large">
-        <thead>
-          <tr>
-            <th>Release</th>
-            <th>Released</th>
-            <th>End of life</th>
-            <th>Extended security maintenance</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-            <td>Aug 2020</td>
-            <td>Apr 2023</td>
-            <td>Apr 2028</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 20.04 LTS</strong></td>
-            <td>Apr 2020</td>
-            <td>Apr 2025</td>
-            <td>Apr 2030</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04.4 LTS</strong></td>
-            <td>Feb 2020</td>
-            <td>Aug 2020</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 19.10 (v5.3)</td>
-            <td>Oct 2019</td>
-            <td>Jul 2020</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
-            <td>Aug 2019</td>
-            <td>Feb 2020</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 19.04 (v5.0)</td>
-            <td>Apr 2019</td>
-            <td>Jan 2020</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-            <td>Feb 2019</td>
-            <td>Aug 2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 18.10 (v4.18)</td>
-            <td>Oct 2018</td>
-            <td>Jul 2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-            <td>Jul 2018</td>
-            <td>Apr 2023</td>
-            <td>Apr 2028</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-            <td>Aug 2018</td>
-            <td>Apr 2021</td>
-            <td>Apr 2024</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-            <td>Apr 2018</td>
-            <td>Apr 2023</td>
-            <td>Apr 2028</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-            <td>Aug 2016</td>
-            <td>Apr 2021</td>
-            <td>Apr 2024</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
-            <td>Aug 2016</td>
-            <td>Apr 2019</td>
-            <td>Apr 2022</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-            <td>Apr 2016</td>
-            <td>Apr 2021</td>
-            <td>Apr 2024</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-            <td>Aug 2014</td>
-            <td>Apr 2019</td>
-            <td>Apr 2022</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 12.04.5 LTS (v3.13)</strong></td>
-            <td>Aug 2014</td>
-            <td>Apr 2017</td>
-            <td>Apr 2019</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-            <td>Apr 2014</td>
-            <td>Apr 2019</td>
-            <td>Apr 2022</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 12.04.1 LTS (v3.2)</strong></td>
-            <td>Aug 2012</td>
-            <td>Apr 2017</td>
-            <td>Apr 2019</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 12.04.0 LTS (v3.2)</strong></td>
-            <td>Apr 2012</td>
-            <td>Apr 2017</td>
-            <td>Apr 2019</td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="u-fixed-width">
+      <p>Interim releases will introduce new capabilities from Canonical and upstream open source projects, they serve as a proving ground for these new capabilities. Many developers run interim releases because they provide newer compilers or access to newer kernels and newer libraries, and they are often used inside rapid devops processes like CI/CD pipelines where the lifespan of an artifact is likely to be less than the support period of the interim release. Interim releases receive full security maintenance for ‘main’ during their lifespan.</p>
     </div>
-  </div>
+  </section>
 
-  <div class="u-fixed-width">
-    <p>For more information on previous and upcoming kernel releases please see the <a href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack " class="p-link--external ">Ubuntu LTS Enablement Stack wiki page</a>.</p>
-  </div>
-</section>
-
-<section class="p-strip--light  is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="ubuntu-openstack-release-cycle">Ubuntu OpenStack release cycle</h2>
-      <p>Canonical’s Cloud Archive allows users the ability to install newer releases of Ubuntu <a href="https://wiki.ubuntu.com/OpenStack" class="p-link--external">OpenStack</a> on an Ubuntu server as they become available. A given LTS release of Ubuntu will have the current release of OpenStack packaged in its release archives. The next four releases of OpenStack will then be published in the Cloud Archive for that LTS.</p>
-      <p>That means that it is possible to upgrade OpenStack four times on the same Ubuntu LTS release base operating system (upgrading the OpenStack without upgrading the operating system), and then one has the same OpenStack version that is included with the subsequent LTS release, and can choose to upgrade the operating system without upgrading the OpenStack version.</p>
-      <p>The middle OpenStack release (one year after the LTS release and one year before the next LTS release) is maintained for an extended period. Many customers therefore opt to make annual upgrades to their OpenStack rather than tracking each six-monthly release. The actual upgrade is fully supported using Canonical OpenStack tools and operator guides, and involves hopping through the six-monthly versions for database upgrade purposes, but the next effect is an annual upgrade to a version that is fully supportable.</p>
-      <p>The Ubuntu OpenStack support lifecycle can be represented this way:</p>
+  <section class="p-strip--light is-bordered ">
+    <div class="u-fixed-width">
+      <h2>Release components - debs, snaps, images, containers</h2>
+      <p>A release of Ubuntu is made through several different channels. What you consume will depend on where you are and what your interests happen to be.</p>
+      <p>The heart of Ubuntu is a collection of ‘deb’ packages which are tested and integrated so that they work well as a set. Debs are optimised for highly structured dependency management, enabling you to combine debs very richly while ensuring that the necessary software dependencies for each deb (themselves delivered as debs) are installed on your machine.</p>
+      <p>Ubuntu also supports ‘snap’ packages which are more suited for third-party applications and tools which evolve at their own speed, independently of Ubuntu. If you want to install a high-profile app like Skype or a toolchain like the latest version of Golang, you probably want the snap because it will give you fresher versions and more control of the specific major versions you want to track.</p>
+      <p>Snaps each pick a ‘base’, for example Ubuntu18 (corresponding to the set of minimal debs in Ubuntu 18.04 LTS). Nevertheless, the choice of base does not impact on your ability to use a snap on any of the supported Linux distributions or versions &mdash; it’s a choice of the publisher and should be invisible to you as a user or developer.</p>
+      <p>A snap can be strictly confined, which means that it operates in a secure box with only predefined points of access to the rest of the system. For third-party applications, this means that you will have a very high level of confidence that the app can only see appropriate data that you have provided to it. Snaps can also be ‘classic’ which means that they behave more like debs, and can see everything on your system. You should make sure you have a high level of confidence in the publisher of any classic snap you install, since a compromise or bad faith behaviour in that code is not confined to the app itself.</p>
+      <p>It is also common to consume Ubuntu as an image on a public cloud, or as a container. Ubuntu is published by Canonical on all major public clouds, and the latest image for each LTS version will always include security updates rolled up to at most two weeks ago. You may benefit from installing newer updates than that, but the base image you boot on the cloud should always be the current one from Canonical to ensure that it is broadly up to date and the number of updates needed for full security is minimal.</p>
+      <p>Canonical also publishes a set of images and containers that you can download for use with VMware or other local hypervisors and private cloud technologies. These include standard Ubuntu images on the Docker Hub, and standard images for use with LXD and MAAS. These images are also kept up to date, with publication of rolled up security updated images on a regular cadence, and you should automate your use of the latest images to ensure consistent security coverage for your users.</p>
     </div>
-  </div>
+  </section>
 
-  <div class="row">
-    <div class="col-10" style="overflow: auto;">
-      <div class="u-hide--small" id="openstack-eol"></div>
-      <table class="u-hide--medium u-hide--large">
-        <thead>
-          <tr>
-            <th>Release</th>
-            <th>Released</th>
-            <th>End of life</th>
-            <th>Extended customer support</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>OpenStack Ussuri LTS</td>
-            <td>Apr 2020</td>
-            <td>Apr 2025</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 20.04 LTS</td>
-            <td>Apr 2020</td>
-            <td>Apr 2025</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Ussuri</td>
-            <td>Feb 2020</td>
-            <td>Apr 2023</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Train</td>
-            <td>Aug 2019</td>
-            <td>Feb 2021</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Stein</td>
-            <td>Apr 2019</td>
-            <td>Oct 2020</td>
-            <td>Apr 2022</td>
-          </tr>
-          <tr>
-            <td>OpenStack Rocky</td>
-            <td>Aug 2018</td>
-            <td>Feb 2020</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Queens</td>
-            <td>Apr 2018</td>
-            <td>Apr 2023</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 18.04 LTS</strong></td>
-            <td>Apr 2018</td>
-            <td>Apr 2023</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Queens</td>
-            <td>Feb 2018</td>
-            <td>Apr 2021</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Pike</td>
-            <td>Aug 2017</td>
-            <td>Feb 2019</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Ocata</td>
-            <td>Feb 2017</td>
-            <td>Aug 2018</td>
-            <td>Feb 2020</td>
-          </tr>
-          <tr>
-            <td>OpenStack Newton</td>
-            <td>Oct 2016</td>
-            <td>Apr 2018</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td>OpenStack Mitaka</td>
-            <td>Apr 2016</td>
-            <td>Apr 2021</td>
-            <td>&nbsp;</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 16.04 LTS</strong></td>
-            <td>Apr 2016</td>
-            <td>Apr 2021</td>
-            <td>&nbsp;</td>
-          </tr>
-        </tbody>
-      </table>
+  <section class="p-strip is-bordered ">
+    <div class="u-fixed-width">
+      <h2>Editions, Classic and Core</h2>
+      <p>Each release of Ubuntu is available in minimal configurations which have the fewest possible packages installed: available in the installer for Server, Desktop and as separate cloud images. There are also multiple flavours of desktop Ubuntu corresponding to a number of desktop GUI preferences. All of these images are considered ‘Classic’ Ubuntu because they use debs as their base and may add snaps for specific packages or applications.</p>
+      <p>The Ubuntu Core image is an all-snap edition of Ubuntu. It is unusual in that the base operating system itself is delivered as a snap; that makes it suitable for embedded appliances where all the possible apps that might need to be installed are available as strictly confined snaps. Ubuntu Core is an appliance or embedded oriented edition of Ubuntu, not particularly comfortable for humans but highly reliable and secure for large-scale appliance deployments such as IoT and CPE in the telco world.</p>
     </div>
-  </div>
+  </section>
 
-  <div class="u-fixed-width">
-    <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive " class="p-link--external ">Ubuntu Cloud Archive wiki page</a>.</p>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</h2>
-      <p>The release cycle of the Charmed Kubernetes is tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of nine months, subject to changes in the upstream release cycle.</p>
-      <p>The Charmed Kubernetes support lifecycle can be represented this way:</p>
+  <section class="p-strip--light is-bordered ">
+    <div class="u-fixed-width">
+      <h2>Maintenance and security updates</h2>
+      <p>The debs in Ubuntu are categorised by whether they are considered part of the base system (‘main’ and ‘restricted’ are in the base and ‘universe’ and ‘multiverse’ are not) and whether they are open source (‘main’ and ‘universe’ are, ‘restricted’ and ‘multiverse’ are not).</p>
     </div>
-  </div>
 
-  <div class="row">
-    <div class="col-10" style="overflow: auto;">
-      <div class="u-hide--small" id="kubernetes-eol"></div>
-      <table class="u-hide--medium u-hide--large">
-        <thead>
-          <tr>
-            <th>Release</th>
-            <th>Released</th>
-            <th>End of life</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Kubernetes 1.18</strong></td>
-            <td align='right'>Mar 2020</td>
-            <td align='right'>Dec 2020</td>
-          </tr>
-          <tr>
-            <td><strong>Kubernetes 1.17</strong></td>
-            <td align='right'>Jan 2020</td>
-            <td align='right'>Oct 2020</td>
-          </tr>
-          <tr>
-            <td><strong>Kubernetes 1.16</strong></td>
-            <td align='right'>Oct 2019</td>
-            <td align='right'>Jul 2020</td>
-          </tr>
-          <tr>
-            <td><strong>Kubernetes 1.16</strong></td>
-            <td>Sep 2019</td>
-            <td>Jun 2020</td>
-          </tr>
-          <tr>
-            <td><strong>Kubernetes 1.15</strong></td>
-            <td>Jun 2019</td>
-            <td>Mar 2020</td>
-          </tr>
-          <tr>
-            <td><strong>Kubernetes 1.14</strong></td>
-            <td>Mar 2019</td>
-            <td>Dec 2019</td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="row">
+      <div class="col-10" style="overflow: auto;">
+        <table style="margin-top: 1rem;">
+          <thead>
+            <tr>
+              <th>&nbsp;</th>
+              <th scope="col">Base Packages</th>
+              <th scope="col">Extended Packages</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Open Source</strong></td>
+              <td>main</td>
+              <td>universe</td>
+            </tr>
+            <tr>
+              <td><strong>Not Open Source</strong></td>
+              <td>restricted</td>
+              <td>multiverse</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <p>For more information on previous and current releases of Charmed Kubernetes, please see the <a href="/kubernetes/docs/release-notes">Charmed Kubernetes release notes</a>.</p>
-  </div>
-</section>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js" defer></script>
-<script src="{{ versioned_static('js/build/release-chart.min.js') }}" defer></script>
+    <div class="u-fixed-width">
+      <p>The base system receives a commitment to public maintenance for the period where it is the current LTS or interim release and for a period thereafter.</p>
+      <p>Customers of Canonical often ask for an extended security maintenance commitment, either to ‘main’ for a longer period of time, or to ‘universe’ software packages during the initial maintenance period of the LTS. This is known as '<a href="/esm">Extended Security Maintenance</a>' or ESM and is available for LTS releases since Ubuntu 12.04 LTS.</p>
+    </div>
 
-{% endblock content %}
+    <div class="row">
+      <div class="col-10" style="overflow: auto;">
+        <table style="margin-top: 1rem; width: auto;">
+          <thead>
+            <tr>
+              <th>LTS security maintenance</th>
+              <th scope="col">5 years initial period</th>
+              <th scope="col">Further 3 years</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>main</strong></td>
+              <td>public</td>
+              <td>ESM</td>
+            </tr>
+            <tr>
+              <td><strong>universe</strong></td>
+              <td>ESM</td>
+              <td>ESM</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <p>Ubuntu LTS releases transition into Extended Security Maintenance (ESM) phase as the standard, five-year public support window comes to a close. It is recommended for users and organisations to upgrade to the latest LTS release or <a href="/esm">subscribe to ESM</a> for continued security coverage.</p>
+        <p>This command will print the exact status of your system:</p>
+        <div class="p-code-copyable" style="margin-top: .5rem;">
+          <input class="p-code-copyable__input" value="ubuntu-support-status" readonly="readonly">
+          <button class="p-code-copyable__action">Copy to clipboard</button>
+        </div>
+        <p>The <a class="p-link--external" href="https://wiki.ubuntu.com/Releases">Ubuntu Releases wiki</a> has current information on previous and upcoming versions.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-bordered ">
+    <div class="u-fixed-width">
+      <h2 id="ubuntu-kernel-release-cycle">Ubuntu kernel release cycle</h2>
+      <p>Canonical maintains multiple kernel packages for each LTS version of Ubuntu, which serve different purposes. Several of the kernel packages address the need for kernels with specific performance priorities, for example the low-latency kernel package. Others are focused on optimisation for a particular hypervisor, for example the kernel packages which are named after public clouds. You are recommended to use the <a class="p-link--external" href="https://wiki.ubuntu.com/Kernel">detailed Ubuntu kernel guide</a> to select the best Ubuntu kernel for your application.</p>
+      <p>In general, all of the LTS kernel packages will use the same base version of the Linux kernel, for example Ubuntu 18.04 LTS kernels typically used the 4.15 upstream Linux kernel as a base. Some cloud-specific kernels may use a newer version in order to benefit from improved mechanisms in performance or security that are material to that cloud. These kernels are all supported for the full life of their underlying LTS release.</p>
+      <p>In addition, the kernel versions from the subsequent four releases are made available on the latest LTS release of Ubuntu. So Ubuntu 16.04 LTS received the kernels from Ubuntu 16.10, 17.04, 17.10 and 18.04 LTS. These kernels use newer upstream versions and as a result offer an easy path to newer features and newer classes of hardware for many users of Ubuntu. Note however that these kernels ‘roll’ which means that they jump every six months until the next LTS. Large scale deployments that adopt these ‘hardware enablement’ or HWE kernels should manage those transitions explicitly. These newer HWE kernels are accompanied by a collection of userspace tools closely tied to the kernel and hardware, specifically X display enablement on newer graphics cards.</p>
+      <p>The Ubuntu kernel support lifecycle is as follows:</p>
+    </div>
+
+    <div class="row">
+      <div class="col-10" style="overflow: auto;">
+        <div class="u-hide--small" id="kernel-eol"></div>
+        <table class="u-hide--medium u-hide--large">
+          <thead>
+            <tr>
+              <th>Release</th>
+              <th>Released</th>
+              <th>End of life</th>
+              <th>Extended security maintenance</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+              <td>Aug 2020</td>
+              <td>Apr 2023</td>
+              <td>Apr 2028</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.04 LTS</strong></td>
+              <td>Apr 2020</td>
+              <td>Apr 2025</td>
+              <td>Apr 2030</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.4 LTS</strong></td>
+              <td>Feb 2020</td>
+              <td>Aug 2020</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 19.10 (v5.3)</td>
+              <td>Oct 2019</td>
+              <td>Jul 2020</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
+              <td>Aug 2019</td>
+              <td>Feb 2020</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 19.04 (v5.0)</td>
+              <td>Apr 2019</td>
+              <td>Jan 2020</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
+              <td>Feb 2019</td>
+              <td>Aug 2019</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 18.10 (v4.18)</td>
+              <td>Oct 2018</td>
+              <td>Jul 2019</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
+              <td>Jul 2018</td>
+              <td>Apr 2023</td>
+              <td>Apr 2028</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
+              <td>Aug 2018</td>
+              <td>Apr 2021</td>
+              <td>Apr 2024</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
+              <td>Apr 2018</td>
+              <td>Apr 2023</td>
+              <td>Apr 2028</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
+              <td>Aug 2016</td>
+              <td>Apr 2021</td>
+              <td>Apr 2024</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
+              <td>Aug 2016</td>
+              <td>Apr 2019</td>
+              <td>Apr 2022</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
+              <td>Apr 2016</td>
+              <td>Apr 2021</td>
+              <td>Apr 2024</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
+              <td>Aug 2014</td>
+              <td>Apr 2019</td>
+              <td>Apr 2022</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 12.04.5 LTS (v3.13)</strong></td>
+              <td>Aug 2014</td>
+              <td>Apr 2017</td>
+              <td>Apr 2019</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
+              <td>Apr 2014</td>
+              <td>Apr 2019</td>
+              <td>Apr 2022</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 12.04.1 LTS (v3.2)</strong></td>
+              <td>Aug 2012</td>
+              <td>Apr 2017</td>
+              <td>Apr 2019</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 12.04.0 LTS (v3.2)</strong></td>
+              <td>Apr 2012</td>
+              <td>Apr 2017</td>
+              <td>Apr 2019</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="u-fixed-width">
+      <p>For more information on previous and upcoming kernel releases please see the <a href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack " class="p-link--external ">Ubuntu LTS Enablement Stack wiki page</a>.</p>
+    </div>
+  </section>
+
+  <section class="p-strip--light  is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2 id="ubuntu-openstack-release-cycle">Ubuntu OpenStack release cycle</h2>
+        <p>Canonical’s Cloud Archive allows users the ability to install newer releases of Ubuntu <a href="https://wiki.ubuntu.com/OpenStack" class="p-link--external">OpenStack</a> on an Ubuntu server as they become available. A given LTS release of Ubuntu will have the current release of OpenStack packaged in its release archives. The next four releases of OpenStack will then be published in the Cloud Archive for that LTS.</p>
+        <p>That means that it is possible to upgrade OpenStack four times on the same Ubuntu LTS release base operating system (upgrading the OpenStack without upgrading the operating system), and then one has the same OpenStack version that is included with the subsequent LTS release, and can choose to upgrade the operating system without upgrading the OpenStack version.</p>
+        <p>The middle OpenStack release (one year after the LTS release and one year before the next LTS release) is maintained for an extended period. Many customers therefore opt to make annual upgrades to their OpenStack rather than tracking each six-monthly release. The actual upgrade is fully supported using Canonical OpenStack tools and operator guides, and involves hopping through the six-monthly versions for database upgrade purposes, but the next effect is an annual upgrade to a version that is fully supportable.</p>
+        <p>The Ubuntu OpenStack support lifecycle can be represented this way:</p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-10" style="overflow: auto;">
+        <div class="u-hide--small" id="openstack-eol"></div>
+        <table class="u-hide--medium u-hide--large">
+          <thead>
+            <tr>
+              <th>Release</th>
+              <th>Released</th>
+              <th>End of life</th>
+              <th>Extended customer support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>OpenStack Ussuri LTS</td>
+              <td>Apr 2020</td>
+              <td>Apr 2025</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 20.04 LTS</td>
+              <td>Apr 2020</td>
+              <td>Apr 2025</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Ussuri</td>
+              <td>Feb 2020</td>
+              <td>Apr 2023</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Train</td>
+              <td>Aug 2019</td>
+              <td>Feb 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Stein</td>
+              <td>Apr 2019</td>
+              <td>Oct 2020</td>
+              <td>Apr 2022</td>
+            </tr>
+            <tr>
+              <td>OpenStack Rocky</td>
+              <td>Aug 2018</td>
+              <td>Feb 2020</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Queens</td>
+              <td>Apr 2018</td>
+              <td>Apr 2023</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04 LTS</strong></td>
+              <td>Apr 2018</td>
+              <td>Apr 2023</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Queens</td>
+              <td>Feb 2018</td>
+              <td>Apr 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Pike</td>
+              <td>Aug 2017</td>
+              <td>Feb 2019</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Ocata</td>
+              <td>Feb 2017</td>
+              <td>Aug 2018</td>
+              <td>Feb 2020</td>
+            </tr>
+            <tr>
+              <td>OpenStack Newton</td>
+              <td>Oct 2016</td>
+              <td>Apr 2018</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Mitaka</td>
+              <td>Apr 2016</td>
+              <td>Apr 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 16.04 LTS</strong></td>
+              <td>Apr 2016</td>
+              <td>Apr 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="u-fixed-width">
+      <p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive " class="p-link--external ">Ubuntu Cloud Archive wiki page</a>.</p>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-8">
+        <h2 id="charmed-kubernetes-release-cycle">Charmed Kubernetes<sup>&reg;</sup> release cycle</h2>
+        <p>The release cycle of the Charmed Kubernetes is tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of nine months, subject to changes in the upstream release cycle.</p>
+        <p>The Charmed Kubernetes support lifecycle can be represented this way:</p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-10" style="overflow: auto;">
+        <div class="u-hide--small" id="kubernetes-eol"></div>
+        <table class="u-hide--medium u-hide--large">
+          <thead>
+            <tr>
+              <th>Release</th>
+              <th>Released</th>
+              <th>End of life</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Kubernetes 1.18</strong></td>
+              <td align='right'>Mar 2020</td>
+              <td align='right'>Dec 2020</td>
+            </tr>
+            <tr>
+              <td><strong>Kubernetes 1.17</strong></td>
+              <td align='right'>Jan 2020</td>
+              <td align='right'>Oct 2020</td>
+            </tr>
+            <tr>
+              <td><strong>Kubernetes 1.16</strong></td>
+              <td align='right'>Oct 2019</td>
+              <td align='right'>Jul 2020</td>
+            </tr>
+            <tr>
+              <td><strong>Kubernetes 1.16</strong></td>
+              <td>Sep 2019</td>
+              <td>Jun 2020</td>
+            </tr>
+            <tr>
+              <td><strong>Kubernetes 1.15</strong></td>
+              <td>Jun 2019</td>
+              <td>Mar 2020</td>
+            </tr>
+            <tr>
+              <td><strong>Kubernetes 1.14</strong></td>
+              <td>Mar 2019</td>
+              <td>Dec 2019</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="row">
+      <p>For more information on previous and current releases of Charmed Kubernetes, please see the <a href="/kubernetes/docs/release-notes">Charmed Kubernetes release notes</a>.</p>
+    </div>
+  </section>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js" defer></script>
+  <script src="{{ versioned_static('js/build/release-chart.min.js') }}" defer></script>
+
+  {% endblock content %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,24 +727,6 @@
   dependencies:
     vanilla-framework "2.5.0"
 
-"@cypress/listr-verbose-renderer@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
-  integrity sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
-"@cypress/xvfb@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
-  integrity sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
-  dependencies:
-    debug "^3.1.0"
-    lodash.once "^4.1.1"
-
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -806,11 +788,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-
-"@types/sizzle@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
-  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -1114,11 +1091,6 @@ aproba@^1.0.3, aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-arch@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.1.tgz#8f5c2731aa35a30929221bb0640eed65175ec84e"
-  integrity sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==
-
 are-we-there-yet@~1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
@@ -1207,11 +1179,6 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
   integrity sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=
-
-async@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.1.1.tgz#dd3542db03de837979c9ebbca64ca01b06dc98df"
-  integrity sha512-X5Dj8hK1pJNC2Wzo2Rcp9FBVdJMGRR/S7V+lH46s8GVFhtbo5O4Le5GECCF/8PISVdkUA6mMPvgz7qTTD1rf1g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1322,7 +1289,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@3.7.2, bluebird@^3.5.5:
+bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -1436,11 +1403,6 @@ browserslist@^4.8.3, browserslist@^4.8.5:
     electron-to-chromium "^1.3.349"
     node-releases "^1.1.49"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1500,11 +1462,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-cachedir@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
-  integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
 
 caller-callsite@^2.0.0:
   version "2.0.0"
@@ -1584,14 +1541,6 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@3.0.0, chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1603,6 +1552,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -1611,11 +1568,6 @@ chalk@~0.4.0:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
-
-check-more-types@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
-  integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
 
 chokidar@^2.0.2:
   version "2.1.8"
@@ -1691,7 +1643,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-cursor@^1.0.1, cli-cursor@^1.0.2:
+cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
@@ -1794,11 +1746,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
-  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
-
 commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -1808,11 +1755,6 @@ commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
-common-tags@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
-  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1834,7 +1776,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@1.6.2, concat-stream@^1.4.6, concat-stream@^1.5.0:
+concat-stream@^1.4.6, concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -2005,45 +1947,6 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.0.2.tgz#ede194d7bc73fb449f8de553c9e1db4ca15309ef"
-  integrity sha512-WRzxOoSd+TxyXKa7Zi9orz3ii5VW7yhhVYstCU+EpOKfPan9x5Ww2Clucmy4H/W0GHUYAo7GYFZRD33ZCSNBQA==
-  dependencies:
-    "@cypress/listr-verbose-renderer" "0.4.1"
-    "@cypress/xvfb" "1.2.4"
-    "@types/sizzle" "2.3.2"
-    arch "2.1.1"
-    bluebird "3.7.2"
-    cachedir "2.3.0"
-    chalk "3.0.0"
-    check-more-types "2.24.0"
-    commander "4.1.0"
-    common-tags "1.8.0"
-    debug "4.1.1"
-    eventemitter2 "4.1.2"
-    execa "3.3.0"
-    executable "4.1.1"
-    extract-zip "1.6.7"
-    fs-extra "8.1.0"
-    getos "3.1.4"
-    is-ci "2.0.0"
-    is-installed-globally "0.1.0"
-    lazy-ass "1.6.0"
-    listr "0.14.3"
-    lodash "4.17.15"
-    log-symbols "3.0.0"
-    minimist "1.2.0"
-    moment "2.24.0"
-    ramda "0.26.1"
-    request "2.88.0"
-    request-progress "3.0.0"
-    supports-color "7.1.0"
-    tmp "0.1.0"
-    untildify "4.0.0"
-    url "0.11.0"
-    yauzl "2.10.0"
-
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -2064,24 +1967,17 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3:
+debug@^2.1.1, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
-debug@4.1.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
@@ -2453,11 +2349,6 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-eventemitter2@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-4.1.2.tgz#0e1a8477af821a6ef3995b311bf74c23a5247f15"
-  integrity sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=
-
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -2470,22 +2361,6 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
-
-execa@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-3.3.0.tgz#7e348eef129a1937f21ecbbd53390942653522c1"
-  integrity sha512-j5Vit5WZR/cbHlqU97+qcnw9WHRCIL4V1SVe75VcHcD1JRBdt8fv0zw89b7CQHQdUHTt2VjuhcF5ibAgVOxqpg==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    p-finally "^2.0.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
 
 execa@^1.0.0:
   version "1.0.0"
@@ -2515,13 +2390,6 @@ execa@^3.4.0:
     p-finally "^2.0.0"
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
-
-executable@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
-  integrity sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==
-  dependencies:
-    pify "^2.2.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -2597,16 +2465,6 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
-  integrity sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
-  dependencies:
-    concat-stream "1.6.2"
-    debug "2.6.9"
-    mkdirp "0.5.1"
-    yauzl "2.4.1"
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -2649,20 +2507,6 @@ fastq@^1.6.0:
   integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
   dependencies:
     reusify "^1.0.0"
-
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
-  dependencies:
-    pend "~1.2.0"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
-  dependencies:
-    pend "~1.2.0"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -2822,15 +2666,6 @@ front-matter@2.1.2:
   dependencies:
     js-yaml "^3.4.6"
 
-fs-extra@8.1.0, fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
@@ -2838,6 +2673,15 @@ fs-extra@^3.0.1:
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
     universalify "^0.1.0"
 
 fs-write-stream-atomic@^1.0.8:
@@ -2974,13 +2818,6 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getos@3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/getos/-/getos-3.1.4.tgz#29cdf240ed10a70c049add7b6f8cb08c81876faf"
-  integrity sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==
-  dependencies:
-    async "^3.1.0"
-
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -3023,13 +2860,6 @@ glob@~3.1.21:
     graceful-fs "~1.2.0"
     inherits "1"
     minimatch "~0.2.11"
-
-global-dirs@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
-  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
-  dependencies:
-    ini "^1.3.4"
 
 global-modules@2.0.0:
   version "2.0.0"
@@ -3131,7 +2961,7 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.0, har-validator@~5.1.3:
+har-validator@~5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
   integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
@@ -3476,13 +3306,6 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-ci@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
-  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
-  dependencies:
-    ci-info "^2.0.0"
-
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -3573,14 +3396,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-installed-globally@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
-  integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
-  dependencies:
-    global-dirs "^0.1.0"
-    is-path-inside "^1.0.0"
-
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
@@ -3620,13 +3435,6 @@ is-observable@^1.1.0:
   integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
   dependencies:
     symbol-observable "^1.1.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
-  dependencies:
-    path-is-inside "^1.0.1"
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -3849,11 +3657,6 @@ known-css-properties@^0.3.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.3.0.tgz#a3d135bbfc60ee8c6eacf2f7e7e6f2d4755e49a4"
   integrity sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==
 
-lazy-ass@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
-  integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
-
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -3941,7 +3744,7 @@ listr-verbose-renderer@^0.5.0:
     date-fns "^1.27.2"
     figures "^2.0.0"
 
-listr@0.14.3, listr@^0.14.3:
+listr@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
   integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
@@ -4006,22 +3809,10 @@ lodash.kebabcase@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
   integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
-lodash.once@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
-  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash@4.17.13, lodash@4.17.15, lodash@^3.5.0, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.3.0, lodash@~1.0.1, lodash@~4.17.12:
+lodash@4.17.13, lodash@^3.5.0, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.3.0, lodash@~1.0.1, lodash@~4.17.12:
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
-
-log-symbols@3.0.0, log-symbols@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
-  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
-  dependencies:
-    chalk "^2.4.2"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -4036,6 +3827,13 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -4262,7 +4060,7 @@ minimist@1.1.x:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
   integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
 
-minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -4291,17 +4089,12 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-moment@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -4838,11 +4631,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4853,7 +4641,7 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
-pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
@@ -5001,7 +4789,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24, psl@^1.1.28:
+psl@^1.1.28:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.7.0.tgz#f1c4c47a8ef97167dea5d6bbf4816d736e884a3c"
   integrity sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==
@@ -5048,7 +4836,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@^1.2.4, punycode@^1.4.1:
+punycode@^1.2.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
@@ -5072,11 +4860,6 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-ramda@0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
@@ -5240,39 +5023,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-request-progress@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
-  integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
-  dependencies:
-    throttleit "^1.0.0"
-
-request@2.88.0:
-  version "2.88.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.0"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.4.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
 
 request@^2.87.0, request@^2.88.0:
   version "2.88.2"
@@ -5940,13 +5690,6 @@ supports-color@6.1.0, supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@7.1.0, supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -5965,6 +5708,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
 
 symbol-observable@^1.1.0:
   version "1.2.0"
@@ -6026,11 +5776,6 @@ text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-throttleit@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
-  integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
-
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -6050,13 +5795,6 @@ timers-browserify@^2.0.4:
   integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-tmp@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
-  dependencies:
-    rimraf "^2.6.3"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -6099,14 +5837,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-tough-cookie@~2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
-  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
-  dependencies:
-    psl "^1.1.24"
-    punycode "^1.4.1"
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -6232,11 +5962,6 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-untildify@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
-  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
-
 upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
@@ -6254,7 +5979,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url@0.11.0, url@^0.11.0:
+url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
@@ -6624,18 +6349,3 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
-
-yauzl@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
-  dependencies:
-    fd-slicer "~1.0.1"


### PR DESCRIPTION
## Done

- Replaced image of releases with d3 chart

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Wee that the chart appears and is a table on small screens


## Issue / Card

Fixes #6694

## Screenshots

![image](https://user-images.githubusercontent.com/441217/75239145-110fc080-57ba-11ea-8086-758bf84dfeff.png)

