### PR TITLE
Add covid update to homepage banner

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -61,4 +61,8 @@
   {% with lang="zh", text="嗨！你知道我们有中文站吗？立即带我去！", url="https://cn.ubuntu.com", icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
     {% include "shared/_notice_default.html" %}
   {% endwith %}
+  {% with lang="en", text="
+Update: Canonical managed services and Ubuntu support during COVID-19 outbreak", url="/blog/canonical-managed-services-ubuntu-support-covid-19", icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
+    {% include "shared/_notice_default.html" %}
+  {% endwith %}
 {% endblock notices_content %}

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -3,7 +3,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         {% if icon %}<img src="{{icon}}" alt="{{text}}" class="p-heading-icon__img" />{% endif %}
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="{{url}}" {%if url=="http"%}class="p-link--external">{{text}}{% else %}>{{text}}&nbsp;&rsaquo;{% endif %}</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="{{url}}" {%if "http" in url%}class="p-link--external">{{text}}{% else %}>{{text}}&nbsp;&rsaquo;{% endif %}</a></h4>
       </div>
     </div>
   </div>

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -3,7 +3,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         {% if icon %}<img src="{{icon}}" alt="{{text}}" class="p-heading-icon__img" />{% endif %}
-        <h4 class="p-heading-icon__title"><a href="{{url}}" class="p-link--external">{{text}}</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="{{url}}" {%if url=="http"%}class="p-link--external">{{text}}{% else %}>{{text}}&nbsp;&rsaquo;{% endif %}</a></h4>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add a notification to the ubuntu.com homepage linking to Mark's blog post
- Add logic to add `&nbsp;&rsaquo;` for local links and `p-link--external` for external ones

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the notification appears for english and the normal ones appear for chinese or japanese language (chrome://settings/langages) 


## Screenshots

![image](https://user-images.githubusercontent.com/441217/77256755-0d137900-6c68-11ea-9368-a7a11b67bc0c.png)

