### PR TITLE
Add smart start takeover

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -857,7 +857,7 @@
       type="webinar" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
-    
+
     {% with title="Artificial Intelligence at the edge in a 5G world",
       description="Deploying AI/ML solutions in latency-sensitive environments requires a new solution architecture approach",
       slug="ai-edge-webinar",
@@ -865,7 +865,7 @@
       type="webinar" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
-    
+
     {% with title="Deploy Kubernetes in your data centre",
       description="Learn what sets Kubernetes apart from other options and how you can get started.",
       slug="dell-kubernetes-webinar",
@@ -879,6 +879,14 @@
     {% with title="An introduction to Anbox Cloud",
       description="Enpowering innovators to create righ digital experiences on various mobile form factors",
       slug="anbox-cloud-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+
+    {% with title="Accelerating IoT device time to market",
+      description="Launching IoT devices and managing them at scale can be a time intensive and complex process. ",
+      slug="smart-start-webinar",
       group="webinar",
       type="webinar" %}
       {% include "engage/_article-card.html" %}

--- a/templates/engage/smart-start-webinar.md
+++ b/templates/engage/smart-start-webinar.md
@@ -6,7 +6,7 @@ context:
      meta_image: "https://assets.ubuntu.com/v1/c1d4abdf-Meta+data+img.jpg"
      meta_copydoc: "https://docs.google.com/document/d/1g0qFcM4VJbrnj-LRn0FS3Pj5pD2vYtQNhUgkH-vMHlw"
      header_title: "Accelerating IoT device time to market"
-     header_subtitle: "Challenges and soloutions for IoT execution "
+     header_subtitle: "Challenges and solutions for IoT execution "
      header_image: "https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg"
      header_image_width: "250"
      header_image_height: "250"

--- a/templates/engage/smart-start-webinar.md
+++ b/templates/engage/smart-start-webinar.md
@@ -11,6 +11,9 @@ context:
      header_image_width: "250"
      header_image_height: "250"
      header_class: p-engage-banner--grad
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_cta_class: p-button--positive
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 385799, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---
 

--- a/templates/engage/smart-start-webinar.md
+++ b/templates/engage/smart-start-webinar.md
@@ -1,0 +1,21 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Accelerating IoT device time to market"
+     meta_description: "Launching IoT devices and managing them at scale can be a time intensive and complex process. With 85% of IoT initiatives not launched after a year of development, it is inevitable that change is needed."
+     meta_image: "https://assets.ubuntu.com/v1/c1d4abdf-Meta+data+img.jpg"
+     meta_copydoc: "https://docs.google.com/document/d/1g0qFcM4VJbrnj-LRn0FS3Pj5pD2vYtQNhUgkH-vMHlw"
+     header_title: "Accelerating IoT device time to market"
+     header_subtitle: "Challenges and soloutions for IoT execution "
+     header_image: "https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg"
+     header_image_width: "250"
+     header_image_height: "250"
+     header_class: p-engage-banner--grad
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 385799, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Launching IoT devices and managing them at scale can be a time intensive and complex process. With 85% of IoT initiatives not launched after a year of development, it is inevitable that change is needed.
+
+To overcome these challenges, Canonical has introduced Smart Start, a package that reduces business and technical decision making into a 2-week, fixed-cost decision. Smart Start provides a guided journey through the infrastructure needed to develop, customise, and distribute software to fleets of devices. With consulting services to de-risk the journey at critical points, an enterprise’s IoT strategy is fast tracked to market.
+
+This webinar details the learnings from over 30 project summaries and case studies of Canonical customers. Nilay Patel, Product Manager for IoT and Devices, will speak about the lessons to take away, and why businesses such as Rigado, Cyberdyne and Fingbox chose Canonical to launch their IoT devices.

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
   {% include "takeovers/_451-microk8s.html" %}
-  {% include "takeovers/_dell-kubernetes-webinar.html" %}
+  {% include "takeovers/_smart-start-webinar.html" %}
   {% include "takeovers/_anbox-cloud-webinar.html" %}
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_smart-start-webinar.html
+++ b/templates/takeovers/_smart-start-webinar.html
@@ -1,5 +1,5 @@
 {% with title="Accelerating IoT device time to market",
-subtitle="Challenges and soloutions for IoT execution ",
+subtitle="Challenges and solutions for IoT execution ",
 class="p-takeover--grad",
 header_image="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg",
 image_height="350",

--- a/templates/takeovers/_smart-start-webinar.html
+++ b/templates/takeovers/_smart-start-webinar.html
@@ -1,0 +1,16 @@
+{% with title="Accelerating IoT device time to market",
+subtitle="Challenges and soloutions for IoT execution ",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg",
+image_height="350",
+image_width="350",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/smart-start-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_IOT_SmartStart_WBN_Timetomarket",
+primary_cta="Watch the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -61,6 +61,7 @@
 {% include "takeovers/_rigado_webinar.html" %}
 {% include "takeovers/_robotics-takeover.html" %}
 {% include "takeovers/_shift-to-app-store_takeover.html" %}
+{% include "takeovers/_smart-start-webinar.html" %}
 {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
 {% include "takeovers/_snap-deltas-takeover.html" %}
 {% include "takeovers/_spicule_takeover.html" %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -61,7 +61,6 @@
 {% include "takeovers/_rigado_webinar.html" %}
 {% include "takeovers/_robotics-takeover.html" %}
 {% include "takeovers/_shift-to-app-store_takeover.html" %}
-{% include "takeovers/_smart-start-webinar.html" %}
 {% include "takeovers/_snapcraft-brand-store_takeover.html" %}
 {% include "takeovers/_snap-deltas-takeover.html" %}
 {% include "takeovers/_spicule_takeover.html" %}
@@ -109,4 +108,6 @@
 {% include "takeovers/_dell-kubernetes-webinar.html" %}
 <p>25 Feb 2020</p>
 {% include "takeovers/_anbox-cloud-webinar.html" %}
+<p>26 Feb 2020</p>
+{% include "takeovers/_smart-start-webinar.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Added a smart start takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the smart start takeover appears, follow it to the engage page

[Brief](https://docs.google.com/spreadsheets/d/1BHbx3SYPCJrGij5wc7kzH5Y-KN4QqACEdd8iJzb_KAs/edit#gid=0)


## Issue / Card

Fixes #6765 
