### PR TITLE
Update PR template with dotrun

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## QA
 
 - Check out this feature branch
-- Run the site using the command `./run serve`
+- Run the site using the command `./run serve` or `dotrun`
 - View the site locally in your web browser at: http://0.0.0.0:8001/
 - Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
 - [List additional steps to QA the new features or prove the bug has been resolved]


### PR DESCRIPTION
## Done

I found myself writing `dotrun` in the QA instructions every time, and since people are already using it, I guess this needs to be updated.

