### PR TITLE
Add cloud cost analysis takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -891,6 +891,14 @@
       type="webinar" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Hosted private cloud infrastructure: a cost analysis",
+      description="Accelerate initial deployment and reduce operational costs by outsourcing private cloud infrastructure management",
+      slug="private-cloud-cost-analysis-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/private-cloud-cost-analysis-webinar.md
+++ b/templates/engage/private-cloud-cost-analysis-webinar.md
@@ -1,0 +1,24 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Hosted private cloud infrastructure: a cost analysis"
+     meta_description: "Accelerate initial deployment and reduce operational costs by outsourcing private cloud infrastructure management"
+     meta_image: "https://assets.ubuntu.com/v1/3d436203-Meta+data+img.jpg"
+     meta_copydoc: "https://docs.google.com/document/d/1Ju0tF-bvFns_91a37MP6LQ6-pTDuHqbeYI_QxXftPK0/edit"
+     header_title: "Hosted private cloud infrastructure: a cost analysis"
+     header_subtitle: "Accelerate initial deployment and reduce operational costs by outsourcing private cloud infrastructure management"
+     header_image: "https://assets.ubuntu.com/v1/a1fce041-Private+Cloud+-+white.svg"
+     header_image_width: "250"
+     header_image_height: "229"
+     header_url: "#register-section"
+     header_cta: "Watch the webinar"
+     header_class: p-engage-banner--dark
+     header_lang: en
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 387966, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Private cloud infrastructure remains an essential part of every enterprise nowadays. However, due to the increasing number of workloads and data, the overhead of managing bare metal servers, virtual machines and containers can mount up. Although tools like MAAS, OpenStack and Kubernetes help to address this problem, upskilling operations teams with those tools may take months. As a result, many organisations have started to either fully outsource operations of their private cloud infrastructure or for the initial rollout.
+
+Join Tytus Kurek, Product Manager, and James Troup, Engineering Director, from Canonical in this webinar to learn how outsourcing private cloud infrastructure management help enterprises accelerate the initial deployment and reduce ongoing operational costs.
+
+Tytus and James will present Canonical&rsquo;s approach to hosted infrastructure for bare metal, OpenStack and Kubernetes including the tools and best practices that delivers a production-grade managed service. In addition, they will provide a detailed cost analysis highlighting the savings an organisation can make by outsourcing operations of private cloud infrastructure to a trusted managed service provider.

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
+  {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_smart-start-webinar.html" %}
   {% include "takeovers/_anbox-cloud-webinar.html" %}

--- a/templates/takeovers/_cloud-cost-analysis.html
+++ b/templates/takeovers/_cloud-cost-analysis.html
@@ -1,0 +1,13 @@
+{% with title="Hosted private cloud infrastructure: a cost analysis",
+subtitle="Accelerate initial deployment and reduce operational costs by outsourcing private cloud infrastructure management",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/a1fce041-Private+Cloud+-+white.svg",
+image_style="width: 250px;",
+image_hide_small="true",
+primary_url="/engage/private-cloud-cost-analysis-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_OpenStack_WBN_CloudCostAnalysis",
+primary_cta="Watch the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -110,4 +110,6 @@
 {% include "takeovers/_anbox-cloud-webinar.html" %}
 <p>26 Feb 2020</p>
 {% include "takeovers/_smart-start-webinar.html" %}
+<p>4th Mar 2020</p>
+{% include "takeovers/_cloud-cost-analysis.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Added private cloud cost analysis takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh until you see the "Hosted private cloud infrastructure: a cost analysis" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1Yg_sHVjaGh4snje5TltN6SFH0PDyhTEWllnaaEkKmnw/edit#gid=877682240) and [the design](https://github.com/canonical-web-and-design/web-squad/issues/2405)
- Click through to the engage page
- Check that it matches [the copy doc](https://docs.google.com/document/d/1Ju0tF-bvFns_91a37MP6LQ6-pTDuHqbeYI_QxXftPK0/edit), [the brief](https://docs.google.com/spreadsheets/d/1Yg_sHVjaGh4snje5TltN6SFH0PDyhTEWllnaaEkKmnw/edit#gid=877682240) and [the design](https://github.com/canonical-web-and-design/web-squad/issues/2405)
- Go to /takeovers and check that the new takeover is at the bottom of the page
- Go to /engage and check that the new engage page is at the bottom of the page
- Test the engage page on [https://socialdebug.com/](https://socialdebug.com/) or [http://debug.iframely.com/](http://debug.iframely.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)

## Issue / Card

Fixes #6872 