### PR TITLE
Update to Managed OpenStack on /kubernetes/manages page

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -360,7 +360,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2>Refresh your data centre with managed Kubernetes on OpenStack</h2>
+      <h2>Refresh your data centre with Managed Kubernetes on OpenStack</h2>
     </div>
   </div>
   <div class="u-fixed-width">
@@ -440,7 +440,7 @@
       <li class="p-matrix__item">
         <div class="p-matrix__content">
           <h3 class="p-matrix__title p-heading--four">NFV ready</h3>
-          <p class="p-matrix__desc">Managed OpenStack is your fastest path to a modern VIM. As a VNF vendor, managed OpenStack enables you to test your VNFs on the most widely used OpenStack in telco.</p>
+          <p class="p-matrix__desc">Managed OpenStack is your fastest path to a modern VIM. As a VNF vendor, Managed OpenStack enables you to test your VNFs on the most widely used OpenStack in telco.</p>
         </div>
       </li>
       <li class="p-matrix__item">

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -10,7 +10,7 @@
       <td class="p-table__cell--highlight u-align--center">$4,380/year</td>
     </tr>
     <tr>
-      <th>Price per node (physical) *, on managed OpenStack **</th>
+      <th>Price per node (physical) *, on Managed OpenStack **</th>
       <td class="p-table__cell--highlight u-align--center">$2,190/year</td>
     </tr>
     <tr>
@@ -62,4 +62,4 @@
 </table>
 
 <p><small>* Minimums apply</small></p>
-<p><small>** <a href="/openstack/managed">Managed OpenStack</a> pricing is in addition to the managed Kubernetes price of $2,190. You can run an unlimited number of virtual Kubernetes nodes on top of each OpenStack physical node.</small></p>
+<p><small>** <a href="/openstack/managed">Managed OpenStack</a> pricing is in addition to the Managed Kubernetes price of $2,190. You can run an unlimited number of virtual Kubernetes nodes on top of each OpenStack physical node.</small></p>


### PR DESCRIPTION
## Done

- Update to Managed OpenStack on /kubernetes/manages page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1Qv379nYnod9e4jMrsdDND8D7mbPyqELi2lowjkfD-gU/edit#)


## Issue / Card

Fixes #6914

