### PR TITLE
Correct meta tag URL for TCO calculator copydoc

### DIFF
--- a/templates/tco-calculator/index.html
+++ b/templates/tco-calculator/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--suru is-dark">
@@ -49,7 +49,7 @@
           <div class="js-tco-calculator__range">
             <input type="number" name="data-volume" id="data-volume__input" min="1" max="10000" value="1">
             <input type="range" id="data-volume__range" min="1" max="10000" value="1" step="1">
-            
+
             <div class="p-calculator__range-hint">
               <span>0</span>
               <span class="u-align--right">10,000 TB</span>
@@ -144,10 +144,10 @@
         <div class="col-3 u-vertically-center u-align--right">
           <p class="p-heading--three" id="yearly-cost--managed">$0</p>
         </div>
-      </div>  
+      </div>
 
       <hr />
-      
+
       <p>Canonical’s managed services for OpenStack and Kubernetes allow to fully outsource cloud operational tasks to the Canonical’s team of cloud experts. Managed services may be the best option during the initial phase of private cloud deployment process, but under certain circumstances they may be also cheaper than the self-managed option. Remember that the self-managed option on the right does not include the cloud operations team's annual salary.</p>
 
       <p class="p-heading--five">* Canonical provides managed services only for OpenStack and Kubernetes deployments based on Juju charms.</p>


### PR DESCRIPTION
## Done

- Added the correct URL for the TCO calculator copydoc

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tco-calculator
- See that the meta tag has the correct [copydoc](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #2507
