### PR TITLE
Update ubuntu-release-info to get full_codename

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ marshmallow==3.5.1
 mistune==0.8.4
 psycopg2-binary==2.8.4
 pyyaml==5.3.1
-ubuntu-release-info==20.1
+ubuntu-release-info==20.2
 
 # This should be removed once we update to canonicalwebteam.http 1.0.2
 httpretty==1.0.2

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -88,13 +88,10 @@ def releasenotes_redirect():
     for codename, release in Data().releases.items():
         short_version = ".".join(release.version.split(".")[:2])
         if version == short_version:
-            full_codename = (
-                re.match(r".*\((.*)\)$", release.name)
-                .groups()[0]
-                .replace(" ", "")
-            )
+            release_slug = release.full_codename.replace(" ", "")
+
             return flask.redirect(
-                f"https://wiki.ubuntu.com/{full_codename}/ReleaseNotes"
+                f"https://wiki.ubuntu.com/{release_slug}/ReleaseNotes"
             )
 
     return flask.redirect(f"https://wiki.ubuntu.com/Releases")


### PR DESCRIPTION
v20.2 of ubuntu-release-info incorporates [this PR](https://github.com/powersj/ubuntu-release-info/pull/3) to provide full_codename, so we don't need to use regex.

QA
--

`dotrun`, go to e.g. http://0.0.0.0:8001/getubuntu/releasenotes?os=ubuntu&ver=17.04.4&lang=en and check it still redirects you to the right release notes.