### PR TITLE
Add content strips page to docs section

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -784,12 +784,14 @@ documentation:
   children:
     - title: Overview
       path: /_docs
-    - title: Strips
+    - title: Hero strips
       path: /_docs/strips
     - title: Takeovers
       path: /_docs/takeovers
     - title: Engage pages
       path: /_docs/engage_pages
+    - title: Content strips
+      path: /_docs/content_strips
 
 kernel:
   title: Kernel

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -521,3 +521,11 @@ summary {
     @extend .p-heading-icon__img;
   }
 }
+
+.is-dark {
+  .p-heading-icon--muted {
+    .p-heading-icon__title {
+      color: inherit;
+    }
+  }
+}

--- a/templates/_docs/content_strips.html
+++ b/templates/_docs/content_strips.html
@@ -1,0 +1,131 @@
+
+{% extends "templates/one-column.html" %}
+
+{% block title %}Content strips | ubuntu.com documentation{% endblock %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
+{% block content %}
+
+<section class="p-strip--light is-shallow">
+  <div class="row">
+    <div class="col-8">
+      <h1>Content strips</h1>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--suru-accent is-dark">
+  <div class="row">
+    <div class="col-3 p-card u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/3e31f0f5-ITstrategen+logo.svg",
+          alt="",
+          height="52",
+          width="229",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-8 col-start-large-5">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/fc781c43-Case+study+-+white.svg",
+              alt="",
+              height="32",
+              width="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img"},
+            ) | safe
+          }}
+          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">CASE STUDY</p>
+        </div>
+        <h4>ITstrategen keeps their applications secure with ESM</h4>
+        <p>The security of customer data is of utmost importance to ITstrategen. That’s why Ubuntu is their server
+          operating system of choice.</p>
+        <p><a href="/engage/ITstrategen-case-study" class="p-button--neutral">Read the case study</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--suru is-dark">
+  <div class="u-fixed-width">
+    <h3>Webinars and case studies</h3>
+    <div class="row p-divider u-no-padding--left u-no-padding--right">
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/30037eac-datasheet-white.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Datasheet</h4>
+          </div>
+          <h3 class="p-heading--four"><a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/8db65a1e-Kubernetes-for-the-Enterprise.pdf">Kubernetes for the enterprise</a></h3>
+        </div>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/005c3416-webinar-white.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Webinar</h4>
+          </div>
+          <h3 class="p-heading--four"><a class="p-link--external p-link--inverted" href="/blog/kubernetes-for-the-enterprise-1-2-3-go" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
+        </div>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/574aaef4-whitepaper-white.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Whitepaper</h4>
+          </div>
+          <h3 class="p-heading--four"><a class="p-link--external p-link--inverted" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="p-strip--suru is-dark">
+  <div class="u-fixed-width">
+    <blockquote class="p-pull-quote">
+      <p class="p-pull-quote__quote">A new wave of workloads demand breakthrough efficiencies in density, energy, and operational costs which can be scaled to a customer&rsquo;s IT environment</p>
+      <cite class="p-pull-quote__citation">Paul Santeler, VP &amp; GM, Hyperscale Business Unit, HP</cite>
+    </blockquote>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/_docs/index.html
+++ b/templates/_docs/index.html
@@ -29,10 +29,10 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <h3 class="p-card__title">
-        <a href="/_docs/strips">Strips</a>
+        <a href="/_docs/strips">Hero strips</a>
       </h3>
       <p class="p-card__content">
-        Learn how to use the eight suru strips that have been designed to be used on the header banners of each section of the website.
+        Learn how to use suru strips that have been designed to be used on the header banners of each section of the website.
       </p>
     </div>
     <div class="col-4 p-card">
@@ -49,6 +49,14 @@
       </h3>
       <p class="p-card__content">
         Get the code and learn how to use the new Markdown templates for our engage pages.
+      </p>
+    </div>
+    <div class="col-4 p-card">
+      <h3 class="p-card__title">
+        <a href="/_docs/content_strips">Content strips</a>
+      </h3>
+      <p class="p-card__content">
+        Get the code and see examples of suru strips designed to highlight sections across the pages.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add new content strips page to docs
- Add new page to docs navigation
- Add card for new page on docs homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/_docs/content_strips
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that page includes the sections requested in [the issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6952)
- Check that the new page appears in the breadcrumb navigation
- Check that a card for the new page appears on /_docs


## Issue / Card

Fixes #6952 
Fixes #6950