### PR TITLE
correct heading heirarchy on /kubeflow

### DIFF
--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -300,7 +300,7 @@
 
 <section class="p-strip is-bordered">
   <div class="u-fixed-width">
-    <h1>NVIDIA and Canonical accelerate AI everywhere</h1>
+    <h2>NVIDIA and Canonical accelerate AI everywhere</h2>
     <p>
       NVIDIA and Canonical collaborate to ensure that AI hardware acceleration is available on every public cloud, on premise and in IoT devices.
     </p>
@@ -334,7 +334,7 @@
 
 <section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
-    <h1>Partner with us</h1>
+    <h2>Partner with us</h2>
     <p>It takes an open ecosystem to solve the diverse challenges of AI infrastructure across every sector and in every region. Our partners ensure that you have the widest range of capabilities available for automated integration in your cloud, and that you can get insight and support locally.</p>
     <p>To learn more about our partners or becoming a Canonical AI partner, please contact us today.</p>
     <p><a class="p-button--positive" href="https://partners.ubuntu.com/contact-us"><span class="p-link--external">Get in touch</span></a> or <a class="p-link--external" href="https://partners.ubuntu.com/partnering-with-us">learn more about partnering with us</a>


### PR DESCRIPTION
## Done

- changed two `h1` elements to `h2`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the "NVIDIA and Canonical accelerate AI everywhere" and "Partner with us" headings are `h2` elements, not `h1`


## Issue / Card

Fixes #6949 
