### PR TITLE
Add Azure to public cloud page

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -151,7 +151,7 @@
             image(
               url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
               alt="AWS",
-              height="125",
+              height="67",
               width="210",
               hi_def=True,
               loading="lazy",

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -152,7 +152,7 @@
               url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
               alt="AWS",
               height="67",
-              width="210",
+              width="112",
               hi_def=True,
               loading="lazy",
             ) | safe

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -23,25 +23,19 @@
 
 <section class="p-strip--light is-deep is-bordered">
   <div class="row u-equal-height">
-    <div class="col-6 p-card">
+    <div class="col-4 p-card">
       <h2>Ubuntu Server on public cloud</h2>
       <p>
         <ul class="p-list">
+          <li class="p-list__item is-ticked">Maintenance and security updates guaranteed for five years with Ubuntu LTS</li>
+          <li class="p-list__item is-ticked">Enterprise-grade support and management tools available direct from Canonical</li>
           <li class="p-list__item is-ticked">Proven for enterprise-scale workloads on all leading public clouds</li>
           <li class="p-list__item is-ticked">Free from licence fees, regardless of how many images you run</li>
-          <li class="p-list__item is-ticked">Enterprise-grade support and management tools available direct from Canonical</li>
-          <li class="p-list__item is-ticked">Maintenance and security updates guaranteed for five years with Ubuntu LTS</li>
         </ul>
-      </p>
-
-      <p>
-        <a href="/blog/certified-ubuntu-cloud-guest-the-best-of-ubuntu-on-the-best-clouds" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Get the Ubuntu cloud guest whitepaper', 'eventLabel' : 'from ubuntu.com/public-cloud', 'eventValue' : undefined });">
-          Get the Ubuntu cloud guest whitepaper&nbsp;&rsaquo;
-        </a>
       </p>
     </div>
 
-    <div class="col-6 p-card">
+    <div class="col-8 p-card">
       <h2>Ubuntu Pro on public cloud</h2>
       <p>
         <ul class="p-list">
@@ -51,19 +45,25 @@
           <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
         </ul>
       </p>
-
-      <p>
-        <a class="p-link--external" href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf">Get the Ubuntu Pro datasheet</a>
-      </p>
-
-      <p>
-        <a class="p-button--positive" href="/aws/pro">Learn more about Ubuntu Pro on AWS</a>
-      </p>
+      <div class="row">
+        <div class="col-4">
+          <p>
+            <a class="p-link--external" href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf">Get the Ubuntu Pro for AWS datasheet</a>
+          </p>
+          <a class="p-button--positive" href="/aws/pro">Learn about Ubuntu Pro for AWS</a>
+        </div>
+        <div class="col-4">
+          <p>
+            <a class="p-link--external" href="https://assets.ubuntu.com/v1/27a386bc-Ubuntu_Pro_Azure_03.04.20.pdf">Get the Ubuntu Pro for Azure datasheet</a>
+          </p>
+          <a class="p-button--positive" href="/azure/pro">Learn about Ubuntu Pro for Azure</a>
+        </div>
+      </div>
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <p class="p-heading--six"><em>18.04 LTS certifications are in-progress and will be available Q1 2020. Certified components and kernel live patches are not available for Ubuntu 14.04 LTS.</em></p>
+    <p class="p-heading--six"><em>18.04 LTS certifications are in-progress and will be available Q2 2020. Certified components and kernel live patches are not available for Ubuntu 14.04 LTS.</em></p>
   </div>
 </section>
 
@@ -130,30 +130,47 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="col-8">
+    <div class="col-6">
       <h2>Ready to get started?</h2>
       <p>Ubuntu Pro for AWS is a premium image designed by Canonical to provide the most comprehensive feature set for production environments running in the public cloud.</p>
       <p>
-        <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">Launch Ubuntu Pro 18.04 LTS on AWS</a>
+        <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">Launch Ubuntu Pro 18.04 LTS for AWS</a>
       </p>
-
+      <p>
+        <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview">Launch Ubuntu Pro 18.04 LTS for Azure</a>
+      </p>
       <p>Ubuntu Server {{ releases.lts.short_version }} LTS is a free download that includes five years worth of  security and maintenance updates, guaranteed. Using an Ubuntu partner cloud ensures access to the latest certified Ubuntu cloud images. To run Ubuntu as guest on participating public clouds, the simplest way is to use the image maintained on their server.</p>
       <p>
         <a class="p-button--positive" href="/download/cloud">Start using Ubuntu today</a>
       </p>
     </div>
-
-    <div class="col-4 u-hide--small u-vertically-center u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
-          alt="",
-          height="125",
-          width="210",
-          hi_def=True,
-          loading="lazy",
-        ) | safe
-      }}
+    <div class="col-6 u-vertically-center">
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+              alt="AWS",
+              height="125",
+              width="210",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
+        </li>
+        <li class="p-inline-images__item">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
+              alt="Microsoft Azure",
+              width="350",
+              height="100",
+              hi_def=True,
+              loading="auto",
+            ) | safe
+          }}
+        </li>
+      </ul>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated the /public-cloud page to include Azure

[Copydoc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit#)

*Note for design*: I've taken some liberties with the styling of the row that contains "Ubuntu Pro on public cloud" as the content on the right-hand column has increased significantly. Feel free to suggest alternative layouts.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #2589