### PR TITLE
Add linkchecker tests

### DIFF
--- a/.github/workflows/external-links.yaml
+++ b/.github/workflows/external-links.yaml
@@ -1,0 +1,23 @@
+name: Links on live
+
+on:
+  schedule:
+    - cron: "30 7 * * 1"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+
+      - name: Install linkchecker
+        run: sudo apt update && sudo apt install linkchecker
+
+      - name: Run linkchecker
+        run: linkchecker --check-extern --ignore-url '.*&start=.*' --ignore-url 'https://ubuntuforums.org' --ignore-url 'https://res.cloudinary.com' --ignore-url /q_auto --ignore-url /fl_sanitize --ignore-url /w_* --ignore-url /h_* --ignore-url '/blog/*' --no-warnings http://localhost
+
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=%23web-team

--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -1,0 +1,23 @@
+name: Links on live
+
+on:
+  schedule:
+    - cron: "20 7 * * *"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+
+      - name: Install linkchecker
+        run: sudo apt update && sudo apt install linkchecker
+
+      - name: Run linkchecker
+        run: linkchecker --ignore-url '.*&start=.*' --ignore-url /q_auto --ignore-url /fl_sanitize --ignore-url /w_* --ignore-url /h_* --ignore-url /blog --no-warnings https://ubuntu.com
+
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=%23web-team

--- a/.github/workflows/master-links.yaml
+++ b/.github/workflows/master-links.yaml
@@ -1,11 +1,11 @@
-name: Check links
+name: Links in master
 
 on:
   schedule:
     - cron: "10 7 * * *"
 
 jobs:
-  run-cypress:
+  check-links:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt update && sudo apt install linkchecker
 
       - name: Run linkchecker
-        run: linkchecker --threads 0 --timeout 120 --ignore-url /usn --ignore-url /search --ignore-url ".*(?:png|jpg|jpeg|gif|bmp|svg|js)$" --ignore-url /q_auto --ignore-url /fl_sanitize --ignore-url /w_* --ignore-url /h_* --ignore-url /blog --ignore-url /server/docs --no-warnings http://127.0.0.1
+        run: linkchecker --threads 0 --timeout 120 --ignore-url /search --ignore-url /q_auto --ignore-url /fl_sanitize --ignore-url /w_* --ignore-url /h_* --ignore-url /blog --ignore-url /server/docs --no-warnings http://127.0.0.1
 
       - name: Send message on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # ![ubuntu](https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg "Ubuntu").com codebase
 
-[![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/ubuntu.com.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/ubuntu.com)
 [![Code coverage](https://codecov.io/gh/canonical-web-and-design/ubuntu.com/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/ubuntu.com)
 [![Cypress checks](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Cypress+checks%22)
+[![Links in master](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20in%20master/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+in+master%22)
+[![Links on live](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20on%20live/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+on+live%22)
+[![External links](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20on%20live/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+on+live%22)
 
 Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things. [Ubuntu.com](https://ubuntu.com) is the website that helps people learn about, download and get started with Ubuntu. This repo is the codebase and content for the [ubuntu.com](https://ubuntu.com) website.
 
@@ -18,7 +20,7 @@ If you have found a bug in the Ubuntu OS itself, the please file it [here](https
 
 The simplest way to run the site locally is using [the `dotrun` snap](https://github.com/canonical-web-and-design/dotrun/):
 
-``` bash
+```bash
 dotrun
 ```
 
@@ -29,6 +31,5 @@ For more detailed local development instructions, see [HACKING.md](HACKING.md).
 ## License
 
 The content of this project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/), and the underlying code used to format and display that content is licensed under the [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd](http://www.canonical.com/).
-
 
 With ♥ from Canonical

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Cypress checks](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Cypress+checks%22)
 [![Links in master](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20in%20master/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+in+master%22)
 [![Links on live](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20on%20live/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+on+live%22)
-[![External links](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20on%20live/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+on+live%22)
+[![External links](https://github.com/canonical-web-and-design/ubuntu.com/workflows/External%20links/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22External+links%22)
 
 Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things. [Ubuntu.com](https://ubuntu.com) is the website that helps people learn about, download and get started with Ubuntu. This repo is the codebase and content for the [ubuntu.com](https://ubuntu.com) website.
 

--- a/templates/legal/launchpad-terms-of-service.html
+++ b/templates/legal/launchpad-terms-of-service.html
@@ -13,13 +13,13 @@
       <section>
         <h2 id="trademark-and-logo">Trademark and logo licence</h2>
         <p>"<em>Launchpad</em>" and the Launchpad "Gem" logo are trademarks of Canonical Ltd.</p>
-        <p>The Launchpad "Gem" logo was created by <a class="p-link--external" href="https://launchpad.net/~etretyak">Eugene Tretyak</a> as part of the <a class="p-link--external" href="https://help.launchpad.net/logo">Launchpad Logo Contest</a>. The copyright in the Launchpad logo is owned by Canonical Ltd. and is licensed under a <a class="p-link--external" href="http://creativecommons.org/licenses/by-nd/2.0/uk/">Creative Commons Attribution-No Derivative Works 2.0 UK: England &amp; Wales License</a>.</p>
+        <p>The Launchpad "Gem" logo was created by <a class="p-link--external" href="https://launchpad.net/~etretyak">Eugene Tretyak</a> as part of the <a class="p-link--external" href="https://help.launchpad.net/logo">Launchpad Logo Contest</a>. The copyright in the Launchpad logo is owned by Canonical Ltd. and is licensed under a <a class="p-link--external" href="https://creativecommons.org/licenses/by-nd/2.0/uk/">Creative Commons Attribution-No Derivative Works 2.0 UK: England &amp; Wales License</a>.</p>
         <p>You can use one of the images from the <a class="p-link--external" href="https://help.launchpad.net/BadgeKit">Launchpad Badge Kit</a> to show that your project uses Launchpad. Canonical may revoke your permission to use these images if you make modifications to the images or use them incorrectly (e.g., on a project that does not use Launchpad.net).</p>
       </section>
 
       <section>
         <h2 id="help-dev-and-news">Help, Dev, and News Content Licence</h2>
-        <p>The documentation contained in the <a class="p-link--external" href="https://help.launchpad.net/">Launchpad Help wiki</a>, the <a class="p-link--external" href="https://dev.launchpad.net/">Launchpad Development wiki</a>, and on the <a class="p-link--external" href="http://blog.launchpad.net/">Launchpad blog</a> is owned by Canonical Ltd. and is licensed under a <a class="p-link--external" href="http://creativecommons.org/licenses/by/2.0/uk/">Creative Commons Attribution 2.0 UK: England &amp; Wales License</a>.</p>
+        <p>The documentation contained in the <a class="p-link--external" href="https://help.launchpad.net/">Launchpad Help wiki</a>, the <a class="p-link--external" href="https://dev.launchpad.net/">Launchpad Development wiki</a>, and on the <a class="p-link--external" href="http://blog.launchpad.net/">Launchpad blog</a> is owned by Canonical Ltd. and is licensed under a <a class="p-link--external" href="https://creativecommons.org/licenses/by/2.0/uk/">Creative Commons Attribution 2.0 UK: England &amp; Wales License</a>.</p>
         <p>For information about the licence of the Launchpad source code itself, please see <a class="p-link--external" href="https://dev.launchpad.net/LaunchpadLicense">LaunchpadLicense</a>.</p>
       </section>
 
@@ -83,12 +83,12 @@
           <li class="p-list__item"><a href="/licensing">Ubuntu "main" and "restricted" Component license Policy Compliant</a></li>
           <li class="p-list__item">Select Creative Commons Licenses
             <ul>
-              <li class="p-list__item"><a class="p-link--external" href="http://creativecommons.org/licenses/publicdomain/">CC PD</a></li>
-              <li class="p-list__item"><a class="p-link--external" href="http://creativecommons.org/licenses/by/3.0/">CC-BY</a></li>
-              <li class="p-list__item"><a class="p-link--external" href="http://creativecommons.org/licenses/by-nd/3.0/">CC BY-ND</a></li>
-              <li class="p-list__item"><a class="p-link--external" href="http://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC</a></li>
-              <li class="p-list__item"><a class="p-link--external" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">CC BY-NC-SA</a></li>
-              <li class="p-list__item"><a class="p-link--external" href="http://creativecommons.org/licenses/by-nc-nd/3.0/">CC BY-NC-ND</a></li>
+              <li class="p-list__item"><a class="p-link--external" href="https://creativecommons.org/licenses/publicdomain/">CC PD</a></li>
+              <li class="p-list__item"><a class="p-link--external" href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a></li>
+              <li class="p-list__item"><a class="p-link--external" href="https://creativecommons.org/licenses/by-nd/3.0/">CC BY-ND</a></li>
+              <li class="p-list__item"><a class="p-link--external" href="https://creativecommons.org/licenses/by-nc/3.0/">CC BY-NC</a></li>
+              <li class="p-list__item"><a class="p-link--external" href="https://creativecommons.org/licenses/by-nc-sa/3.0/">CC BY-NC-SA</a></li>
+              <li class="p-list__item"><a class="p-link--external" href="https://creativecommons.org/licenses/by-nc-nd/3.0/">CC BY-NC-ND</a></li>
             </ul>
           </li>
         </ul>

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -79,7 +79,7 @@
         Common Criteria is an internationally recognized set of standards used by Federal agencies, financial institutions and many other organizations dealing with sensitive data. The evaluation was performed on Intel x86_64, IBM Power8 and IBM Z hardware platforms.
       </p>
       <p>
-        <a class="p-link--external" href="http://fmv.se/Global/Bilder/Verksamhet/CSEC/Certification%20Report%20Ubuntu%20LTS%2016.04.4.pdf">Read the CSEC certification report</a>
+        <a class="p-link--external" href="https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20Ubuntu%20LTS%2016.04.4.pdf">Read the CSEC certification report</a>
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -99,7 +99,7 @@
         <p>If you are just looking for some free support for yourself, you can try:</p>
         <ul class="p-list--divided">
           <li class="p-list__item"><a class="p-link--external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
-          <li class="p-list__item"><a class="p-link--external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>
+          <li class="p-list__item"><a class="p-link--external" href="https://ubuntuforums.org/">The Ubuntu forum</a></li>
           <li class="p-list__item"><a class="p-link--external" href="https://help.ubuntu.com/">Help docs</a></li>
         </ul>
       </div>

--- a/templates/shared/forms/_desktop_help.html
+++ b/templates/shared/forms/_desktop_help.html
@@ -3,7 +3,7 @@
   <p>If you are just looking for some free support for yourself, you can try:</p>
   <ul class="p-list">
     <li class="p-list__item"><a class="p-link--external" href="http://askubuntu.com/">Ask Ubuntu</a></li>
-    <li class="p-list__item"><a class="p-link--external" href="http://ubuntuforums.org/">The Ubuntu forum</a></li>
+    <li class="p-list__item"><a class="p-link--external" href="https://ubuntuforums.org/">The Ubuntu forum</a></li>
     <li class="p-list__item"><a class="p-link--external" href="https://help.ubuntu.com/">Help docs</a></li>
   </ul>
 </div>


### PR DESCRIPTION
I've added the following scheduled checks, and added badges for them to the README.

- "Links in master": Check internal links against master branch
   - Run daily at 7:10
- "Links on live": Check internal links on https://ubuntu.com
   - Run daily at 7:20
- "External links": Check external links from https://ubuntu.com
   - Run weekly at 7:30 on Monday

The "external links" check fails and shows many existing 404s. I can't fix them all in this branch, so we should address this when we can. Fortunately we'll be reminded every Monday ;)

I've fixed about a million 404s from tutorials and server docs, and I've fixed some from this codebase, but there are definitely quite a few more.

QA
--

Don't think this can really be QAed, more than reading the code. We'll just have to see how it goes when we merge it.