### PR TITLE
Security API authentication & proof of concept

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 ADVANTAGE_API=https://contracts.staging.canonical.com/
 DATABASE_URL=sqlite:///usn.sqlite3
+SECRET_KEY=insecure_dev_key
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,5 @@ mistune==0.8.4
 psycopg2-binary==2.8.4
 pyyaml==5.3.1
 ubuntu-release-info==20.2
-
-# This should be removed once we update to canonicalwebteam.http 1.0.2
-httpretty==1.0.2
+launchpadlib==1.10.10
+macaroonbakery==1.3.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -49,8 +49,8 @@ from webapp.security.views import (
     notice,
     notices,
     notices_feed,
+    api_create_notice,
 )
-
 
 CAPTCHA_TESTING_API_KEY = os.getenv(
     "CAPTCHA_TESTING_API_KEY", "6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
@@ -121,7 +121,7 @@ app.add_url_rule(
     methods=["POST"],
 )
 app.add_url_rule(
-    "/advantage/renewals/{renewal_id}", view_func=get_renewal, methods=["GET"],
+    "/advantage/renewals/{renewal_id}", view_func=get_renewal, methods=["GET"]
 )
 
 app.add_url_rule(
@@ -157,11 +157,10 @@ app.register_blueprint(blog_blueprint, url_prefix="/blog")
 # usn section
 app.add_url_rule("/security/notices", view_func=notices)
 app.add_url_rule("/security/notices/<feed_type>.xml", view_func=notices_feed)
-# app.add_url_rule(
-#     "/security/notices", view_func=api_create_notice, methods=["POST"]
-# )
+app.add_url_rule(
+    "/security/notices", view_func=api_create_notice, methods=["POST"]
+)
 app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
-
 
 # Login
 app.add_url_rule("/login", methods=["GET", "POST"], view_func=login_handler)

--- a/webapp/security/auth.py
+++ b/webapp/security/auth.py
@@ -1,0 +1,109 @@
+# Standard library
+from datetime import datetime, timedelta
+
+# Packages
+import flask
+from launchpadlib.launchpad import Launchpad
+from macaroonbakery import bakery, checkers, httpbakery
+
+
+AUTHORIZED_TEAMS = ["canonical-security", "canonical-webmonkeys"]
+IDENTITY_CAVEATS = [
+    checkers.need_declared_caveat(
+        checkers.Caveat(
+            location="https://api.jujucharms.com/identity",
+            condition="is-authenticated-user",
+        ),
+        ["username"],
+    )
+]
+
+
+class Identity(bakery.Identity):
+    """Identity information for a Candid third party caveat."""
+
+    def __init__(self, identity):
+        parts = identity.split("@", 1)
+        self._username = parts[0]
+        self._domain = parts[1] if len(parts) == 2 else ""
+
+    def username(self):
+        return self._username
+
+    def domain(self):
+        return self._domain
+
+
+class IdentityClient(bakery.IdentityClient):
+    """Basic identity client based on the username returned by Candid."""
+
+    def identity_from_context(self, ctx):
+        return None, IDENTITY_CAVEATS
+
+    def declared_identity(self, ctx, declared):
+        """Return the identity from the given declared attributes."""
+        username = declared.get("username")
+        if username is None:
+            raise bakery.IdentityError("no username found")
+        return Identity(username)
+
+
+def authorization_required(func):
+    """
+    Decorator that checks if a user is logged in, and redirects
+    to login page if not.
+    """
+
+    def is_authorized(*args, **kwargs):
+        macaroon_bakery = bakery.Bakery(
+            location="ubuntu.com/security",
+            locator=httpbakery.ThirdPartyLocator(),
+            identity_client=IdentityClient(),
+            key=bakery.generate_key(),
+            root_key_store=bakery.MemoryKeyStore(
+                flask.current_app.config["SECRET_KEY"]
+            ),
+        )
+        macaroons = httpbakery.extract_macaroons(flask.request.headers)
+        auth_checker = macaroon_bakery.checker.auth(macaroons)
+        launchpad = Launchpad.login_anonymously(
+            "ubuntu.com/security", "production", version="devel"
+        )
+
+        try:
+            auth_info = auth_checker.allow(
+                checkers.AuthContext(), [bakery.LOGIN_OP]
+            )
+        except bakery._error.DischargeRequiredError:
+            macaroon = macaroon_bakery.oven.macaroon(
+                version=bakery.VERSION_2,
+                expiry=datetime.utcnow() + timedelta(seconds=600),
+                caveats=IDENTITY_CAVEATS,
+                ops=[bakery.LOGIN_OP],
+            )
+
+            content, headers = httpbakery.discharge_required_response(
+                macaroon, "/", "cookie-suffix"
+            )
+            return content, 401, headers
+
+        username = auth_info.identity.username()
+        lp_user = launchpad.people(username)
+        authorized = False
+
+        for team in AUTHORIZED_TEAMS:
+            if lp_user in launchpad.people(team).members:
+                authorized = True
+                break
+
+        if not authorized:
+            return (
+                f"{username} is not in any of the authorized teams: "
+                f"{str(AUTHORIZED_TEAMS)}",
+                401,
+            )
+
+        # Validate authentication token
+        return func(*args, **kwargs)
+
+    return is_authorized


### PR DESCRIPTION
This adds an "authorization_required" decorator for securing API endpoints for the security section, and applies it to a POST endpoint at /security/notices.

This will expect to be provided with a valid macaroonbakery macaroon, and if it doesn't find one, will return a macaroonbakery JSON data structure to ask the client to forward the user to api.jujucharms.com/identity to login.

This should be all we need to allow clients to authenticate with our API. All the clients need is the small amount of code you can see in [my gist](https://gist.github.com/nottrobin/8e89667066815a263021a5d3ba248e22), the important part of which is:

``` python3
client = httpbakery.Client(cookies=MozillaCookieJar(".login"))
if os.path.exists(client.cookies.filename):
    client.cookies.load(ignore_discard=True)
response = client.request("POST", "http://ubuntu.com/some/endpoint")
client.cookies.save(ignore_discard=True)
```

Pretty simple.

QA
--

Download [post-cve.py](https://gist.githubusercontent.com/nottrobin/8e89667066815a263021a5d3ba248e22/raw/0fe6ec67595dc732b8bd01035f8ca9ffa1528f00/post-cve.py), which is a script that makes use of macaroonbakery.httpbakery to POST to `https://ubuntu-com-canonical-web-and-design-pr-7154.run.demo.haus/security/cve` on the demo of this PR.

Now run it:

```
python3 -m venv .venv
source .venv/bin/activate
pip3 install macaroonbakery
python3 post-cve.py
```

You should be prompted to open a browser to login, and once you have, you should see:

```
<Response [400]> {
  "message": "No payload received"
}
```

Which means success. ('cos I'm not actually submitting anything with the POST here)