### PR TITLE
K8s 1.18 release docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -182,6 +182,9 @@ kubernetes:
         - title: OpenStack integration
           path: /kubernetes/docs/openstack-integration
           hidden: True
+        - title: Azure integration
+          path: /kubernetes/docs/azure-integration
+          hidden: True
         - title: CNI overview
           path: /kubernetes/docs/cni-overview
           hidden: True

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -194,6 +194,9 @@ kubernetes:
         - title: Canal
           path: /kubernetes/docs/cni-canal
           hidden: True
+        - title: Multus
+          path: /kubernetes/docs/cni-multus
+          hidden: True
         - title: Using Tigera Secure EE
           path: /kubernetes/docs/tigera-secure-ee
           hidden: True

--- a/templates/kubernetes/docs/azure-integration.md
+++ b/templates/kubernetes/docs/azure-integration.md
@@ -1,0 +1,193 @@
+---
+wrapper_template: "kubernetes/docs/base_docs.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "Charmed Kubernetes on Azure"
+  description: Running Charmed Kubernetes on Azure using the azure-integrator.
+keywords: azure, integrator
+tags: [install]
+sidebar: k8smain-sidebar
+permalink: azure-integration.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+**Charmed Kubernetes** will run seamlessly on Microsoft Azure <sup>&reg;</sup>.
+With the  addition of the `azure-integrator`, your cluster will also be able
+to directly  use Azure native features.
+
+
+## Azure integrator
+
+The `aws-integrator` charm simplifies working with **Charmed Kubernetes** on
+Azure. Using the credentials provided to **Juju**, it acts as a proxy between
+Charmed Kubernetes and the underlying cloud, granting permissions to
+dynamically create, for example, storage.
+
+### Installing
+
+If you install **Charmed Kubernetes** [using the Juju bundle][install],
+you can add the aws-integrator at the same time by using the following
+overlay file ([download it here][asset-azure-overlay]):
+
+```yaml
+description: Charmed Kubernetes overlay to add native Azure support.
+applications:
+  aws-integrator:
+    annotations:
+      gui-x: "600"
+      gui-y: "300"
+    charm: cs:~containers/azure-integrator
+    num_units: 1
+    trust: true
+relations:
+  - ['azure-integrator', 'kubernetes-master']
+  - ['azure-integrator', 'kubernetes-worker']
+  ```
+
+To use this overlay with the **Charmed Kubernetes** bundle, it is specified
+during deploy like this:
+
+```bash
+juju deploy charmed-kubernetes --overlay azure-overlay.yaml --trust
+```
+
+... and remember to fetch the configuration file!
+
+```bash
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    A standard install of Charmed Kubernetes will use more resources than the
+    current quotas allocated to a new Azure account. If you see error messages
+    saying allocating machines would exceed your quota, you will need to log a
+
+    <a href="https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests" class="p-notification__action">support request with Azure</a> to increase the quota accordingly.
+
+  </p>
+</div>
+
+
+
+<div class="p-notification--caution">
+  <p class="p-notification__response">
+    <span class="p-notification__status">Resource usage:</span>
+    By relating to this charm, other charms can directly allocate resources, such
+    as managed disks and load balancers, which could lead to cloud charges and
+    count against quotas. Because these resources are not managed by Juju, they
+    will not be automatically deleted when the models or applications are
+    destroyed, nor will they show up in Juju's status or GUI. It is therefore up
+    to the operator to manually delete these resources when they are no longer
+    needed, using the Azure management website or API.
+  </p>
+</div>
+
+## Storage
+
+This section describes creating a busybox pod with a persistent volume claim
+backed by
+Azure's Disk Storage.
+
+### 1. Create a storage class using the `kubernetes.io/azure-disk` provisioner:
+
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azure-standard
+provisioner: kubernetes.io/azure-disk
+parameters:
+  storageaccounttype: Standard_LRS
+  kind: managed
+EOY
+```
+
+### 2. Create a persistent volume claim using that storage class:
+
+```bash
+kubectl create -f - <<EOY
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: azure-standard
+EOY
+```
+
+### 3. Create the busybox pod with a volume using that PVC:
+
+```bash
+kubectl create -f - <<EOY
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+      volumeMounts:
+        - mountPath: "/pv"
+          name: testvolume
+  restartPolicy: Always
+  volumes:
+    - name: testvolume
+      persistentVolumeClaim:
+        claimName: testclaim
+EOY
+```
+
+Charmed Kubernetes can make use of additional types of storage - for more
+information see the [storage documentation][storage].
+
+## Azure load-balancers
+
+The following commands start the 'hello-world' pod behind an Azure-backed
+load-balancer.
+
+```bash
+kubectl run hello-world --replicas=5 --labels="run=load-balancer-example" --image=gcr.io/google-samples/node-hello:1.0  --port=8080
+kubectl expose deployment hello-world --type=LoadBalancer --name=hello
+watch kubectl get svc -o wide --selector=run=load-balancer-example
+```
+
+You can then verify this works by loading the described IP address (on port
+8080!) in a browser.
+
+For more configuration options and details of the permissions which the integrator uses,
+please see the [azure charm page][azure-integrator].
+
+<!-- LINKS -->
+
+[asset-azure-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/azure-overlay.yaml
+
+[storage]: /kubernetes/docs/storage
+[azure-integrator]: /kubernetes/docs/charm-azure-integrator
+
+[install]: /kubernetes/docs/install-manual
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/aws-integration.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -103,8 +103,11 @@ juju run-action new-etcd/0 restore --wait
 Once the restore action has finished, you should see output confirming that the operation is `completed`. The new etcd application will need to be connected to the rest of the deployment:
 
 ```bash
-juju add-relation new-etcd kubernetes-master
 juju add-relation new-etcd flannel
+juju add-relation new-etcd kubernetes-master
+juju add-relation kubeapi-load-balancer:certificates new-easyrsa:client
+juju add-relation kubernetes-master:certificates new-easyrsa:client
+juju add-relation kubernetes-worker:certificates new-easyrsa:client
 ```
 
 To restore the cluster capabilities of etcd, you can now add more units:

--- a/templates/kubernetes/docs/charm-openstack-integrator.md
+++ b/templates/kubernetes/docs/charm-openstack-integrator.md
@@ -67,16 +67,9 @@ OpenStack's PersistentDisk.
 ```sh
 #!/bin/bash
 
-# create a storage class using the `kubernetes.io/cinder` provisioner
-kubectl create -f - <<EOY
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: openstack-standard
-provisioner: kubernetes.io/cinder
-EOY
-
-# create a persistent volume claim using that storage class
+# create a persistent volume claim using the StorageClass which is
+# automatically created by Charmed Kubernetes when it is related to
+# the openstack-integrator
 kubectl create -f - <<EOY
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -88,7 +81,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-  storageClassName: openstack-standard
+  storageClassName: cdk-cinder
 EOY
 
 # create the busybox pod with a volume using that PVC:

--- a/templates/kubernetes/docs/cis-compliance.md
+++ b/templates/kubernetes/docs/cis-compliance.md
@@ -38,8 +38,8 @@ analysis.
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-etcd --noremediations --noresults master
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets etcd
   report: juju scp etcd/0:/home/ubuntu/kube-bench-results/results-text-49681_7h .
   summary: |
     == Summary ==
@@ -66,13 +66,12 @@ apply any automatic remediations.
 
 Specify an archive of custom configuration scripts to use during the benchmark.
 This parameter is set by default to an archive that is known to work with
-snap-based components.
+snap-related components.
 
 ### release
 
-Specify the `kube-bench` release to install and run. The default value of
-`upstream` will compile and use a local kube-bench binary built from the master
-branch of the [upstream repository][kube-bench].
+Specify the `kube-bench` release to install and run. This parameter is set by
+default to a release that is known to work with snap-related components.
 
 ## Example use case
 
@@ -81,20 +80,20 @@ configuration archive:
 
 ```bash
 juju run-action --wait kubernetes-worker/0 cis-benchmark \
-  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip'
+  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip'
 ```
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-k8s --noremediations --noresults node
-  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-8c71ktcn .
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets node
+  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-nmmlsvy3 .
   summary: |
     == Summary ==
     16 checks PASS
-    5 checks FAIL
-    2 checks WARN
-    1 checks INFO
+    4 checks FAIL
+    3 checks WARN
+    0 checks INFO
 status: completed
 ```
 
@@ -104,36 +103,36 @@ configuration archive:
 ```bash
 juju run-action --wait kubernetes-worker/0 cis-benchmark \
   apply='dangerous' \
-  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip'
+  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip'
 ```
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-k8s --noremediations --noresults node
-  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-json-7b3g6jdg .
-  summary: Applied 5 remediations. Re-run with "apply=none" to generate a new report.
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets node
+  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-json-dozp8j3z .
+  summary: Applied 4 remediations. Re-run with "apply=none" to generate a new report.
 status: completed
 ```
 
-Re-run the initial action to see if previous failures have been fixed:
+Re-run the earlier action to verify previous failures have been fixed:
 
 ```bash
 juju run-action --wait kubernetes-worker/0 cis-benchmark \
-  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/master.zip'
+  config='https://github.com/charmed-kubernetes/kube-bench-config/archive/cis-1.5.zip'
 ```
 
 ```yaml
 results:
-  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg --version
-    1.13-snap-k8s --noremediations --noresults node
-  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-m72vicwe .
+  cmd: /home/ubuntu/kube-bench/kube-bench -D /home/ubuntu/kube-bench/cfg-ck
+    --benchmark cis-1.5 --noremediations --noresults run --targets node
+  report: juju scp kubernetes-worker/0:/home/ubuntu/kube-bench-results/results-text-4agbktbf .
   summary: |
     == Summary ==
-    21 checks PASS
+    20 checks PASS
     0 checks FAIL
-    2 checks WARN
-    1 checks INFO
+    3 checks WARN
+    0 checks INFO
 status: completed
 ```
 

--- a/templates/kubernetes/docs/cni-multus.md
+++ b/templates/kubernetes/docs/cni-multus.md
@@ -1,0 +1,232 @@
+---
+wrapper_template: "kubernetes/docs/base_docs.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "CNI with Multus"
+  description: How to deploy and use Multus in Charmed Kubernetes
+keywords: CNI, networking, multus
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: cni-multus.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+[Multus][multus] is a CNI plugin for Kubernetes which enables attaching multiple
+network interfaces to pods. Multus support for **Charmed Kubernetes** is
+provided by the Multus charm, which must be deployed into a Kubernetes model
+in Juju.
+
+## Requirements
+
+### Juju 2.8 features
+
+The Multus charm requires functionality from Juju 2.8+, which is currently
+under active development. In order to run Multus, you will need a Juju
+controller running a Juju 2.8 build from edge.
+
+Install the Juju 2.8 client from edge:
+
+```
+sudo snap install juju --channel edge --classic
+```
+
+Or if Juju is already installed, refresh it:
+
+```
+sudo snap refresh juju --channel edge
+```
+
+Once you have the Juju 2.8 edge client, any new controllers you bootstrap will
+include the 2.8 features required by Multus.
+
+### CNI providers
+
+Multus is not a replacement for other CNI providers. Your **Charmed Kubernetes**
+deployment must include at least one of the other CNI providers documented in the
+[CNI overview][cni-overview] page.
+
+### Persistent volume support
+
+In order to deploy Multus, you will need a Kubernetes model in Juju, which
+requires persistent volume support to be enabled in your **Charmed Kubernetes**
+cluster.
+
+If your cluster includes any of the cloud integrator charms, then you should
+have persistent volume support already. Otherwise, you can read the
+[Storage][storage] documentation page to learn how to enable persistent volume
+support by adding Ceph to your cluster.
+
+### Creating a Kubernetes model in Juju
+
+To deploy the Multus charm, you will first need a Kubernetes model in Juju.
+
+Make sure your local kubeconfig is pointing to the correct Kubernetes cluster:
+
+```
+juju scp kubernetes-master/0:config ~/.kube/config
+```
+
+Next, add your Kubernetes as a cloud to your Juju controller:
+
+```
+juju add-k8s my-k8s-cloud --controller $(juju switch | cut -d: -f1)
+```
+
+And create a new Kubernetes model:
+
+```
+juju add-model my-k8s-model my-k8s-cloud
+```
+
+## Deploying Multus
+
+Once all of the requirements have been met, you can deploy Multus into a
+Kubernetes model by running:
+
+```
+juju deploy cs:~containers/multus
+```
+
+## Configuring the Default CNI
+
+Multus delegates to a single CNI network by default. If you have multiple CNI
+subordinates in your cluster then you can use the default-cni config on
+kubernetes-master to set the default:
+
+```
+juju config kubernetes-master default-cni=flannel
+```
+
+Multus will use this as the default network as well.
+
+## Example: Pod with multiple Flannel interfaces
+
+If you have Flannel in your cluster, then you can use it to attach additional
+network interfaces to your pods. In this example, we'll create an Ubuntu pod
+with 2 extra Flannel interfaces, in addition to the default one.
+
+Create a NetworkAttachmentDefinition for Flannel:
+```
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: flannel
+spec:
+  config: |
+    {
+        "cniVersion": "0.3.1",
+        "plugins": [
+          {
+            "type": "flannel",
+            "delegate": {
+              "hairpinMode": true,
+              "isDefaultGateway": true
+            }
+          },
+          {
+            "type": "portmap",
+            "capabilities": {"portMappings": true},
+            "snat": true
+          }
+        ]
+    }
+```
+
+Create a Pod with the `k8s.v1.cni.cncf.io/networks` annotation:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+  annotations:
+    k8s.v1.cni.cncf.io/networks: flannel, flannel
+spec:
+  containers:
+  - name: ubuntu
+    image: ubuntu
+    command: ['sleep', '3600']
+```
+
+That's it. After the pod comes up, you can exec into the pod and confirm that
+it has multiple network interfaces with IP addresses belonging to the Flannel
+network:
+
+```
+$ kubectl exec -it ubuntu bash
+root@ubuntu:/# apt update && apt install -y net-tools
+...
+root@ubuntu:/# ifconfig
+eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 8951
+        inet 10.1.34.6  netmask 255.255.255.0  broadcast 0.0.0.0
+        inet6 fe80::c001:5aff:feb8:fefd  prefixlen 64  scopeid 0x20<link>
+        ether c2:01:5a:b8:fe:fd  txqueuelen 0  (Ethernet)
+        RX packets 5447  bytes 18185162 (18.1 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 4666  bytes 356784 (356.7 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+        inet 127.0.0.1  netmask 255.0.0.0
+        inet6 ::1  prefixlen 128  scopeid 0x10<host>
+        loop  txqueuelen 1000  (Local Loopback)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+net1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 8951
+        inet 10.1.34.3  netmask 255.255.255.0  broadcast 0.0.0.0
+        inet6 fe80::78fe:9ff:fe80:ec57  prefixlen 64  scopeid 0x20<link>
+        ether 7a:fe:09:80:ec:57  txqueuelen 0  (Ethernet)
+        RX packets 42  bytes 3220 (3.2 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 11  bytes 838 (838.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+net2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 8951
+        inet 10.1.34.4  netmask 255.255.255.0  broadcast 0.0.0.0
+        inet6 fe80::acad:f6ff:feaa:416f  prefixlen 64  scopeid 0x20<link>
+        ether ae:ad:f6:aa:41:6f  txqueuelen 0  (Ethernet)
+        RX packets 40  bytes 3088 (3.0 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 11  bytes 838 (838.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+```
+
+In this case, `eth0` is the default interface that gets attached to all pods,
+while `net1` and `net2` are the additional interfaces that Multus attached to
+the pod based on the pod's `k8s.v1.cni.cncf.io/networks` annotation.
+
+For additional examples of how you can use Multus, please refer to the official
+Multus documentation here: [Create network attachment definition][multus-examples].
+
+## Troubleshooting
+
+If there is an issue with Multus, it can be useful to inspect the Juju logs. To
+see a complete set of logs for Multus:
+
+```bash
+juju debug-log --replay --include=multus
+```
+
+For additional troubleshooting pointers, please see the [dedicated troubleshooting page][troubleshooting].
+
+<!-- LINKS -->
+
+[multus]: https://github.com/intel/multus-cni
+[cni-overview]: /kubernetes/docs/cni-overview
+[storage]: /kubernetes/docs/storage
+[multus-examples]: https://github.com/intel/multus-cni/blob/master/doc/how-to-use.md#create-network-attachment-definition
+[troubleshooting]: /kubernetes/docs/troubleshooting
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/cni-multus.md" class="p-notification__action">edit this page</a> 
+    or 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/cni-overview.md
+++ b/templates/kubernetes/docs/cni-overview.md
@@ -33,6 +33,7 @@ The currently supported CNI solutions for **Charmed Kubernetes** are:
  -   [Calico][calico]
  -   [Canal][canal]
  -   [Tigera Secure EE][tigera]
+ -   [Multus][multus]
 
 By default, **Charmed Kubernetes** will deploy the cluster using flannel. To chose a different CNI provider, see the individual links above.
 
@@ -49,6 +50,7 @@ Kubernetes, such a migration should be manageable with no downtime.
 [calico]: /kubernetes/docs/cni-calico
 [canal]: /kubernetes/docs/cni-canal
 [tigera]: /kubernetes/docs/tigera-secure-ee
+[multus]: /kubernetes/docs/cni-multus
 [install]: /kubernetes/docs/install-manual
 [federation]: https://github.com/kubernetes-sigs/kubefed
 

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -29,13 +29,11 @@ and basic (htpasswd) authentication enabled.
 
 If needed, consult the [quickstart guide][quickstart] to install
 **Charmed Kubernetes**. Then deploy and configure `docker-registry` as
-follows.  This example relates to a containerd charm; this can be replaced
-with any [container runtime][container-runtime].
+follows.
 
 ```bash
 juju deploy ~containers/docker-registry
 juju add-relation docker-registry easyrsa:client
-juju add-relation docker-registry containerd
 juju config docker-registry \
   auth-basic-user='admin' \
   auth-basic-password='password'
@@ -109,6 +107,24 @@ Verify basic authentication is working:
 juju run --unit docker-registry/0 "docker login -u admin -p password $REGISTRY"
 Login Succeeded
 ...
+```
+
+## Connecting to a Charmed Kubernetes cluster
+
+Relate the deployed registry to the appropriate
+[container runtime][container-runtime] for your cluster. This configures
+the runtime with authentication, proxy, and/or TLS data from the registry.
+
+### Containerd
+
+```bash
+juju add-relation docker-registry containerd
+```
+
+### Docker
+
+```bash
+juju add-relation docker-registry docker
 ```
 
 ## Kubernetes images

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -140,6 +140,13 @@ the default components and configuration. If you wish to customise this install
 (which may be helpful if you are close to the system requirements), please see
 the [main install page][install].
 
+In order to avoid potential IP masquerading issues with kube-proxy on LXD, we
+also recommend configuring kube-proxy to use its userspace proxy mode:
+
+```
+juju config kubernetes-master proxy-extra-args="proxy-mode=userspace"
+juju config kubernetes-worker proxy-extra-args="proxy-mode=userspace"
+```
 
 ## Next Steps
 

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -232,6 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
+| 1.18.x         | [charmed-kubernetes-430](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-430/archive/bundle.yaml) |
 | 1.17.x         | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |
 | 1.16.x         | [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-316/archive/bundle.yaml) |
 | 1.15.x         | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
@@ -348,7 +349,7 @@ kubernetes-worker:
   expose: true
   num_units: 3
   options:
-    channel: 1.17/stable
+    channel: 1.18/stable
   resources:
     cni-amd64: 12
     cni-arm64: 10

--- a/templates/kubernetes/docs/multiple-networks.md
+++ b/templates/kubernetes/docs/multiple-networks.md
@@ -3,8 +3,8 @@ wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
-  title: "Using Multiple Networks"
-  description: Using multiple networks with Charmed Kubernetes.
+  title: "Using Multiple Host Networks"
+  description: Using multiple host networks with Charmed Kubernetes.
 keywords: juju, network, networking
 tags: [operating]
 sidebar: k8smain-sidebar
@@ -12,6 +12,10 @@ permalink: multiple-networks.html
 layout: [base, ubuntu-com]
 toc: False
 ---
+
+This page is about using multiple host networks with Charmed Kubernetes. For
+information on using multiple container networks, please refer to the
+[Multus](/kubernetes/docs/cni-multus) page instead.
 
 Using network spaces and bindings in Juju, it's possible to deploy Charmed
 Kubernetes in an environment with multiple networks and assign traffic to

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,96 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.18
+
+### April 13, 2020 - [charmed-kubernetes-430](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-430/archive/bundle.yaml)
+
+Before upgrading, please read the [upgrade notes](/kubernetes/docs/upgrade-notes).
+
+## What's new
+
+- New SSL options for nginx-ingress-controller
+
+New configuration options on the kubernetes-worker charm,
+`ingress-default-ssl-certificate` and `ingress-default-ssl-key`, allow you to
+configure nginx-ingress-controller with your own SSL certificate for serving
+Kubernetes ingress traffic.
+
+- Multus support
+
+This release of Charmed Kubernetes introduces support for
+[Multus](https://github.com/intel/multus-cni), a CNI provider that makes it
+possible to attach multiple network interfaces to your pods.
+
+Along the way, we've also updated existing charms to make it possible for
+multiple CNI providers to be deployed together in the same cluster.
+
+Please note that while we are making Multus support available today, it is
+dependent on functionality in Juju that is not yet considered stable. For more
+details on the current state of Multus support in Charmed Kubernetes and how to
+get started, please refer to the
+[Multus documentation page](/kubernetes/docs/cni-multus).
+
+- CIS Benchmark 1.5.0
+
+The `cis-benchmark` action now supports version 1.5.0 of the CIS Kubernetes Benchmark.
+See the [CIS compliance](/kubernetes/docs/cis-compliance) page for information on
+running this action on Charmed Kubernetes components.
+
+- Containerd version hold
+
+The version of [containerd](https://containerd.io/) will now be held. This means 
+that the version of [containerd](https://containerd.io/) will not be upgraded along
+with the charm. To update containerd to the latest stable, currently 1.3.3, you can
+call the `upgrade-containerd` action:
+
+```bash
+juju run-action --wait containerd/0 upgrade-containerd
+```
+
+This will perform the upgrade and return any output. If you have more than
+one unit of containerd,  you should run this on each unit. The upgrades can be
+staggered to avoid downtime.
+
+## Component Upgrades
+
+Many of the components in Charmed Kubernetes 1.18 have been upgraded. The following list
+highlights some of the more notable version changes:
+
+- containerd 1.3.3 (see above)
+- coredns 1.6.7
+- dashboard 2.0.0-rc5
+- etcd 3.3.15
+- openstack-provider 1.17
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.18](https://launchpad.net/charmed-kubernetes/+milestone/1.18).
+
+## Notes / Known Issues
+
+- Heapster, InfluxDB, Grafana addons have been removed from `cdk-addons`
+
+Heapster was initially [deprecated][heapster-deprecation] in 1.11; users
+were encouraged to move to the `metrics-server` for similar functionality.
+With 1.18, the `cluster-monitoring` addons (Heapster, InfluxDB, and Grafana)
+have been removed from the Kubernetes source tree and therefore removed from
+the `cdk-addons` snap as well. Customers relying on these addons should
+migrate to a `metrics-server` solution prior to upgrading. Note: these
+removals do not affect the Kubernetes Dashboard nor the methods described in
+[Monitoring Charmed Kubernetes](/kubernetes/docs/monitoring).
+
+- Containerd cannot pull images from a registry with TLS mutual authentication
+
+An issue with the `containerd` charm prevents pulling images from a private
+container registry when TLS mutual authentication is enabled. Where possible,
+users can workaround this issue by disabling mutual authentication on the
+registry. More details can be found in the following bug:
+
+https://bugs.launchpad.net/charm-containerd/+bug/1853653
+
+=======
 # 1.17+ck2 Bugfix release
 
 ### March 2, 2020 - [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml)
@@ -476,6 +566,7 @@ Please see [this page][historic] for release notes of earlier versions.
 [containerd]: /kubernetes/docs/containerd
 [container-runtime]: /kubernetes/docs/container-runtime
 [cis-benchmark]: https://www.cisecurity.org/benchmark/kubernetes/
+[heapster-deprecation]: https://github.com/kubernetes-retired/heapster/blob/master/docs/deprecation.md
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -7,6 +7,7 @@
   - [Local install](/kubernetes/docs/install-local)
 - **Cloud Integration**
   - [AWS integration](/kubernetes/docs/aws-integration)
+  - [Azure integration](/kubernetes/docs/azure-integration)
   - [GCP integration](/kubernetes/docs/gcp-integration)
   - [OpenStack integration](/kubernetes/docs/openstack-integration)
   - [LXD](/kubernetes/docs/install-local)
@@ -16,6 +17,7 @@
   - [Calico](/kubernetes/docs/cni-calico)
   - [Canal](/kubernetes/docs/cni-canal)
   - [Tigera Secure EE](/kubernetes/docs/tigera-secure-ee)  
+  - [Multus](/kubernetes/docs/cni-multus)
   - [Using multiple networks](/kubernetes/docs/multiple-networks)  
 - **Container Runtimes**
   - [Containerd & Docker](/kubernetes/docs/container-runtime)

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -19,6 +19,20 @@ The notes are organised according to the upgrade path below, but also be aware t
 upgrade that spans more than one minor version may need to beware of notes in
 any of the intervening steps.
 
+<a  id="1.18"> </a>
+
+## Upgrading to 1.18
+
+### CDK Addons
+
+As stated in the release notes, from 1.18, the `cluster-monitoring` addons (Heapster, InfluxDB, and Grafana)
+have been removed from the Kubernetes source tree and therefore removed from the `cdk-addons` snap as well. 
+
+Customers relying on these addons should migrate to a `metrics-server` solution prior to upgrading. 
+
+**Note:** these removals do not affect the Kubernetes Dashboard nor the methods described in
+[Monitoring Charmed Kubernetes](/kubernetes/docs/monitoring).
+
 <a  id="1.16"> </a>
 
 ## Upgrading to 1.16

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -40,10 +40,10 @@ As with all upgrades, there is a possibility that there may be unforeseen diffic
 
 You should also make sure:
 
-- The machine from which you will perform the backup has sufficient internet access to retrieve updated software
-- Your cluster is running normally
-- You read the [Upgrade notes][notes] to see if any caveats apply to the versions you are upgrading to/from
-- You read the [Release notes][release-notes] for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster
+-   The machine from which you will perform the backup has sufficient internet access to retrieve updated software
+-   Your cluster is running normally
+-   You read the [Upgrade notes][notes] to see if any caveats apply to the versions you are upgrading to/from
+-   You read the [Release notes][release-notes] for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster
 
 ## Infrastructure updates
 
@@ -54,21 +54,39 @@ This includes:
 - Docker
 - easyrsa
 - etcd
-- flannel
+- flannel, calico or other CNI
 
 Note that this may include other applications which you may have installed, such as Elasticsearch, Prometheus, Nagios, Helm, etc.
 
+
+
+<a id='upgrading-containerd'> </a>
+
+### Upgrading Containerd
+
+By default, Versions 1.15 and later use Containerd as the container
+runtime. This subordinate charm can be upgraded with the command:
+
+```bash
+juju upgrade-charm containerd
+```
+
 <a id='upgrading-docker'> </a>
 
-### Upgrading Docker
+### Upgrading Docker (if used)
 
-**Charmed Kubernetes** will use the latest stable version of Docker when it is deployed. Since upgrading Docker
-can cause service disruption, there will be no automatic upgrades and instead this process must
-be triggered by the operator.
+By default, versions of Charmed Kubernetes since 1.15 use the Containerd
+runtime. You will only need to upgrade the Docker runtime if you have
+explicitly set that to be the container runtime. If this is not the case, you
+should skip this section.
 
-Note that this upgrade step only applies to deployments which actually use the Docker
-container runtime. Versions 1.15 and later use containerd by default, and you should
-instead follow the [instructions below](#upgrading-containerd).
+**Charmed Kubernetes** will use the latest stable version of Docker when it is
+deployed. Since upgrading Docker can cause service disruption, there will be no
+automatic upgrades and instead this process must be triggered by the operator.
+
+Note that this upgrade step only applies to deployments which actually use the
+Docker container runtime. Versions 1.15 and later use containerd by default,
+and you should instead follow the [instructions above](#upgrading-containerd).
 
 #### Version 1.15 and later
 
@@ -115,16 +133,7 @@ juju run-action kubernetes-worker/0 upgrade-docker --wait
 As previously, wait between running the action on sucessive units to allow pods to migrate.
 
 
-<a id='upgrading-containerd'> </a>
 
-### Upgrading containerd
-
-By default, Versions 1.15 and later use Containerd as the container
-runtime. This subordinate charm can be upgraded with the command:
-
-```bash
-juju upgrade-charm containerd
-```
 
 ### Upgrading etcd
 
@@ -160,17 +169,21 @@ The other infrastructure applications can be upgraded by running the `upgrade-ch
 command:
 
 ```bash
-juju upgrade-charm flannel
 juju upgrade-charm easyrsa
 ```
 
-Any other infrastructure charms can be upgraded in a similar way.
+Any other infrastructure charms should be upgraded in a similar way. For
+example, if you are using the flannel CNI:
+
+```bash
+juju upgrade-charm flannel
+```
 
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
 Some services may be briefly interrupted during the upgrade process. Upgrading
-<strong>flannel</strong> will cause a small amount of network downtime. Upgrading
+your CNI (e.g. flannel) will cause a small amount of network downtime. Upgrading
 <strong>easyrsa</strong> will not cause any downtime. The behaviour of other
 components you have added to your cluster may vary - check individual documentation
 for these charms for more information on upgrades.
@@ -410,6 +423,7 @@ kube-system                       monitoring-influxdb-grafana-v4-65cc9bb8c8-mwvc
 
 [k8s-release]: https://github.com/kubernetes/kubernetes/releases
 [backups]: /kubernetes/docs/backups
+[release-notes]: /kubernetes/docs/release-notes
 [notes]: /kubernetes/docs/upgrade-notes
 [snap-channels]: https://docs.snapcraft.io/reference/channels
 [blue-green]: https://martinfowler.com/bliki/BlueGreenDeployment.html
@@ -418,9 +432,9 @@ kube-system                       monitoring-influxdb-grafana-v4-65cc9bb8c8-mwvc
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/upgrading.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/upgrading.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>


### PR DESCRIPTION
## Done

Update docs for 1.18 release
Add page for Multus
Add page for Azure integration

N.B. The text changes for these docs [have been reviewed already]( https://github.com/charmed-kubernetes/kubernetes-docs/tree/master)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
