### PR TITLE
7060 add cve to navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -721,6 +721,8 @@ security:
     - title: Notices
       path: https://usn.ubuntu.com
       persist: True
+    - title: CVEs
+      path: /security/cve
 
 licensing:
   title: Licensing

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -299,13 +299,19 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a class="p-link--external" href="https://usn.ubuntu.com">Security notices</a>
+            <a href="/security">Security</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/security/certifications">Certifications</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--external" href="https://usn.ubuntu.com">Notices</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/security/cve">CVEs</a>
           </li>
           <li class="p-inline-list__item">
             <a href="/esm">Extended Security Maintenance</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="/security">Security</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Add a link to /security/cve in /security secondary navigation, footer and Developer mega menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that there is a link to "CVEs" in the secondary navigation and that it takes you to the "CVE reports" page
- Check that there is a link to "CVEs" in the footer underneath the "Security" heading and that it takes you to the "CVE reports" page
- Check that there is a link to "CVEs" in the horizontal "Security" section at the bottom of the "Developer" mega menu and that it takes you to the "CVE reports" page
- Check that the order of the horizontal "Security" section at the bottom of the "Developer" mega menu matches the order specificed in [the design doc](https://docs.google.com/document/d/1VuAElUpFay7MBFNmE3NhSyY9TkXiqHcA1ZHQ11AYO-Q/edit#heading=h.n4ejodulp804) underneath the "Ribbon navigation" heading


## Issue / Card

Fixes #7060