### PR TITLE
Update /telecommmunications illustrations

### DIFF
--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -26,7 +26,16 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/03853de5-Joint+Lime-illustration-white.svg" width="330" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/01a65abc-telecommunications-white.svg",
+          alt="",
+          height="341",
+          width="325",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -136,7 +145,16 @@
             <p>Talk to an expert from Canonical. Designing NFV requires deep technical knowledge. Benefit from the cloud-native framework developed by Canonical and used by leading telecommunications companies.</p>
           </div>
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/4287c2b2-transfer.svg" alt="" width="134">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg",
+                alt="",
+                height="96",
+                width="134",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
           </div>
         </div>
       </li>
@@ -149,7 +167,16 @@
             <p>Use Juju to model your platform. Declare what to build. Juju can be used for both NFVI and MANO implementation.</p>
           </div>
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/43798107-Laptop_4px.svg" alt="" width="134">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/46439b10-2.+model_AW.svg",
+                alt="",
+                height="96",
+                width="134",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
           </div>
         </div>
       </li>
@@ -162,7 +189,16 @@
             <p>Let Juju build the platform for you. Forget the "How to build?" question. Benefit from the intelligence provided by charms and the declarative DevOps approach.</p>
           </div>
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
-            <img style="margin-left: -1rem;" src="https://assets.ubuntu.com/v1/e96658e8-transfer_4px.svg" alt="" width="164">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/0cfe6c2d-build.svg",
+                alt="",
+                height="96",
+                width="134",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
           </div>
         </div>
       </li>
@@ -173,6 +209,18 @@
               Operate
             </h3>
             <p>Use Juju to orchestrate your workloads and operate the platform. Build fully-functional lifecycle management framework around Juju and charms.</p>
+          </div>
+          <div class="col-4 u-align--center u-vertically-center u-hide--small">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/ada1d5b5-operate.svg",
+                alt="",
+                height="96",
+                width="134",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}
           </div>
         </div>
       </li>
@@ -355,7 +403,16 @@
       </p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/11095006-open_mano.png" width="150" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          height="178",
+          width="250",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </section>

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -45,28 +45,108 @@
     <h2 class="p-muted-heading u-no-max-width">PROVEN IN THE FIELD - OUR TELCO CUSTOMERS</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png" width="88" alt="BT" style="max-width:88px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png",
+            alt="BT",
+            height="88",
+            width="88",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/25de1877-Tele2.svg" width="90" alt="Tele2" style="max-width:90px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/25de1877-Tele2.svg",
+            alt="Tele2",
+            height="35",
+            width="90",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/eaf98009-Bell_Blue_large_transparent.png" width="90" alt="Bell Canada" style="max-width:90px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/eaf98009-Bell_Blue_large_transparent.png",
+            alt="Bell Canada",
+            height="64",
+            width="90",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg" width="242" alt="Deutshe Telekom" style="max-width:130px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
+            alt="Deutshe Telekom",
+            height="29",
+            width="130",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b6e008be-Colt-Logo.svg" width="100" alt="Colt" style="max-width:100px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/b6e008be-Colt-Logo.svg",
+            alt="Colt",
+            height="40",
+            width="100",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/481063cd-pccw.svg" width="144" alt="PCCW" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/481063cd-pccw.svg",
+            alt="PCCW",
+            height="50",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg" width="145" alt="AT&T" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
+            alt="AT&T",
+            height="88",
+            width="88",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/9ca791fd-Sky_Logo_seit_Dezember_2015.png?w=90" width="90" alt="Sky" style="max-width:90px;" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/9ca791fd-Sky_Logo_seit_Dezember_2015.png",
+            alt="Sky",
+            height="63",
+            width="90",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -77,31 +157,121 @@
     <h2 class="p-muted-heading u-no-max-width">OPEN SOURCE COMES THROUGH CONTRIBUTION - PROGRAMS WE ARE PROUD TO BE PART OF</h2>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d10b4578-etsi.svg" width="88" alt="ETSI" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/d10b4578-etsi.svg",
+            alt="ETSI",
+            height="88",
+            width="88",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4a8b06e9-onap_logo.png?w=144" width="144" alt="ONAP" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/4a8b06e9-onap_logo.png",
+            alt="ONAP",
+            height="88",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f15a069c-opnfv_logo_wp.png?w=144" width="144" alt="OPNFV" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/f15a069c-opnfv_logo_wp.png",
+            alt="OPNFV",
+            height="31",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg" width="144" alt="Open Source MANO"  style="width: 144px;"/>
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
+            alt="Open Source MANO",
+            height="52",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5ac9bab5-logo_cord-1.png?w=144" width="144" alt="CORD" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/5ac9bab5-logo_cord-1.png",
+            alt="CORD",
+            height="88",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/9e564bf9-open-baton.png?w=120" width="120" alt="Open Baton" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/9e564bf9-open-baton.png",
+            alt="Open Baton",
+            height="30",
+            width="120",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/9635c8f7-opencompute-logo-green.png?w=144" width="144" alt="Open Compute" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/9635c8f7-opencompute-logo-green.png",
+            alt="Open Compute",
+            height="58",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img style="width: 300px;" class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/eeae998a-telecominfraproject-logo.svg" width="144" alt="Telecom Infra Project" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/eeae998a-telecominfraproject-logo.svg",
+            alt="Telecom Infra Project",
+            height="23",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/061ffe4a-onf-logo.jpg?w=144" width="144" alt="ONF" />
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/061ffe4a-onf-logo.jpg",
+            alt="ONF",
+            height="85",
+            width="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
       </li>
     </ul>
   </div>
@@ -268,7 +438,16 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg" alt="" width="220">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg",
+          alt="",
+          height="106",
+          width="220",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
   <div class="u-fixed-width">
@@ -276,7 +455,16 @@
   </div>
   <div class="row u-vertically-center">
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg" alt="" width="200">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
+          alt="",
+          height="156",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-8">
       <h3>
@@ -307,7 +495,16 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg" width="250" height="90" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
+          alt="",
+          height="90",
+          width="250",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -340,7 +537,16 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg" width="150" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg",
+          alt="",
+          height="150",
+          width="150",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
   <div class="u-fixed-width">
@@ -348,7 +554,16 @@
   </div>
   <div class="row u-vertically-center">
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/77c24034-maas-logo.svg" width="200" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/77c24034-maas-logo.svg",
+          alt="",
+          height="65",
+          width="200",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
     <div class="col-8">
       <h3>
@@ -384,7 +599,16 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/805f2b3a-core_black-orange_st_hex.svg" width="100" alt="">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/805f2b3a-core_black-orange_st_hex.svg",
+          alt="",
+          height="135",
+          width="100",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -421,7 +645,17 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <blockquote class="p-pull-quote  has-image">
-        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/c2b1de52-BT_logo.svg" height="40" alt="BT">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c2b1de52-BT_logo.svg",
+            alt="BT",
+            height="32",
+            width="66",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-pull-quote__image"}
+          ) | safe
+        }}
         <p class="p-pull-quote__quote">
           Canonical is providing us with the ‘cloud-native’ foundation that enables us to create a smart and fully converged network. Utilising open source and best-of-breed technologies will ensure we can deliver on our convergence vision, and enable a world-leading 5G and FTTP experience for our customers.
         </p>
@@ -432,7 +666,17 @@
     </div>
     <div class="col-6 p-divider__block">
       <blockquote class="p-pull-quote  has-image">
-        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg"  height="40" alt="AT&amp;T">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
+            alt="AT&amp;T",
+            height="32",
+            width="78",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-pull-quote__image"}
+          ) | safe
+        }}
         <p class="p-pull-quote__quote">
           We&rsquo;re reinventing how we scale by becoming simpler and modular, similar to how applications have evolved in cloud data centers. Open source and OpenStack innovations represent a unique opportunity to meet these requirements and Canonical&rsquo;s cloud and open source expertise make them a good choice for AT&amp;T.
         </p>
@@ -444,13 +688,10 @@
   </div>
 </section>
 
-
 {% with first_item="_cloud_nfv", second_item="_cloud_newsletter", third_item="_telco_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Updated illustrations according to [brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6490)
- Replaced image tags with the image module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/telecommunications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the illustrations mentioned in the [brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6490) are present


## Issue / Card

Fixes #6490 
