### PR TITLE
Tidy up scripts

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -16,8 +16,6 @@
   <!-- Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660) -->
   <script src="https://polyfill.io/v3/polyfill.min.js?features=URLSearchParams%2CArray.from%2CNodeList.prototype.forEach%2Cfetch%2CString.prototype.startsWith%2CElement.prototype.closest"></script>
 
-  <!-- Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660) -->
-  <script src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
   <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -11,7 +11,6 @@
 
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
-  <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js" defer></script>
 
   <!-- Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660) -->
   <script src="https://polyfill.io/v3/polyfill.min.js?features=URLSearchParams%2CArray.from%2CNodeList.prototype.forEach%2Cfetch%2CString.prototype.startsWith%2CElement.prototype.closest"></script>

--- a/templates/whitepapers/beta/shared/form.html
+++ b/templates/whitepapers/beta/shared/form.html
@@ -70,4 +70,3 @@
 <!-- dependencies -->
 <script src="https://assets.ubuntu.com/v1/ec520d10-XMLHttpRequest.min.js"></script>
 <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js"></script>
-<script src="https://assets.ubuntu.com/v1/6b7597df-event-listener-polyfill.js"></script>

--- a/templates/whitepapers/shared/form.html
+++ b/templates/whitepapers/shared/form.html
@@ -70,5 +70,4 @@
 <!-- dependencies -->
 <script src="https://assets.ubuntu.com/v1/ec520d10-XMLHttpRequest.min.js"></script>
 <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js"></script>
-<script src="https://assets.ubuntu.com/v1/6b7597df-event-listener-polyfill.js"></script>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,8 +10,7 @@ module.exports = {
       "./static/js/src/polyfills.js",
       "./static/js/src/dynamic-contact-form.js",
       "./static/js/src/core.js",
-      // Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660)
-      // "./static/js/src/navigation.js",
+      "./static/js/src/navigation.js",
       "./static/js/src/form-validation.js",
       "./static/js/src/scratch.js"
     ],


### PR DESCRIPTION
## Done

- Added navigation.js back to main bundle
- Removed unused event listener polyfill for IE 6 -8
- Removed global link to serialize.js as is linked to on pages that use it

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the main navigation dropdowns work in modern browsers and IE 11
- Check that the forms on the following two pages work in IE 11
  - [http://0.0.0.0:8001/whitepapers/beta/robotics](http://0.0.0.0:8001/whitepapers/beta/robotics)
  - [http://0.0.0.0:8001/whitepapers/robotics](http://0.0.0.0:8001/whitepapers/robotics)


## Issue / Card

Fixes #6925