### PR TITLE
Update download desktop page

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -4,12 +4,12 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip--suru-topped is-bordered">
+<section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
     <h1>Download Ubuntu Desktop</h1>
   </div>
-</div>
-<div class="p-strip--light is-bordered">
+</section>
+<section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
     <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
     <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
@@ -34,11 +34,14 @@
       </div>
     </div>
   </div>
+
+  {% if releases.latest.short_version > releases.lts.short_version %}
   <div class="p-strip is-shallow">
     <div class="u-fixed-width">
       <hr>
     </div>
   </div>
+
   <div class="u-fixed-width">
     <h2>Ubuntu {{ releases.latest.full_version }}</h2>
     <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
@@ -57,9 +60,10 @@
       </div>
     </div>
   </div>
-</div>
+  {% endif %}
+</section>
 
-<div class="p-strip is-bordered">
+<section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>Easy ways to switch to Ubuntu</h2>
   </div>
@@ -137,7 +141,7 @@
       </ul>
     </div>
   </div>
-</div>
+</section>
 
 {% with strip="light" %}
   {% include 'download/shared/_multipass-install.html' %}

--- a/templates/download/shared/_multipass-install.html
+++ b/templates/download/shared/_multipass-install.html
@@ -5,13 +5,13 @@
 {% endif %}
   <div class="row u-equal-height">
     <div class="col-7">
-      <h2>Multipass for instant Ubuntu VMs</h2>
+      <h2>Spin up Ubuntu VMs on Linux, Mac or&nbsp;Windows</h2>
       <p>With Multipass you can download, configure, and control Ubuntu Server virtual machines with latest updates preinstalled. Set up a mini-cloud on your Linux, Windows, or macOS system.</p>
       <p>
         <a id="multipass-os-cta" href="https://multipass.run/docs" class="p-button--neutral"><span class="p-link--external">Install</span></a>
       </p>
       <p>
-        <a href="https://multipass.run" class="p-link--external">Learn more about multipass</a>
+        <a href="https://multipass.run" class="p-link--external">Learn more about Multipass</a>
       </p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">


### PR DESCRIPTION
## Done

- Update download desktop page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#) and play with the releases.yaml to test the logic


## Issue / Card

Fixes #7167 
