### PR TITLE
Make serialize available globally

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -14,7 +14,7 @@
 
   <!-- Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660) -->
   <script src="https://polyfill.io/v3/polyfill.min.js?features=URLSearchParams%2CArray.from%2CNodeList.prototype.forEach%2Cfetch%2CString.prototype.startsWith%2CElement.prototype.closest"></script>
-
+  <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js"></script>
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
   <script src="{{ versioned_static('js/build/main.min.js') }}" defer></script>
 

--- a/templates/whitepapers/beta/shared/form.html
+++ b/templates/whitepapers/beta/shared/form.html
@@ -69,4 +69,3 @@
 <!-- /MARKETO FORM -->
 <!-- dependencies -->
 <script src="https://assets.ubuntu.com/v1/ec520d10-XMLHttpRequest.min.js"></script>
-<script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js"></script>

--- a/templates/whitepapers/shared/form.html
+++ b/templates/whitepapers/shared/form.html
@@ -69,5 +69,4 @@
 <!-- /MARKETO FORM -->
 <!-- dependencies -->
 <script src="https://assets.ubuntu.com/v1/ec520d10-XMLHttpRequest.min.js"></script>
-<script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js"></script>
 


### PR DESCRIPTION
## Done

- Made the serialize js library available globally

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/starting-with-ai
- Submit the form and check that it submits properly
- Go to http://0.0.0.0:8001/download/server
- Choose a download and submit the form on that page
- Check that the form submits properly