### PR TITLE
Add lang="nl" to the dutch takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,8 +30,9 @@
   {% include "takeovers/_vmware-to-charmed-openstack_german.html" %}
   {# SPANISH #}
   {% include "takeovers/_vmware-to-charmed-openstack_spanish.html" %}
-  {# ALL #}
+  {# DUTCH #}
   {% include "takeovers/_nl-pre-kubecon.html" %}
+  {# ALL #}
   {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_smart-start-webinar.html" %}

--- a/templates/takeovers/_nl-pre-kubecon.html
+++ b/templates/takeovers/_nl-pre-kubecon.html
@@ -8,6 +8,7 @@ primary_url="/engage/pre-kubecon-event?utm_source=Takeover&utm_medium=Takeover&u
 primary_cta="Register now",
 primary_cta_class="",
 secondary_url="",
-secondary_cta="" %}
+secondary_cta="",
+lang="nl" %}
 {% include "takeovers/_template.html" %}
 {% endwith %}


### PR DESCRIPTION
## Done

- added `lang="nl"` to the   takeovers/_nl-pre-kubecon.html takeover
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the takeover does not appear until you change your language setting to dutch
