### PR TITLE
Add subnav for azure

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1,3 +1,19 @@
+azure:
+  title: Azure
+  path: /azure
+
+  children:
+    - title: Overview
+      path: /azure
+    - title: Pro
+      path: /azure/pro
+    - title: Contact us
+      path: /azure/contact-us
+      hidden: True
+    - title: Thank you
+      path: /azure/thank-you
+      hidden: True
+
 aws:
   title: AWS
   path: /aws


### PR DESCRIPTION
## Done

Added subnav to /azure

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure and see the subnav
- Test the links
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

