### PR TITLE
Pre-Kubecon takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -935,6 +935,14 @@
       type="case study" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Virtual event: MicroK8s & Kubernetes",
+      description="Join our virtual event to learn more about MicroK8s, what it is and why you should use it. This event will also include discussions on Kubernetes, an introduction to Canonical and much more!",
+      slug="pre-kubecon-event",
+      group="event",
+      type="event" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/pre-kubecon-event.md
+++ b/templates/engage/pre-kubecon-event.md
@@ -28,7 +28,7 @@ March 30, 2020
 
 **Who should attend:** Open to IT teams in the Netherlands wanting to learn more about MicroK8s and Kubernetes, and how to innovate with these.
 
-**What you will learn:** Broad by design, we will discuss Canonical and Ubuntu, MicroK8s, Kubernetes. There will also be time for questions or scheduling 121s with us.
+**What you will learn:** Broad by design, we will discuss Canonical, Ubuntu, MicroK8s and Kubernetes. There will also be time for questions or scheduling 121s with us.
 
 **Takeaways:** Ideas and building blocks for today and the future.
 

--- a/templates/engage/pre-kubecon-event.md
+++ b/templates/engage/pre-kubecon-event.md
@@ -1,0 +1,35 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+    title: "Pre-Kubecon event NL"
+    meta_description: "Kubernetes, microK8s, kubecon, canonical, ubuntu"
+    meta_image: "https://assets.ubuntu.com/v1/7d8a36c9-Meta+data+img+-+Pre-Kubecon+event.jpg"
+    meta_copydoc: "https://docs.google.com/document/d/1Ov_JCaTymV3_OY-_sACJNbfbEUetUjkB28T83kJZZ7U/"
+    header_title: "Virtual event:<br>MicroK8s & Kubernetes"
+    header_subtitle: "Join our virtual event to learn more about MicroK8s, what it is and why you should use it. This event will also include discussions on Kubernetes, an introduction to Canonical and much more!"
+    header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
+    header_image_width: "419"
+    header_image_height: "172"
+    header_url: 'https://primetime.bluejeans.com/a2m/register/daqpkkyc'
+    header_cta: Register
+    header_cta_class: "p-button--positive"
+    header_class: p-engage-banner--dark
+    header_lang: en
+---
+
+## About the event
+
+**Date and time:**
+March 30, 2020
+[2-5pm]
+
+
+**What it is:** A free digital conference for anyone from the Netherlands. As KubeCon in Amsterdam, we wanted to still bring Kubernetes and MicroK8s to you.
+
+**Who should attend:** Open to IT teams in the Netherlands wanting to learn more about MicroK8s and Kubernetes, and how to innovate with these.
+
+**What you will learn:** Broad by design, we will discuss Canonical and Ubuntu, MicroK8s, Kubernetes. There will also be time for questions or scheduling 121s with us.
+
+**Takeaways:** Ideas and building blocks for today and the future.
+
+<a href="https://primetime.bluejeans.com/a2m/register/daqpkkyc" class="p-button--positive">Register</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
   {# ALL #}
+  {% include "takeovers/_nl-pre-kubecon.html" %}
   {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_smart-start-webinar.html" %}

--- a/templates/takeovers/_nl-pre-kubecon.html
+++ b/templates/takeovers/_nl-pre-kubecon.html
@@ -1,0 +1,13 @@
+{% with title="Kubernetes for innovation: a virtual event",
+subtitle="Join us to learn more about Charmed Kuberenetes and MicroK8s ",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg",
+image_style="width: 419px;",
+image_hide_small="true",
+primary_url="/engage/pre-kubecon-event?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Kubernetes_EVT_Pre-KubeconNL2020",
+primary_cta="Register now",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_nl-pre-kubecon.html
+++ b/templates/takeovers/_nl-pre-kubecon.html
@@ -1,5 +1,5 @@
 {% with title="Kubernetes for innovation: a virtual event",
-subtitle="Join us to learn more about Charmed Kuberenetes and MicroK8s ",
+subtitle="Join us to learn more about Charmed Kubernetes and MicroK8s ",
 class="p-takeover--dark",
 header_image="https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg",
 image_style="width: 419px;",

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -112,4 +112,6 @@
 {% include "takeovers/_smart-start-webinar.html" %}
 <p>4th Mar 2020</p>
 {% include "takeovers/_cloud-cost-analysis.html" %}
+<p>24th Mar 2020</p>
+{% include "takeovers/_nl-pre-kubecon.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Build pre-Kubecon takeover
- Build pre-Kubecon engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refresh the page until you see the "Virtual event: MicroK8s & Kubernetes" takeover
- Check that the takeover matches [the brief](https://docs.google.com/spreadsheets/d/1uDmHeijZ4qvWwRvWumZvw7h4iUnlk67OLsaz4E_BecY/edit#gid=2113339190)
- Click the CTA in the takeover and check that it takes you to /engage/pre-kubecon-event
- Check that the page matches [the copy doc](https://docs.google.com/document/d/1Ov_JCaTymV3_OY-_sACJNbfbEUetUjkB28T83kJZZ7U/edit#)
- Check that the CTA takes you to [the event](https://primetime.bluejeans.com/a2m/register/daqpkkyc)
- Check that the takeover appears at the bottom of /takeovers
- Check that the engage page appears at the bottom of /engage
- Test the engage page on [https://socialdebug.com/](https://socialdebug.com/) or [http://debug.iframely.com/](http://debug.iframely.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)



## Issue / Card

Fixes #7052 