### PR TITLE
Add endpoints for renewals

### DIFF
--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -129,3 +129,21 @@ def get_renewal(session, renewal_id):
         )
 
     return response.json()
+
+
+def accept_renewal(session, renewal_id):
+    try:
+        response = _send(
+            _prepare_request(
+                method="post",
+                path=f"v1/renewals/{renewal_id}/acceptance",
+                session=session,
+            )
+        )
+    except HTTPError as e:
+        return (
+            {"method": e.response.text, "status_code": e.response.status_code},
+            e.response.status_code,
+        )
+
+    return response.json()

--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -94,13 +94,13 @@ def get_contract_machines(contract, session):
     return payload
 
 
-def post_method_id(session, account_id, stripe_method_id):
+def put_method_id(session, account_id, payment_method_id):
     try:
         response = _send(
             _prepare_request(
-                method="post",
+                method="put",
                 path=f"v1/accounts/{account_id}/payment-method/stripe",
-                data={"paymentMethodID": stripe_method_id},
+                data={"paymentMethodID": payment_method_id},
                 session=session,
             )
         )

--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -2,6 +2,7 @@ import os
 
 from requests import Request, Session
 from pymacaroons import Macaroon
+from requests.exceptions import HTTPError
 
 from webapp.macaroons import binary_serialize_macaroons
 
@@ -91,3 +92,40 @@ def get_contract_machines(contract, session):
 
     payload = response.json()
     return payload
+
+
+def post_method_id(session, account_id, stripe_method_id):
+    try:
+        response = _send(
+            _prepare_request(
+                method="post",
+                path=f"v1/accounts/{account_id}/payment-method/stripe",
+                data={"paymentMethodID": stripe_method_id},
+                session=session,
+            )
+        )
+    except HTTPError as e:
+        return (
+            {"method": e.response.text, "status_code": e.response.status_code},
+            e.response.status_code,
+        )
+
+    return response.json()
+
+
+def get_renewal(session, renewal_id):
+    try:
+        response = _send(
+            _prepare_request(
+                method="get",
+                path=f"v1/renewals/{renewal_id}",
+                session=session,
+            )
+        )
+    except HTTPError as e:
+        return (
+            {"method": e.response.text, "status_code": e.response.status_code},
+            e.response.status_code,
+        )
+
+    return response.json()

--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -2,7 +2,6 @@ import os
 
 from requests import Request, Session
 from pymacaroons import Macaroon
-from requests.exceptions import HTTPError
 
 from webapp.macaroons import binary_serialize_macaroons
 
@@ -95,55 +94,35 @@ def get_contract_machines(contract, session):
 
 
 def put_method_id(session, account_id, payment_method_id):
-    try:
-        response = _send(
-            _prepare_request(
-                method="put",
-                path=f"v1/accounts/{account_id}/payment-method/stripe",
-                data={"paymentMethodID": payment_method_id},
-                session=session,
-            )
+    response = _send(
+        _prepare_request(
+            method="put",
+            path=f"v1/accounts/{account_id}/payment-method/stripe",
+            data={"paymentMethodID": payment_method_id},
+            session=session,
         )
-    except HTTPError as e:
-        return (
-            {"method": e.response.text, "status_code": e.response.status_code},
-            e.response.status_code,
-        )
+    )
 
     return response.json()
 
 
 def get_renewal(session, renewal_id):
-    try:
-        response = _send(
-            _prepare_request(
-                method="get",
-                path=f"v1/renewals/{renewal_id}",
-                session=session,
-            )
+    response = _send(
+        _prepare_request(
+            method="get", path=f"v1/renewals/{renewal_id}", session=session,
         )
-    except HTTPError as e:
-        return (
-            {"method": e.response.text, "status_code": e.response.status_code},
-            e.response.status_code,
-        )
+    )
 
     return response.json()
 
 
 def accept_renewal(session, renewal_id):
-    try:
-        response = _send(
-            _prepare_request(
-                method="post",
-                path=f"v1/renewals/{renewal_id}/acceptance",
-                session=session,
-            )
+    response = _send(
+        _prepare_request(
+            method="post",
+            path=f"v1/renewals/{renewal_id}/acceptance",
+            session=session,
         )
-    except HTTPError as e:
-        return (
-            {"method": e.response.text, "status_code": e.response.status_code},
-            e.response.status_code,
-        )
+    )
 
     return response.json()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -40,7 +40,7 @@ from webapp.views import (
     blog_press_centre,
     download_thank_you,
     get_renewal,
-    post_stripe_method_id,
+    put_stripe_method_id,
     releasenotes_redirect,
 )
 from webapp.login import login_handler, logout
@@ -117,8 +117,8 @@ def utility_processor():
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule(
     "/advantage/payment-method",
-    view_func=post_stripe_method_id,
-    methods=["POST"],
+    view_func=put_stripe_method_id,
+    methods=["PUT"],
 )
 app.add_url_rule(
     "/advantage/renewal", view_func=get_renewal, methods=["POST"],

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -40,7 +40,7 @@ from webapp.views import (
     blog_press_centre,
     download_thank_you,
     get_renewal,
-    put_stripe_method_id,
+    post_stripe_method_id,
     releasenotes_redirect,
 )
 from webapp.login import login_handler, logout
@@ -117,15 +117,17 @@ def utility_processor():
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule(
     "/advantage/payment-method",
-    view_func=put_stripe_method_id,
-    methods=["PUT"],
+    view_func=post_stripe_method_id,
+    methods=["POST"],
 )
 app.add_url_rule(
-    "/advantage/renewal", view_func=get_renewal, methods=["POST"],
+    "/advantage/renewals/{renewal_id}", view_func=get_renewal, methods=["GET"],
 )
 
 app.add_url_rule(
-    "/advantage/accept-renewal", view_func=accept_renewal, methods=["POST"],
+    "/advantage/renewals/{renewal_id}/process-payment",
+    view_func=accept_renewal,
+    methods=["POST"],
 )
 app.add_url_rule(
     (

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -38,6 +38,8 @@ from webapp.views import (
     blog_custom_topic,
     blog_press_centre,
     download_thank_you,
+    get_renewal,
+    post_stripe_method_id,
     releasenotes_redirect,
 )
 from webapp.login import login_handler, logout
@@ -112,6 +114,14 @@ def utility_processor():
 
 # Simple routes
 app.add_url_rule("/advantage", view_func=advantage_view)
+app.add_url_rule(
+    "/advantage/payment-method",
+    view_func=post_stripe_method_id,
+    methods=["POST"],
+)
+app.add_url_rule(
+    "/advantage/renewal", view_func=get_renewal, methods=["POST"],
+)
 app.add_url_rule(
     (
         "/download"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -32,6 +32,7 @@ from webapp.context import (
     releases,
 )
 from webapp.views import (
+    accept_renewal,
     advantage_view,
     blog_blueprint,
     blog_custom_group,
@@ -121,6 +122,10 @@ app.add_url_rule(
 )
 app.add_url_rule(
     "/advantage/renewal", view_func=get_renewal, methods=["POST"],
+)
+
+app.add_url_rule(
+    "/advantage/accept-renewal", view_func=accept_renewal, methods=["POST"],
 )
 app.add_url_rule(
     (

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -225,6 +225,40 @@ def advantage_view():
     )
 
 
+def post_stripe_method_id():
+    if auth.is_authenticated(flask.session):
+        if not flask.request.is_json:
+            return flask.jsonify({"error": "JSON required"}), 400
+
+        stripe_method_id = flask.request.json.get("stripe_method_id")
+        if not stripe_method_id:
+            return flask.jsonify({"error": "stripe_method_id required"}), 400
+
+        account_id = flask.request.json.get("account_id")
+        if not account_id:
+            return flask.jsonify({"error": "account_id required"}), 400
+
+        return advantage.post_method_id(
+            flask.session, stripe_method_id, account_id
+        )
+    else:
+        return flask.jsonify({"error": "authentication required"}), 401
+
+
+def get_renewal():
+    if auth.is_authenticated(flask.session):
+        if not flask.request.is_json:
+            return flask.jsonify({"error": "JSON required"}), 400
+
+        renewal_id = flask.request.json.get("renewal_id")
+        if not renewal_id:
+            return flask.jsonify({"error": "renewal_id required"}), 400
+
+        return advantage.get_renewal(flask.session, renewal_id)
+    else:
+        return flask.jsonify({"error": "authentication required"}), 401
+
+
 # Blog
 # ===
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -225,21 +225,21 @@ def advantage_view():
     )
 
 
-def post_stripe_method_id():
+def put_stripe_method_id():
     if auth.is_authenticated(flask.session):
         if not flask.request.is_json:
             return flask.jsonify({"error": "JSON required"}), 400
 
-        stripe_method_id = flask.request.json.get("stripe_method_id")
-        if not stripe_method_id:
-            return flask.jsonify({"error": "stripe_method_id required"}), 400
+        payment_method_id = flask.request.json.get("payment_method_id")
+        if not payment_method_id:
+            return flask.jsonify({"error": "payment_method_id required"}), 400
 
         account_id = flask.request.json.get("account_id")
         if not account_id:
             return flask.jsonify({"error": "account_id required"}), 400
 
-        return advantage.post_method_id(
-            flask.session, stripe_method_id, account_id
+        return advantage.put_method_id(
+            flask.session, payment_method_id, account_id
         )
     else:
         return flask.jsonify({"error": "authentication required"}), 401

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -245,21 +245,15 @@ def post_stripe_method_id():
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def get_renewal(renewal_id=""):
+def get_renewal(renewal_id):
     if auth.is_authenticated(flask.session):
-        if not renewal_id:
-            return flask.jsonify({"error": "renewal_id required"}), 400
-
         return advantage.get_renewal(flask.session, renewal_id)
     else:
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def accept_renewal(renewal_id=""):
+def accept_renewal(renewal_id):
     if auth.is_authenticated(flask.session):
-        if not renewal_id:
-            return flask.jsonify({"error": "renewal_id required"}), 400
-
         return advantage.accept_renewal(flask.session, renewal_id)
     else:
         return flask.jsonify({"error": "authentication required"}), 401

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -239,7 +239,7 @@ def put_stripe_method_id():
             return flask.jsonify({"error": "account_id required"}), 400
 
         return advantage.put_method_id(
-            flask.session, payment_method_id, account_id
+            flask.session, account_id, payment_method_id
         )
     else:
         return flask.jsonify({"error": "authentication required"}), 401

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -259,6 +259,20 @@ def get_renewal():
         return flask.jsonify({"error": "authentication required"}), 401
 
 
+def accept_renewal():
+    if auth.is_authenticated(flask.session):
+        if not flask.request.is_json:
+            return flask.jsonify({"error": "JSON required"}), 400
+
+        renewal_id = flask.request.json.get("renewal_id")
+        if not renewal_id:
+            return flask.jsonify({"error": "renewal_id required"}), 400
+
+        return advantage.accept_renewal(flask.session, renewal_id)
+    else:
+        return flask.jsonify({"error": "authentication required"}), 401
+
+
 # Blog
 # ===
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -225,7 +225,7 @@ def advantage_view():
     )
 
 
-def put_stripe_method_id():
+def post_stripe_method_id():
     if auth.is_authenticated(flask.session):
         if not flask.request.is_json:
             return flask.jsonify({"error": "JSON required"}), 400
@@ -245,12 +245,8 @@ def put_stripe_method_id():
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def get_renewal():
+def get_renewal(renewal_id=""):
     if auth.is_authenticated(flask.session):
-        if not flask.request.is_json:
-            return flask.jsonify({"error": "JSON required"}), 400
-
-        renewal_id = flask.request.json.get("renewal_id")
         if not renewal_id:
             return flask.jsonify({"error": "renewal_id required"}), 400
 
@@ -259,12 +255,8 @@ def get_renewal():
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def accept_renewal():
+def accept_renewal(renewal_id=""):
     if auth.is_authenticated(flask.session):
-        if not flask.request.is_json:
-            return flask.jsonify({"error": "JSON required"}), 400
-
-        renewal_id = flask.request.json.get("renewal_id")
         if not renewal_id:
             return flask.jsonify({"error": "renewal_id required"}), 400
 


### PR DESCRIPTION
## Done

In every endpoint send the session so we can  authenticate the user. 

- Add endpoints:
  - Set payment method for account
```
Returns what is returned by the API: 
POST /advantage/payment-method
{
  "stripe_method_id": "<STRIPE_METHOD_ID>",
  "account_id": "<ACCOUNT_ID>"
}
```
   - Accept renewal
```
POST      /advantage/renewals/{renewal_id}/process-payment
```
   - Get renewal (returns what is returned by https://github.com/CanonicalLtd/ua-contracts/blob/develop/docs/contracts.yaml#L2187 )
```
GET     /advantage/renewals/{renewal_id}
```


Basically the flow that we need:
- setup an payment method linked to an account (via modal or whatever) -> so one POST to the first api  (`/advantage/payment-method`)
- Open a renewal that needs to be processed
- Accept the renewal (or press pay) (`/advantage/accept-renewal`)
- Those first steps could be done when approving the payment (2 calls in a row)
- Go to a view that display the status of the payment. To do that request every 5 seconds ` /advantage/renewal`