### PR TITLE
Extract siteKey for captcha into variable

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@ PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
 ADVANTAGE_API=https://contracts.canonical.com/
+
+# This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
+CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -18,11 +18,14 @@
 
     // recaptcha submitCallback
     window.CaptchaCallback = function() {
-      let recaptchas = document.querySelectorAll("div[class^=g-recaptcha]");
+      let recaptchas = [].slice.call(
+        document.querySelectorAll("div[class^=g-recaptcha]")
+      );
       recaptchas.forEach(function(field) {
         if (!field.hasAttribute("data-widget-id")) {
+          let siteKey = field.getAttribute("data-sitekey");
           const recaptchaWidgetId = grecaptcha.render(field, {
-            sitekey: "6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
+            sitekey: siteKey
           });
           field.setAttribute("data-widget-id", recaptchaWidgetId);
         }

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -51,7 +51,7 @@
         </span>
       </div>
 
-      <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+      <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
 
       <p>
         <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -205,7 +205,7 @@
                 <span class="mktFormMsg"></span>
               </span>
             </div>
-            <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 1rem 0;"></div>
+            <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 1rem 0;"></div>
             <p>
               <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
             </p>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -100,7 +100,7 @@
             </li>
 
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
 
             <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -66,7 +66,7 @@
               <label class="mktoLabel mktoHasWidth" for="CanonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
             </li>
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
             <li class="mktField p-list__item">
               <button type="submit" class="mktoButton p-button--positive">Download the white paper</button>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -74,7 +74,7 @@
             </li>
 
             <li class="p-list__item" >
-              <div class="g-recaptcha" style="margin-bottom: 2rem;" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+              <div class="g-recaptcha" style="margin-bottom: 2rem;" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
             </li>
 
             <li class="mktField p-list__item">

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -51,7 +51,7 @@
             </li>
             <li><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></li>
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
             <li class="mktField p-list__item">
               <button type="submit" class="mktoButton p-button--positive">Subscribe and download</button>

--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -161,7 +161,7 @@
                 </p>
               </li>
               <li class="mktField">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
               <li class="mktField">
                 <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">

--- a/templates/engage/events.html
+++ b/templates/engage/events.html
@@ -76,7 +76,7 @@
           </ul>
           <ul class="p-list">
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
           </ul>
           <ul class="p-list u-no-margin--bottom">

--- a/templates/engage/fr/openstack-made-easy.html
+++ b/templates/engage/fr/openstack-made-easy.html
@@ -101,7 +101,7 @@
               <input name="RichText" type="hidden" aria-label="RichText">
             </li>
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
             <li class="mktField">
               <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -44,7 +44,7 @@
         <input name="RichText" type="hidden" aria-label="RichText">
       </li>
       <li class="p-list__item">
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+        <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
       <li class="mktField">
         <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -52,7 +52,7 @@
         </p>
       </li>
       <li class="mktField">
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+        <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
       <li class="mktField">
         <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -51,7 +51,7 @@
         </p>
       </li>
       <li class="mktField">
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+        <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
       <li class="mktField">
         <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -39,7 +39,7 @@
         <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes : <a href="/legal/data-privacy" target="_blank" class="mchNoDecorate">Politique de confidentialité</a></p>
       </li>
       <li class="mktField">
-        <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+        <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
       <li class="mktField p-list__item">
         <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'server-esm', 'eventValue' : undefined });">{% if cta %}{{ cta }}{% else %}Télécharger le livre blanc{% endif %}</button>

--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -60,7 +60,7 @@
             <label class="mktoLabel mktoHasWidth" for="3-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
           </li>
           <li class="p-list__item">
-            <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+            <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
           </li>
           <li class="mktField p-list__item">
             <button type="submit" class="p-button--positive mktoButton" aria-label="Submit">Get the whitepaper</button>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -88,7 +88,7 @@
               </p>
             </li>
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
             <li  class="mktField">
               <button type="submit" class="mktoButton">Submit request</button>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -59,7 +59,7 @@
             </li>
             <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
             <li class="mktField p-list__item">
               <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -66,7 +66,7 @@
             <li class="p-list__item">
               Mit der Absendung dieses Formulars bestätige ich, dass ich <a href="/legal/data-privacy/contact">Canonicals Datenschutzerklärung</a> und <a href="/legal/data-privacy">richtlinie zur Kenntnis</a> genommen habe.
             </li>
-            <li class="p-list__item"><div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div></li>
+            <li class="p-list__item"><div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div></li>
             <li class="mktField p-list__item">
               <button style="margin: 1rem 0 0 0" type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Absenden</button>
             </li>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -67,7 +67,7 @@
           </ul>
           <ul class="p-list">
             <li class="p-list__item">
-              <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
           </ul>
           <ul class="p-list">

--- a/templates/shared/forms/interactive/_aws.html
+++ b/templates/shared/forms/interactive/_aws.html
@@ -125,7 +125,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_bootstack.html
+++ b/templates/shared/forms/interactive/_bootstack.html
@@ -315,7 +315,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_embedded.html
+++ b/templates/shared/forms/interactive/_embedded.html
@@ -167,7 +167,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_general.html
+++ b/templates/shared/forms/interactive/_general.html
@@ -200,7 +200,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_kubeflow.html
+++ b/templates/shared/forms/interactive/_kubeflow.html
@@ -150,7 +150,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_kubernetes.html
+++ b/templates/shared/forms/interactive/_kubernetes.html
@@ -231,7 +231,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_masters-conference.html
+++ b/templates/shared/forms/interactive/_masters-conference.html
@@ -18,7 +18,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_openstack.html
+++ b/templates/shared/forms/interactive/_openstack.html
@@ -317,7 +317,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_partner-dell.html
+++ b/templates/shared/forms/interactive/_partner-dell.html
@@ -216,7 +216,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_pricing-infra.html
+++ b/templates/shared/forms/interactive/_pricing-infra.html
@@ -172,7 +172,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
             <div class="u-hide">

--- a/templates/shared/forms/interactive/_robotics.html
+++ b/templates/shared/forms/interactive/_robotics.html
@@ -184,7 +184,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_storage.html
+++ b/templates/shared/forms/interactive/_storage.html
@@ -159,7 +159,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/shared/forms/interactive/_support-openstack.html
+++ b/templates/shared/forms/interactive/_support-openstack.html
@@ -570,7 +570,7 @@
               <li class="p-list__item">
                 <div
                   class="g-recaptcha"
-                  data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
+                  data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"
                   style="margin: 2rem 0;"
                 ></div>
               </li>

--- a/templates/shared/forms/interactive/_support.html
+++ b/templates/shared/forms/interactive/_support.html
@@ -170,7 +170,7 @@
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
               </li>
             </ul>
 

--- a/templates/whitepapers/beta/shared/form.html
+++ b/templates/whitepapers/beta/shared/form.html
@@ -51,7 +51,7 @@
       <input type="hidden" name="Consent_to_Processing__c" class="mktoField mktoFormCol" aria-label="Consent_to_Processing__c" value="Yes" >
     </li>
     <li class="p-list__item">
-      <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+      <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
     </li>
     <li class="mktField p-list__item">
       <button type="submit" class="mktoButton u-no-margin--bottom">Continue reading</button>

--- a/templates/whitepapers/shared/form.html
+++ b/templates/whitepapers/shared/form.html
@@ -51,7 +51,7 @@
       <input type="hidden" name="Consent_to_Processing__c" class="mktoField mktoFormCol" aria-label="Consent_to_Processing__c" value="Yes">
     </li>
     <li class="p-list__item">
-      <div class="g-recaptcha" data-sitekey="6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if" style="margin: 2rem 0;"></div>
+      <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
     </li>
     <li class="mktField p-list__item">
       <button type="submit" class="mktoButton u-no-margin--bottom">Continue reading</button>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,6 +3,7 @@ A Flask application for ubuntu.com
 """
 
 # Packages
+import os
 import talisker.requests
 import flask
 import math
@@ -41,6 +42,10 @@ from webapp.views import (
 )
 from webapp.login import login_handler, logout
 
+
+CAPTCHA_TESTING_API_KEY = os.getenv(
+    "CAPTCHA_TESTING_API_KEY", "6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
+)
 
 # Set up application
 # ===
@@ -87,6 +92,7 @@ def context():
         "utm_campaign": flask.request.args.get("utm_campaign", ""),
         "utm_medium": flask.request.args.get("utm_medium", ""),
         "utm_source": flask.request.args.get("utm_source", ""),
+        "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
     }
 
 


### PR DESCRIPTION
## Done

Extract the captcha siteKey into a variable to be able to inject the testing siteKey provided by reCaptcha V2: https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Try different forms with captcha:
  - http://0.0.0.0:8001/download/server/thank-you
  - http://0.0.0.0:8001/download/server/thank-you
  - http://0.0.0.0:8001/openstack#get-in-touch
  - http://0.0.0.0:8001/core/contact-us
  - http://0.0.0.0:8001/engage/anbox-cloud-gaming-whitepaper
- All should have the error message that you see in the image but you should sitll be able to validate the forms
![image](https://user-images.githubusercontent.com/2707508/75369419-4ea84280-58bb-11ea-82fb-263edf13f129.png)

- Try to remove the env var `CAPTCHA_TESTING_API_KEY ` from `.env`
- Go through the the forms again. The error shouldn't be there anymore and you should be able to make validation


## Issue / Card

Fixes #2408
