### PR TITLE
Setup views for cve

### DIFF
--- a/templates/security/cve/base_cve.html
+++ b/templates/security/cve/base_cve.html
@@ -1,0 +1,5 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+{% block content %}{% endblock %}
+{% endblock %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -1,0 +1,11 @@
+{% extends "security/cve/base_cve.html" %}
+
+{% block title %}CVEs{% endblock %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1>CVE release</h1>
+  </div>
+</section>
+{% endblock %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -1,0 +1,11 @@
+{% extends "security/cve/base_cve.html" %}
+
+{% block title %}CVEs{% endblock %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1>CVE reports</h1>
+  </div>
+</section>
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,6 +46,7 @@ from webapp.security.views import (
     notice,
     notices,
     notices_feed,
+    cve,
 )
 
 
@@ -144,6 +145,10 @@ app.add_url_rule("/security/notices/<feed_type>.xml", view_func=notices_feed)
 #     "/security/notices", view_func=api_create_notice, methods=["POST"]
 # )
 app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
+
+
+# cve section
+app.add_url_rule("/security/<cve_id>", view_func=cve)
 
 
 # Login

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -5,6 +5,7 @@ from math import ceil
 
 # Packages
 import flask
+import re
 from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
 from marshmallow import EXCLUDE
@@ -258,3 +259,15 @@ def api_create_notice():
     db_session.commit()
 
     return flask.jsonify({"message": "Notice created"}), 201
+
+
+# CVE views
+# ===
+def cve(cve_id):
+    match_cves = re.compile(r"cve-\d{4}-\d{4,7}")
+    if cve_id == "cve":
+        return flask.render_template("security/cve/index.html")
+    elif match_cves.search(cve_id) is not None:
+        return flask.render_template("security/cve/cve.html")
+    else:
+        flask.abort(404)


### PR DESCRIPTION
## Done

Setup views for CVE index and release/package page

## QA

- Run the site using the command `./run serve` or the dotrun snap
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- It should go to the list page
- Visit `/security/cve-2019-1234` should go to the detail cve page.
- Visit `/security/cve-231231231231` should go to 404
## Issue / Card

Fixes #7023 

Supercedes #7061 
