### PR TITLE
remove emtpy attribute values from image modules

### DIFF
--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -19,8 +19,7 @@
           width="200",
           height="200",
           hi_def=True,
-          loading="auto",
-          attrs={"class": ""},
+          loading="auto"
         ) | safe
       }}
     </div>

--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -177,8 +177,7 @@
           width="306",
           height="183",
           hi_def=True,
-          loading="lazy",
-          attrs={"class": ""},
+          loading="lazy"
         ) | safe
       }}
     </div>
@@ -211,8 +210,7 @@
           width="450",
           height="267",
           hi_def=True,
-          loading="lazy",
-          attrs={"class": ""},
+          loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -50,8 +50,7 @@
             height="380",
             width="439",
             hi_def=True,
-            attrs={"class": ""},
-            loading="lazy",
+            loading="lazy"
           ) | safe
         }}
         <p><small>Source: Eclipse Community survey, 2014, Stackoverflow annual survey 2016</small></p>
@@ -124,8 +123,7 @@
             height="209",
             width="290",
             hi_def=True,
-            attrs={"class": ""},
-            loading="lazy",
+            loading="lazy"
           ) | safe
         }}
       </div>
@@ -232,8 +230,7 @@
             height="256",
             width="413",
             hi_def=True,
-            attrs={"class": ""},
-            loading="lazy",
+            loading="lazy"
           ) | safe
         }}
       </div>
@@ -260,8 +257,7 @@
             height="394",
             width="442",
             hi_def=True,
-            attrs={"class": ""},
-            loading="lazy",
+            loading="lazy"
           ) | safe
         }}
       </div>

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -48,8 +48,7 @@
             height="233",
             width="380",
             hi_def=True,
-            attrs={"class": ""},
-            loading="auto",
+            loading="auto"
           ) | safe
         }}
       </div>
@@ -229,8 +228,7 @@
           height="414",
           width="556",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>
@@ -247,8 +245,7 @@
           height="390",
           width="500",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>
@@ -275,8 +272,7 @@
           height="398",
           width="520",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>
@@ -305,8 +301,7 @@
           height="379",
           width="531",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
       <h2>Organise your photos</h2>
@@ -324,8 +319,8 @@
               height="36",
               width="36",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+  
+              loading="lazy"
             ) | safe
           }}
         </li>
@@ -337,8 +332,8 @@
               height="36",
               width="36",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+  
+              loading="lazy"
             ) | safe
           }}
         </li>
@@ -350,8 +345,8 @@
               height="36",
               width="36",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+  
+              loading="lazy"
             ) | safe
           }}
         </li>
@@ -363,8 +358,8 @@
               height="36",
               width="36",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+  
+              loading="lazy"
             ) | safe
           }}
         </li>
@@ -387,8 +382,7 @@
           height="336",
           width="542",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -273,8 +273,7 @@
           height="368",
           width="428",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
       <p>
@@ -302,8 +301,7 @@
           height="350",
           width="502",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -124,8 +124,7 @@
           height="311",
           width="502",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -108,8 +108,7 @@
             width="125",
             height="168",
             hi_def=True,
-            loading="lazy",
-            attrs={"class": ""},
+            loading="lazy"
           ) | safe
         }}
       </div>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -30,8 +30,7 @@
             height="218",
             width="250",
             hi_def=True,
-            attrs={"class": ""},
-            loading="auto",
+            loading="auto"
           ) | safe
         }}
       </div>
@@ -165,8 +164,7 @@
         height="35",
         width="185",
         hi_def=True,
-        attrs={"class": ""},
-        loading="lazy",
+        loading="lazy"
       ) | safe
     }}
     <blockquote class="p-pull-quote">
@@ -398,8 +396,7 @@
           height="178",
           width="250",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -28,8 +28,7 @@
             height="295",
             width="466",
             hi_def=True,
-            attrs={"class": ""},
-            loading="auto",
+            loading="auto"
           ) | safe
         }}
       </div>
@@ -167,8 +166,7 @@
               height="65",
               width="133",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>
@@ -188,8 +186,7 @@
               height="65",
               width="238",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>
@@ -210,8 +207,7 @@
               height="65",
               width="98",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>
@@ -230,8 +226,7 @@
               height="65",
               width="171",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>
@@ -261,8 +256,7 @@
               height="65",
               width="108",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>
@@ -282,8 +276,7 @@
               height="65",
               width="154",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>
@@ -305,8 +298,7 @@
               height="65",
               width="148",
               hi_def=True,
-              attrs={"class": ""},
-              loading="lazy",
+              loading="lazy"
             ) | safe
           }}
         </a>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -296,8 +296,7 @@
           height="120",
           width="120",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>
@@ -316,8 +315,7 @@
           height="120",
           width="120",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>
@@ -346,8 +344,7 @@
           height="120",
           width="120",
           hi_def=True,
-          attrs={"class": ""},
-          loading="lazy",
+          loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -213,7 +213,7 @@
               height="44",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-inline-images__logo"},
           ) | safe
         }}
       </li>

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -19,8 +19,7 @@
             width="200",
             height="200",
             hi_def=True,
-            loading="auto",
-            attrs={"class": "", "id": ""},
+            loading="auto"
         ) | safe
       }}
     </div>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -156,8 +156,7 @@
               width="150",
               height="150",
               hi_def=True,
-              loading="lazy",
-              attrs={"class": "", "id": ""},
+              loading="lazy"
           ) | safe
         }}
       </div>
@@ -330,8 +329,7 @@
                 width="150",
                 height="150",
                 hi_def=True,
-                loading="lazy",
-                attrs={"class": "", "id": ""},
+                loading="lazy"
             ) | safe
           }}
         </div>

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -21,8 +21,7 @@
             width="200",
             height="200",
             hi_def=True,
-            loading="auto",
-            attrs={"class": "", "id": ""},
+            loading="auto"
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

- removed empty `attrs={"foo": ""}` from image modules

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page is not broken/doesn't return a template error, and that images are rendered correctly.
- Repeat for:
  - /dell
  - /desktop/developers
  - /desktop/features
  - /desktop/organisations
  - /desktop/partners
  - /download/iot
  - /internet-of-things/appstore
  - /internet-of-things/digital-signage
  - /internet-of-things/gateways
  - /server
  - /support/community-support
  - /support
  - /support/thank-you


## Issue / Card

Fixes #6747 