### PR TITLE
move repeated "further reading" markup to shared partial

### DIFF
--- a/templates/shared/contextual_footers/_cloud_further_reading.html
+++ b/templates/shared/contextual_footers/_cloud_further_reading.html
@@ -1,26 +1,3 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Further reading</h3>
-  <ul class="p-list" id="latest-articles">
-    <i class="p-icon--spinner u-animation--spin">Loading...</i>
-  </ul>
-</div>
-
-<template style="display:none" id="article-template">
-  <li class="p-list__item">
-    <a class="article-link article-title">
-      <span class="article-title">&nbsp;›
-    </a>
-  </li>
-</template>
-
-<script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
-<script>
-  fetchLatestNews(
-    {
-      articlesContainerSelector: "#latest-articles",
-      articleTemplateSelector: "#article-template",
-      limit: "5",
-      tagId: "1833"
-    }
-  )
-</script>
+{% with limit="5", tagId="1833" %}
+  {% include "shared/contextual_footers/_further_reading.html" %}
+{% endwith %}

--- a/templates/shared/contextual_footers/_desktop_further_reading.html
+++ b/templates/shared/contextual_footers/_desktop_further_reading.html
@@ -1,26 +1,3 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Further reading</h3>
-  <ul class="p-list" id="latest-articles">
-    <i class="p-icon--spinner u-animation--spin">Loading...</i>
-  </ul>
-</div>
-
-<template style="display:none" id="article-template">
-  <li class="p-list__item">
-    <a class="article-link article-title">
-      <span class="article-title">&nbsp;›
-    </a>
-  </li>
-</template>
-
-<script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
-<script>
-  fetchLatestNews(
-    {
-      articlesContainerSelector: "#latest-articles",
-      articleTemplateSelector: "#article-template",
-      limit: "5",
-      groupId: "1479"
-    }
-  )
-</script>
+{% with limit="5", groupId="1479" %}
+  {% include "shared/contextual_footers/_further_reading.html" %}
+{% endwith %}

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -1,7 +1,7 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Further reading</h3>
   <ul class="p-list" id="latest-articles">
-    <i class="p-icon--spinner u-animation--spin">Loading...</i>
+    <li><i class="p-icon--spinner u-animation--spin">Loading...</i></li>
   </ul>
 </div>
 
@@ -19,7 +19,13 @@
     {
       articlesContainerSelector: "#latest-articles",
       articleTemplateSelector: "#article-template",
-      limit: "5"
+      limit: "{{ limit }}",
+      {% if tagId %}
+      tagId: "{{ tagId }}",
+      {% endif %}
+      {% if groupId %}
+      groupId: "{{ groupId }}",
+      {% endif %}
     }
   )
 </script>

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -7,9 +7,7 @@
 
 <template style="display:none" id="article-template">
   <li class="p-list__item">
-    <a class="article-link article-title">
-      <span class="article-title">&nbsp;›
-    </a>
+    <a class="article-link article-title"></a>
   </li>
 </template>
 

--- a/templates/shared/contextual_footers/_iot_further_reading.html
+++ b/templates/shared/contextual_footers/_iot_further_reading.html
@@ -1,26 +1,3 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Further reading</h3>
-  <ul class="p-list" id="latest-articles">
-    <i class="p-icon--spinner u-animation--spin">Loading...</i>
-  </ul>
-</div>
-
-<template style="display:none" id="article-template">
-  <li class="p-list__item">
-    <a class="article-link article-title">
-      <span class="article-title">&nbsp;›
-    </a>
-  </li>
-</template>
-
-<script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
-<script>
-  fetchLatestNews(
-    {
-      articlesContainerSelector: "#latest-articles",
-      articleTemplateSelector: "#article-template",
-      limit: "5",
-      groupId: "1666"
-    }
-  )
-</script>
+{% with limit="5", groupId="1666" %}
+  {% include "shared/contextual_footers/_further_reading.html" %}
+{% endwith %}

--- a/templates/shared/contextual_footers/_security_further_reading.html
+++ b/templates/shared/contextual_footers/_security_further_reading.html
@@ -1,26 +1,3 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Further reading</h3>
-  <ul class="p-list" id="latest-articles">
-    <i class="p-icon--spinner u-animation--spin">Loading...</i>
-  </ul>
-</div>
-
-<template style="display:none" id="article-template">
-  <li class="p-list__item">
-    <a class="article-link article-title">
-      <span class="article-title">&nbsp;›
-    </a>
-  </li>
-</template>
-
-<script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
-<script>
-  fetchLatestNews(
-    {
-      articlesContainerSelector: "#latest-articles",
-      articleTemplateSelector: "#article-template",
-      limit: "5",
-      tagId: "1364"
-    }
-  )
-</script>
+{% with limit="5", tagId="1364" %}
+  {% include "shared/contextual_footers/_further_reading.html" %}
+{% endwith %}

--- a/templates/shared/contextual_footers/_telco_further_reading.html
+++ b/templates/shared/contextual_footers/_telco_further_reading.html
@@ -1,26 +1,3 @@
-<div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Further reading</h3>
-  <ul class="p-list" id="latest-articles">
-    <i class="p-icon--spinner u-animation--spin">Loading...</i>
-  </ul>
-</div>
-
-<template style="display:none" id="article-template">
-  <li class="p-list__item">
-    <a class="article-link article-title">
-      <span class="article-title">&nbsp;›
-    </a>
-  </li>
-</template>
-
-<script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
-<script>
-  fetchLatestNews(
-    {
-      articlesContainerSelector: "#latest-articles",
-      articleTemplateSelector: "#article-template",
-      limit: "5",
-      tagId: "1378"
-    }
-  )
-</script>
+{% with limit="5", tagId="1378" %}
+  {% include "shared/contextual_footers/_further_reading.html" %}
+{% endwith %}

--- a/templates/shared/contextual_footers/_ua_further_reading.html
+++ b/templates/shared/contextual_footers/_ua_further_reading.html
@@ -1,26 +1,3 @@
-<div class="col-4 p-divider__block">
-    <h3 class="p-heading--four">Further reading about UA</h3>
-    <ul class="p-list" id="latest-articles">
-      <i class="p-icon--spinner u-animation--spin">Loading...</i>
-    </ul>
-  </div>
-
-  <template style="display:none" id="article-template">
-    <li class="p-list__item">
-      <a class="article-link article-title">
-        <span class="article-title">&nbsp;›
-      </a>
-    </li>
-  </template>
-
-  <script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
-  <script>
-    fetchLatestNews(
-      {
-        articlesContainerSelector: "#latest-articles",
-        articleTemplateSelector: "#article-template",
-        tagId: "1486",
-        limit: "3"
-      }
-    )
-  </script>
+{% with limit="3", tagId="1486" %}
+  {% include "shared/contextual_footers/_further_reading.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- Fixed invalid markup in "Further reading" markup. 
  - The issue suggested changing it from a `ul` to a `div` and updating the JS to wrap its output in a `ul`, but the simplest solution seemed to be to wrap the offending `i` spinner element in a `li`, which is then removed anyway when the script completes.
- Moved repeated "Further reading" markup to a shared partial.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the "Further reading" list in the footer renders correctly (compare to ubuntu.com/advantage) and test it on https://validator.w3.org/ to see that the error mentioned in the issue is not present.
- Repeat for the following pages:
  - /telecommunications
  - /security
  - /robotics
  - /desktop/organisations
  - /kubeflow/features


## Issue / Card

Fixes #6725 
