### PR TITLE
Add resources to /telecommunications page

### DIFF
--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -1,8 +1,9 @@
 {% extends "templates/one-column.html" %}
 
-
 {% block title %}Open source NFV platform for 5G{% endblock %}
+
 {% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit#heading=h.t5nt9uvsqry{% endblock meta_copydoc %}
 
 {% block content %}
@@ -28,12 +29,12 @@
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/01a65abc-telecommunications-white.svg",
-          alt="",
-          height="341",
-          width="325",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/01a65abc-telecommunications-white.svg",
+        alt="",
+        height="341",
+        width="325",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>
@@ -47,104 +48,104 @@
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png",
-            alt="BT",
-            height="88",
-            width="88",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/022f6f41-logo-bt.png",
+          alt="BT",
+          height="88",
+          width="88",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/25de1877-Tele2.svg",
-            alt="Tele2",
-            height="35",
-            width="90",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/25de1877-Tele2.svg",
+          alt="Tele2",
+          height="35",
+          width="90",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/eaf98009-Bell_Blue_large_transparent.png",
-            alt="Bell Canada",
-            height="64",
-            width="90",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/eaf98009-Bell_Blue_large_transparent.png",
+          alt="Bell Canada",
+          height="64",
+          width="90",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
-            alt="Deutshe Telekom",
-            height="29",
-            width="130",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
+          alt="Deutshe Telekom",
+          height="29",
+          width="130",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/b6e008be-Colt-Logo.svg",
-            alt="Colt",
-            height="40",
-            width="100",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/b6e008be-Colt-Logo.svg",
+          alt="Colt",
+          height="40",
+          width="100",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/481063cd-pccw.svg",
-            alt="PCCW",
-            height="50",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/481063cd-pccw.svg",
+          alt="PCCW",
+          height="50",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
-            alt="AT&T",
-            height="88",
-            width="88",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
+          alt="AT&T",
+          height="88",
+          width="88",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/9ca791fd-Sky_Logo_seit_Dezember_2015.png",
-            alt="Sky",
-            height="63",
-            width="90",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/9ca791fd-Sky_Logo_seit_Dezember_2015.png",
+          alt="Sky",
+          height="63",
+          width="90",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
@@ -159,117 +160,117 @@
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/d10b4578-etsi.svg",
-            alt="ETSI",
-            height="88",
-            width="88",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/d10b4578-etsi.svg",
+          alt="ETSI",
+          height="88",
+          width="88",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/4a8b06e9-onap_logo.png",
-            alt="ONAP",
-            height="88",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/4a8b06e9-onap_logo.png",
+          alt="ONAP",
+          height="88",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/f15a069c-opnfv_logo_wp.png",
-            alt="OPNFV",
-            height="31",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/f15a069c-opnfv_logo_wp.png",
+          alt="OPNFV",
+          height="31",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
-            alt="Open Source MANO",
-            height="52",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
+          alt="Open Source MANO",
+          height="52",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/5ac9bab5-logo_cord-1.png",
-            alt="CORD",
-            height="88",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/5ac9bab5-logo_cord-1.png",
+          alt="CORD",
+          height="88",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/9e564bf9-open-baton.png",
-            alt="Open Baton",
-            height="30",
-            width="120",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/9e564bf9-open-baton.png",
+          alt="Open Baton",
+          height="30",
+          width="120",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/9635c8f7-opencompute-logo-green.png",
-            alt="Open Compute",
-            height="58",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/9635c8f7-opencompute-logo-green.png",
+          alt="Open Compute",
+          height="58",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/eeae998a-telecominfraproject-logo.svg",
-            alt="Telecom Infra Project",
-            height="23",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/eeae998a-telecominfraproject-logo.svg",
+          alt="Telecom Infra Project",
+          height="23",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/061ffe4a-onf-logo.jpg",
-            alt="ONF",
-            height="85",
-            width="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+          url="https://assets.ubuntu.com/v1/061ffe4a-onf-logo.jpg",
+          alt="ONF",
+          height="85",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
       </li>
@@ -317,12 +318,12 @@
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
             {{
               image(
-                url="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg",
-                alt="",
-                height="96",
-                width="134",
-                hi_def=True,
-                loading="lazy"
+              url="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg",
+              alt="",
+              height="96",
+              width="134",
+              hi_def=True,
+              loading="lazy"
               ) | safe
             }}
           </div>
@@ -339,12 +340,12 @@
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
             {{
               image(
-                url="https://assets.ubuntu.com/v1/46439b10-2.+model_AW.svg",
-                alt="",
-                height="96",
-                width="134",
-                hi_def=True,
-                loading="lazy"
+              url="https://assets.ubuntu.com/v1/46439b10-2.+model_AW.svg",
+              alt="",
+              height="96",
+              width="134",
+              hi_def=True,
+              loading="lazy"
               ) | safe
             }}
           </div>
@@ -361,12 +362,12 @@
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
             {{
               image(
-                url="https://assets.ubuntu.com/v1/0cfe6c2d-build.svg",
-                alt="",
-                height="96",
-                width="134",
-                hi_def=True,
-                loading="lazy"
+              url="https://assets.ubuntu.com/v1/0cfe6c2d-build.svg",
+              alt="",
+              height="96",
+              width="134",
+              hi_def=True,
+              loading="lazy"
               ) | safe
             }}
           </div>
@@ -383,12 +384,12 @@
           <div class="col-4 u-align--center u-vertically-center u-hide--small">
             {{
               image(
-                url="https://assets.ubuntu.com/v1/ada1d5b5-operate.svg",
-                alt="",
-                height="96",
-                width="134",
-                hi_def=True,
-                loading="lazy"
+              url="https://assets.ubuntu.com/v1/ada1d5b5-operate.svg",
+              alt="",
+              height="96",
+              width="134",
+              hi_def=True,
+              loading="lazy"
               ) | safe
             }}
           </div>
@@ -434,18 +435,25 @@
         <a class="p-link--external" href="https://www.openstack.org/">OpenStack</a> is a core component of an open source NFVI. It provides the IaaS (Infrastructure-as-a-Service) functionality which allows you to launch virtual machines from the self-service portal. It is a cloud operating system which allows organisations to manage large pools of distributed compute, network and storage resources in a data center. With the help of charms you can get OpenStack up and running with all necessary performance extensions (SR-IOV, DPDK, CPU pinning and more) in minutes.
       </p>
       <p>
-        <a class="p-link--external" href="https://jaas.ai/openstack">Learn more about Charmed OpenStack</a>
+        <a class="p-button" href="https://jaas.ai/openstack">
+          <span class="p-link--external">
+            Learn more about Charmed OpenStack
+          </span>
+        </a>
+      </p>
+      <p>
+        <a href="/engage/charmed-openstack-adoption-whitepaper">Read the whitepaper - “A guide to a successful OpenStack adoption and deployment”&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg",
-          alt="",
-          height="106",
-          width="220",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg",
+        alt="",
+        height="106",
+        width="220",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -457,12 +465,12 @@
     <div class="col-4 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
-          alt="",
-          height="156",
-          width="200",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
+        alt="",
+        height="156",
+        width="200",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -474,7 +482,16 @@
         While OpenStack allows you to launch virtual machines, <a class="p-link--external" href="https://kubernetes.io/">Kubernetes</a> allows you to launch containers. With the increasing adoption of microservice-based cloud-native Container Network Functions (CNFs), the importance of Kubernetes is constantly growing. Kubernetes is usually deployed on top of OpenStack, but you can deploy it on bare metal too. Together with OpenStack, Kubernetes is a key component of the <a class="p-link--external" href="https://www.opnfv.org/">OPNFV</a> architecture. Like OpenStack, you can get Kubernetes up and running with the charms.
       </p>
       <p>
-        <a class="p-link--external" href="https://jaas.ai/kubernetes">Get Charmed Kubernetes</a>
+        <a class="p-button" href="https://jaas.ai/kubernetes">
+          <span class="p-link--external">
+            Get Charmed Kubernetes
+          </span>
+        </a>
+      </p>
+      <p>
+        <a href="/engage/kata-containers-webinar">
+          Watch the webinar - “Ensuring security and isolation in Kubernetes with Kata Containers”&nbsp;&rsaquo;
+        </a>
       </p>
     </div>
   </div>
@@ -491,18 +508,27 @@
         ">OSM</a> is an open-source implementation of the ETSI NFV MANO (MANagement and Orchestration) stack. It was founded by ETSI and is fully aligned with ETSI NFV Information Models. OSM allows Telecommunications Service Providers (TSPs) to move from traditional, legacy networking services to cloud-native network functions and accelerates their NFV transformation. OSM assists with network functions onboarding and orchestration in physical, virtual, containerised and hybrid environments, as required in modern telco networks.
       </p>
       <p>
-        <a class="p-link--external" href="https://charmed-osm.com">Explore Charmed OSM</a>
+        <a class="p-button" href="https://charmed-osm.com">
+          <span class="p-link--external">
+            Explore Charmed OSM
+          </span>
+        </a>
+      </p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/379298">
+          Watch the webinar - "How using Charmed OSM helps telcos to accelerate their NFV transformation"
+        </a>
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
-          alt="",
-          height="90",
-          width="250",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
+        alt="",
+        height="90",
+        width="250",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -530,21 +556,25 @@
         Designed for edge appliances with limited hardware resources, MicroK8s provides the "Kubernetes at the edge" possibility. With MicroK8s you can get the smallest, fastest Kubernetes cluster up and running in seconds! By using Charmed Kubernetes in the network core and MicroK8s at the edge, you can rely on the same upstream platform for running your VNF workloads.
       </p>
       <p>
-        <a  class="p-link--external" href="https://www.brighttalk.com/webcast/6793/362200/using-kubernetes-at-the-edge-architecture-tools-for-edge-clouds-and-devices">Watch the webinar - “Using Kubernetes at the edge”</a>
+        <a class="p-button" href="https://microk8s.io/">
+          <span class="p-link--external">
+            Learn more about MicroK8s
+          </span>
+        </a>
       </p>
       <p>
-        <a  class="p-link--external" href="https://microk8s.io/">Learn more about MicroK8s</a>
+        <a  class="p-link--external" href="https://www.brighttalk.com/webcast/6793/362200/using-kubernetes-at-the-edge-architecture-tools-for-edge-clouds-and-devices">Watch the webinar - “Using Kubernetes at the edge”</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg",
-          alt="",
-          height="150",
-          width="150",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/9309d097-MicroK8s_SnapStore_icon.svg",
+        alt="",
+        height="150",
+        width="150",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -556,12 +586,12 @@
     <div class="col-4 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/77c24034-maas-logo.svg",
-          alt="",
-          height="65",
-          width="200",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/77c24034-maas-logo.svg",
+        alt="",
+        height="65",
+        width="200",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -573,10 +603,14 @@
         Your edge appliances will never have to be provisioned with an on-site assistance again. Although designed for data centers, MAAS (Metal-As-A-Service) is an alluring opportunity for the network edge. Deploy it once and benefit from remote devices provisioning all over the time.
       </p>
       <p>
-        <a class="p-link--external" href="#">Watch the webinar - “MAAS at the edge”</a>
+        <a class="p-button" href="https://maas.io/">
+          <span class="p-link--external">
+            Learn more about MAAS
+          </span>
+        </a>
       </p>
       <p>
-        <a class="p-link--external" href="https://maas.io/">Learn more about  MAAS</a>
+        <a class="p-link--external" href="#">Watch the webinar - “MAAS at the edge”</a>
       </p>
     </div>
   </div>
@@ -592,21 +626,23 @@
         Avoid device lock-in by using the secure embedded operating system for IoT - Ubuntu Core. Designed for appliances with limited hardware resources, Ubuntu Core is lightweight and robust.
       </p>
       <p>
-        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/339167?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_IOT_UbuntuCore_WBN_Core%2018">Watch the webinar - “An Introduction to Ubuntu Core 18”</a>
+        <a class="p-button" href="/core">
+          Learn more about Ubuntu Core
+        </a>
       </p>
       <p>
-        <a href="https://ubuntu.com/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/339167?utm_source=Takeover&utm_medium=Takeover&utm_campaign=FY19_IOT_UbuntuCore_WBN_Core%2018">Watch the webinar - “An Introduction to Ubuntu Core 18”</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/805f2b3a-core_black-orange_st_hex.svg",
-          alt="",
-          height="135",
-          width="100",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/805f2b3a-core_black-orange_st_hex.svg",
+        alt="",
+        height="135",
+        width="100",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -629,12 +665,12 @@
     <div class="col-4 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-          alt="",
-          height="178",
-          width="250",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        height="178",
+        width="250",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -647,13 +683,13 @@
       <blockquote class="p-pull-quote  has-image">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/c2b1de52-BT_logo.svg",
-            alt="BT",
-            height="32",
-            width="66",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-pull-quote__image"}
+          url="https://assets.ubuntu.com/v1/c2b1de52-BT_logo.svg",
+          alt="BT",
+          height="32",
+          width="66",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-pull-quote__image"}
           ) | safe
         }}
         <p class="p-pull-quote__quote">
@@ -668,13 +704,13 @@
       <blockquote class="p-pull-quote  has-image">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
-            alt="AT&amp;T",
-            height="32",
-            width="78",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-pull-quote__image"}
+          url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
+          alt="AT&amp;T",
+          height="32",
+          width="78",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-pull-quote__image"}
           ) | safe
         }}
         <p class="p-pull-quote__quote">

--- a/templates/telecommunications/index.html
+++ b/templates/telecommunications/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit#heading=h.t5nt9uvsqry{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--suru is-dark is-deep">
@@ -610,7 +610,7 @@
         </a>
       </p>
       <p>
-        <a class="p-link--external" href="#">Watch the webinar - “MAAS at the edge”</a>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/362201/maas-at-the-edge-the-importance-of-bare-metal-provisioning-in-edge-computing">Watch the webinar - “MAAS at the edge”</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add resources to /telecommunications page, made many primary ctas into buttons

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/telecommunications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit#) and resolve comments in there


## Issue / Card

Fixes #7177
