### PR TITLE
Update the thank-you-s380x page

### DIFF
--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -19,8 +19,14 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <p><a  class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-server-s390x.iso">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a></p>
-      <p><a  class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.latest.full_version }}</a></p>
+      <p>
+        <a  class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
+      </p>
+      {% if releases.latest.short_version > releases.lts.short_version %}
+      <p>
+        <a  class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.latest.full_version }}</a>
+      </p>
+      {% endif %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update the thank-you-s380x page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/thank-you-s390x
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1GptXtMfbgOjOmqb8DZCCTRwogkiP_cM95U9Z0gFSt7g/edit#) and change the release.yaml to see the page change


## Issue / Card

Fixes #7210

