### PR TITLE
Update illustration on /desktop/organisations

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -213,12 +213,24 @@
   </div>
 </section>
 
-<section class="p-strip--security is-bordered">
-  <div class="row">
+<section class="p-strip is-bordered">
+  <div class="row u-equal-height">
     <div class="col-6">
       <h2>Ubuntu is at the forefront of safety and reliability</h2>
       <p>Your Ubuntu software is built with unrivalled security in mind — and is secure from the moment you install it, and will remain so because Canonical’s team of security experts will ensure that security updates are always available on Ubuntu first.</p>
       <p><a href="/security">Learn more about the security of Ubuntu&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -233,7 +245,6 @@
           height="285",
           width="567",
           hi_def=True,
-          attrs={"class": ""},
           loading="lazy",
         ) | safe
       }}


### PR DESCRIPTION
## Done

- Update the illustration for the "Ubuntu is at the forefront of safety and reliability" section of /desktop/organisations
- Removed the empty attributes property from an instance of the image template

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/organisations
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the illustration under "Ubuntu is at the forefront of safety and reliability" matches [this one](https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg)


## Issue / Card

Fixes #6947 