### PR TITLE
Add asset server url to engage pages

### DIFF
--- a/templates/engage/developing-android-on-ubuntu.md
+++ b/templates/engage/developing-android-on-ubuntu.md
@@ -7,7 +7,7 @@ context:
      meta_copydoc: https://docs.google.com/document/d/10w-f6FEEYGPGcrFFPiZmWioZnfC3lfvfjqx_tMsi1nE/edit
      header_title: A guide to developing Android apps on Ubuntu
      header_title_class: 'u-no-margin--bottom'
-     header_image: 30f461a5-android-on-ubuntu.svg
+     header_image: https://assets.ubuntu.com/v1/30f461a5-android-on-ubuntu.svg
      header_url: '#register-section'
      header_cta: Download the whitepaper
      header_class: p-strip--dark p-takeover--android-on-ubuntu

--- a/templates/engage/enterprise-snap-management.md
+++ b/templates/engage/enterprise-snap-management.md
@@ -7,7 +7,7 @@ context:
      meta_copydoc: https://docs.google.com/document/d/1iSLsV7PD7BhF0OhxfD8KpfdQzDscxvO7UToLF7h_1vU/edit
      header_title: "Management of snaps in a controlled, enterprise environment"
      header_subtitle: "How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies"
-     header_image: 9c67dde5-network-snap-logo.svg
+     header_image: https://assets.ubuntu.com/v1/9c67dde5-network-snap-logo.svg
      header_url: '#register-section'
      header_cta: "Download the whitepaper"
      header_class: "p-strip--dark p-takeover--ent-snap-mgmt"


### PR DESCRIPTION
## Done

- 2 engage pages didn't have the asset server url 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/engage/developing-android-on-ubuntu
    - http://0.0.0.0:8001/engage/enterprise-snap-management
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the banner images appear

