### PR TITLE
add support cost to managed service cost calculator

### DIFF
--- a/static/js/src/tco-calculator.js
+++ b/static/js/src/tco-calculator.js
@@ -151,6 +151,8 @@ function updateTotals() {
   // an additional 3 hosts are required to host MAAS, Juju, etc
   const hostCost = SERVICE_LEVEL_COST_PER_HOST[serviceLevel] * (hosts + 3);
   const maasHostCost = MANAGED_SERVICE_COSTS["maas"] * 3;
+  const managedSupportCost =
+    SERVICE_LEVEL_COST_PER_HOST["advanced"] * (hosts + 3);
 
   let managedServicesCost = 0;
   let rollout = 0;
@@ -179,7 +181,8 @@ function updateTotals() {
   }
 
   if (openstack.checked || kubernetes.checked) {
-    yearly += managedServicesCost + storageCost + maasHostCost;
+    yearly +=
+      managedServicesCost + managedSupportCost + storageCost + maasHostCost;
     selfYearly += hostCost + storageCost;
   }
 

--- a/templates/tco-calculator/index.html
+++ b/templates/tco-calculator/index.html
@@ -19,7 +19,7 @@
 <section class="p-strip js-tco-calculator is-bordered p-calculator">
   <div class="row">
     <div class="col-4">
-      <div class="row" style="height: 50%;">
+      <div class="row" style="height: 47%;">
         <div class="col-4 p-card--highlighted">
           <h2 class="p-heading--three">
             Number of hosts
@@ -36,7 +36,7 @@
         </div>
       </div>
 
-      <div class="row" style="height: 50%;">
+      <div class="row">
         <div class="col-4 p-card--highlighted">
           <h2 class="p-heading--three">
             Data volume


### PR DESCRIPTION
## Done

- Managed service yearly operational costs previously weren't taking into account a support cost, and since each managed service host comes with Ubuntu Advantage Advanced by default, that cost is 1500 per host.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tco-calculator
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Fill out the calculator with the figures and options mentioned in [the issue](https://github.com/canonical-web-and-design/web-squad/issues/2478), and see that the total matches what Tytus is expecting, and compare it to ubuntu.com/tco-calculator to see the difference.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2478
