### PR TITLE
Add online competition privacy notice to legal section

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -36,7 +36,8 @@
         <li class="p-list__item"><a href="/legal/data-privacy/partner-portal">Partner Portal privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/esxi">ESXi privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/survey">Survey privacy notice&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/legal/data-privacy/events">Events privacy notice&nbsp;&rsquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/events">Events privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/online-competitions">Online competitions privacy notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">

--- a/templates/legal/data-privacy/online-competitions.md
+++ b/templates/legal/data-privacy/online-competitions.md
@@ -1,0 +1,120 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Privacy Notice – Online Competitions"
+  description: This Privacy Notice tells you about the information collected from you when you enter into an online competition and agree to your personal data being stored by Canonical.
+  copydoc: https://docs.google.com/document/d/1vy3Ta47YBWoKtvpbJyk01iYv3czAQMWz54G-UErA9zE/edit#
+---
+
+<h4 class="p-muted-heading">Version - April 2020</h4>
+<hr style="margin-bottom: 2rem;" />
+
+# Privacy Notice – Online&nbsp;competitions
+
+This Privacy Notice tells you about the information collected from you when you enter into an online competition and agree to your personal data being stored by Canonical. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our privacy policy.
+
+# Who are we?
+
+We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.
+
+We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
+What personal data do we collect?
+
+When you enter into an online competition, we may ask you for your name, address, contact telephone number and email address. If you are entering on behalf of a company, in accordance with the terms and conditions of the online competition, we may ask you for your company name, your job title, your work email and additional information about your company. We will retain your details in order to carry out the online competition, to contact you about the prize and/or notify you about the final winner. For the purposes of administering the online competition, the collection, use and processing of personal data may be completed by Canonical, its group companies or other third parties.
+
+## Why do we collect this information?
+
+We require this information for the purposes of administering the online competition, verifying eligibility and for fulfilment, delivery and arrangement of the prize. We may also contact you to follow up with you after the online competition, to provide you with information about Canonical’s products and services and to inform you of future competitions.
+
+## What do we do with your information?
+
+Your information is stored in our database and may be processed outside of the European Economic Area (EEA).
+
+Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of your personal information. If you would like further information please contact us (see “Your right to complain” below).
+
+Your data may be shared with third parties as reasonably required for Canonical to process and store your data in accordance with this privacy notice or respond to your request.
+
+## Our legal basis to use your Personal information
+
+### Our legitimate business interests
+
+Our legal basis for using your personal information is that it is necessary for our legitimate interest in holding the online competition, for your participation in the online competition and in accordance with the terms and conditions between us.
+
+We may contact you from time to time with information about products and services that we offer (see <a href="https://ubuntu.com/legal/data-privacy/partner-portal#mkt-comms">Marketing Communications to Businesses</a>). Our legal basis for using your personal information to contact you is that it is necessary for our legitimate interest in keeping you informed of the products and services that we offer. You can opt out of marketing communications as set out below.
+
+### Your consent
+
+If you enter into an online  competition, you will have the option to provide your consent to us sending you information about the products and services that we offer (see <a href="https://ubuntu.com/legal/data-privacy/partner-portal#mkt-comms">Email Marketing Communications</a>). You can withdraw your consent at any time.
+
+## How long do we keep your information for?
+
+We keep your information for the duration of the online competition and thereafter for so long as you consent and as reasonably required in accordance with our record retention policy.
+
+## Your rights over your information
+
+You have a number of important rights under data protection laws. In summary, those include rights to:
+
+- fair processing of information and transparency over how we use your personal information;
+- access to your personal information and to certain other supplementary information that this Privacy Notice is already designed to address;
+- require us to correct any mistakes in your information which we hold;
+- require the erasure of personal information concerning you in certain situations;
+- receive the personal information concerning you which you have provided to us, in a structured, commonly used and machine-readable format and have the right to transmit that data to a third party in certain situations;
+- object at any time to processing of personal information concerning you for direct marketing;
+- object to decisions being taken by automated means which produce legal effects concerning you or similarly significantly affect you;
+- object in certain other situations to our continued processing of your personal information;
+- otherwise restrict our processing of your personal information in certain circumstances;
+- claim compensation for damages caused by our breach of any data protection laws.
+
+For further information on each of those rights, including the circumstances in which they apply, see the Guidance from the UK Information Commissioner’s Office (ICO) on individuals rights.
+
+If you would like to exercise any of those rights, please:
+
+- email, call or write to us, please see “Your right to complain” section below;
+- let us have enough information to identify you;
+- let us have proof of your identity and address (a copy of your driving licence or passport and a recent utility or credit card bill); and
+- let us know the information to which your request relates.
+
+If you would like to unsubscribe from any email please see below.
+
+By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.
+
+You can also ask us to give you a copy of the information and to stop using your information for a period of time if you believe we are not doing so lawfully.
+To submit a request by email, post or telephone, please use the contact information provided above.
+
+## Email marketing communications
+
+Canonical offers a free email newsletter subscription service to keep you informed of our products and services. You may receive these marketing communications from us. We incorporate a tracking system in our email marketing communications which allows us to monitor whether the email has been opened and which links are the most popular. This allows us to tailor and refine our service to ensure that the emails you receive are relevant to your interests.
+
+Where you have consented to receiving email marketing material from us or are currently receiving material relating to similar products or services, you may at any time ask us to cease sending you such material by (i) clicking the unsubscribe button at the end of the email, (ii) reply to the email with “STOP”, (iii) sending an email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>, or (iv) navigating to your subscription centre page (you will need to login if you have not already done so) and click the 'unsubscribe' link at the foot of the page as appropriate.
+
+## Keeping your personal information secure
+
+We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorised way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorised manner and are subject to a duty of confidentiality.
+
+We also have procedures in place to deal with any suspected data security breach. We will notify you and any applicable regulator of a suspected data breach where we are legally required to do so.
+
+## Changes to this Privacy Notice
+
+This Privacy Notice will be reviewed from time to time. If we decide to change this Privacy Notice we will post the changes here. However, if we intend to make material changes to the way we use your personal information we will notify you before doing so. Any personal information held will be governed by our most current notice.
+
+## Your right to complain
+
+We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> or to the address below:
+
+Legal, Canonical
+5th Floor, Blue Fin Building
+110 Southwark Street
+London, SE1 0SU
+United Kingdom
+
+Alternatively, you can use the relevant contact us form.
+
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="https://ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:
+
+Information Commissioner's Office
+Wycliffe House
+Water Lane
+Wilmslow
+Cheshire
+SK9 5AF
+United Kingdom

--- a/templates/legal/data-privacy/online-competitions.md
+++ b/templates/legal/data-privacy/online-competitions.md
@@ -13,7 +13,7 @@ context:
 
 This Privacy Notice tells you about the information collected from you when you enter into an online competition and agree to your personal data being stored by Canonical. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our privacy policy.
 
-# Who are we?
+## Who are we?
 
 We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.
 
@@ -40,11 +40,11 @@ Your data may be shared with third parties as reasonably required for Canonical 
 
 Our legal basis for using your personal information is that it is necessary for our legitimate interest in holding the online competition, for your participation in the online competition and in accordance with the terms and conditions between us.
 
-We may contact you from time to time with information about products and services that we offer (see <a href="https://ubuntu.com/legal/data-privacy/partner-portal#mkt-comms">Marketing Communications to Businesses</a>). Our legal basis for using your personal information to contact you is that it is necessary for our legitimate interest in keeping you informed of the products and services that we offer. You can opt out of marketing communications as set out below.
+We may contact you from time to time with information about products and services that we offer (see <a href="/legal/data-privacy/partner-portal#mkt-comms">Marketing Communications to Businesses</a>). Our legal basis for using your personal information to contact you is that it is necessary for our legitimate interest in keeping you informed of the products and services that we offer. You can opt out of marketing communications as set out below.
 
 ### Your consent
 
-If you enter into an online  competition, you will have the option to provide your consent to us sending you information about the products and services that we offer (see <a href="https://ubuntu.com/legal/data-privacy/partner-portal#mkt-comms">Email Marketing Communications</a>). You can withdraw your consent at any time.
+If you enter into an online  competition, you will have the option to provide your consent to us sending you information about the products and services that we offer (see <a href="/legal/data-privacy/partner-portal#mkt-comms">Email Marketing Communications</a>). You can withdraw your consent at any time.
 
 ## How long do we keep your information for?
 
@@ -101,20 +101,28 @@ This Privacy Notice will be reviewed from time to time. If we decide to change t
 
 We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> or to the address below:
 
-Legal, Canonical
-5th Floor, Blue Fin Building
-110 Southwark Street
-London, SE1 0SU
-United Kingdom
+<div style="margin: 2rem;">
+  <p>
+    Legal, Canonical<br />
+    5th Floor, Blue Fin Building<br />
+    110 Southwark Street<br />
+    London, SE1 0SU<br />
+    United Kingdom
+  </p>
+</div>
 
 Alternatively, you can use the relevant contact us form.
 
-If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="https://ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a class="p-link--external" href="https://ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:
 
-Information Commissioner's Office
-Wycliffe House
-Water Lane
-Wilmslow
-Cheshire
-SK9 5AF
-United Kingdom
+<div style="margin: 2rem;">
+  <p>
+    Information Commissioner's Office<br />
+    Wycliffe House<br />
+    Water Lane<br />
+    Wilmslow<br />
+    Cheshire<br />
+    SK9 5AF<br />
+    United Kingdom
+  </p>
+</div>


### PR DESCRIPTION
## Done

Added competition privacy notice to the legal section

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8001/legal/data-privacy
- See the link to "Online competitions privacy notice" and click it
- Compare the page with the [copydoc](https://docs.google.com/document/d/1vy3Ta47YBWoKtvpbJyk01iYv3czAQMWz54G-UErA9zE/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #7223 
