### PR TITLE
add illustration to /support hero strip

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -17,6 +17,18 @@
         <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-button--neutral">Read the datasheet</a>
       </p>
     </div>
+    <div class="col-4 u-hide--small u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg",
+          alt="",
+          height="286",
+          width="270",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Added illustration to /support hero strip

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that [the brief](https://github.com/canonical-web-and-design/ubuntu.com/issues/6928) has been met


## Issue / Card

Fixes #6928 
