### PR TITLE
Fix link managed-apps/contact-us

### DIFF
--- a/templates/managed-apps/index.html
+++ b/templates/managed-apps/index.html
@@ -504,7 +504,7 @@
         Our Managed Apps portfolio is constantly evolving and expanding. Speak to us today about your specific needs.
       </p>
       <p>
-        <a class="js-invoke-modal" href="/mangeed-apps/contact-us">
+        <a class="js-invoke-modal" href="/managed-apps/contact-us">
           Contact us about your unique requirements&nbsp;&rsaquo;
         </a>
       </p>


### PR DESCRIPTION
## Done

Fixes #7122
- Fix typo in link

https://github.com/canonical-web-and-design/ubuntu.com/actions/runs/68845928


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed-apps
- `ctrl-f` "Contact us about your unique requirements"
- click the link, a modal should open
