### PR TITLE
Fix conflict in template

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -54,7 +54,6 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card u-align--center">
-<<<<<<< HEAD
       <p>
         <a href="https://usn.ubuntu.com/">
           {{
@@ -70,11 +69,7 @@
         </a>
       </p>
 
-      <h3 class="p-heading--four u-no-margin--bottom"><a class="p-link--external" href="https://usn.ubuntu.com/"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Security notices', 'eventLabel' : 'Security notices - find out more' : undefined });">Security notices</a></h3>
-=======
-      <p><a href="/security/notices"><img src="https://assets.ubuntu.com/v1/df54bb6a-document-open-icon.svg" width="56" alt="" style="max-height: 47px;" /></a></p>
       <h3 class="p-heading--four u-no-margin--bottom"><a href="/security/notices"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventAction' : 'Security notices', 'eventLabel' : 'Security notices - find out more' : undefined });">Security notices</a></h3>
->>>>>>> update links to usn.u.c to /security/notices
     </div>
     <div class="col-4 p-card u-align--center">
       <p>


### PR DESCRIPTION
Fix a funky conflict in the template for security :)

# qa 

- `./run`
- http://0.0.0.0:8001/security/certifications 
- There should be a normal icon on the security notices link.