### PR TITLE
Add IBM Athena release takeover - release 3pm(1500h) 14 April 2020

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,7 @@
   {% include "takeovers/fr/_vmware-to-charmed-openstack_french.html" %}
 
   {# ALL #}
+  {% include "takeovers/_ibm_athena_release.html" %}
   {% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
   {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_charmed-openstack-adoption.html" %}

--- a/templates/takeovers/_ibm_athena_release.html
+++ b/templates/takeovers/_ibm_athena_release.html
@@ -1,0 +1,18 @@
+{% with title="Cyber resilience and privacy at scale",
+subtitle="Trusted execution environment for Linux",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/6258fcd0-ibm-plus-cof.svg",
+image_style="",
+image_height="85",
+image_width="362",
+image_hide_small=true,
+equal_cols=true,
+primary_url="https://partners.ubuntu.com/ibm",
+primary_cta="Secure your cloud",
+primary_cta_class="",
+secondary_url="https://www.ibm.com/blogs/systems/secure-z-linuxone",
+secondary_cta="Read the blog",
+lang="en",
+locale="en-GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_ibm_athena_release.html
+++ b/templates/takeovers/_ibm_athena_release.html
@@ -10,8 +10,6 @@ equal_cols=true,
 primary_url="https://partners.ubuntu.com/ibm",
 primary_cta="Secure your cloud",
 primary_cta_class="",
-secondary_url="https://www.ibm.com/blogs/systems/secure-z-linuxone",
-secondary_cta="Read the blog",
 lang="en",
 locale="en-GB" %}
 {% include "takeovers/_template.html" %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -122,6 +122,8 @@
 {% include "takeovers/_rule4-core-cybersecurity.html" %}
 <p>7 Apr 2020</p>
 {% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
-<p>9 Apr 2020</p>
+<p>17 Apr 2020</p>
 {% include "takeovers/_managed-apps.html" %}
+<p>17 April 2020</p>
+{% include "templates/takeovers/_ibm_athena_release.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add IBM Athena release takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and http://0.0.0.0:8001/takeovers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refer to the [brief for copy](https://docs.google.com/document/d/1nycVKZMjLmyC8xMtAJVRRgAUUaOlyVVa6CbU_2hkq04/edit)


## Issue / Card

Fixes #7119

