### PR TITLE
Updated the /masters-conference page with the upcoming virtual event

### DIFF
--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -83,7 +83,7 @@
       <h2>The Ubuntu Masters community</h2>
       <p>Changing the technology world together, the Ubuntu Masters Community is a platform for Ubuntu users to share their solutions on a global scale for the mutual benefit of the IT community. Leverage the knowledge from these experts to improve the security, performance, design and efficiency of your environment.</p>
 
-      <p>Our first Ubuntu Masters Conference took place at the NVIDIA campus in California this October 2019. .Events will be ongoing to help support idea sharing within the community.</p>
+      <p>Our first Ubuntu Masters Conference took place at the NVIDIA campus in California this October 2019. Events will be ongoing to help support idea sharing within the community.</p>
 
       <p class="u-no-margin--bottom">
         <a href="/masters-conference/contact-us" class="p-button--neutral js-invoke-modal">Get notified about future events</a>

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -11,24 +11,66 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6">
       <h1>Ubuntu Masters:<br />the masters speak</h1>
-      <p>Ubuntu Masters are IT practitioners who are driving revolutionary change in the corporate space. Watch videos from our first Ubuntu Masters Conference, featuring these inspiring doers to hear how they are solving complex industry-wide challenges.</p>
+      <p>Ubuntu Masters are IT practitioners who are driving revolutionary change in the corporate space. Watch videos from previous Ubuntu Masters speakers, featuring inspiring doers who are solving complex industry-wide challenges. And, sign up for future events and content updates.</p>
 
       <p>
-        <a href="/masters-conference/contact-us" class="p-button--positive">Get in touch</a>
+        <a href="/masters-conference/contact-us" class="p-button--positive">
+          Get in touch
+        </a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--right">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/4b34a715-ubuntu-masters-logo.svg",
-          alt="",
-          height="130",
-          width="300",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "u-hide--small"},
+        url="https://assets.ubuntu.com/v1/4b34a715-ubuntu-masters-logo.svg",
+        alt="",
+        height="130",
+        width="300",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-hide--small"},
         ) | safe
       }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-4">
+      <h2>
+        Ubuntu Masters Virtual Conference: April 29, 2020
+      </h2>
+      <a class="p-button--positive" href="#">Register</a>
+    </div>
+    <div class="col-8">
+      <table>
+        <tr>
+          <th width="25%">11:00 am ET</th>
+          <td><strong>Opening Session</strong></td>
+        </tr>
+        <tr>
+          <th>11:30 pm ET</th>
+          <td>
+            <strong>Scaling years of growth in one week: Building a high-performance global internet edge using Ubuntu and open source</strong><br />
+            <cite><a class="p-link--external" href="https://www.linkedin.com/in/robwc/">Rob Cameron</a>, Technical Director, Cloud Services, Roblox</cite>
+          </td>
+        </tr>
+        <tr>
+          <th>12:30 pm ET</th>
+          <td>
+            <strong>Introduction to edge computing for computer vision and robotics</strong><br />
+            <cite><a class="p-link--external" href="https://www.linkedin.com/in/seankellydev/">Sean Kelly</a>, Senior Software Engineer, ifm</cite>
+          </td>
+        </tr>
+        <tr>
+          <th>1:30 pm ET</th>
+          <td>
+            <strong>Building the datacentre: Implementing self-service for large-scale operations</strong><br />
+            <cite><a class="p-link--external" href="https://www.linkedin.com/in/joshuamcclintock/">Joshua McClintock</a>, MTS, Systems Design Engineering, T-Mobile</cite>
+          </td>
+        </tr>
+      </table>
     </div>
   </div>
 </section>
@@ -39,7 +81,7 @@
       <h2>The Ubuntu Masters community</h2>
       <p>Changing the technology world together, the Ubuntu Masters Community is a platform for Ubuntu users to share their solutions on a global scale for the mutual benefit of the IT community. Leverage the knowledge from these experts to improve the security, performance, design and efficiency of your environment.</p>
 
-      <p>Our first Ubuntu Masters Conference took place at the NVIDIA campus in California this October 2019. More events are being planned to help support idea-sharing within the community. You can rely on one event per quarter and monthly topics from the Masters.</p>
+      <p>Our first Ubuntu Masters Conference took place at the NVIDIA campus in California this October 2019. .Events will be ongoing to help support idea sharing within the community.</p>
 
       <p class="u-no-margin--bottom">
         <a href="/masters-conference/contact-us" class="p-button--neutral js-invoke-modal">Get notified about future events</a>

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -41,7 +41,6 @@
       <h2>
         Ubuntu Masters Virtual Conference: April 29, 2020
       </h2>
-      <a class="p-button--positive" href="#">Register</a>
     </div>
     <div class="col-8">
       <table>
@@ -71,6 +70,9 @@
           </td>
         </tr>
       </table>
+      <p>
+      <a class="p-button--positive" href="https://www.brighttalk.com/summit/4702-ubuntu-masters-digital-conference-the-masters-speak/?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_UbuntuMasters_EVT_UMq2">Register now</a>
+      </p>
     </div>
   </div>
 </section>

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -39,7 +39,7 @@
   <div class="row">
     <div class="col-4">
       <h2>
-        Ubuntu Masters Virtual Conference: April 29, 2020
+        Ubuntu Masters Virtual Conference: 30 April 2020
       </h2>
     </div>
     <div class="col-8">

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -52,7 +52,7 @@
           <th>11:30 pm ET</th>
           <td>
             <strong>Scaling years of growth in one week: Building a high-performance global internet edge using Ubuntu and open source</strong><br />
-            <cite><a class="p-link--external" href="https://www.linkedin.com/in/robwc/">Rob Cameron</a>, Technical Director, Cloud Services, Roblox</cite>
+            <cite><a class="p-link--external" href="https://www.linkedin.com/in/robwc/">Rob Cameron</a>, Technical Director, Cloud Services, Roblox &amp; Adam Mills, Principal Engineer, Roblox</cite>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
## Done

- Updated the /masters-conference page with the upcoming virtual event

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/masters-conference
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1Z63eMCe9o4Onk2ezPFLPDTbI-uJezAOzI-aSpXmZ5lc/edit#heading=h.vcxakwtmfdmp)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2532
