### PR TITLE
add anbox cloud webinar takeover and engage

### DIFF
--- a/templates/engage/anbox-cloud-webinar.md
+++ b/templates/engage/anbox-cloud-webinar.md
@@ -5,7 +5,7 @@ context:
      meta_description: "Enpowering innovators to create righ digital experiences on various mobile form factors"
      meta_image: https://assets.ubuntu.com/v1/cee46078-Meta+data+img.jpg
      meta_copydoc: https://docs.google.com/document/d/1xJVtEHr5ROGNzDblPDNVNk4DcX5HGcXL7gyrRPKcUdE
-     header_title: "An introduction to Anbox Cloud"
+     header_title: "An introduction to <br class='u-hide--small'>Anbox Cloud"
      header_subtitle: "Scalable Android&trade; in the cloud"
      header_image: "https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg"
      header_image_width: "250"

--- a/templates/engage/anbox-cloud-webinar.md
+++ b/templates/engage/anbox-cloud-webinar.md
@@ -1,0 +1,22 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "An introduction to Anbox Cloud"
+     meta_description: "Enpowering innovators to create righ digital experiences on various mobile form factors"
+     meta_image: https://assets.ubuntu.com/v1/cee46078-Meta+data+img.jpg
+     meta_copydoc: https://docs.google.com/document/d/1xJVtEHr5ROGNzDblPDNVNk4DcX5HGcXL7gyrRPKcUdE
+     header_title: "An introduction to Anbox Cloud"
+     header_subtitle: "Scalable Android&trade; in the cloud"
+     header_image: "https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg"
+     header_image_width: "250"
+     header_image_height: "182"
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--grad
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 387150, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Anbox Cloud, Canonical’s recently launched platform, delivers Android at scale in the cloud. Leveraging Android as a guest operating system to virtualise mobile workloads on servers while streaming graphical output to clients, Anbox Cloud empowers innovators to create rich digital experiences on various mobile form factors. Delivered as self-hosted PaaS in the cloud or at the edge, Anbox Cloud addresses market needs pertaining to game streaming, enterprise mobile application management, Android app testing at scale, and value-added services for mobile 5G customers.
+ 
+This webinar gives a broad overview of Anbox Cloud, covering product vision, value proposition, underlying technology stack, distribution channels and pricing model. Additional questions will be answered in detail by Galem Kayo, product manager for Anbox Cloud, in a live product Q&A session following the webinar presentation.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -874,5 +874,15 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
+
+  <div class="row u-equal-height u-clearfix">
+    {% with title="An introduction to Anbox Cloud",
+      description="Enpowering innovators to create righ digital experiences on various mobile form factors",
+      slug="anbox-cloud-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
   {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_dell-kubernetes-webinar.html" %}
+  {% include "takeovers/_anbox-cloud-webinar.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,6 @@
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
-  {% include "takeovers/_anbox-takeover.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_dell-kubernetes-webinar.html" %}
   {% include "takeovers/_anbox-cloud-webinar.html" %}

--- a/templates/takeovers/_anbox-cloud-webinar.html
+++ b/templates/takeovers/_anbox-cloud-webinar.html
@@ -1,4 +1,4 @@
-{% with title="An introduction to Anbox Cloud",
+{% with title="An introduction to<br class='u-hide--small' /> Anbox Cloud",
 subtitle="Scalable Android&trade; in the cloud",
 class="p-takeover--grad",
 header_image="https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg",

--- a/templates/takeovers/_anbox-cloud-webinar.html
+++ b/templates/takeovers/_anbox-cloud-webinar.html
@@ -1,0 +1,16 @@
+{% with title="An introduction to Anbox Cloud",
+subtitle="Scalable Android&trade; in the cloud",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg",
+image_height="246",
+image_width="338",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/anbox-cloud-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud",
+primary_cta="Watch the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -6,7 +6,7 @@
           {{ title | safe }}
         </h1>
         {% if subtitle %}<h4>
-          {{ subtitle }}
+          {{ subtitle | safe }}
         </h4>{% endif %}
         <div class="u-hide--small">
           {% if primary_url %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -106,4 +106,6 @@
 <p>7 Feb 2020</p>
 {% include "takeovers/_ai-edge-webinar.html" %}
 {% include "takeovers/_dell-kubernetes-webinar.html" %}
+<p>25 Feb 2020</p>
+{% include "takeovers/_anbox-cloud-webinar.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Added /engage/anbox-cloud-webinar and associated takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see a takeover with the title "An introduction to Anbox Cloud", see that it complies with the [design](https://github.com/canonical-web-and-design/web-squad/issues/2400#issuecomment-590848140) and the [brief](https://docs.google.com/spreadsheets/d/19HsZx5SCw9nKq2AXklGAvHJoFp2DJ-g6cEe0vP7JWCw/edit#gid=2113339190)
  - @pmahnke the brief mentions this takeover should be added as the 4th takeover, but obviously there's already a similar takeover for a whitepaper; should this one replace that one?
- Follow the takeover CTA to the engage page, see that it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2400#issuecomment-590848140) and the [copy doc](https://docs.google.com/document/d/1xJVtEHr5ROGNzDblPDNVNk4DcX5HGcXL7gyrRPKcUdE/edit#)
- Test the page on https://cards-dev.twitter.com/validator, see that it pulls through a relevant title, description and image
- Visit /takeovers, see that the takeover is visible at the bottom of the list
- Visit /engage, see that there is a card for the engage page


## Issue / Card

Fixes #6844
