### PR TITLE
Update download server arm page

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -16,13 +16,13 @@
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-            url="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg",
-            alt="",
-            width="200",
-            height="61",
-            hi_def=True,
-            loading="auto",
-          ) | safe
+        url="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg",
+        alt="",
+        width="200",
+        height="61",
+        hi_def=True,
+        loading="auto",
+        ) | safe
       }}
     </div>
   </div>
@@ -37,15 +37,17 @@
           This is the iso image of the Ubuntu Server installer.
         </p>
         <p>
-          <a href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          <a href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
             Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
           </a>
         </p>
+        {% if releases.latest.short_version > releases.lts.short_version %}
         <p>
           <a href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-arm64.iso" class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
             Download Ubuntu {{ releases.latest.full_version }}
           </a>
         </p>
+        {% endif %}
         <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
       </div>
     </div>
@@ -57,18 +59,20 @@
         </p>
         <p>
           <a href="http://cdimage.ubuntu.com/netboot/{{ releases.lts.short_version }}" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-          Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
-        </a>
+            Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+          </a>
         </p>
+        {% if releases.latest.short_version > releases.lts.short_version %}
         <p>
           <a href="http://cdimage.ubuntu.com/netboot/{{ releases.latest.short_version }}" class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-          Download Ubuntu {{ releases.latest.full_version }}
-        </a>
+            Download Ubuntu {{ releases.latest.full_version }}
+          </a>
         </p>
+        {% endif %}
         <p>
           <a class="p-link--external" href="https://help.ubuntu.com/community/Installation/Netboot">
-          Learn about netboot images
-        </a>
+            Learn about netboot images
+          </a>
         </p>
       </div>
     </div>
@@ -90,13 +94,13 @@
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-            url="https://assets.ubuntu.com/v1/5eebb138-Servers.svg",
-            alt="",
-            width="294",
-            height="132",
-            hi_def=True,
-            loading="lazy",
-          ) | safe
+        url="https://assets.ubuntu.com/v1/5eebb138-Servers.svg",
+        alt="",
+        width="294",
+        height="132",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
       }}
     </div>
   </div>
@@ -107,13 +111,13 @@
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-            url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-            alt="",
-            width="281",
-            height="200",
-            hi_def=True,
-            loading="lazy",
-          ) | safe
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        width="281",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
       }}
     </div>
     <div class="col-8">


### PR DESCRIPTION
## Done

- Update download server arm page
- Moved to the live server version

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/arm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit) and change the releases.yaml variables to see the page change


## Issue / Card

Fixes #7172

## Screenshots

[If relevant, please include a screenshot.]
