### PR TITLE
Add managed apps takeover and engage page

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -92,7 +92,7 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow is-bordered">
+<section class="{% if content_class %}{{ content_class }}{% else %}p-strip is-shallow is-bordered{% endif %}">
   <div class="row">
     <div class="{% if form_id %}col-7{% else %}col-8{% endif %}">
       {{ content | safe }}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -967,6 +967,14 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Managed apps webinar",
+      description="Maintaining business focus in a cloud-native world with Managed Apps",
+      slug="managed-apps-webinar",
+      group="webinar",
+      type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 </section>
 {% endblock content %}

--- a/templates/engage/managed-apps-webinar.md
+++ b/templates/engage/managed-apps-webinar.md
@@ -1,0 +1,18 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Have your apps deployed an operated as a fully managed service"
+     meta_description: "Maintaining business focus in a cloud native world with Managed Apps"
+     meta_image:
+     meta_copydoc: https://docs.google.com/document/d/18_laMez3IfrPsB_EB86U8Js3QybDlFlZbxDHjZ1BxZI/edit#heading=h.6n03f2ujlktd
+     header_title: "Maintaining business focus in a cloud-native world with Managed Apps"
+     header_subtitle: ""
+     header_image: "https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg"
+     header_image_width: "250"
+     header_image_height: "250"
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--dark
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 394568, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---

--- a/templates/engage/managed-apps-webinar.md
+++ b/templates/engage/managed-apps-webinar.md
@@ -14,5 +14,6 @@ context:
      header_cta: Watch the webinar
      header_cta_class: p-button--positive
      header_class: p-engage-banner--dark
+     content_class: u-hide
      webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 394568, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,7 @@
   {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_charmed-openstack-adoption.html" %}
   {% include "takeovers/_rule4-core-cybersecurity.html" %}
+  {% include "takeovers/_managed-apps.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_managed-apps.html
+++ b/templates/takeovers/_managed-apps.html
@@ -1,0 +1,13 @@
+{% with title="Maintaining business focus in a cloud-native world with Managed Apps",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
+image_width=250,
+image_height=250,
+image_hide_small=true,
+primary_url="/engage/managed-apps-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_ManagedApps_WBN_ManagedApps",
+primary_cta="Learn More",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -122,4 +122,6 @@
 {% include "takeovers/_rule4-core-cybersecurity.html" %}
 <p>7 Apr 2020</p>
 {% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
+<p>9 Apr 2020</p>
+{% include "takeovers/_managed-apps.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Added managed apps takeover and engage page
- There is no content for the engage page so the content pane is hidden and the embed has all the content

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and refresh until you see the "Maintaining business focus..." takeover
- Click through to the engage page
- Check the design, copy and test in all viewports
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #7133 