### PR TITLE
Update the download server s390x page

### DIFF
--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -1,6 +1,6 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Ubuntu Server for IBM LinuxONE and IBM Z | Download{% endblock %}
+{% block title %}Ubuntu Server LTS for IBM Z and LinuxONE{% endblock %}
 {% block meta_description %}Ubuntu for IBM LinuxONE and IBM Z brings the Ubuntu Server and Ubuntu Server for cloud with the OpenStack, KVM and LXD ecosystem to IBM’s premium platform.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit{% endblock meta_copydoc %}
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
@@ -9,7 +9,7 @@
 <div class="p-strip--suru-topped is-bordered">
   <div class="row">
     <div class="col-12">
-      <h1>Ubuntu Server for IBM LinuxONE and IBM Z</h1>
+      <h1>Ubuntu Server LTS for IBM Z and LinuxONE</h1>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Update the download server s390x page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/s390x
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit)


## Issue / Card

Fixes #7170
