### PR TITLE
Ubuntu masters virtual conference takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,7 @@
   {% include "takeovers/fr/_vmware-to-charmed-openstack_french.html" %}
 
   {# ALL #}
+  {% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
   {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_charmed-openstack-adoption.html" %}
   {% include "takeovers/_rule4-core-cybersecurity.html" %}

--- a/templates/takeovers/_ubuntu-masters-virtual-202004.html
+++ b/templates/takeovers/_ubuntu-masters-virtual-202004.html
@@ -1,5 +1,5 @@
-{% with title="Join the virtual Ubuntu Masters event",
-subtitle="Join the demos and interactive sessions with leading technologists using Ubuntu on 29 April 2020",
+{% with title="Join the Ubuntu Masters virtual event",
+subtitle="Join the demos and interactive sessions with leading technologists using Ubuntu on 30 April 2020",
 class="p-takeover--aqua",
 header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
 image_style="width: 270px; height: 150px;",

--- a/templates/takeovers/_ubuntu-masters-virtual-202004.html
+++ b/templates/takeovers/_ubuntu-masters-virtual-202004.html
@@ -1,0 +1,15 @@
+{% with title="Join the virtual Ubuntu Masters event",
+subtitle="Join the demos and interactive sessions with leading technologists using Ubuntu on 29 April 2020",
+class="p-takeover--aqua",
+header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
+image_style="width: 270px; height: 150px;",
+image_hide_small=true,
+equal_cols=true,
+primary_url="https://www.brighttalk.com/summit/4702-ubuntu-masters-digital-conference-the-masters-speak/?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_UbuntuMasters_EVT_UMq2",
+primary_cta="Register now",
+primary_cta_class="",
+secondary_url="/masters-conference",
+secondary_cta="Read more about our Ubuntu Masters event"
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -120,4 +120,6 @@
 {% include "takeovers/_charmed-openstack-adoption.html" %}
 <p>06 Apr 2020</p>
 {% include "takeovers/_rule4-core-cybersecurity.html" %}
+<p>7 Apr 2020</p>
+{% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Create the ubuntu masters virtual event takeover
- Added it to the homepage
- Added it to the /takeover page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ or the bottom of http://0.0.0.0:8001/takeovers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1Rj_FAPxxyx0SPP5qMOZJpgPCMhK81SBTHz5ZsY6n2z0/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2531

## Screenshots

![image](https://user-images.githubusercontent.com/441217/77669866-54a64780-6f7d-11ea-9f5b-0224d8e85985.png)