### PR TITLE
Add core security audit engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -951,6 +951,14 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Ubuntu Core: a cybersecurity analysis",
+      description="An independent evaluation of Ubuntu Core’s security capabilities",
+      slug="ubuntu-core-security-audit",
+      group="whitepaper",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/ubuntu-core-security-audit.md
+++ b/templates/engage/ubuntu-core-security-audit.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Ubuntu Core: a cybersecurity analysis"
+  meta_description: "An independent evaluation of Ubuntu Core’s security capabilities"
+  meta_image: "https://assets.ubuntu.com/v1/bb88c7f2-security.png"
+  meta_copydoc: "https://docs.google.com/document/d/1558Cr1tMQFtB569N08jVcjqUpk4TN460cwjfAwBm0Gs/edit"
+  header_title: "Ubuntu Core:<br>a cybersecurity analysis"
+  header_subtitle: "An independent evaluation of Ubuntu Core’s security&nbsp;capabilities"
+  header_url: "#register-section"
+  header_cta: Download report
+  header_class: p-engage-banner--grad
+  header_image: "https://assets.ubuntu.com/v1/db57e396-ubuntu-core-security.svg"
+  header_lang: fr
+  form_include: fr
+  form_id: 3550
+  form_return_url: "https://pages.ubuntu.com/CoreSecurityAudit_TY.html"
+---
+
+Manufacturers of Internet of Things (IoT) devices require an embedded operating system that is feature-rich, scalable, and &mdash; most importantly &mdash; secure. Built from the ground-up to meet these requirements, Ubuntu Core represents a comprehensive ecosystem for large-scale IoT deployments that solves many of the security challenges associated with traditional Linux distribution models &mdash; while also empowering developers with unprecedented flexibility and control.
+
+This whitepaper from global cybersecurity experts, Rule4, provides an independent, third-party evaluation of Ubuntu Core’s security capabilities. Following a data-driven approach, all aspects received extensive testing to validate the strengths of its cybersecurity controls.
+
+Read the report to learn about:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">The features and design tenets &mdash; such as application sandboxing &mdash; that make Ubuntu Core inherently secure out-of-the-box</li>
+  <li class="p-list__item is-ticked">The case for adopting Ubuntu Core for IoT devices in light of this testing</li>
+  <li class="p-list__item is-ticked">Rule4’s evaluation methodology and a summary of its results, which included no critical findings</li>
+</ul>


### PR DESCRIPTION
## Done

Built ubuntu core security audit engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/ubuntu-core-security-audit
- Check that the page matches [the brief](https://docs.google.com/spreadsheets/d/1p_0IXORPQYA4-0wFciTVFGrDLcB8Hu615hz3PYsxm4I/edit#gid=1271849439) and [the design](https://github.com/canonical-web-and-design/web-squad/issues/2453)
- Check that the form works
- Check that this page is included at the bottom of /engage


## Issue / Card

Fixes #7006 