### PR TITLE
Add copy global nav step to build-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-links": "./entrypoint 0.0.0.0:${PORT} && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --ignore-url /server/docs --no-warnings http://127.0.0.1:8000",
     "copy-global-nav": "cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/build/",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
-    "build-js": "webpack",
+    "build-js": "webpack && yarn run copy-global-nav",
     "build": "yarn run build-css && yarn run build-js && yarn copy-global-nav",
     "watch-css": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'static/js/src/**/*.js' -p 'static/js/data/**/*.js' -p 'static/js/third-party/**/*.js' -c 'yarn run build-js'",


### PR DESCRIPTION
## Done
Fixes the missing global-nav JS issue.

## QA

- Check out this feature branch
- `DOCKER_BUILDKIT=1 docker build . -t ubuntu.com`
- `docker run -ti -p 8001:80 --env DATABASE_URL="sqlite:///" ubuntu.com`
- Check `http://localhost:8001/static/js/build/global-nav.js`


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
