### PR TITLE
Add rule4 takeover.

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -959,8 +959,7 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
-  </div>
-  <div class="row u-equal-height u-clearfix">
+
     {% with title="A guide to a successful OpenStack adoption and deployment",
       description="Discover Canonical’s proven OpenStack implementation process",
       slug="charmed-openstack-adoption-whitepaper",

--- a/templates/engage/ubuntu-core-security-audit.md
+++ b/templates/engage/ubuntu-core-security-audit.md
@@ -7,14 +7,9 @@ context:
   meta_copydoc: "https://docs.google.com/document/d/1558Cr1tMQFtB569N08jVcjqUpk4TN460cwjfAwBm0Gs/edit"
   header_title: "Ubuntu Core:<br>a cybersecurity analysis"
   header_subtitle: "An independent evaluation of Ubuntu Core’s security&nbsp;capabilities"
-  header_url: "#register-section"
-  header_cta: Download report
   header_class: p-engage-banner--grad
   header_image: "https://assets.ubuntu.com/v1/db57e396-ubuntu-core-security.svg"
   header_lang: en
-  form_include: en
-  form_id: 3550
-  form_return_url: "https://pages.ubuntu.com/CoreSecurityAudit_TY.html"
 ---
 
 Manufacturers of Internet of Things (IoT) devices require an embedded operating system that is feature-rich, scalable, and &mdash; most importantly &mdash; secure. Built from the ground-up to meet these requirements, Ubuntu Core represents a comprehensive ecosystem for large-scale IoT deployments that solves many of the security challenges associated with traditional Linux distribution models &mdash; while also empowering developers with unprecedented flexibility and control.
@@ -28,3 +23,5 @@ Read the report to learn about:
   <li class="p-list__item is-ticked">The case for adopting Ubuntu Core for IoT devices in light of this testing</li>
   <li class="p-list__item is-ticked">Rule4’s evaluation methodology and a summary of its results, which included no critical findings</li>
 </ul>
+
+<a href="https://pages.ubuntu.com/rs/066-EOV-335/images/R4_Canonical_Ubuntu_Core_White_Paper_2020-01-14_v1.1%20%281%29.pdf" class="p-button--positive">Download report</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,6 +45,8 @@
   {% include "takeovers/_smart-start-webinar.html" %}
   {% include "takeovers/_anbox-cloud-webinar.html" %}
   {% include "takeovers/_charmed-openstack-adoption.html" %}
+  {% include "takeovers/_rule4-core-cybersecurity.html" %}
+
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_rule4-core-cybersecurity.html
+++ b/templates/takeovers/_rule4-core-cybersecurity.html
@@ -1,0 +1,16 @@
+{% with title="Ubuntu Core: a cybersecurity analysis",
+subtitle="An independent evaluation of Ubuntu Core’s security capabilities",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/db57e396-ubuntu-core-security.svg",
+image_height="250",
+image_width="250",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/ubuntu-core-security-audit?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_IOT_Core_Whitepaper_CoreSecurityAudit",
+primary_cta="Download report",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -118,4 +118,6 @@
 {% include "takeovers/fr/_vmware-to-charmed-openstack_french.html" %}
 <p>30th Mar 2020</p>
 {% include "takeovers/_charmed-openstack-adoption.html" %}
+<p>06 Apr 2020</p>
+{% include "takeovers/_rule4-core-cybersecurity.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Added a new takeover for the Rule4 core cybersecurity report
- Modified the existing engage page to remove the form and add a direct link to the PDF
- Fixed some incorrect markup on the /engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Refresh until you get the "Ubuntu Core: a cybersecurity analysis" takeover
- Check that the takeover looks good at all viewports
- Click the CTA
- Check that the engage page looks good and that the "Download report" button works
- Check the last row on http://0.0.0.0:8001/engage is displaying correctly
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/2596