### PR TITLE
Move requested subscription to the top of the table

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -213,9 +213,15 @@ def advantage_view():
                             "renewals"
                         ][0]
 
-                    enterprise_contracts.setdefault(
+                    enterprise_contract = enterprise_contracts.setdefault(
                         contract["accountInfo"]["name"], []
-                    ).append(contract)
+                    )
+                    # If a subscription id is present and this contract matches
+                    # add it to the start of the list
+                    if contract["contractInfo"]["id"] == open_subscription:
+                        enterprise_contract.insert(0, contract)
+                    else:
+                        enterprise_contract.append(contract)
 
     return (
         flask.render_template(


### PR DESCRIPTION
## Done

- If a subscription ID is present ensure that subscription is the first item in the table

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit http://0.0.0.0:8001/advantage and note the top subscription
- Visit http://0.0.0.0:8001/advantage?subscription=cAM3HMVaKsoTuMVdhGK5lWnQej0GlnuqufQNI0tlz58s the top subscription should now be different

## Issue / Card

Fixes #7157 

