### PR TITLE
Use ubuntu-release-info

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ marshmallow==3.5.1
 mistune==0.8.4
 psycopg2-binary==2.8.4
 pyyaml==5.3.1
+ubuntu-release-info==20.1
 
 # This should be removed once we update to canonicalwebteam.http 1.0.2
 httpretty==1.0.2

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -8,6 +8,7 @@ import dateutil.parser
 import feedparser
 import flask
 import pytz
+from ubuntu_release_info.data import Data
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
 from geolite2 import geolite2
@@ -82,29 +83,21 @@ def releasenotes_redirect():
     Old apache redirects: https://pastebin.canonical.com/p/3TXyyNkWkg/
     """
 
-    releaseName = {
-        "12.04": "PrecisePangolin",
-        "12.10": "QuantalQuetzal",
-        "13.04": "RaringRingtail",
-        "13.10": "SaucySalamander",
-        "14.04": "TrustyTahr",
-        "14.10": "UtopicUnicorn",
-        "15.04": "VividVervet",
-        "15.10": "WilyWerewolf",
-        "16.10": "YakketyYak",
-        "17.04": "ZestyZapus",
-        "17.10": "ArtfulAardvark",
-    }
+    version = flask.request.args.get("ver", "")[:5]
 
-    ver = flask.request.args.get("ver")[:5]
+    for codename, release in Data().releases.items():
+        short_version = ".".join(release.version.split(".")[:2])
+        if version == short_version:
+            full_codename = (
+                re.match(r".*\((.*)\)$", release.name)
+                .groups()[0]
+                .replace(" ", "")
+            )
+            return flask.redirect(
+                f"https://wiki.ubuntu.com/{full_codename}/ReleaseNotes"
+            )
 
-    if ver in releaseName:
-        ver = releaseName[ver]
-
-    if ver:
-        return flask.redirect(f"https://wiki.ubuntu.com/{ver}/ReleaseNotes")
-    else:
-        return flask.redirect(f"https://wiki.ubuntu.com/Releases")
+    return flask.redirect(f"https://wiki.ubuntu.com/Releases")
 
 
 def advantage_view():


### PR DESCRIPTION
QA
--

```
dotrun serve &
curl http://localhost:8001/getubuntu/releasenotes?ver=12.04.4
curl http://localhost:8001/getubuntu/releasenotes  # no arguments
curl http://localhost:8001/getubuntu/releasenotes?ver=18.04
```

^ Check curl always wants to redirect you somewhere sensible.