### PR TITLE
Build base CVE template

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -721,6 +721,8 @@ security:
     - title: Notices
       path: https://usn.ubuntu.com
       persist: True
+    - title: CVEs
+      path: /security/cve
 
 licensing:
   title: Licensing

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -18,7 +18,10 @@
   font-family: "UbtuOverride";
   font-style: normal;
   font-weight: 300;
-  src: url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2") format("woff2"), url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
+  src:
+    url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2")
+    format("woff2"),
+    url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
 }
 
 // import vanilla-framework
@@ -27,7 +30,7 @@
 
 // Vanilla framework overrides
 $font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
-$color-shadow: rgba(0, 0, 0, .5) !default;
+$color-shadow: rgba(0, 0, 0, 0.5) !default;
 
 // import site specific patterns and overrides
 @import "pattern_blog-featured";
@@ -103,14 +106,23 @@ $color-shadow: rgba(0, 0, 0, .5) !default;
 
 // Layouts:
 @import "layout-documentation";
+
 @include layout-documentation;
+
 @import "layout-legal-pages";
+
 @include layout-legal-pages;
+
 @import "layout-whitepapers";
+
 @include layout-whitepapers;
+
 @import "layout-tutorials";
+
 @include layout-tutorials;
+
 @import "layout-tutorial";
+
 @include layout-tutorial;
 
 // Bug fixes
@@ -241,8 +253,6 @@ fieldset:last-child {
   }
 }
 
-.p-pull-quote--large
-
 // sass-lint:disable no-qualifying-elements
 h1.u-align--center,
 h2.u-align--center,
@@ -255,18 +265,17 @@ p.u-align--center {
 }
 // sass-lint:enable no-qualifying-elements
 
-
 /// XXX Caleb: abbr hotfix - to be fixed in Vanilla
 // https://github.com/vanilla-framework/vanilla-framework/issues/1962
 abbr[title] {
-  border-bottom: .1em dotted;
+  border-bottom: 0.1em dotted;
   cursor: help;
   text-decoration: none;
 }
 
 // Hack to change the global navigation styling to match the local header
 .global-nav .global-nav__header-logo-anchor {
-  padding: .6875rem 1rem !important;
+  padding: 0.6875rem 1rem !important;
 }
 
 // XXX Ant: is-bordered hotfix - to be removed when the following is resolved:
@@ -278,6 +287,7 @@ abbr[title] {
 // Override for wordpress use of <figure>
 .blog-article figure {
   @extend %max-width--p;
+
   text-align: center;
 }
 
@@ -297,6 +307,7 @@ summary {
 
   &--subtext {
     max-width: 28em;
+
     @media only screen and (max-width: 874px) and (min-width: 620px) {
       width: 50%;
     }
@@ -324,7 +335,7 @@ summary {
     }
 
     &:last-of-type::after {
-      bottom: .5rem;
+      bottom: 0.5rem;
     }
   }
 }
@@ -370,13 +381,21 @@ summary {
   transform: rotate(180deg);
 }
 
+.p-table-expanding__panel {
+  @extend %vf-card;
+  @extend %vf-is-bordered;
+  @extend %vf-has-round-corners;
+
+  margin-bottom: 0;
+}
+
 .p-table--advantage {
   overflow: visible;
 
   th,
   td {
-    padding-left: .5rem;
-    padding-right: .5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
 
   .p-table__row {
@@ -397,13 +416,6 @@ summary {
   code {
     background-color: transparent;
     box-shadow: none;
-  }
-
-  .p-table-expanding__panel {
-    @extend %vf-card;
-    @extend %vf-is-bordered;
-    @extend %vf-has-round-corners;
-    margin-bottom: 0;
   }
 
   .p-table--open {
@@ -429,7 +441,7 @@ summary {
   @media only screen and (min-width: $breakpoint-small) {
     &::after {
       background: $color-x-light;
-      box-shadow: -1px -1px 0 1px rgba(17, 17, 17, .1);
+      box-shadow: -1px -1px 0 1px rgba(17, 17, 17, 0.1);
       content: "";
       height: 1rem;
       pointer-events: none;
@@ -462,7 +474,6 @@ summary {
   a img {
     width: 143px;
   }
-
 }
 
 .p-tile {
@@ -536,4 +547,32 @@ summary {
 // Bug: https://github.com/canonical-web-and-design/vanilla-framework/issues/2926
 .p-accordion__tab {
   background-position: top $spv-inner--medium left $sph-inner;
+}
+
+.p-corner-ribbon {
+  background-color: $color-brand;
+  color: $color-x-light;
+  padding-bottom: $spv-inner--x-small;
+  padding-top: $spv-inner--x-small;
+  position: absolute;
+  right: -50px;
+  text-align: center;
+  top: 38px;
+  transform: rotate(45deg);
+  width: 225px;
+}
+
+.u-negative {
+  background-color: $color-negative;
+  color: $color-x-light;
+}
+
+.u-positive {
+  background-color: $color-positive;
+  color: $color-x-light;
+}
+
+.u-caution {
+  background-color: $color-caution;
+  color: $color-x-light;
 }

--- a/templates/security/cve/base_cve.html
+++ b/templates/security/cve/base_cve.html
@@ -1,0 +1,5 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+{% block content %}{% endblock %}
+{% endblock %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -1,11 +1,140 @@
-{% extends "security/cve/base_cve.html" %}
-
-{% block title %}CVEs{% endblock %}
-
+{% extends "security/cve/base_cve.html" %} {% block title %}CVEs{% endblock %}
 {% block content %}
 <section class="p-strip">
+  <div class="p-corner-ribbon u-hide--small">
+    Not in Ubuntu
+  </div>
   <div class="u-fixed-width">
-    <h1>CVE release</h1>
+    <h1>CVE-2019-1010318</h1>
+    <p>Published 2020-03-18 20:14:22 UTC</p>
+    <p>
+      ** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: <a href="https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-11498.html">CVE-2019-11498</a>.<br>
+      Reason: This candidate is a reservation duplicate of <a href="https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-11498.html">CVE-2019-11498</a>.<br> Notes: All CVE users should reference <a href="https://people.canonical.com/~ubuntu-security/cve/2019/CVE-2019-11498.html">CVE-2019-11498</a> instead of this candidate.<br>
+      All references and descriptions in this candidate have been removed to prevent accidental usage.
+    </p>
+
+    <h2>From the Ubuntu Security Team</h2>
+    <p>Jasiel Spelman discovered that a double free existed in
+      docker-credential-helpers. A local attacker could use this to cause a denial
+      of service (crash) or possibly execute arbitrary code.</p>
+
+    <h2>Status</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Package</th>
+          <th>Release</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="7">
+            Source: <a href="https://people.canonical.com/~ubuntu-security/cve/pkg/docker.io.html">docker.io</a> (<a href="https://launchpad.net/distros/ubuntu/+source/docker.io">LP</a> <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords=docker.io">Ubuntu</a> <a href="https://tracker.debian.org/docker.io">Debian</a>)
+          </td>
+          <td>Upstream</td>
+          <td>Needs triage</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 12.04 ESM (Precise Pangolin)</td>
+          <td class="u-positive">DNE</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 14.04 ESM (Trusty Tahr)</td>
+          <td class="u-positive">DNE</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/xenial/+source/docker.io">Ubuntu 16.04 LTS (Xenial Xerus)</a>
+          </td>
+          <td>released (18.09.7-0ubuntu1~16.04.5</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/bionic/+source/docker.io">Ubuntu 18.04 LTS (Bionic Beaver)</a>
+          </td>
+          <td>released (18.09.7-0ubuntu1~18.04.4</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/eoan/+source/docker.io">Ubuntu 19.10 (Eoan Ermine)</a>
+          </td>
+          <td class="u-positive">not-affected (19.03.2-0ubuntu1)</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/focal/+source/docker.io">Ubuntu 20.04 (Focal Fossa)</a>
+          </td>
+          <td class="u-positive">not-affected (19.03.6-0ubuntu1)</td>
+        </tr>
+        <tr>
+          <td rowspan="7">
+            Source: <a href="https://people.canonical.com/~ubuntu-security/cve/pkg/golang-github-docker-docker-credential-helpers.html">golang-github-docker-credential-helpers</a> (<a href="https://launchpad.net/distros/ubuntu/+source/golang-github-docker-docker-credential-helpers">LP</a> <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords=golang-github-docker-docker-credential-helpers">Ubuntu</a> <a href="https://tracker.debian.org/golang-github-docker-docker-credential-helpers">Debian</a>)
+          </td>
+          <td>Upstream</td>
+          <td>needs-triage</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 12.04 ESM (Precise Pangolin)</td>
+          <td class="u-positive">DNE</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 14.04 ESM (Trusty Tahr)</td>
+          <td class="u-positive">DNE</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 16.04 ESM (Xenial Xerus)</td>
+          <td class="u-positive">DNE</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/bionic/+source/golang-github-docker-docker-credential-helpers">Ubuntu 18.04 LTS (Bionic Beaver)</a>
+          </td>
+          <td class="u-negative">needed</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/eoan/+source/golang-github-docker-docker-credential-helpers">Ubuntu 19.10 (Eoan Ermine)</a>
+          </td>
+          <td class="u-positive">not-affected (0.6.1-4)</td>
+        </tr>
+        <tr>
+          <td>
+            <a href="https://launchpad.net/ubuntu/focal/+source/golang-github-docker-docker-credential-helpers">Ubuntu 20.04 (Focal Fossa)</a>
+          </td>
+          <td class="u-positive">not-affected (0.6.1-4)</td>
+        </tr>
+      </tbody>
+    </table>
+    <h2>Notes</h2>
+    <P>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi aliquam eos consequatur possimus nulla a velit minima, et aspernatur praesentium! Recusandae, dignissimos ex nostrum nihil molestiae non quibusdam et. Placeat!</P>
+    <h2>References</h2>
+    <ul>
+      <li>
+        <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010318">
+          https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010318
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/dbry/WavPack/commit/bc6cba3f552c44565f7f1e66dc1580189addb2b4">
+          https://github.com/dbry/WavPack/commit/bc6cba3f552c44565f7f1e66dc1580189addb2b4
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/dbry/WavPack/issues/67">
+          https://github.com/dbry/WavPack/issues/67
+        </a>
+      </li>
+      <li>
+        <a href="https://usn.ubuntu.com/usn/usn-4062-1">
+          https://usn.ubuntu.com/usn/usn-4062-1
+        </a>
+      </li>
+    </ul>
   </div>
 </section>
-{% endblock %}
+
+{% with first_item="_security_discussion", second_item="_security_esm",
+third_item="_security_further_reading" %}{% include
+"shared/contextual_footers/_contextual_footer.html" %}{% endwith %} {% endblock
+%}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -1,0 +1,11 @@
+{% extends "security/cve/base_cve.html" %}
+
+{% block title %}CVEs{% endblock %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1>CVE release</h1>
+  </div>
+</section>
+{% endblock %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -1,0 +1,11 @@
+{% extends "security/cve/base_cve.html" %}
+
+{% block title %}CVEs{% endblock %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1>CVE reports</h1>
+  </div>
+</section>
+{% endblock %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -6,6 +6,10 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h1>CVE reports</h1>
+    <p><a href="/security/cve-2019-1010318">Example CVE page</a></p>
   </div>
 </section>
+
+{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
 {% endblock %}

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -299,13 +299,19 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a class="p-link--external" href="https://usn.ubuntu.com">Security notices</a>
+            <a href="/security">Security</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/security/certifications">Certifications</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a class="p-link--external" href="https://usn.ubuntu.com">Notices</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/security/cve">CVEs</a>
           </li>
           <li class="p-inline-list__item">
             <a href="/esm">Extended Security Maintenance</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="/security">Security</a>
           </li>
         </ul>
       </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,6 +46,7 @@ from webapp.security.views import (
     notice,
     notices,
     notices_feed,
+    cve,
 )
 
 
@@ -144,6 +145,10 @@ app.add_url_rule("/security/notices/<feed_type>.xml", view_func=notices_feed)
 #     "/security/notices", view_func=api_create_notice, methods=["POST"]
 # )
 app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
+
+
+# cve section
+app.add_url_rule("/security/<cve_id>", view_func=cve)
 
 
 # Login

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -150,7 +150,9 @@ app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
 
 # cve section
 app.add_url_rule("/security/cve", view_func=cve_index)
-app.add_url_rule("/security/<regex('cve-d{4}-d{4,7}'):cve_id>", view_func=cve)
+app.add_url_rule(
+    "/security/<regex('cve-\\d{4}-\\d{4,7}'):cve_id>", view_func=cve
+)
 
 
 # Login

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,6 +46,7 @@ from webapp.security.views import (
     notice,
     notices,
     notices_feed,
+    cve_index,
     cve,
 )
 
@@ -148,7 +149,8 @@ app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
 
 
 # cve section
-app.add_url_rule("/security/<cve_id>", view_func=cve)
+app.add_url_rule("/security/cve", view_func=cve_index)
+app.add_url_rule("/security/<regex('cve-d{4}-d{4,7}'):cve_id>", view_func=cve)
 
 
 # Login

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -5,7 +5,6 @@ from math import ceil
 
 # Packages
 import flask
-import re
 from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
 from marshmallow import EXCLUDE
@@ -263,11 +262,9 @@ def api_create_notice():
 
 # CVE views
 # ===
+def cve_index():
+    return flask.render_template("security/cve/index.html")
+
+
 def cve(cve_id):
-    match_cves = re.compile(r"cve-\d{4}-\d{4,7}")
-    if cve_id == "cve":
-        return flask.render_template("security/cve/index.html")
-    elif match_cves.search(cve_id) is not None:
-        return flask.render_template("security/cve/cve.html")
-    else:
-        flask.abort(404)
+    return flask.render_template("security/cve/cve.html")

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -5,6 +5,7 @@ from math import ceil
 
 # Packages
 import flask
+import re
 from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
 from marshmallow import EXCLUDE
@@ -258,3 +259,15 @@ def api_create_notice():
     db_session.commit()
 
     return flask.jsonify({"message": "Notice created"}), 201
+
+
+# CVE views
+# ===
+def cve(cve_id):
+    match_cves = re.compile(r"cve-\d{4}-\d{4,7}")
+    if cve_id == "cve":
+        return flask.render_template("security/cve/index.html")
+    elif match_cves.search(cve_id) is not None:
+        return flask.render_template("security/cve/cve.html")
+    else:
+        flask.abort(404)


### PR DESCRIPTION
## Done

Build basic template with all required components for all types of CVE page (rejected, non-Ubuntu and Ubuntu)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve-2019-1010318
- Check that the elements of all types of CVE page (rejected, non-Ubuntu and Ubuntu) are present on this page
- Please bear in mind this is dummy data based on existing examples

## Issue / Card

Fixes #7054

## Screenshots

![cve_page_all_states](https://user-images.githubusercontent.com/501889/77532356-a622d980-6e8c-11ea-926b-02bfb70b55ee.png)
