### PR TITLE
fix header being hidden when navigating tutorial steps

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -73,6 +73,7 @@
   }
 
   .l-tutorial__content {
+    margin-top: -9rem; // ensure header is visible when navigating between steps (pt. 1 of 2)
     overflow: hidden; // stops pre from stretching out the flex column
     padding-top: $sp-large;
     width: 100%;
@@ -87,6 +88,7 @@
 
     &:target {
       display: block;
+      padding-top: 9rem; // ensure header is visible when navigating between steps (pt. 2 of 2)
     }
 
     h2 {


### PR DESCRIPTION
## Done

Fixed header being hidden when navigating tutorial steps (tested on Chrome, Safari and Firefox)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click the link of any tutorial, see that the header is visible (without scrolling) when you land on the page, and that it remains visible when you use the side navigation to select different steps.
- **Test it on Chrome, Firefox, and any other browser you've got**


## Issue / Card

Fixes #6974
