### PR TITLE
ensure page is scrolled to top when visiting first tutorial step

### DIFF
--- a/static/js/src/tutorial.js
+++ b/static/js/src/tutorial.js
@@ -53,6 +53,7 @@ if (!window.location.hash) {
     const url = window.location + hash;
 
     window.location.replace(url);
+    window.scrollTo(0, 0);
   }
 } else {
   // Redirect #0, #1 etc. to the correct section


### PR DESCRIPTION
## Done

- made it so that visiting a tutorial doesn't hide the header initially
  - @matthewpaulthomas apologies! I was certain there'd been a conversation during a standup where it was decided that, given scrolling to an anchor present in the URL is default browser behavior, this wasn't a concern. This PR fixes the initial page position, but do you also want to prevent the page jumping around when clicking other tutorial steps?

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click the "Setup Intel Joule" tutorial link
- See that the page header is present
