### PR TITLE
Disable notices API

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,7 +42,7 @@ from webapp.views import (
 )
 from webapp.login import login_handler, logout
 from webapp.security.views import (
-    api_create_notice,
+    # api_create_notice,
     notice,
     notices,
     notices_feed,
@@ -140,9 +140,9 @@ app.register_blueprint(blog_blueprint, url_prefix="/blog")
 # usn section
 app.add_url_rule("/security/notices", view_func=notices)
 app.add_url_rule("/security/notices/<feed_type>.xml", view_func=notices_feed)
-app.add_url_rule(
-    "/security/notices", view_func=api_create_notice, methods=["POST"]
-)
+# app.add_url_rule(
+#     "/security/notices", view_func=api_create_notice, methods=["POST"]
+# )
 app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
 
 


### PR DESCRIPTION
## Done

- To get a first draft of the notices we are disabling the api for now.

## QA

- Check out this feature branch
- run `./run --env FLASK_APP=webapp.app:app exec flask routes`
- There should be no POST routes for `/security/notices`
