### PR TITLE
UA renewal info markup

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -18,8 +18,8 @@
   font-family: "UbtuOverride";
   font-style: normal;
   font-weight: 300;
-  src:
-    url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2") format("woff2"),
+  src: url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2")
+      format("woff2"),
     url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
 }
 
@@ -566,14 +566,6 @@ summary {
 // Bug: https://github.com/canonical-web-and-design/vanilla-framework/issues/2926
 .p-accordion__tab {
   background-position: top $spv-inner--medium left $sph-inner;
-}
-
-#reveal-table {
-  @media only (min-width: $breakpoint-small) {
-    bottom: 0.3rem;
-    position: absolute;
-    right: 0;
-  }
 }
 
 // Local override for custom table

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -449,6 +449,21 @@ summary {
     background: transparent;
     border: 0;
     margin-bottom: 0;
+
+    &--full-width {
+      overflow: hidden;
+      padding-right: 2rem;
+      position: relative;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 100%;
+
+      .p-icon--contextual-menu {
+        position: absolute;
+        right: 0.5rem;
+        top: 0.6rem;
+      }
+    }
   }
 }
 
@@ -459,17 +474,23 @@ summary {
 
   @media only screen and (min-width: $breakpoint-small) {
     &::after {
-      background: $color-x-light;
+      background: $color-light;
       box-shadow: -1px -1px 0 1px rgba(17, 17, 17, 0.1);
       content: "";
       height: 1rem;
       pointer-events: none;
       position: absolute;
       right: 2.1rem;
-      top: -2rem;
+      top: -1.2rem;
       transform: rotate(45deg);
       width: 1rem;
       z-index: 5;
+    }
+  }
+
+  @media only screen and (min-width: $breakpoint-large) {
+    &::after {
+      top: -2rem;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -390,7 +390,7 @@ summary {
 
 .p-table--advantage-contract {
   margin: 0 auto;
-  max-width: 530px;
+  max-width: 630px;
 
   td {
     flex: 1 !important;
@@ -463,6 +463,10 @@ summary {
         right: 0.5rem;
         top: 0.6rem;
       }
+    }
+
+    &[aria-expanded="true"] .u-toggle__supplemental {
+      display: none;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -390,10 +390,14 @@ summary {
 
 .p-table--advantage-contract {
   margin: 0 auto;
-  max-width: 630px;
+  width: auto;
 
   td {
-    flex: 1 !important;
+    display: table-cell;
+  }
+
+  tr {
+    display: table-row;
   }
 }
 

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -22,7 +22,7 @@
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>You are signed in as {{ openid.fullname }}<br />
-        <small style="color:#666">({{ openid.email }})</small></p>
+        <small style="color: #666;">({{ openid.email }})</small></p>
         <p class="u-no-margin--bottom">
           <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
             'event' : 'GAEvent',
@@ -99,7 +99,7 @@
                               {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} d</div>{% endif %}
                           </a>
                       </td>
-                      <td style="text-transform: capitalize"><span class="u-truncate" style="padding-top:.35rem;">{{ contract['supportLevel'] }}</span></td>
+                      <td style="text-transform: capitalize;"><span class="u-truncate" style="padding-top: 0.35rem;">{{ contract['supportLevel'] }}</span></td>
                       <td class="u-align--center {% if loop.index == 1 and outer_loop.index == 1 %}p-table--open{% endif %}">
                         <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if loop.index == 1 and outer_loop.index == 1 %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
                           {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if loop.index == 1 and outer_loop.index == 1 %}u-rotate{% endif %}">Open</i>
@@ -112,7 +112,7 @@
                           <span class="u-truncate"><i class="p-icon--success"></i> {% if contract['entitlements']['esm-infra'] == True %}Infra{% else %}Apps{% endif %} <i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
-                        <span style="padding-top:.35rem;">N/A</span>
+                        <span style="padding-top: 0.35rem;">N/A</span>
                         {% endif %}
                       </td>
                       <td class="u-align--center">
@@ -121,7 +121,7 @@
                           <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
-                        <span style="padding-top:.35rem;">N/A</span>
+                        <span style="padding-top: 0.35rem;">N/A</span>
                         {% endif %}
                       </td>
                       <td class="u-align--center">
@@ -130,7 +130,7 @@
                           <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
-                        <span style="padding-top:.35rem;">N/A</span>
+                        <span style="padding-top: 0.35rem;">N/A</span>
                         {% endif %}
                       </td>
                       <td class="u-align--center">
@@ -139,7 +139,7 @@
                           <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
-                        <span style="padding-top:.35rem;">N/A</span>
+                        <span style="padding-top: 0.35rem;">N/A</span>
                         {% endif %}
                       </td>
 

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -90,7 +90,7 @@
                   {% if contract["contractInfo"]["status"] != 'expired' %}
 
                     {% if contract["contractInfo"]["daysTillExpiry"] %}
-                      {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] < 3000 %}
+                      {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] <= 30 %}
                     {% endif %}
 
                     <tr class="p-table__row">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -87,8 +87,8 @@
                     {% endif %}
 
                     <tr class="p-table__row">
-                      <td class="u-no-padding--left">
-                          <a href="#" class="p-button u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show" style="padding-left: 0.5rem;">
+                      <td>
+                          <a href="#" class="p-button u-toggle u-toggle--full-width u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show" style="padding-left: 0.5rem;">
                               {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} days</div>{% endif %}
                           </a>
                       </td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -37,7 +37,7 @@
 
   {% if enterprise_contracts %}
     <section class="p-strip is-shallow" style="overflow: visible;">
-      <div class="row">
+      <div class="row u-vertically-center">
         <div class="col-6 col-medium-3">
           <h2>Your paid subscriptions</h2>
         </div>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -21,8 +21,7 @@
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-        <p>You are signed in as {{ openid.fullname }}<br />
-        <small style="color: #666;">({{ openid.email }})</small></p>
+        <p>You are signed in as {{ openid.fullname }} ({{ openid.email }})</p>
         <p class="u-no-margin--bottom">
           <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
             'event' : 'GAEvent',
@@ -38,15 +37,9 @@
 
   {% if enterprise_contracts %}
     <section class="p-strip is-shallow" style="overflow: visible;">
-      <div class="row u-equal-height">
-        <div class="col-12">
-          <hr />
-        </div>
-      </div>
-
       <div class="row">
         <div class="col-6 col-medium-3">
-          <h2 class="p-heading--four u-no-margin--bottom">Your paid subscriptions</h2>
+          <h2>Your paid subscriptions</h2>
         </div>
         <div class="col-6 col-medium-3 u-align--right">
           <div id="reveal-table">
@@ -96,7 +89,7 @@
                     <tr class="p-table__row">
                       <td class="u-no-padding--left">
                           <a href="#" class="p-button u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show" style="padding-left: 0.5rem;">
-                              {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} d</div>{% endif %}
+                              {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} days</div>{% endif %}
                           </a>
                       </td>
                       <td style="text-transform: capitalize;"><span class="u-truncate" style="padding-top: 0.35rem;">{{ contract['supportLevel'] }}</span></td>
@@ -155,13 +148,13 @@
                                 {% if expiring_soon %}
                                   <tr style="border-top: 0;">
                                     <td class="u-align--right">
-                                      <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Effective to:
+                                      <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Ends:
                                     </td>
-                                    <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
+                                    <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;&mdash;&nbsp;in {{ contract['contractInfo']['daysTillExpiry'] }} days</td>
                                   </tr>
                                 {% else %}
                                   <tr style="border-top: 0;">
-                                    <td class="u-align--right">Effective to:</td>
+                                    <td class="u-align--right">Ends:</td>
                                     <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
                                   </tr>
                                 {% endif %}
@@ -246,25 +239,16 @@
           {% endfor %}
         </div>
       </div>
-      <div class="row u-sv3">
-
-      </div>
     </section>
   {% endif %}
 
-  <section class="p-strip is-shallow" style="overflow: visible;">
+  <section class="p-strip u-no-padding--top" style="overflow: visible;">
     <div class="row">
       <div class="col-12">
-        <hr />
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-4">
-        <h2 class="p-heading--four">Your free personal subscription</h2>
+        <h2>Your free personal subscription</h2>
       </div>
 
-      <div class="col-8 u-hide--small">
+      <div class="col-12 u-hide--small">
         <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply). And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>      <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
 
         <table style="width: auto;">
@@ -279,7 +263,7 @@
         </table>
       </div>
 
-      <div class="col-8 u-hide--medium u-hide--large">
+      <div class="col-12 u-hide--medium u-hide--large">
         <dl>
           <dt>To attach a machine:</dt>
           <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></dd>
@@ -294,7 +278,7 @@
   {% if not enterprise_contracts %}
     <section class="p-strip is-shallow is-bordered">
       <div class="row">
-        <h2 class="p-heading--four">Plans for enterprise use</h2>
+        <h2>Plans for enterprise use</h2>
         {% include "advantage/_table.html" %}
       </div>
     </section>
@@ -325,11 +309,6 @@
 
   <section class="p-strip is-shallow">
     <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
       <div class="col-6">
         <h2>Free for personal use</h2>
         <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
@@ -348,12 +327,6 @@
   </section>
 
   <section class="p-strip is-shallow is-bordered">
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-
     <div class="row">
       <h2>Plans for enterprise use</h2>
       {% include "advantage/_table.html" %}

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -81,15 +81,10 @@
               <tbody>
                 {% for contract in enterprise_contracts[account] %}
                   {% if contract["contractInfo"]["status"] != 'expired' %}
-
-                    {% if contract["contractInfo"]["daysTillExpiry"] %}
-                      {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] <= 3000 %}
-                    {% endif %}
-
                     <tr class="p-table__row">
                       <td>
                           <a href="#" class="p-button u-toggle u-toggle--full-width u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show" style="padding-left: 0.5rem;">
-                              {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} days</div>{% endif %}
+                              {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if contract["expiring"] %}<div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} days</div>{% endif %}
                           </a>
                       </td>
                       <td style="text-transform: capitalize;"><span class="u-truncate" style="padding-top: 0.35rem;">{{ contract['supportLevel'] }}</span></td>
@@ -145,7 +140,7 @@
                                 <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
                               </tr>
                               {% if contract['contractInfo']['effectiveTo'] %}
-                                {% if expiring_soon %}
+                                {% if contract["expiring"] %}
                                   <tr style="border-top: 0;">
                                     <td class="u-align--right">
                                       <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Ends:

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -88,11 +88,14 @@
         <tbody>
           {% for contract in enterprise_contracts[account] %}
           {% if contract["contractInfo"]["status"] != 'expired' %}
+            {% if contract["contractInfo"]["daysTillExpiry"] %}
+              {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] < 3000 %}
+            {% endif %}
           <tr class="p-table__row">
             <td>
-              <button class="u-toggle u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                  {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
-              </button>
+                <a href="#" class="u-toggle u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                    {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} d</div>{% endif %}
+                </a>
             </td>
             <td style="text-transform: capitalize"><span class="u-truncate" style="padding-top:.35rem;">{{ contract['supportLevel'] }}</span></td>
             <td class="u-align--center {% if loop.index == 1 and outer_loop.index == 1 %}p-table--open{% endif %}">
@@ -147,10 +150,17 @@
                       <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
                     </tr>
                     {% if contract['contractInfo']['effectiveTo'] %}
-                    <tr>
-                      <td class="u-align--right">Effective to:</dt>
-                      <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
-                    </tr>
+                      <tr>
+                      {% if expiring_soon %}
+                        <td class="u-align--right">
+                          <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Effective to:
+                        </td>
+                        <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
+                      {% else %}
+                        <td class="u-align--right">Effective to:</td>
+                        <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
+                      {% endif %}
+                      </tr>
                     {% endif %}
                   </table>
                 </div>
@@ -347,6 +357,7 @@
       toggles = table.querySelectorAll('.u-toggle');
       for (var i = 0; i < toggles.length; i++) {
         toggles[i].addEventListener('click', function (e) {
+          e.preventDefault()
           var targetTable = e.target.closest('.p-table-expanding');
           var target = targetTable.querySelector(
             this.getAttribute('aria-controls')

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -56,7 +56,7 @@
       </div>
     </section>
 
-    <section class="p-strip is-shallow u-hide p-card u-no-margin--bottom" aria-hidden="true" id="enterprise-table" style="overflow: visible; border-left: 0; border-right: 0;">
+    <section class="p-strip--light is-shallow u-hide p-card u-no-margin--bottom" aria-hidden="true" id="enterprise-table" style="border-left: 0; border-right: 0; overflow: visible;">
       <div class="row u-arrow-up">
         <div class="col-12">
           {% include "advantage/_table.html" %}
@@ -94,8 +94,8 @@
                     {% endif %}
 
                     <tr class="p-table__row">
-                      <td>
-                          <a href="#" class="u-toggle u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                      <td class="u-no-padding--left">
+                          <a href="#" class="p-button u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show" style="padding-left: 0.5rem;">
                               {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} d</div>{% endif %}
                           </a>
                       </td>
@@ -152,17 +152,19 @@
                                 <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
                               </tr>
                               {% if contract['contractInfo']['effectiveTo'] %}
-                                <tr>
                                 {% if expiring_soon %}
-                                  <td class="u-align--right">
-                                    <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Effective to:
-                                  </td>
-                                  <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
+                                  <tr style="border-top: 0;">
+                                    <td class="u-align--right">
+                                      <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Effective to:
+                                    </td>
+                                    <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
+                                  </tr>
                                 {% else %}
-                                  <td class="u-align--right">Effective to:</td>
-                                  <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
+                                  <tr style="border-top: 0;"></tr>
+                                    <td class="u-align--right">Effective to:</td>
+                                    <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
+                                  </tr>
                                 {% endif %}
-                                </tr>
                               {% endif %}
                             </table>
                           </div>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -90,7 +90,7 @@
                   {% if contract["contractInfo"]["status"] != 'expired' %}
 
                     {% if contract["contractInfo"]["daysTillExpiry"] %}
-                      {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] <= 30 %}
+                      {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] <= 3000 %}
                     {% endif %}
 
                     <tr class="p-table__row">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -160,7 +160,7 @@
                                     <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
                                   </tr>
                                 {% else %}
-                                  <tr style="border-top: 0;"></tr>
+                                  <tr style="border-top: 0;">
                                     <td class="u-align--right">Effective to:</td>
                                     <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
                                   </tr>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -6,26 +6,21 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped is-shallow" style="padding-top: 6rem">
 {% if openid %}
+  <section class="p-strip--suru-topped is-shallow" style="padding-top: 6rem;">
+    <script>
+      dataLayer.push({
+        'event' : 'GAEvent',
+        'eventCategory' : 'Advantage',
+        'eventAction' : 'Authentication',
+        'eventLabel' : 'Logged in',
+        'eventValue' : undefined
+      });
+    </script>
 
-  <script>
-    dataLayer.push({
-      'event' : 'GAEvent',
-      'eventCategory' : 'Advantage',
-      'eventAction' : 'Authentication',
-      'eventLabel' : 'Logged in',
-      'eventValue' : undefined
-    });
-  </script>
-
-  <div class="row">
-    <div class="col-6">
-      <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-    </div>
-
-    <div class="col-5 col-start-large-8">
-      <div class="u-no-margin--bottom p-card">
+    <div class="row">
+      <div class="col-12">
+        <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>You are signed in as {{ openid.fullname }}<br />
         <small style="color:#666">({{ openid.email }})</small></p>
         <p class="u-no-margin--bottom">
@@ -39,267 +34,277 @@
         </p>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% if enterprise_contracts %}
-<section class="p-strip--light is-shallow" style="overflow: visible;">
-  <div class="row u-equal-height">
-    <div class="col-6">
-      <h2 class="u-no-margin--bottom">Your paid subscriptions</h2>
-    </div>
-    <div class="col-6 u-align--right" style="position: relative;">
-      <div id="reveal-table">
-        <a href="#reveal-table" class="p-button u-no-margin--bottom" id="js-reveal-table" aria-controls="enterprise-table" aria-expanded="false">Add another subscription <i class="p-icon--contextual-menu">Open</i></a>
+  {% if enterprise_contracts %}
+    <section class="p-strip is-shallow" style="overflow: visible;">
+      <div class="row u-equal-height">
+        <div class="col-12">
+          <hr />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-6 col-medium-3">
+          <h2 class="p-heading--four u-no-margin--bottom">Your paid subscriptions</h2>
+        </div>
+        <div class="col-6 col-medium-3 u-align--right">
+          <div id="reveal-table">
+            <a href="#reveal-table" class="p-button u-no-margin--bottom" id="js-reveal-table" aria-controls="enterprise-table" aria-expanded="false">Add another subscription <i class="p-icon--contextual-menu">Open</i></a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="p-strip is-shallow u-hide p-card u-no-margin--bottom" aria-hidden="true" id="enterprise-table" style="overflow: visible; border-left: 0; border-right: 0;">
+      <div class="row u-arrow-up">
+        <div class="col-12">
+          {% include "advantage/_table.html" %}
+        </div>
+      </div>
+    </section>
+
+    <section class="p-strip u-no-padding--top is-shallow">
+      <div class="row">
+        <div class="col-12">
+          {% for account in enterprise_contracts %}
+            {% set outer_loop = loop %}
+            <table class="p-table-expanding p-table--advantage">
+              <thead>
+                <tr class="p-table__row">
+                  <th>{{ account }}</th>
+                  <th>UA plan</th>
+                  <th class="u-align--center">Attached</th>
+                  <th class="u-align--center">ESM</th>
+                  <th class="u-align--center">Livepatch</th>
+                  <th class="u-align--center">FIPS</th>
+                  <th class="u-align--center">CC-EAL</th>
+                  <th class="u-hide">&nbsp;</th>
+                  <th class="u-hide">&nbsp;</th>
+                  <th class="u-hide">&nbsp;</th>
+                  <th class="u-hide">&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for contract in enterprise_contracts[account] %}
+                  {% if contract["contractInfo"]["status"] != 'expired' %}
+
+                    {% if contract["contractInfo"]["daysTillExpiry"] %}
+                      {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] < 3000 %}
+                    {% endif %}
+
+                    <tr class="p-table__row">
+                      <td>
+                          <a href="#" class="u-toggle u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                              {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} d</div>{% endif %}
+                          </a>
+                      </td>
+                      <td style="text-transform: capitalize"><span class="u-truncate" style="padding-top:.35rem;">{{ contract['supportLevel'] }}</span></td>
+                      <td class="u-align--center {% if loop.index == 1 and outer_loop.index == 1 %}p-table--open{% endif %}">
+                        <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if loop.index == 1 and outer_loop.index == 1 %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
+                          {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if loop.index == 1 and outer_loop.index == 1 %}u-rotate{% endif %}">Open</i>
+                        </button>
+                      </td>
+
+                      <td class="u-align--center">
+                        {% if contract['entitlements']['esm-infra'] == True or contract['entitlements']['esm-apps'] == True %}
+                        <button class="u-toggle" aria-controls="#expanded-row-esm-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                          <span class="u-truncate"><i class="p-icon--success"></i> {% if contract['entitlements']['esm-infra'] == True %}Infra{% else %}Apps{% endif %} <i class="p-icon--contextual-menu">Open</i></span>
+                        </button>
+                        {% else %}
+                        <span style="padding-top:.35rem;">N/A</span>
+                        {% endif %}
+                      </td>
+                      <td class="u-align--center">
+                        {% if contract['entitlements']['livepatch'] == True %}
+                        <button class="u-toggle" aria-controls="#expanded-row-livepatch-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                          <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
+                        </button>
+                        {% else %}
+                        <span style="padding-top:.35rem;">N/A</span>
+                        {% endif %}
+                      </td>
+                      <td class="u-align--center">
+                        {% if contract['entitlements']['fips']  == True %}
+                        <button class="u-toggle" aria-controls="#expanded-row-fips-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                          <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
+                        </button>
+                        {% else %}
+                        <span style="padding-top:.35rem;">N/A</span>
+                        {% endif %}
+                      </td>
+                      <td class="u-align--center">
+                        {% if contract['entitlements']['cc-eal']  == True %}
+                        <button class="u-toggle" aria-controls="#expanded-row-cc-eal-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                          <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
+                        </button>
+                        {% else %}
+                        <span style="padding-top:.35rem;">N/A</span>
+                        {% endif %}
+                      </td>
+
+                      <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+                        <div class="row">
+                          <div class="col-12 u-align--center">
+                            <table class="p-table--advantage-contract">
+                              <tr>
+                                <td class="u-align--right">Created on:</td>
+                                <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
+                              </tr>
+                              {% if contract['contractInfo']['effectiveTo'] %}
+                                <tr>
+                                {% if expiring_soon %}
+                                  <td class="u-align--right">
+                                    <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Effective to:
+                                  </td>
+                                  <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
+                                {% else %}
+                                  <td class="u-align--right">Effective to:</td>
+                                  <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
+                                {% endif %}
+                                </tr>
+                              {% endif %}
+                            </table>
+                          </div>
+                        </div>
+                      </td>
+
+                      <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if loop.index == 1 and outer_loop.index == 1 %}false{% else %}true{% endif %}">
+                        <div class="row">
+                          <div class="col-12 u-align--center">
+                            To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code>
+                          </div>
+                        </div>
+                      </td>
+                      <td id="expanded-row-esm-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+                        <div class="row">
+                          {% if contract['entitlements']['esm-infra'] == True %}
+                          <div class="p-notification--information">
+                            <p class="p-notification__response">
+                              ESM is active by default on any newly-attached Ubuntu 14.04 LTS system.
+                            </p>
+                          </div>
+                          <div class="col-12 u-align--center">
+                            To deactivate: <code>sudo ua disable esm-infra</code><br/>
+                            To reactivate: <code>sudo ua enable esm-infra</code>&nbsp;&nbsp;
+                          </div>
+                          {% else %}
+                          <div class="p-notification--information">
+                            <p class="p-notification__response">
+                              ESM-apps is active by default on any newly-attached Ubuntu 14.04 LTS system.
+                            </p>
+                          </div>
+                          <div class="col-12 u-align--center">
+                            To deactivate: <code>sudo ua disable esm-apps</code><br/>
+                            To reactivate: <code>sudo ua enable esm-apps</code>&nbsp;&nbsp;
+                          </div>
+                          {% endif %}
+                        </div>
+                      </td>
+                      <td id="expanded-row-livepatch-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+                        <div class="row">
+                          <div class="col-12 u-align--center">
+                            To activate Livepatch: <code>sudo ua enable livepatch</code>
+                          </div>
+                        </div>
+                      </td>
+                      <td id="expanded-row-fips-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+                        <div class="row">
+                          <div class="col-12">
+                            <div class="p-notification--caution">
+                              <p class="p-notification__response">
+                                Older versions of software are used for FIPS-certified packages. Use them only if your organisation requires it.
+                              </p>
+                            </div>
+                          </div>
+                          <div class="col-12 u-align--center">
+                            To activate FIPS: <code>sudo ua enable fips</code>
+                          </div>
+                        </div>
+                      </td>
+                      <td id="expanded-row-cc-eal-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+                        <div class="row">
+                          <div class="col-12">
+                            <div class="p-notification--caution">
+                              <p class="p-notification__response">
+                                Older versions of software are used for CC-EAL-certified packages. Use them only if your organisation requires it.
+                              </p>
+                            </div>
+                          </div>
+                          <div class="col-12 u-align--center">
+                            To activate CC-EAL: <code>sudo ua enable cc-eal</code>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  {% endif %}
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="row u-sv3">
+
+      </div>
+    </section>
+  {% endif %}
+
+  <section class="p-strip is-shallow" style="overflow: visible;">
+    <div class="row">
+      <div class="col-12">
+        <hr />
       </div>
     </div>
-  </div>
-</section>
 
-<section class="p-strip is-shallow u-hide p-card u-no-margin--bottom" aria-hidden="true" id="enterprise-table" style="overflow: visible; border-left: 0; border-right: 0;">
-  <div class="row u-arrow-up">
-    <div class="col-12">
-      {% include "advantage/_table.html" %}
-    </div>
-  </div>
-</section>
+    <div class="row">
+      <div class="col-4">
+        <h2 class="p-heading--four">Your free personal subscription</h2>
+      </div>
 
-<section class="p-strip--light u-no-padding--top is-shallow">
-  <div class="row">
-    <div class="col-12">
-      {% for account in enterprise_contracts %}
-      {% set outer_loop = loop %}
-      <table class="p-table-expanding p-table--advantage">
-        <thead>
-          <tr class="p-table__row">
-            <th>{{ account }}</th>
-            <th>UA plan</th>
-            <th class="u-align--center">Attached</th>
-            <th class="u-align--center">ESM</th>
-            <th class="u-align--center">Livepatch</th>
-            <th class="u-align--center">FIPS</th>
-            <th class="u-align--center">CC-EAL</th>
-            <th class="u-hide">&nbsp;</th>
-            <th class="u-hide">&nbsp;</th>
-            <th class="u-hide">&nbsp;</th>
-            <th class="u-hide">&nbsp;</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for contract in enterprise_contracts[account] %}
-          {% if contract["contractInfo"]["status"] != 'expired' %}
-            {% if contract["contractInfo"]["daysTillExpiry"] %}
-              {% set expiring_soon = contract["contractInfo"]["daysTillExpiry"] < 3000 %}
-            {% endif %}
-          <tr class="p-table__row">
-            <td>
-                <a href="#" class="u-toggle u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                    {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>{% if expiring_soon %}<div class="" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} d</div>{% endif %}
-                </a>
-            </td>
-            <td style="text-transform: capitalize"><span class="u-truncate" style="padding-top:.35rem;">{{ contract['supportLevel'] }}</span></td>
-            <td class="u-align--center {% if loop.index == 1 and outer_loop.index == 1 %}p-table--open{% endif %}">
-              <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if loop.index == 1 and outer_loop.index == 1 %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
-                {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if loop.index == 1 and outer_loop.index == 1 %}u-rotate{% endif %}">Open</i>
-              </button>
-            </td>
-
-            <td class="u-align--center">
-              {% if contract['entitlements']['esm-infra'] == True or contract['entitlements']['esm-apps'] == True %}
-              <button class="u-toggle" aria-controls="#expanded-row-esm-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <span class="u-truncate"><i class="p-icon--success"></i> {% if contract['entitlements']['esm-infra'] == True %}Infra{% else %}Apps{% endif %} <i class="p-icon--contextual-menu">Open</i></span>
-              </button>
-              {% else %}
-              <span style="padding-top:.35rem;">N/A</span>
-              {% endif %}
-            </td>
-            <td class="u-align--center">
-              {% if contract['entitlements']['livepatch'] == True %}
-              <button class="u-toggle" aria-controls="#expanded-row-livepatch-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
-              </button>
-              {% else %}
-              <span style="padding-top:.35rem;">N/A</span>
-              {% endif %}
-            </td>
-            <td class="u-align--center">
-              {% if contract['entitlements']['fips']  == True %}
-              <button class="u-toggle" aria-controls="#expanded-row-fips-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
-              </button>
-              {% else %}
-              <span style="padding-top:.35rem;">N/A</span>
-              {% endif %}
-            </td>
-            <td class="u-align--center">
-              {% if contract['entitlements']['cc-eal']  == True %}
-              <button class="u-toggle" aria-controls="#expanded-row-cc-eal-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
-              </button>
-              {% else %}
-              <span style="padding-top:.35rem;">N/A</span>
-              {% endif %}
-            </td>
-
-            <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-              <div class="row">
-                <div class="col-12 u-align--center">
-                  <table class="p-table--advantage-contract">
-                    <tr>
-                      <td class="u-align--right">Created on:</td>
-                      <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
-                    </tr>
-                    {% if contract['contractInfo']['effectiveTo'] %}
-                      <tr>
-                      {% if expiring_soon %}
-                        <td class="u-align--right">
-                          <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Effective to:
-                        </td>
-                        <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;({{ contract['contractInfo']['daysTillExpiry'] }} days)</td>
-                      {% else %}
-                        <td class="u-align--right">Effective to:</td>
-                        <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong></td>
-                      {% endif %}
-                      </tr>
-                    {% endif %}
-                  </table>
-                </div>
-              </div>
-            </td>
-
-            <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if loop.index == 1 and outer_loop.index == 1 %}false{% else %}true{% endif %}">
-              <div class="row">
-                <div class="col-12 u-align--center">
-                  To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code>
-                </div>
-              </div>
-            </td>
-            <td id="expanded-row-esm-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-              <div class="row">
-                {% if contract['entitlements']['esm-infra'] == True %}
-                <div class="p-notification--information">
-                  <p class="p-notification__response">
-                    ESM is active by default on any newly-attached Ubuntu 14.04 LTS system.
-                  </p>
-                </div>
-                <div class="col-12 u-align--center">
-                  To deactivate: <code>sudo ua disable esm-infra</code><br/>
-                  To reactivate: <code>sudo ua enable esm-infra</code>&nbsp;&nbsp;
-                </div>
-                {% else %}
-                <div class="p-notification--information">
-                  <p class="p-notification__response">
-                    ESM-apps is active by default on any newly-attached Ubuntu 14.04 LTS system.
-                  </p>
-                </div>
-                <div class="col-12 u-align--center">
-                  To deactivate: <code>sudo ua disable esm-apps</code><br/>
-                  To reactivate: <code>sudo ua enable esm-apps</code>&nbsp;&nbsp;
-                </div>
-                {% endif %}
-              </div>
-            </td>
-            <td id="expanded-row-livepatch-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-              <div class="row">
-                <div class="col-12 u-align--center">
-                  To activate Livepatch: <code>sudo ua enable livepatch</code>
-                </div>
-              </div>
-            </td>
-            <td id="expanded-row-fips-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-              <div class="row">
-                <div class="col-12">
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      Older versions of software are used for FIPS-certified packages. Use them only if your organisation requires it.
-                    </p>
-                  </div>
-                </div>
-                <div class="col-12 u-align--center">
-                  To activate FIPS: <code>sudo ua enable fips</code>
-                </div>
-              </div>
-            </td>
-            <td id="expanded-row-cc-eal-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-              <div class="row">
-                <div class="col-12">
-                  <div class="p-notification--caution">
-                    <p class="p-notification__response">
-                      Older versions of software are used for CC-EAL-certified packages. Use them only if your organisation requires it.
-                    </p>
-                  </div>
-                </div>
-                <div class="col-12 u-align--center">
-                  To activate CC-EAL: <code>sudo ua enable cc-eal</code>
-                </div>
-              </div>
-            </td>
-          </tr>
-          {% endif %}
-          {% endfor %}
-        </tbody>
-      </table>
-      {% endfor %}
-    </div>
-  </div>
-  <div class="row u-sv3">
-
-  </div>
-
-{% endif %}
-<section class="p-strip--light is-shallow" style="overflow: visible;">
-  <div class="row">
-    <div class="col-6">
-      <h2>Your free personal subscription</h2>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-12 u-hide--small">
+      <div class="col-8 u-hide--small">
         <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply). And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>      <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
-      <table style="width:auto;">
-        <tr style="border: 0;">
-          <td class="u-align--right">To attach a machine:</td>
-          <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></td>
-        </tr>
-        <tr style="border: 0;">
-          <td class="u-align--right">To check status:</td>
-          <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</code></pre></td>
-        </tr>
-      </table>
+
+        <table style="width: auto;">
+          <tr style="border: 0;">
+            <td class="u-align--right">To attach a machine:</td>
+            <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></td>
+          </tr>
+          <tr style="border: 0;">
+            <td class="u-align--right">To check status:</td>
+            <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</code></pre></td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="col-8 u-hide--medium u-hide--large">
+        <dl>
+          <dt>To attach a machine:</dt>
+          <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></dd>
+          <dt>To check status:</dt>
+          <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</pre></code></dd>
+        </dl>
+      </div>
     </div>
-    <div class="col-12 u-hide--medium u-hide--large">
-      <dl>
-        <dt>To attach a machine:</dt>
-        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></dd>
-        <dt>To check status:</dt>
-        <dd class="u-no-margin--left"><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</pre></code></dd>
-      </dl>
-    </div>
-  </div>
-</section>
+  </section>
 
 
-{% if not enterprise_contracts %}
-<section class="p-strip is-shallow is-bordered">
-  <div class="row">
-    <h2>Plans for enterprise use</h2>
-    {% include "advantage/_table.html" %}
-  </div>
-</section>
-{% endif %}
+  {% if not enterprise_contracts %}
+    <section class="p-strip is-shallow is-bordered">
+      <div class="row">
+        <h2 class="p-heading--four">Plans for enterprise use</h2>
+        {% include "advantage/_table.html" %}
+      </div>
+    </section>
+  {% endif %}
 
 {% else %}
-  <div class="row">
-    <div class="col-6">
-      <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-      <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
-    </div>
-    <div class="col-5 col-start-large-8">
-      <div class="u-no-margin--bottom p-card">
-        <p>
-           Sign in to access your personal or paid subscriptions.
-        </p>
+  <section class="p-strip--suru-topped is-shallow" style="padding-top: 6rem;"></section>
+    <div class="row">
+      <div class="col-12">
+        <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
+        <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
+        <p>Sign in to access your personal or paid subscriptions.</p>
         <p class="u-no-margin--bottom">
           <a href="/login" class="p-button--neutral u-no-margin--bottom"
             onclick="dataLayer.push({
@@ -314,34 +319,44 @@
         </p>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip--light is-shallow">
-  <div class="row">
-    <div class="col-6">
-      <h2>Free for personal use</h2>
-      <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
-      <p class="u-no-margin--bottom">
-        <span class="u-sv1"><small>Initially, free subscription is available for Ubuntu 14.04 LTS only. By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
-        <a href="/login" class="p-button--positive" onclick="dataLayer.push({
-          'event' : 'GAEvent',
-          'eventCategory' : 'Advantage',
-          'eventAction' : 'Authentication',
-          'eventLabel' : 'Register',
-          'eventValue' : undefined
-        });">Register</a> to get your free subscription.
-      </p>
+  <section class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-  </div>
-</section>
+    <div class="row">
+      <div class="col-6">
+        <h2>Free for personal use</h2>
+        <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>
+        <p class="u-no-margin--bottom">
+          <span class="u-sv1"><small>Initially, free subscription is available for Ubuntu 14.04 LTS only. By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
+          <a href="/login" class="p-button--positive" onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'Advantage',
+            'eventAction' : 'Authentication',
+            'eventLabel' : 'Register',
+            'eventValue' : undefined
+          });">Register</a> to get your free subscription.
+        </p>
+      </div>
+    </div>
+  </section>
 
-<section class="p-strip is-shallow is-bordered">
-  <div class="row">
-    <h2>Plans for enterprise use</h2>
-    {% include "advantage/_table.html" %}
-  </div>
-</section>
+  <section class="p-strip is-shallow is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
+    </div>
+
+    <div class="row">
+      <h2>Plans for enterprise use</h2>
+      {% include "advantage/_table.html" %}
+    </div>
+  </section>
 {% endif %}
 
 <script>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -199,10 +199,15 @@ def advantage_view():
                             "effectiveToFormatted"
                         ] = effective_to.strftime("%d %B %Y")
 
-                        if effective_to < datetime.utcnow().replace(
-                            tzinfo=pytz.utc
-                        ):
+                        time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+                        if effective_to < time_now:
                             contract["contractInfo"]["status"] = "expired"
+                        else:
+                            date_difference = effective_to - time_now
+                            contract["contractInfo"][
+                                "daysTillExpiry"
+                            ] = date_difference.days
 
                     if "renewals" in contract["contractInfo"]:
                         contract["renewal"] = contract["contractInfo"][

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -205,6 +205,7 @@ def advantage_view():
                             contract["contractInfo"]["status"] = "expired"
                         else:
                             date_difference = effective_to - time_now
+                            contract["expiring"] = date_difference.days <= 30
                             contract["contractInfo"][
                                 "daysTillExpiry"
                             ] = date_difference.days


### PR DESCRIPTION
# Done

- Updated the layout of /advantage based on the feedback received below. When a renewal is due to expire soon, there is now information to that effect in the table indicating how many days are left. This PR doesn't provide a way for the user to do anything about it, that will come with the [Stripe integration work](https://github.com/canonical-web-and-design/ubuntu.com/issues/6202).

# QA

**QAing this is dependent on you having some subscriptions on the staging contracts service**

- Check out this branch, or visit the demo link
- Visit /advantage
- Log out, if you aren't already logged out
- See that the page looks good
- Click the sign in button at the top of the page
- If you have subscriptions associated with your account that have "effective to" dates, see that there is warning information indicating how many days until they expire.
- See that the page looks good

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2481

## Screenshot

![FireShot Capture 002 - Ubuntu Advantage for Infrastructure - Ubuntu_ - ubuntu-com-canonical-web-and-design-pr-7042 run demo haus](https://user-images.githubusercontent.com/2376968/78347316-33a2af80-7598-11ea-9eff-8b8d62d53fd5.png)
