### PR TITLE
Update illustrations on /training page

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -9,22 +9,23 @@
 {% block outer_content %}
 {% block content %}
 
-<section class="p-strip is-deep is-bordered u-image-position">
-  <div class="row">
-    <div class="col-6">
-      <h1>Train with Ubuntu</h1>
-      <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
+<section class="p-strip--suru-topped is-deep is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h1>Train with Ubuntu</h1>
+        <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
+      </div>
     </div>
-    <div class="col-6 u-hide--small" style="position: relative; margin-top: -6rem;">
+    <div class="col-6 u-align--center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg",
+        url="https://assets.ubuntu.com/v1/a22613fc-train-with-ubuntu_AW.svg",
         alt="",
-        width="460",
-        height="263",
+        width="350",
+        height="350",
         hi_def=True,
         loading="auto",
-        attrs={"class": "u-image-position--top u-image-position--right u-hide--small u-no-margin--top", "style": "width: 460px;"},
         ) | safe
       }}
     </div>
@@ -252,19 +253,19 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
+  <div class="row u-equal-height">
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
       <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/_support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training">Contact us&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-5 u-align--center u-hide--small">
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/9b170f06-picto-help-orange.svg",
+        url="https://assets.ubuntu.com/v1/0e5f4269-questions.svg",
         alt="",
-        width="135",
-        height="135",
+        width="200",
+        height="200",
         hi_def=True,
         loading="lazy",
         ) | safe


### PR DESCRIPTION
## Done

Update the illustrations on /training

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the changes requested in [the issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/6954) have been made


## Issue / Card

Fixes #6954