### PR TITLE
Add blog images to /robotics/community

### DIFF
--- a/static/js/src/latest-news.js
+++ b/static/js/src/latest-news.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
   function _formatDate(date) {
     const parsedDate = new Date(date);
     const monthNames = [
@@ -13,7 +13,7 @@
       "September",
       "October",
       "November",
-      "December"
+      "December",
     ];
     return (
       parsedDate.getDate() +
@@ -29,11 +29,29 @@
     const time = articleFragment.querySelector(".article-time");
     const link = articleFragment.querySelector(".article-link");
     const title = articleFragment.querySelector(".article-title");
+    const image = articleFragment.querySelector(".article-image");
 
     let url = "";
 
     if (options.hostname) {
       url = "https://" + options.hostname;
+    }
+
+    let articleImage;
+
+    if (
+      article._embedded &&
+      article._embedded["wp:featuredmedia"] &&
+      article._embedded["wp:featuredmedia"][0]
+    ) {
+      let media = article._embedded["wp:featuredmedia"][0];
+
+      articleImage = {
+        url: media.source_url,
+        alt: media.alt_text,
+        width: media.media_details.width,
+        height: media.media_details.height,
+      };
     }
 
     if (time) {
@@ -44,12 +62,12 @@
     if (link) {
       link.href = url + "/blog/" + article.slug;
       if (options.gtmEventLabel) {
-        link.onclick = function() {
+        link.onclick = function () {
           dataLayer.push({
             event: "GAEvent",
             eventCategory: "blog",
             eventAction: options.gtmEventLabel + " news link",
-            eventLabel: article.slug
+            eventLabel: article.slug,
           });
         };
       }
@@ -57,6 +75,15 @@
 
     if (title) {
       title.innerHTML = article.title.rendered;
+    }
+
+    if (image && articleImage) {
+      let img = document.createElement("img");
+      img.setAttribute("src", articleImage.url);
+      img.setAttribute("alt", articleImage.alt);
+      img.setAttribute("width", articleImage.width);
+      img.setAttribute("height", articleImage.height);
+      image.appendChild(img);
     }
 
     return articleFragment;
@@ -80,7 +107,7 @@
   }
 
   function _latestArticlesCallback(options) {
-    return function(event) {
+    return function (event) {
       const articlesContainer = document.querySelector(
         options.articlesContainerSelector
       );
@@ -110,7 +137,7 @@
       }
 
       if (data.latest_articles) {
-        data.latest_articles.forEach(function(article) {
+        data.latest_articles.forEach(function (article) {
           articlesContainer.appendChild(
             _articleDiv(article, options.articleTemplateSelector, options)
           );

--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -253,6 +253,7 @@
 
   <template style="display:none" id="robot-template">
     <div class="col-3 p-divider__block">
+      <div class="article-image u-hide--small"></div>
       <p><strong><a class="article-link article-title"></a></strong></p>
       <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
     </div>


### PR DESCRIPTION
## Done

- Updated latest-news script to allow for article images
- Added article images to /robotics/community

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics/community
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Scroll down to the 'Recent news' section and see that the blog posts have their associated images displayed


## Issue / Card

Fixes #7175