### PR TITLE
Add marketo form testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     es6: true,
     jest: true
   },
-  extends: ["eslint:recommended", "eslint-config-prettier"],
+  extends: ["eslint:recommended", "eslint-config-prettier", "plugin:cypress/recommended"],
   globals: {
     Atomics: "readonly",
     SharedArrayBuffer: "readonly",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/js/build etc/",
     "serve": "./entrypoint $(hostname -I | awk '{print $1;}'):${PORT}",
     "start": "yarn run build && concurrently --raw 'yarn run watch-css' 'yarn run watch-js' 'yarn run serve'",
-    "cypress:run": "cypress run --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:${PORT}",
-    "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:${PORT}"
+    "cypress:run": "cypress run --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}",
+    "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}"
   },
   "husky": {
     "hooks": {
@@ -46,6 +46,7 @@
     "concurrently": "5.1.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
+    "eslint-plugin-cypress": "^2.10.3",
     "exports-loader": "0.7.0",
     "husky": "4.2.3",
     "jest": "25.1.0",

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -3,5 +3,6 @@
     "video": false,
     "pluginsFile": false,
     "supportFile": false,
-    "fixturesFolder": false
+    "fixturesFolder": false,
+    "chromeWebSecurity": false
 }

--- a/tests/cypress/forms_spec.js
+++ b/tests/cypress/forms_spec.js
@@ -1,0 +1,118 @@
+/// <reference types="cypress" />
+
+// Those functions come from https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/
+const getIframeDocument = () => {
+  return cy
+    .get(".g-recaptcha iframe")
+    .its("0.contentDocument")
+    .should("exist");
+};
+
+const getIframeBody = () => {
+  return getIframeDocument()
+    .its("body")
+    .should("not.be.undefined")
+    .then(cy.wrap);
+};
+
+context("Marketo form", () => {
+  beforeEach(() => {
+    cy.server();
+    cy.route(
+      "POST",
+      "https://app-sjg.marketo.com/index.php/leadCapture/save2"
+    ).as("captureLead");
+  });
+
+  afterEach(() => {
+    cy.wait("@captureLead").should(xhr => {
+      expect(xhr.method).to.equal("POST");
+      expect(xhr.status).to.equal(200);
+    });
+  });
+
+  it("/download/server/thank-you", () => {
+    cy.visit("/download/server/thank-you");
+
+    cy.get('input[name="FirstName"]').type("Test");
+    cy.get('input[name="LastName"]').type("Test");
+    cy.get('input[name="Company"]').type("Test");
+    cy.get('input[name="Title"]').type("Test");
+    cy.get('input[name="Email"]').type("test@test.com");
+
+    getIframeBody()
+      .find(".rc-anchor-content")
+      .click();
+
+    cy.wait(10000); // eslint-disable-line
+    cy.get("#mktoForm_3485").submit();
+  });
+
+  it("/core/contact-us", () => {
+    cy.visit("/core/contact-us");
+
+    cy.get('input[name="FirstName"]').type("Test");
+    cy.get('input[name="LastName"]').type("Test");
+    cy.get('input[name="Email"]').type("test@test.com");
+    cy.get('input[name="Phone"]').type("000000000");
+    cy.get('select[name="Country"]').select("Colombia");
+    cy.get('input[name="Company"]').type("Test");
+    cy.get('input[name="Title"]').type("Test");
+    cy.get('textarea[name="Comments_from_lead__c"]').type(
+      "Test test test test"
+    );
+    cy.get('label[for="canonicalUpdatesOptIn"]').click();
+
+    getIframeBody()
+      .find(".rc-anchor-content")
+      .click();
+
+    cy.wait(10000); // eslint-disable-line
+    cy.get("#mktoForm_1266").submit();
+  });
+
+  it("/engage/anbox-cloud-gaming-whitepaper", () => {
+    cy.visit("/engage/anbox-cloud-gaming-whitepaper");
+
+    cy.get('input[name="FirstName"]').type("Test");
+    cy.get('input[name="LastName"]').type("Test");
+    cy.get('input[name="Company"]').type("Test");
+    cy.get('input[name="Title"]').type("Test");
+    cy.get('input[name="Email"]').type("test@test.com");
+    cy.get('input[name="Phone"]').type("000000000");
+
+    getIframeBody()
+      .find(".rc-anchor-content")
+      .click();
+
+    cy.wait(10000); // eslint-disable-line
+    cy.get("#mktoForm_3494").submit();
+  });
+});
+
+context("Marketo dynamic form", () => {
+  it("/openstack#get-in-touch", () => {
+    cy.visit("/openstack#get-in-touch");
+
+    cy.get(".js-pagination--1 .pagination__link--next").click();
+    cy.get(".js-pagination--2 .pagination__link--next").click();
+
+    cy.get('input[name="FirstName"]').type("Test");
+    cy.get('input[name="LastName"]').type("Test");
+    cy.get('input[name="Email"]').type("test@test.com");
+    cy.get('label[for="canonicalUpdatesOptIn"]').click();
+
+    getIframeBody()
+      .find(".rc-anchor-content")
+      .click();
+
+    cy.wait(10000); // eslint-disable-line
+    cy.get("#mktoForm_1251")
+      .submit()
+      .should(page => {
+        expect(page[0].action).to.equal(
+          "https://pages.ubuntu.com/index.php/leadCapture/save"
+        );
+      });
+  });
+});


### PR DESCRIPTION
~~This PR needs to be merged before: https://github.com/canonical-web-and-design/ubuntu.com/pull/6886~~

## Done

- Add cypress form testing.

## QA

- Check out this feature branch
- `yarn add cypress` (I don't want to install it as a dependencies since it downloads a lot from different  sources when we build)
- Run the site using the command `./run serve`
- In another terminal:
  - `yarn add cypress`
  - `PORT=8001 yarn run cypress:run` <-  should run test tests
  - `PORT=8001 yarn run cypress:open`  <- if you want some swag with a browser open


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2406