### PR TITLE
bump k8s version

### DIFF
--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -24,7 +24,7 @@ Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because 
     </div>
     <div class="col-4 p-divider__block">
       <h3>What's new</h3>
-      <p><a href="/kubernetes/docs/release-notes">Version 1.17 released&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes/docs/release-notes">Version 1.18 released&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Tutorials</h3>


### PR DESCRIPTION
## Done

update front page of docs to 1.18

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
