### PR TITLE
Add feeds endpoints for security notices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ canonicalwebteam.image-template==1.0.0
 canonicalwebteam.discourse-docs==0.11.0
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
+feedgen==0.9.0 
 feedparser==5.2.1
 pymacaroons==0.13.0
 pybreaker==0.6.0

--- a/templates/security/_subscribe.html
+++ b/templates/security/_subscribe.html
@@ -2,13 +2,19 @@
   <h2 class="p-heading--four">Subscribe</h2>
   <ul class="p-list u-no-margin--bottom">
     <li class="p-list__item u-sv1">
-      <a href="#" style="display: flex; align-items: center;">
+      <a href="/security/notices/atom.xml" style="display: flex; align-items: center;">
+        <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
+        Atom
+      </a>
+    </li>
+    <li class="p-list__item u-sv1">
+      <a href="/security/notices/rss.xml" style="display: flex; align-items: center;">
         <i class="p-icon--rss" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
         RSS
       </a>
     </li>
     <li class="p-list__item">
-      <a href="#" style="display: flex; align-items: center;">
+      <a href="https://lists.ubuntu.com/mailman/listinfo/ubuntu-security-announce" style="display: flex; align-items: center;">
         <i class="p-icon--email" style="margin-right: 0.5rem; flex-shrink: 0;"></i>
         Mailing list
       </a>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,6 +44,7 @@ from webapp.security.views import (
     api_create_notice,
     notice,
     notices,
+    notices_feed,
 )
 
 # Set up application
@@ -131,6 +132,7 @@ app.register_blueprint(blog_blueprint, url_prefix="/blog")
 
 # usn section
 app.add_url_rule("/security/notices", view_func=notices)
+app.add_url_rule("/security/notices/<feed_type>.xml", view_func=notices_feed)
 app.add_url_rule(
     "/security/notices", view_func=api_create_notice, methods=["POST"]
 )

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -1,10 +1,12 @@
 # Standard library
-import datetime
 from collections import OrderedDict
+from datetime import datetime
 from math import ceil
 
 # Packages
 import flask
+from feedgen.entry import FeedEntry
+from feedgen.feed import FeedGenerator
 from marshmallow import EXCLUDE
 from marshmallow.exceptions import ValidationError
 from mistune import Markdown
@@ -120,6 +122,61 @@ def notices():
     )
 
 
+# USN Feeds
+# ===
+
+
+def notices_feed(feed_type):
+    if feed_type not in ["atom", "rss"]:
+        flask.abort(404)
+
+    url_root = flask.request.url_root
+    base_url = flask.request.base_url
+
+    feed = FeedGenerator()
+    feed.generator("Feedgen")
+
+    feed.id(url_root)
+    feed.copyright(
+        f"{datetime.now().year} Canonical Ltd. "
+        "Ubuntu and Canonical are registered trademarks of Canonical Ltd."
+    )
+    feed.title("Ubuntu security notices")
+    feed.description("Recent content on Ubuntu security notices")
+    feed.link(href=base_url, rel="self")
+
+    def feed_entry(notice, url_root):
+        _id = f"USN-{notice.id}"
+        title = f"{_id}: {notice.title}"
+        description = notice.details
+        published = notice.published
+        notice_path = flask.url_for(".notice", notice_id=notice.id).lstrip("/")
+        link = f"{url_root}{notice_path}"
+
+        entry = FeedEntry()
+        entry.id(link)
+        entry.title(title)
+        entry.description(description)
+        entry.link(href=link)
+        entry.published(f"{published} UTC")
+        entry.author(dict(name="Ubuntu Security Team"))
+
+        return entry
+
+    notices = (
+        db_session.query(Notice)
+        .order_by(desc(Notice.published))
+        .limit(10)
+        .all()
+    )
+
+    for notice in notices:
+        feed.add_entry(feed_entry(notice, url_root), order="append")
+
+    payload = feed.atom_str() if feed_type == "atom" else feed.rss_str()
+    return flask.Response(payload, mimetype="text/xml")
+
+
 # USN API
 # ===
 
@@ -153,7 +210,7 @@ def api_create_notice():
         summary=data["summary"],
         details=data["description"],
         packages=data["releases"],
-        published=datetime.datetime.fromtimestamp(data["timestamp"]),
+        published=datetime.fromtimestamp(data["timestamp"]),
     )
 
     if "action" in data:


### PR DESCRIPTION
## Done
Add rss and atom feeds for security notices.

## QA

- Check out this feature branch
- Add the sqlite database to the root of the project(ask me)
- Run the site using the command `./run`
- Open `http://localhost:8001/security/notices/rss.xml` and `http://localhost:8001/security/notices/atom.xml` with and RSS reader and make sure they work.
