### PR TITLE
move repeated contextual dropdown js to build pipeline

### DIFF
--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,0 +1,97 @@
+function toggleMenu(element, show) {
+  const dropdown = document.querySelector(
+    element.getAttribute("aria-controls")
+  );
+
+  element.setAttribute("aria-expanded", show);
+  dropdown.setAttribute("aria-hidden", !show);
+}
+
+function attachClickEvent(toggle) {
+  toggle.addEventListener("click", e => {
+    const menuAlreadyOpen = e.target.getAttribute("aria-expanded") === "true";
+
+    e.preventDefault();
+    toggleMenu(e.target, !menuAlreadyOpen);
+  });
+}
+
+function attachHoverEvent(toggle) {
+  const dropdown = document.querySelector(toggle.getAttribute("aria-controls"));
+  let timer = null;
+
+  toggle.addEventListener("click", e => {
+    e.preventDefault();
+  });
+
+  toggle.addEventListener("mouseover", () => {
+    clearTimeout(timer);
+    toggleMenu(toggle, true);
+  });
+
+  toggle.addEventListener("mouseleave", () => {
+    toggleMenu(toggle, true);
+
+    timer = setTimeout(() => {
+      toggleMenu(toggle, false);
+    }, 50);
+  });
+
+  dropdown.addEventListener("mouseover", () => {
+    clearTimeout(timer);
+  });
+
+  dropdown.addEventListener("mouseleave", () => {
+    timer = setTimeout(() => {
+      toggleMenu(toggle, false);
+    }, 50);
+  });
+
+  document.onkeydown = e => {
+    e = e || window.event;
+
+    if (e.keyCode === 27) {
+      toggleMenu(toggle, false);
+    }
+  };
+}
+
+function setupContextualMenuListeners(contextualMenuToggleSelector) {
+  const toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+  toggles.forEach(toggle => {
+    if (toggle.getAttribute("data-trigger") === "click") {
+      attachClickEvent(toggle);
+    } else if (toggle.getAttribute("data-trigger") === "hover") {
+      attachHoverEvent(toggle);
+    }
+  });
+
+  document.addEventListener("click", e => {
+    toggles.forEach(toggle => {
+      const contextualMenu = document.querySelector(
+        toggle.getAttribute("aria-controls")
+      );
+
+      const clickOutside = !(
+        toggle.contains(e.target) || contextualMenu.contains(e.target)
+      );
+
+      if (clickOutside) {
+        toggleMenu(toggle, false);
+      }
+    });
+  });
+
+  document.onkeydown = e => {
+    e = e || window.event;
+
+    if (e.keyCode === 27) {
+      toggles.forEach(toggle => {
+        toggleMenu(toggle, false);
+      });
+    }
+  };
+}
+
+setupContextualMenuListeners(".p-contextual-menu__toggle");

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -386,53 +386,6 @@
   }
 </script>
 
-<script>
-  function toggleMenu(element, show) {
-    element.setAttribute('aria-expanded', show);
-    document
-    .querySelector(element.getAttribute('aria-controls'))
-    .setAttribute('aria-hidden', !show);
-  }
-
-  function setupContextualMenuListeners(contextualMenuToggleSelector) {
-    var toggles = document.querySelectorAll(contextualMenuToggleSelector);
-
-    toggles.forEach(toggle => {
-      toggle.addEventListener('click', e => {
-        e.preventDefault();
-
-        var target = e.target;
-        var menuAlreadyOpen = target.getAttribute('aria-expanded') === 'true';
-
-        toggleMenu(target, !menuAlreadyOpen)
-      });
-    });
-
-    document.addEventListener('click', e => {
-      toggles.forEach(toggle => {
-        var contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
-        var clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
-
-        if (clickOutside) {
-          toggleMenu(toggle, false);
-        }
-      })
-    });
-
-    document.onkeydown = e => {
-      e = e || window.event;
-
-      if (e.keyCode === 27) {
-        toggles.forEach(toggle => {
-          toggleMenu(toggle, false);
-        });
-      }
-    };
-  }
-
-  setupContextualMenuListeners('.p-contextual-menu__toggle');
-</script>
-
 {% with first_item="_ua_got_questions", second_item="_ua_legal", third_item="_ua_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 {% endblock content %}

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,7 +1,7 @@
 <p>
   You can
   <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
+    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
@@ -13,50 +13,3 @@
     </span>
   </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.
 </p>
-
-<script>
-  function toggleMenu(element, show) {
-    element.setAttribute('aria-expanded', show);
-    document
-      .querySelector(element.getAttribute('aria-controls'))
-      .setAttribute('aria-hidden', !show);
-  }
-
-  function setupContextualMenuListeners(contextualMenuToggleSelector) {
-    const toggles = document.querySelectorAll(contextualMenuToggleSelector);
-
-    toggles.forEach(toggle => {
-      toggle.addEventListener('click', e => {
-        e.preventDefault();
-
-        const target = e.target;
-        const menuAlreadyOpen = target.getAttribute('aria-expanded') === 'true';
-
-        toggleMenu(target, !menuAlreadyOpen)
-      });
-    });
-
-    document.addEventListener('click', e => {
-      toggles.forEach(toggle => {
-        const contextualMenu = document.querySelector(toggle.getAttribute('aria-controls'));
-        const clickOutside = !(toggle.contains(e.target) || contextualMenu.contains(e.target));
-
-        if (clickOutside) {
-          toggleMenu(toggle, false);
-        }
-      })
-    });
-
-    document.onkeydown = e => {
-      e = e || window.event;
-
-      if (e.keyCode === 27) {
-        toggles.forEach(toggle => {
-          toggleMenu(toggle, false);
-        });
-      }
-    };
-  }
-
-  setupContextualMenuListeners('.p-contextual-menu__toggle');
-</script>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -82,7 +82,7 @@
         {% for child in breadcrumbs.children %}
           {% if child.path == '/blog/topics' %}
           <li class="breadcrumbs__item p-contextual-menu u-hide--small">
-            <a aria-controls="#topics" class="breadcrumbs__link u-no-margin--bottom {% if child.active %}p-link--active{% else %}p-link--soft{% endif %} p-contextual-menu__toggle" href="#">{{ child.title }}</a>
+            <a aria-controls="#topics" data-trigger="hover" class="breadcrumbs__link u-no-margin--bottom {% if child.active %}p-link--active{% else %}p-link--soft{% endif %} p-contextual-menu__toggle" href="#">{{ child.title }}</a>
 
             <span class="p-contextual-menu__dropdown" id="topics" aria-hidden="true" aria-label="submenu" style="left: 1rem; font-size: .875rem;">
               <span class="p-contextual-menu__group">
@@ -152,58 +152,4 @@
       div.innerHTML = this.responseText;
     });
   }
-</script>
-
-<script>
-  function toggleMenu(toggle, dropdown, show) {
-    toggle.setAttribute('aria-expanded', show);
-    dropdown.setAttribute('aria-hidden', !show);
-  }
-
-  function setupContextualMenuListeners(contextualMenuSelector) {
-    var menus = document.querySelectorAll(contextualMenuSelector);
-
-    for (var i = 0; i < menus.length; i++) {
-      var toggle = menus[i].querySelector('.p-contextual-menu__toggle'),
-          dropdown = menus[i].querySelector('.p-contextual-menu__dropdown'),
-          timer = null;
-
-      toggle.addEventListener('click', function(e) {
-        e.preventDefault();
-      });
-
-      toggle.addEventListener('mouseover', function() {
-        clearTimeout(timer);
-        toggleMenu(toggle, dropdown, true);
-      });
-
-      toggle.addEventListener('mouseleave', function() {
-        toggleMenu(toggle, dropdown, true);
-
-        timer = setTimeout(function() {
-          toggleMenu(toggle, dropdown, false);
-        }, 50);
-      });
-
-      dropdown.addEventListener('mouseover', function() {
-        clearTimeout(timer);
-      });
-
-      dropdown.addEventListener('mouseleave', function() {
-        timer = setTimeout(function() {
-          toggleMenu(toggle, dropdown, false);
-        }, 50);
-      });
-
-      document.onkeydown = function(e) {
-        e = e || window.event;
-
-        if (e.keyCode === 27) {
-          toggleMenu(toggle, dropdown, false);
-        }
-      };
-    };
-  }
-
-  setupContextualMenuListeners('.p-contextual-menu');
 </script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     "image-download": "./static/js/src/image-download.js",
     main: [
       "./static/js/src/polyfills.js",
+      "./static/js/src/contextual-menu.js",
       "./static/js/src/dynamic-contact-form.js",
       "./static/js/src/core.js",
       "./static/js/src/navigation.js",


### PR DESCRIPTION
## Done

- moved repeated contextual menu js to build pipeline

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/topics/design
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Hover over "topics" in the secondary navigation, see that it behaves identically to ubuntu.com/blog/topics/design
- Visit /download/desktop/thank-you?country=GB&version=19.10&architecture=amd64
- Click "verify your download", see that the checksum dropdown appears
