### PR TITLE
400 build error page

### DIFF
--- a/templates/core/build-error.html
+++ b/templates/core/build-error.html
@@ -1,0 +1,17 @@
+{% extends "core/base_core.html" %}
+
+{% block title %}Build error | Ubuntu image builder{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Hw_8dWAAUpHHm5Z_XNUVJaSVE5k5i2Vt6WANcJYUZvY/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col-8">
+      <h1>Build error</h1>
+      <p>{{ build_error }}</p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -30,13 +30,6 @@
   </div>
   {% endif %}
 </section>
-{% elif build_error %}
-<section class="p-strip--suru-topped">
-  <div class="row">
-    <h1>Build error</h1>
-    <p>{{ build_error }}</p>
-  </div>
-</section>
 {% else %}
 <section class="p-strip--suru-topped is-bordered">
   <div class="row">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -122,7 +122,13 @@ def post_build():
         ).json()
     except HTTPError as http_error:
         if http_error.response.status_code == 400:
-            context["build_error"] = http_error.response.content.decode()
+            return (
+                flask.render_template(
+                    "core/build-error.html",
+                    build_error=http_error.response.content.decode(),
+                ),
+                400,
+            )
         else:
             raise http_error
 


### PR DESCRIPTION
The build error page should now have a 400 status.

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2410

QA
--

Run the site with `dotrun` (if it fails, try `dotrun clean` then `dotrun` again).

Now go to `/core/build`, and kick off a build. You should see the success page.

Now open up the network tab, select "HTML" (Firefox) or "Doc" (Chrome), to filter out the noise. Refresh the page, click "resubmit", hopefully you might see an error page with a 400 status. If not, try refreshing again quickly.