### PR TITLE
Add link to domotz homepage from case study

### DIFF
--- a/templates/engage/domotz-case-study.md
+++ b/templates/engage/domotz-case-study.md
@@ -20,7 +20,7 @@ context:
      form_return_url: "https://pages.ubuntu.com/CStudy_Domotz_-TY.html"
 ---
 
-As the number of IoT devices scale, the challenges of provisioning and keeping them up to date in the field increases. Domotz, who manufacture an all-in-one, network monitoring and management device for enterprise IoT networks, found themselves with this challenge that was further compounded by their rapid software release cadence.
+As the number of IoT devices scale, the challenges of provisioning and keeping them up to date in the field increases. <a href="https://domotz.com" class="p-link--external">Domotz</a>, who manufacture an all-in-one, network monitoring and management device for enterprise IoT networks, found themselves with this challenge that was further compounded by their rapid software release cadence.
 
 One of the most crucial and difficult aspects for Domotz to solve was the delivery of automatic updates to the tens of thousands of devices deployed. Domotz turned to snaps and Ubuntu Core to meet their exacting requirements.
 


### PR DESCRIPTION
## Done

- As requested by domotz, this PR add's a link to the domotz homepage (https://domotz.com) in the first paragraph of the enage page case study.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8001/engage/domotz-case-study
- Click the "Domotz" link in the first paragraph
- Make sure it goes to https://domotz.com
