### PR TITLE
Handle UA renewal urls

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -88,16 +88,23 @@
         <tbody>
           {% for contract in enterprise_contracts[account] %}
           {% if contract["contractInfo"]["status"] != 'expired' %}
+          
+          {% if not open_subscription and (loop.index ==1 and outer_loop.index == 1) %}
+            {% set default_open_cell = true %}
+          {% else %}
+            {% set default_open_cell = false %}
+          {% endif %}
+          
           <tr class="p-table__row">
-            <td>
+            <td{% if open_subscription == contract['contractInfo']['id'] %} class="p-table--open"{% endif %}>
               <button class="u-toggle u-align--left u-no-padding--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                  {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
+                  {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu {% if open_subscription == contract['contractInfo']['id']%}u-rotate{% endif %}">Open</i>
               </button>
             </td>
             <td style="text-transform: capitalize"><span class="u-truncate" style="padding-top:.35rem;">{{ contract['supportLevel'] }}</span></td>
-            <td class="u-align--center {% if loop.index == 1 and outer_loop.index == 1 %}p-table--open{% endif %}">
-              <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if loop.index == 1 and outer_loop.index == 1 %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
-                {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if loop.index == 1 and outer_loop.index == 1 %}u-rotate{% endif %}">Open</i>
+            <td class="u-align--center {% if default_open_cell %}p-table--open{% endif %}">
+              <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if default_cell_open %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
+                {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if default_open_cell %}u-rotate{% endif %}">Open</i>
               </button>
             </td>
 
@@ -138,7 +145,7 @@
               {% endif %}
             </td>
 
-            <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+            <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
               <div class="row">
                 <div class="col-12 u-align--center">
                   <table class="p-table--advantage-contract">
@@ -157,7 +164,7 @@
               </div>
             </td>
 
-            <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if loop.index == 1 and outer_loop.index == 1 %}false{% else %}true{% endif %}">
+            <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if default_open_cell %}false{% else %}true{% endif %}">
               <div class="row">
                 <div class="col-12 u-align--center">
                   To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -100,8 +100,7 @@ def advantage_view():
     open_subscription = flask.request.args.get("subscription", None)
 
     if not auth.is_authenticated(flask.session) and open_subscription:
-        redirect_url = urllib.parse.quote(f"{flask.request.full_path}")
-        return flask.redirect(f"/login?next={redirect_url}")
+        return flask.redirect(f"/login?next={flask.request.full_path}")
 
     if auth.is_authenticated(flask.session):
         try:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import urllib.parse
 
 # Packages
 import dateutil.parser
@@ -96,6 +97,11 @@ def advantage_view():
     enterprise_contracts = {}
     entitlements = {}
     openid = flask.session.get("openid")
+    open_subscription = flask.request.args.get("subscription", None)
+
+    if not auth.is_authenticated(flask.session) and open_subscription:
+        redirect_url = urllib.parse.quote(f"{flask.request.full_path}")
+        return flask.redirect(f"/login?next={redirect_url}")
 
     if auth.is_authenticated(flask.session):
         try:
@@ -220,6 +226,7 @@ def advantage_view():
             accounts=accounts,
             enterprise_contracts=enterprise_contracts,
             personal_account=personal_account,
+            open_subscription=open_subscription,
         ),
         {"Cache-Control": "private"},
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,7 +2,6 @@
 import json
 import os
 import re
-import urllib.parse
 
 # Packages
 import dateutil.parser


### PR DESCRIPTION
## Done

- Added extra conditions for opening the table cells if a subscription is passed
- Added a login redirect if a subscription ID is provided but the user is not authenticated

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Logout of SSO
  - Visit http://0.0.0.0:8001/advantage?subscription=<id>
  - You should be redirected to login
  - Log in
  - You should be redirected to http://0.0.0.0:8001/advantage?subscription=<id>
- While logged in visit http://0.0.0.0:8001/advantage?subscription=<id>

Try ID: cAM3HMVaKsoTuMVdhGK5lWnQej0GlnuqufQNI0tlz58s

## Issue / Card

Fixes: https://github.com/canonical-web-and-design/web-squad/issues/2582
Fixes: https://github.com/canonical-web-and-design/web-squad/issues/2583
