### PR TITLE
Build charmed openstack adoption takeover and engage page

### DIFF
--- a/templates/engage/charmed-openstack-adoption-whitepaper.md
+++ b/templates/engage/charmed-openstack-adoption-whitepaper.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "A guide to a successful OpenStack adoption and deployment"
+  meta_description: "A guide to a successful OpenStack adoption and deployment"
+  meta_image: "https://assets.ubuntu.com/v1/55aa7329-77673291-e44df500-6f81-11ea-81b1-ebae39ade688.png"
+  meta_copydoc: "https://docs.google.com/document/d/1MDI2eg5DKHoytmUdXUCziQexEGiXRDml2TnqOwstBYQ/edit"
+  header_title: "A guide to a successful OpenStack adoption and deployment"
+  header_subtitle: "Discover Canonical’s proven OpenStack implementation process"
+  header_url: "#register-section"
+  header_cta: Download whitepaper
+  header_class: p-engage-banner--dark
+  header_image: "https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg"
+  header_lang: en
+  form_include: en
+  form_id: 3540
+  form_return_url: "https://pages.ubuntu.com/AdoptionGuide_TY.html"
+---
+
+OpenStack is one of the most active open source projects in the world. It is an essential component of private cloud infrastructure for countless businesses, and over the last few years, it has evolved to become the de-facto standard for implementing cloud computing platforms. Yet despite its popularity, many organisations still struggle with their OpenStack implementations.
+
+Lack of resources, knowledge, experience, or tools can all stand in the way of a successful OpenStack deployment &mdash; but businesses can overcome these challenges by following a proven adoption process. Canonical provides consulting and tools to assist organisations at each stage of implementation and operation, taking all the complexity out of OpenStack deployment.
+
+This whitepaper will explore each of the five phases of OpenStack adoption, and describe how Canonical’s tools and services can be used to optimise the process, including:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Consulting to help design and implement an OpenStack private cloud, including delivery within two weeks</li>
+  <li class="p-list__item is-ticked">Using Canonical’s tooling to streamline OpenStack modelling, implementation, and orchestration</li>
+  <li class="p-list__item is-ticked">The option for organisations to manage their OpenStack operations themselves, or have Canonical deliver fully managed OpenStack as a service</li>
+</ul>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -954,7 +954,7 @@
   </div>
   <div class="row u-equal-height u-clearfix">
     {% with title="A guide to a successful OpenStack adoption and deployment",
-      description="OpenStack is one of the most active open source projects in the world.",
+      description="Discover Canonical’s proven OpenStack implementation process",
       slug="charmed-openstack-adoption-whitepaper",
       group="whitepaper",
       type="whitepaper" %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -952,5 +952,14 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
+  <div class="row u-equal-height u-clearfix">
+    {% with title="A guide to a successful OpenStack adoption and deployment",
+      description="OpenStack is one of the most active open source projects in the world.",
+      slug="charmed-openstack-adoption-whitepaper",
+      group="whitepaper",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,7 @@
   {% include "takeovers/_451-microk8s.html" %}
   {% include "takeovers/_smart-start-webinar.html" %}
   {% include "takeovers/_anbox-cloud-webinar.html" %}
+  {% include "takeovers/_charmed-openstack-adoption.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_charmed-openstack-adoption.html
+++ b/templates/takeovers/_charmed-openstack-adoption.html
@@ -1,0 +1,13 @@
+{% with title="A guide to a successful OpenStack adoption and deployment",
+subtitle="Overcome OpenStack adoption challenges by following a proven adoption process",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg",
+image_style="width: 320px;",
+image_hide_small="true",
+primary_url="/engage/charmed-openstack-adoption-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_OpenStack_Whitepaper_AdoptionGuide",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -116,4 +116,6 @@
 {% include "takeovers/nl/_nl-pre-kubecon.html" %}
 <p>30 March 2020 - French</p>
 {% include "takeovers/fr/_vmware-to-charmed-openstack_french.html" %}
+<p>30th Mar 2020</p>
+{% include "takeovers/_charmed-openstack-adoption.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Built charmed openstack adoption takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Reload the page until you see the takeover with the heading "A guide to a successful OpenStack adoption and deployment"
- Check that the CTA takes you to /engage/charmed-openstack-adoption-whitepaper
- Check that the form on the engage page works
- Check that the takeover and engage page match [the brief](https://docs.google.com/spreadsheets/d/16TXgQqDczbvzs1vyTAJIbA32VEcHy9QVVe5jFKt3Xis/edit#gid=2113339190) and [the design](https://github.com/canonical-web-and-design/web-squad/issues/2502)
- Test the engage page on [https://socialdebug.com/](https://socialdebug.com/) or [http://debug.iframely.com/](http://debug.iframely.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)

## Issue / Card

Fixes #7037 