### PR TITLE
Add TCO calculator to the secondary nav for /kubernetes and /openstack sections

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -31,6 +31,8 @@ openstack:
       path: /openstack/consulting
     - title: Compare
       path: /openstack/compare
+    - title: TCO calculator
+      path: /tco-calculator
     - title: Install
       path: /openstack/install
     - title: Thank you
@@ -121,6 +123,8 @@ kubernetes:
       path: /kubernetes/features
     - title: Managed
       path: /kubernetes/managed
+    - title: TCO calculator
+      path: /tco-calculator
     - title: Install
       path: /kubernetes/install
     - title: Docs


### PR DESCRIPTION
## Done

- Add TCO calculator to the secondary nav for /kubernetes and /openstack sections

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- http://0.0.0.0:8001/openstack and see "TCO calculator" in secondary nav
- http://0.0.0.0:8001/kubernetes and see "TCO calculator" in secondary nav
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #2506