### PR TITLE
Temp: Remove mirror list to fix mirror issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
 # Set revision ID
 ARG BUILD_ID
 ENV TALISKER_REVISION_ID "${BUILD_ID}"
-ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]


### PR DESCRIPTION
**Temporary fix.**

It seems that a high priority mirror doesn't have the image 19.10. For now I am disabling the mirror list so we avoid adding conditionals in the codebase. **This is a simple fix.**

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag ubuntu.com . `
- `docker run --env DATABASE_URL=sqlite:/// -ti -p "8006:80" ubuntu.com`
- http://0.0.0.0:8006/download/desktop/thank-you?version=19.10&architecture=amd64
- ubuntu should download from releases.ubuntu.com