### PR TITLE
Security notices: display if a release is LTS

### DIFF
--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -5,7 +5,7 @@
   <ul class="p-inline-list u-no-margin">
     {% for release in notice.releases %}
       <li class="p-inline-list__item">
-        <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
+        <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {% if release.lts %} LTS {% endif %}</a>
       </li>
     {% endfor %}
   </ul>

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -20,7 +20,7 @@
       <ul class="p-inline-list u-no-margin--bottom">
         {% for release in notice.releases %}
           <li class="p-inline-list__item">
-            <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }}</a>
+            <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {% if release.lts %} LTS {% endif %}</a>
           </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Done
Wherever we display a release tag append `LTS` if the release is LTS.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- Make sure `LTS` shows where appropriate
