### PR TITLE
6702 rigado engage

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -83,7 +83,6 @@
             height=header_image_height,
             hi_def=True,
             loading="auto",
-            attrs={"style": "max-height: 410px; max-width: 250px;"},
         ) | safe
       }}
       {% else %}

--- a/templates/engage/case-study-rigado.md
+++ b/templates/engage/case-study-rigado.md
@@ -4,7 +4,7 @@ context:
     title: "Rigado cuts customers' time-to-market with Ubuntu Core and AWS"
     meta_description: "Rigado utilises Ubuntu Core and AWS to help their customers get their IoT devices to market quicker."
     meta_image: "https://assets.ubuntu.com/v1/ce17e616-Rigado+meta+data+img.jpg"
-    meta_copydoc: ""
+    meta_copydoc: "https://docs.google.com/document/d/12-M4FY2y3NfhD9FginMYGNXfPHmLOhnmXR1JHL7f3D0/edit?ts=5e73a853"
     header_title: "Rigado cuts customers' <span style=\"white-space: nowrap;\">time-to-market</span>"
     header_subtitle: "with Ubuntu Core and AWS"
     header_image: "https://assets.ubuntu.com/v1/d7fdba0b-Internet+of+Things_digital-gateways-white.svg"

--- a/templates/engage/case-study-rigado.md
+++ b/templates/engage/case-study-rigado.md
@@ -7,7 +7,7 @@ context:
     meta_copydoc: "https://docs.google.com/document/d/12-M4FY2y3NfhD9FginMYGNXfPHmLOhnmXR1JHL7f3D0/edit?ts=5e73a853"
     header_title: "Rigado cuts customers' <span style=\"white-space: nowrap;\">time-to-market</span>"
     header_subtitle: "with Ubuntu Core and AWS"
-    header_image: "https://assets.ubuntu.com/v1/d7fdba0b-Internet+of+Things_digital-gateways-white.svg"
+    header_image: "https://assets.ubuntu.com/v1/1fbf2fe2-Rigado-gateway.svg"
     header_image_width: "400"
     header_image_height: "200"
     header_url: '#register-section'

--- a/templates/engage/case-study-rigado.md
+++ b/templates/engage/case-study-rigado.md
@@ -1,0 +1,40 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+    title: "Rigado cuts customers' time-to-market with Ubuntu Core and AWS"
+    meta_description: "Rigado utilises Ubuntu Core and AWS to help their customers get their IoT devices to market quicker."
+    meta_image: ""
+    meta_copydoc: ""
+    header_title: "Rigado cuts customers' time-to-market with Ubuntu Core and AWS"
+    header_title_class: 'u-no-margin--bottom'
+    header_image: ""
+    header_image_width: "205"
+    header_image_height: "106"
+    header_url: '#register-section'
+    header_cta: Download case study
+    header_class: p-engage-banner--dark
+    header_lang: en
+    form_cta: Download case study
+    form_include: en
+    form_id: 3502
+    form_return_url: https://pages.ubuntu.com/Rigado_TY.html
+---
+
+In the fast-paced world of IoT, being able to reduce time-to-market is a priority. Rigado’s core mission is to provide scalable and secure infrastructure for their customers’ commercial IoT deployments.
+
+It became clear to Rigado that, to achieve the ease of use it was looking for, it needed to redesign its gateway software – and containerisation emerged as the best way. After looking at a number of container options that involved a lot of moving parts, Rigado decided to turn to Ubuntu Core and snaps. Switching to Ubuntu Core has also enabled Rigado to take advantage of Ubuntu Amazon Machine Images (AMIs) to rapidly launch Ubuntu instances in AWS.
+
+
+
+<blockquote class="p-pull-quote--small">
+  <p class="p-pull-quote__quote">We mainly use AMIs for our build servers, but whenever I need a Linux machine for something quickly, my go-to is to spin up an Ubuntu AMI on EC2 – both because it’s easy, and because I trust it. We have confidence in the pipeline Canonical and Amazon have created.</p>
+  <cite class="p-pull-quote__citation">Justin Rigling, CTO at Rigado</cite>
+</blockquote>
+
+Download the case study to learn:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">How customers are shaving up to a year off their development and go-to-market times with AWS and Ubuntu Core while improving the overall experience</li>
+  <li class="p-list__item is-ticked">How Rigado worked with Canonical and AWS to create an AWS IoT Greengrass snap for an easy mechanism to get customer’s Bluetooth-based data to their cloud applications</li>
+  <li class="p-list__item is-ticked">How Canonical’s long term support was important for Rigado’s gateways which are designed to stay in the field for at least five years.</li>
+</ul>

--- a/templates/engage/case-study-rigado.md
+++ b/templates/engage/case-study-rigado.md
@@ -3,16 +3,16 @@ wrapper_template: "engage/_base_engage_markdown.html"
 context:
     title: "Rigado cuts customers' time-to-market with Ubuntu Core and AWS"
     meta_description: "Rigado utilises Ubuntu Core and AWS to help their customers get their IoT devices to market quicker."
-    meta_image: ""
+    meta_image: "https://assets.ubuntu.com/v1/ce17e616-Rigado+meta+data+img.jpg"
     meta_copydoc: ""
-    header_title: "Rigado cuts customers' time-to-market with Ubuntu Core and AWS"
-    header_title_class: 'u-no-margin--bottom'
-    header_image: ""
-    header_image_width: "205"
-    header_image_height: "106"
+    header_title: "Rigado cuts customers' <span style=\"white-space: nowrap;\">time-to-market</span>"
+    header_subtitle: "with Ubuntu Core and AWS"
+    header_image: "https://assets.ubuntu.com/v1/d7fdba0b-Internet+of+Things_digital-gateways-white.svg"
+    header_image_width: "400"
+    header_image_height: "200"
     header_url: '#register-section'
     header_cta: Download case study
-    header_class: p-engage-banner--dark
+    header_class: p-engage-banner--grad
     header_lang: en
     form_cta: Download case study
     form_include: en

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -917,12 +917,22 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
-    
+
     {% with title="Securing ROS robotics platforms",
       description="The steps you need to take to maximise robotics security with Ubuntu",
       slug="securing-ros-on-robotics-platforms-whitepaper",
       group="internet-of-things",
       type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
+
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Rigado cuts customers' time-to-market",
+      description="Rigado utilises Ubuntu Core and AWS to help their customers get their IoT devices to market quicker.",
+      slug="case-study-rigado",
+      group="case-study",
+      type="case study" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>


### PR DESCRIPTION
## Done

- Added an engage page for the rigado case study
- Removed max widths and heights for hero images in engage pages where the height and width are provided with parameters

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Click on the rigado case study (last on the page)
- Check the page in all browsers, check the form, etc.

[Design issue](https://github.com/canonical-web-and-design/web-squad/issues/2379)


## Issue / Card

Fixes #6702 
