### PR TITLE
Removed takeovers from rotation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -41,9 +41,6 @@
 
   {# ALL #}
   {% include "takeovers/_cloud-cost-analysis.html" %}
-  {% include "takeovers/_451-microk8s.html" %}
-  {% include "takeovers/_smart-start-webinar.html" %}
-  {% include "takeovers/_anbox-cloud-webinar.html" %}
   {% include "takeovers/_charmed-openstack-adoption.html" %}
   {% include "takeovers/_rule4-core-cybersecurity.html" %}
 


### PR DESCRIPTION
I removed   451-microk8s, smart-start-webinar and anbox-cloud-webinar

## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
