### PR TITLE
CVE search and pagination

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -616,23 +616,13 @@ summary {
   width: 225px;
 }
 
-.p-icon--container {
-  display: block;
-  float: left;
-  margin-right: 0.5rem;
-  width: 1rem;
+.is-bordered--top {
+  @extend %vf-pseudo-border--top;
 }
 
-.p-container--icon {
-  float: left;
-  width: calc(100% - 1.5rem);
-}
+.p-label--base {
+  @extend %vf-label;
 
-.p-icon--placeholder {
-  display: inline-block;
-  height: 1em;
-  margin-right: 1em;
-  position: relative;
-  top: 2px;
-  width: 1em;
+  background-color: $color-mid-dark;
+  color: $color-x-light;
 }

--- a/templates/security/cve/_pagination.html
+++ b/templates/security/cve/_pagination.html
@@ -1,0 +1,97 @@
+{% if offset >= total_results %}
+  {% set current_page = 1 %}
+{% else %}
+  {% set current_page = ((offset / limit) + 1) | int %}
+{% endif %}
+
+{% if total_results > limit %}
+<div class="u-fixed-width">
+  <ol class="p-pagination u-align--center">
+    <li class="p-pagination__item">
+      {% if current_page > 1 %}
+      <a class="p-pagination__link--previous" href="?{{ modify_query({'offset': offset - limit}) }}" title="Previous page">
+        <i class="p-icon--contextual-menu">Previous page</i>
+      </a>
+      {% else %}
+      <span class="p-pagination__link--previous is-disabled">
+        <i class="p-icon--contextual-menu">Previous page</i>
+      </span>
+      {% endif %}
+    </li>
+
+    {# always show 5 pages in pagination #}
+    {% if current_page > 4 and current_page == total_pages %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page - 5) * limit}) }}" class="p-pagination__link">{{ current_page - 4 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page > 3 and current_page == total_pages - 1 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page - 4) * limit}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page > 3 and current_page == total_pages %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page - 4) * limit}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page > 2 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page - 3) * limit}) }}" class="p-pagination__link">{{ current_page - 2 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page > 1 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page - 2) * limit}) }}" class="p-pagination__link">{{ current_page - 1 }}</a>
+      </li>
+    {% endif %}
+
+    {# current current_page #}
+    <li class="p-pagination__item">
+      <a href="?{{ modify_query({'offset': offset }) }}" class="p-pagination__link is-active">{{ current_page }}</a>
+    </li>
+
+    {% if current_page < total_pages %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link">{{ current_page + 1 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page < total_pages - 1 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page + 1) * limit}) }}" class="p-pagination__link">{{ current_page + 2 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page < total_pages - 2 and current_page <= 2 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page < total_pages - 6 and current_page <= 3 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page + 3) * limit}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
+      </li>
+    {% endif %}
+
+    <li class="p-pagination__item">
+      {% if current_page != total_pages %}
+      <a class="p-pagination__link--next" href="?{{ modify_query({'offset': offset + limit}) }}" title="Next page">
+        <i class="p-icon--contextual-menu">Next page</i>
+      </a>
+      {% else %}
+      <span class="p-pagination__link--next is-disabled">
+        <i class="p-icon--contextual-menu">Next page</i>
+      </span>
+      {% endif %}
+    </li>
+  </ol>
+</div>
+{% endif %}
+
+

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -75,10 +75,37 @@
       {% endif %}
     </div>
 
-    {% if cve.status == 'active' %}
-    <div class="col-4">
-      <p>Priority: {{ cve.priority }}</p>
-      <p>CVSS base score: {{ cve.cvss }}</p>
+    {% if cve.status == 'active' and cve.priority %}
+    <div class="col-4 u-align--right">
+      {% if cve.priority == 'critical' or cve.priority == 'high' %}
+        <div class="p-label--deprecated">
+          Priority: {{ cve.priority }}
+        </div>
+      {% endif %}
+
+      {% if cve.priority == 'medium' %}
+        <div class="p-label--in-progress">
+          Priority: {{ cve.priority }}
+        </div>
+      {% endif %}
+
+      {% if cve.priority == 'low' %}
+        <div class="p-label--validated">
+          Priority: {{ cve.priority }}
+        </div>
+      {% endif %}
+
+      {% if cve.priority == 'negligible' %}
+        <div class="p-label--updated">
+          Priority: {{ cve.priority }}
+        </div>
+      {% endif %}
+
+      {% if cve.cvss %}
+        <div class="p-label--base">
+          CVSS base score: {{ cve.cvss }}
+        </div>
+      {% endif %}
     </div>
     {% endif %}
   </div>

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -3,12 +3,76 @@
 {% block title %}CVEs{% endblock %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
+<section class="p-strip--suru-topped">
   <div class="u-fixed-width">
     <h1>CVE reports</h1>
-    <p>A brief explanation of CVEs. Lorem ipsum, dolor sit amet consectetur adipisicing elit. Officia deleniti dolorum reprehenderit libero ad aliquid eligendi iste minus quis sunt facere ut mollitia ipsam, praesentium consectetur quaerat perferendis, tempora accusamus.</p>
+  </div>
 
-    <h2>Recent CVEs affecting Ubuntu</h2>
+  <div class="u-fixed-width">
+    <h2>Search</h2>
+  </div>
+
+  <form>
+    <div class="row">
+      <div class="col-3">
+        <label for="q">CVE ID:</label>
+        <input type="text" name="q" id="q" value="{{query}}">
+      </div>
+      <div class="col-3">
+        <label for="package">Package:</label>
+        <input type="text" name="package" id="package" value="{{package}}">
+      </div>
+      <div class="col-3">
+        <label for="priority">Priority:</label>
+        <select name="priority" id="priority">
+          <option value="">Any</option>
+          <option value="critical" {% if priority == 'critical' %}selected{% endif %}>
+            Critical
+          </option>
+          <option value="high" {% if priority == 'high' %}selected{% endif %}>
+            High
+          </option>
+          <option value="medium" {% if priority == 'medium' %}selected{% endif %}>
+            Medium
+          </option>
+          <option value="low" {% if priority == 'low' %}selected{% endif %}>
+            Low
+          </option>
+          <option value="negligible" {% if priority == 'negligible' %}selected{% endif %}>
+            Negligible
+          </option>
+        </select>
+      </div>
+      <div class="col-3">
+        <label>&nbsp;</label> <!-- required for layout -->
+        <button type="submit">Search</button>
+      </div>
+    </div>
+  </form>
+
+  <div class="u-fixed-width">
+    {% if query %}
+      <h2>
+        {% if total_results > 1 %}
+          {{ offset + 1 }} &ndash; {{ offset + limit  }} of
+        {% endif %}
+        {{ total_results }} result{% if total_results != 1 %}s{% endif %}
+      </h2>
+    {% else %}
+      <h2>Recent CVEs affecting Ubuntu</h2>
+    {% endif %}
+
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item">
+        <a href="?{{ modify_query({'order-by': 'oldest'}) }}">Oldest first</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a href="?{{ modify_query({'order-by': 'newest'}) }}">Newest first</a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="u-fixed-width">
     <table>
       <thead>
         <tr>
@@ -49,6 +113,10 @@
         {% endfor %}
       </tbody>
     </table>
+
+    {% with %}
+      {% include "security/cve/_pagination.html" %}
+    {% endwith %}
   </div>
 </section>
 

--- a/webapp/security/fixtures/load_sample_cve.py
+++ b/webapp/security/fixtures/load_sample_cve.py
@@ -263,6 +263,114 @@ def load_sample_cve():
                         ),
                     ],
                 ),
+                Package(
+                    name="gitlab2",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE"),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
+                Package(
+                    name="gitlab3",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE"),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
+                Package(
+                    name="gitlab4",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE",),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
             ],
         ),
         CVE(
@@ -309,6 +417,42 @@ def load_sample_cve():
                 ),
                 Package(
                     name="gitlab2",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE"),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
+                Package(
+                    name="gitlab3",
                     type="package",
                     source="https://launchpad.net/distros/"
                     + "ubuntu/+source/gitlab",
@@ -852,6 +996,114 @@ def load_sample_cve():
                     debian="https://tracker.debian.org/pkg/gitlab",
                     releases=[
                         PackageReleaseStatus(name="Upstream", status="DNE"),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
+                Package(
+                    name="gitlab2",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE"),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
+                Package(
+                    name="gitlab3",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE"),
+                        PackageReleaseStatus(
+                            name="Ubuntu 12.04 ESM (Precise Pangolin)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 14.04 ESM (Precise Pangolin)",
+                            status="DNE",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 16.04 LTS (Xenial Xerus)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 18.04 LTS (Bionic Beaver)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 19.10 (Eoan Ermine)",
+                            status="needs-triage",
+                        ),
+                        PackageReleaseStatus(
+                            name="Ubuntu 20.04 (Focal Fossa)",
+                            status="not-affected",
+                            status_description="(1.0.49-4)",
+                        ),
+                    ],
+                ),
+                Package(
+                    name="gitlab4",
+                    type="package",
+                    source="https://launchpad.net/distros/"
+                    + "ubuntu/+source/gitlab",
+                    ubuntu="https://launchpad.net/ubuntu/+source/gitlab",
+                    debian="https://tracker.debian.org/pkg/gitlab",
+                    releases=[
+                        PackageReleaseStatus(name="Upstream", status="DNE",),
                         PackageReleaseStatus(
                             name="Ubuntu 12.04 ESM (Precise Pangolin)",
                             status="needs-triage",

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -315,6 +315,7 @@ def cve_index():
         limit=limit,
         priority=priority,
         query=query,
+        package=package,
     )
 
 


### PR DESCRIPTION
## Done

- Add basic search to /security/cve
- Add pagination to /security/cve

## QA

- Check out this feature branch
- Run the following commands
- `docker-compose up -d`
- `dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres` (exit command once site is ready)
- `dotrun exec python3 webapp/security/fixtures/load_sample_cve.py`
- `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Add the query string `?limit=1` to the URL and check that there is working pagination
- Enter `cve` in the search box and submit the form and check that there is a result
- Enter `gitlab` in the package field and submit the form and check that there is a result
- Change the priority in the dropdown and submit the form and check that there is a result
- Enter the same values in all three form fields (set priority to `medium`) and submit the form and check that there is a result

## Issue / Card

Fixes #7056