### PR TITLE
move image download js to build pipeline

### DIFF
--- a/static/js/src/image-download.js
+++ b/static/js/src/image-download.js
@@ -1,0 +1,76 @@
+function initImageDownload(mirrors, imagePath, GAlabel) {
+  dataLayer.push({
+    event: "GAEvent",
+    eventCategory: "Download",
+    eventAction: "Downloaded",
+    eventLabel: "User downloaded Ubuntu (" + GAlabel + ")",
+    eventValue: undefined
+  });
+
+  startDownload(mirrors, imagePath);
+}
+
+function startDownload(mirrors, imagePath) {
+  var defaultLocation = "http://releases.ubuntu.com/";
+  // Select a random mirror from list
+  var selectedMirror = chooseRandomMirror(mirrors);
+  var downloadLocation = defaultLocation;
+
+  // Build the download link
+  if (selectedMirror && selectedMirror.link) {
+    downloadLocation = selectedMirror.link;
+  }
+
+  var downloadLink = downloadLocation + imagePath;
+
+  // Start download
+  delayStartDownload(downloadLink, 3000);
+}
+
+/**
+ * Kick off a download link
+ * after a certain delay in milliseconds
+ */
+function delayStartDownload(downloadLink, delay) {
+  window.setTimeout(function() {
+    window.location.href = downloadLink;
+  }, delay);
+}
+
+/**
+ * Choose randomly from a given list of mirrors
+ * Weight the choice by the bandwidth of each mirror
+ */
+function chooseRandomMirror(mirrors) {
+  var selectedMirror = null;
+
+  // Calculate total bandwidth
+  var totalBandwidth = 0;
+
+  mirrors.forEach(function(mirror) {
+    mirror.bandwidth = parseInt(mirror.bandwidth)
+      ? parseInt(mirror.bandwidth)
+      : 0;
+    totalBandwidth += mirror.bandwidth;
+  });
+
+  // Random weight-point to download
+  var downloadPoint = Math.floor(Math.random() * totalBandwidth);
+  var weightPoint = 0;
+
+  // Select a mirror based on weighting
+  for (var mirrorIndex = 0; mirrorIndex < mirrors.length; mirrorIndex++) {
+    var mirror = mirrors[mirrorIndex];
+    weightPoint += mirror.bandwidth;
+
+    // If this is the random point to download
+    if (downloadPoint < weightPoint) {
+      selectedMirror = mirror;
+      break;
+    }
+  }
+
+  return selectedMirror;
+}
+
+window.initImageDownload = initImageDownload;

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -543,85 +543,18 @@
 
   {% block footer_extra %}
   {% if start_download %}
-  <script>
-    // Download file information
-    var defaultLocation = 'http://releases.ubuntu.com/'; // Default to releases.ubuntu.com
-    var version = '{{ version }}';
-    var architecture = '{{ architecture }}';
+  <script src="{{ versioned_static('js/build/image-download.min.js') }}"></script>
 
-    // Mirrors for this country
-    var mirrors = {{ mirror_list|safe }};
+  <script defer>
+    var architecture = '{{ architecture }}';
+    var mirrors = {{ mirror_list | safe }};
+    var version = '{{ version }}';
 
     if (version && architecture && architecture != 'amd64+mac') {
-      dataLayer.push({
-        'event': 'GAEvent',
-        'eventCategory': 'Download',
-        'eventAction': 'Downloaded',
-        'eventLabel': 'User downloaded Ubuntu (' + version + '-desktop-' + architecture + ')',
-        'eventValue': undefined
-      });
-      startDownload(mirrors, version, architecture, defaultLocation);
-    }
+      var GAlabel = version + '-desktop-' + architecture;
+      var imagePath = version + '/ubuntu-' + version + '-desktop-' + architecture + '.iso';
 
-    function startDownload(mirrors, version, architecture, defaultLocation) {
-      // Select a random mirror from list
-      var selectedMirror = chooseRandomMirror(mirrors);
-      var downloadLocation = defaultLocation;
-
-      // Build the download link
-      if (selectedMirror && selectedMirror.link) {
-        downloadLocation = selectedMirror.link;
-      }
-      var downloadLink = downloadLocation + version + '/ubuntu-' + version + '-desktop-' + architecture + '.iso';
-
-      // Start download
-      delayStartDownload(downloadLink, 3000);
-    }
-
-    /**
-    * Kick off a download link
-    * after a certain delay in milliseconds
-    */
-    function delayStartDownload(downloadLink, delay) {
-      window.setTimeout(
-      function() {
-        window.location.href = downloadLink;
-      },
-      delay
-      )
-    }
-
-    /**
-    * Choose randomly from a given list of mirrors
-    * Weight the choice by the bandwidth of each mirror
-    */
-    function chooseRandomMirror(mirrors) {
-      var selectedMirror = null;
-
-      // Calculate total bandwidth
-      var totalBandwidth = 0;
-      mirrors.forEach(function(mirror) {
-        mirror.bandwidth = parseInt(mirror.bandwidth) ? parseInt(mirror.bandwidth) : 0;
-        totalBandwidth += mirror.bandwidth;
-      });
-
-      // Random weight-point to download
-      var downloadPoint = Math.floor(Math.random() * totalBandwidth);
-      var weightPoint = 0;
-
-      // Select a mirror based on weighting
-      for (var mirrorIndex = 0; mirrorIndex < mirrors.length; mirrorIndex++) {
-        var mirror = mirrors[mirrorIndex];
-        weightPoint += mirror.bandwidth;
-
-        // If this is the random point to download
-        if (downloadPoint < weightPoint) {
-          selectedMirror = mirror;
-          break;
-        }
-      }
-
-      return selectedMirror;
+      window.initImageDownload(mirrors, imagePath, GAlabel);
     }
   </script>
   {% endif %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -96,85 +96,18 @@
 
   {% endblock content %}
   {% block footer_extra %}
-  <script>
-    // Download file information
-    var defaultLocation = 'http://releases.ubuntu.com/'; // Default to releases.ubuntu.com
-    var version = '{{ version }}';
-    var architecture = '{{ architecture }}';
+  <script src="{{ versioned_static('js/build/image-download.min.js') }}"></script>
 
-    // Mirrors for this country
-    var mirrors = {{ mirror_list|safe }};
+  <script defer>
+    var architecture = '{{ architecture }}';
+    var mirrors = {{ mirror_list | safe }};
+    var version = '{{ version }}';
 
     if (version && architecture) {
-      dataLayer.push({
-        'event': 'GAEvent',
-        'eventCategory': 'Download',
-        'eventAction': 'Downloaded',
-        'eventLabel': 'User downloaded Ubuntu (' + version + '-server-' + architecture + ')',
-        'eventValue': undefined
-      });
-      startDownload(mirrors, version, architecture, defaultLocation);
-    }
+      var GAlabel = version + '-server-' + architecture; 
+      var imagePath = version + '/ubuntu-' + version + '-live-server-' + architecture + '.iso';
 
-    function startDownload(mirrors, version, architecture, defaultLocation) {
-      // Select a random mirror from list
-      var selectedMirror = chooseRandomMirror(mirrors);
-      var downloadLocation = defaultLocation;
-
-      // Build the download link
-      if (selectedMirror && selectedMirror.link) {
-        downloadLocation = selectedMirror.link;
-      }
-      var downloadLink = downloadLocation + version + '/ubuntu-' + version + '-live-server-' + architecture + '.iso';
-
-      // Start download
-      delayStartDownload(downloadLink, 3000);
-    }
-
-    /**
-    * Kick off a download link
-    * after a certain delay in milliseconds
-    */
-    function delayStartDownload(downloadLink, delay) {
-      window.setTimeout(
-      function () {
-        window.location.href = downloadLink;
-      },
-      delay
-      )
-    }
-
-    /**
-    * Choose randomly from a given list of mirrors
-    * Weight the choice by the bandwidth of each mirror
-    */
-    function chooseRandomMirror(mirrors) {
-      var selectedMirror = null;
-
-      // Calculate total bandwidth
-      var totalBandwidth = 0;
-      mirrors.forEach(function (mirror) {
-        mirror.bandwidth = parseInt(mirror.bandwidth) ? parseInt(mirror.bandwidth) : 0;
-        totalBandwidth += mirror.bandwidth;
-      });
-
-      // Random weight-point to download
-      var downloadPoint = Math.floor(Math.random() * totalBandwidth);
-      var weightPoint = 0;
-
-      // Select a mirror based on weighting
-      for (var mirrorIndex = 0; mirrorIndex < mirrors.length;mirrorIndex++) {
-        var mirror = mirrors[mirrorIndex];
-        weightPoint += mirror.bandwidth;
-
-        // If this is the random point to download
-        if (downloadPoint < weightPoint) {
-          selectedMirror = mirror;
-          break;
-        }
-      }
-
-      return selectedMirror;
+      window.initImageDownload(mirrors, imagePath, GAlabel);
     }
   </script>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
       "./static/js/src/tutorial.js"
     ],
     forms: "./static/js/src/forms.js",
+    "image-download": "./static/js/src/image-download.js",
     main: [
       "./static/js/src/polyfills.js",
       "./static/js/src/dynamic-contact-form.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,7 +2315,7 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-prettier@^6.10.0:
+eslint-config-prettier@6.10.0:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
   integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==


### PR DESCRIPTION
## Done

- Moved as much as possible of the JS that handles the downloading of a given desktop/server image to the build pipeline

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select a download, see that you're taken to the thank you page and that the download dialog appears automatically, and that there are no console errors.
- Repeat the process for /download/server

Fixes #6883 
