### PR TITLE
Give the openstack comparison table scroll overflow and remove padding from expanded cells

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -537,3 +537,8 @@ summary {
 .p-accordion__tab {
   background-position: top $spv-inner--medium left $sph-inner;
 }
+
+// Local override for custom table
+.p-accordion.is-compact .p-accordion__panel {
+  padding-left: $sph-inner--small;
+}

--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -14,9 +14,9 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip" style="overflow-x: scroll;">
   <div class="row">
-    <table>
+    <table style="min-width: 800px;">
       <thead>
         <tr>
           <th></th>
@@ -28,7 +28,7 @@
       <tbody>
         <tr>
           <th>Open source</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-open-source" role="tab" aria-controls="content-open-source" aria-expanded="false">Yes</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-open-source">
               <p>The entire platform including packages and OpenStack Charms is fully open source and hosted under the governance of the OpenStack Foundation.</p>
@@ -40,7 +40,7 @@
 
         <tr>
           <th>Release cadence</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-cadence" role="tab" aria-controls="content-cadence" aria-expanded="false">6 months with an LTS every 2 years</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-cadence">
               <p>Charmed OpenStack is released every 6 months with an LTS (long-term support) release every 2 years. Upgrades between each consecutive releases are fully supported.</p>
@@ -52,7 +52,7 @@
 
         <tr>
           <th>Maximum support timeline</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-support-timeline" role="tab" aria-controls="content-support-timeline" aria-expanded="false">10 years</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-support-timeline">
               <p>Canonical provides up to 10 years of support for each LTS release of Charmed OpenStack. After that period, users can easily upgrade to the newer version to extend the support.</p>
@@ -64,7 +64,7 @@
 
         <tr>
           <th>License pricing</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-license-pricing" role="tab" aria-controls="content-license-pricing" aria-expanded="false">No license required</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-license-pricing">
               <p>There is no license required for Charmed OpenStack. It can be used free of charge. For enterprise customers, Canonical offers commercial services including consulting, support and a fully managed offering.</p>
@@ -76,7 +76,7 @@
 
         <tr>
           <th>Support pricing</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-support-pricing" role="tab" aria-controls="content-support-pricing" aria-expanded="false">Per host</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-support-pricing">
               <p>Per socket-pair pricing does not scale and can very quickly result in an inflated TCO (total cost of ownership). Canonical applies per host pricing to support and manage services to make operational costs more predictable.</p>
@@ -88,7 +88,7 @@
 
         <tr>
           <th>Availability of consulting services</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-consulting" role="tab" aria-controls="content-consulting" aria-expanded="false">Yes</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-consulting">
               <p>Canonical offers <a href="/openstack/consulting">consulting services for OpenStack</a> including design and delivery at a fixed price which helps to make deployment costs and timing more predictable.</p>
@@ -100,7 +100,7 @@
 
         <tr>
           <th>Availability of managed services</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-managed" role="tab" aria-controls="content-managed" aria-expanded="false">Yes</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-managed">
               <p>OpenStack operations may be challenging, especially for an inexperienced team. Canonical provides <a href="/openstack/managed">fully managed services for OpenStack</a> allowing to offload the risk associated with OpenStack operations.</p>
@@ -112,7 +112,7 @@
 
         <tr>
           <th>OpenStack deployment mechanism</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-deployment-mechanism" role="tab" aria-controls="content-deployment-mechanism" aria-expanded="false">Juju (model-driven deployments and operations)</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-deployment-mechanism">
               <p>Juju allows to model the entire deployment in the form of a single YAML file and execute even very complex operational tasks by running a single command.</p>
@@ -124,7 +124,7 @@
 
         <tr>
           <th>OpenStack upgrades</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-openstack-upgrades" role="tab" aria-controls="content-openstack-upgrades" aria-expanded="false">Fully automated</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-openstack-upgrades">
               <p>In Charmed OpenStack upgrades are fully automated, providing the ability to upgrade from an older OpenStack version to a newer one even in production environments.</p>
@@ -136,7 +136,7 @@
 
         <tr>
           <th>Bare-metal provisioning tool</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-bare-metal-tool" role="tab" aria-controls="content-bare-metal-tool" aria-expanded="false">MAAS</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-bare-metal-tool">
               <p><a href="https://maas.io">MAAS</a> is a bare-metal provisioning tool developed and maintained by Canonical. It is used by Charmed OpenStack, Mirantis Cloud Platform and in the OpenStack Airship project.</p>
@@ -148,7 +148,7 @@
 
         <tr>
           <th>Operating System management tool</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-os-management-tool" role="tab" aria-controls="content-os-management-tool" aria-expanded="false">Landscape</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-os-management-tool">
               <p><a href="https://landscape.canonical.com/">Landscape</a> is the leading management tool to deploy, monitor and manage Ubuntu servers.</p>
@@ -160,7 +160,7 @@
 
         <tr>
           <th>Control plane</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-control-plane" role="tab" aria-controls="content-control-plane" aria-expanded="false">Containerised</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-control-plane">
               <p>Containers bring a lot of advantages over traditional virtual machines such as better density and management capabilities. The control plane of Charmed OpenStack is fully containerised using <a href="https://linuxcontainers.org/lxd/introduction/">LXD</a> containers.</p>
@@ -172,7 +172,7 @@
 
         <tr>
           <th>Supported hypervisors</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-hypervisors" role="tab" aria-controls="content-hypervisors" aria-expanded="false">KVM, Hyper-V</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-hypervisors">
               <p>Charmed OpenStack provides support for KVM and Hyper-V hypervisors. Other hypervisors are available through the consulting services.</p>
@@ -184,7 +184,7 @@
 
         <tr>
           <th>Supported SDN platforms</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-sdn" role="tab" aria-controls="content-sdn" aria-expanded="false">OVN, OVS, Juniper Contrail, Cisco ACI, Nuage</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-sdn">
               <p>Charmed OpenStack provides support for various SDN platforms, including OVN, OVS, Juniper Contrail, Cisco ACI and Nuage. Other SDN platforms are available through the consulting services.</p>
@@ -196,7 +196,7 @@
 
         <tr>
           <th>Supported storage platforms</th>
-          <td class="p-accordion">
+          <td class="p-accordion is-compact">
             <button class="p-accordion__tab" id="tab-storage-platforms" role="tab" aria-controls="content-storage-platforms" aria-expanded="false">Ceph, SAN, Nexenta, Pure Storage, StorPool</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-storage-platforms">
               <p>Charmed OpenStack provides support for various storage platforms, including Ceph, SAN, Nexenta, Pure Storage and StorPool. Other storage platforms are available through the consulting services.</p>


### PR DESCRIPTION
## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/compare
- Check at all screen sizes including expanding the accordions
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2574

