### PR TITLE
Copy updates to security certifications page

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -99,7 +99,7 @@
         DISA has in conjunction with Canonical developed a STIG for Ubuntu 16.04.
       </p>
       <p>
-        <a href="https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Canonical_Ubuntu_16-04_LTS_V1R2_STIG.zip">Download the STIG</a>
+        <a href="https://nvd.nist.gov/ncp/checklist/859">Read the Ubuntu STIG checklist</a>
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
@@ -113,10 +113,10 @@
     <div class="col-8">
       <h2>CIS Benchmark</h2>
       <p>
-        Center for Internet Security (CIS) is a non-profit organization that uses a consensus process to release benchmarks to safeguard organizations against cyber attacks. The benchmark contains configuration checklists to harden a system making it less vulnerable to malicious attacks. The consensus review process consists of subject matter experts who provide perspective on different backgrounds like audit and compliance, security research, consulting and software development. Each benchmark undergoes two phases of consensus review. In the first phase, a benchmark is drafted with the help of subject matter experts and a initial version of the benchmark is published. In the second phase, feedback from the wider internet community is reviewed and incorporated into the benchmark. Canonical has actively participated in the drafting of Ubuntu 16.04 and Ubuntu 18.04 benchmarks. CIS has also published benchmarks for Ubuntu 12.04 and 14.04 releases.
+        Center for Internet Security (CIS) is a non-profit organization that uses a consensus process to release benchmarks to safeguard organizations against cyber attacks. The benchmark contains configuration checklists to harden a system making it less vulnerable to malicious attacks. The consensus review process consists of subject matter experts who provide perspective on different backgrounds like audit and compliance, security research, consulting and software development. Each benchmark undergoes two phases of consensus review. In the first phase, a benchmark is drafted with the help of subject matter experts and an initial version of the benchmark is published. In the second phase, feedback from the wider internet community is reviewed and incorporated into the benchmark. Canonical has actively participated in the drafting of Ubuntu 16.04 and Ubuntu 18.04 benchmarks. CIS has also published benchmarks for Ubuntu 12.04 and 14.04 releases.
       </p>
       <p>
-        <a class="p-link--external" href="https://www.cisecurity.org/cis-benchmarks/">Download CIS Benchmarks for Ubuntu</a>
+        <a class="p-link--external" href="https://www.cisecurity.org/partner/canonical/">Read CIS Benchmarks for Ubuntu</a>
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

Updated come content on the certs page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Check against the [copydoc](https://docs.google.com/document/d/1CiF-dPqG1Y--h4FWfgKB1ft4G3nC2Boa8NT_JG7D6dQ/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html


## Issue / Card

Fixes #7220 
