### PR TITLE
Add hide_subnav variable to hide the secondary nav from pages where set

### DIFF
--- a/templates/tco-calculator/_base_tco_calculator.html
+++ b/templates/tco-calculator/_base_tco_calculator.html
@@ -1,3 +1,4 @@
+{% set hide_subnav = True %}
 {% extends "templates/base.html" %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY{% endblock meta_copydoc %}

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -68,6 +68,7 @@
   <div class="u-hide" id="community-content"></div>
   <div class="u-hide" id="download-content"></div>
 </div>
+{% if not(hide_subnav == True) %}
 {% if breadcrumbs and breadcrumbs.children and breadcrumbs.children|length > 1 or breadcrumbs.grandchildren %}
 <nav class="p-navigation--secondary">
   <div class="row">
@@ -124,6 +125,7 @@
     </div>
   </div>
 </nav>
+{% endif %}
 {% endif %}
 
 <script>


### PR DESCRIPTION
## Done

- Like hide_nav on /engage, I added hide_subnav to hide the secondary nav in the _navigation.html partial
- This should stop people from going to the tco page from OpenStack and the nav showing the Kubernetes bubble

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/tco-calculator
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is no secondary nav even thought the page is in both the /openstack and /kubernetes bubble.


