### PR TITLE
Replace MongoDB logo with text community edition

### DIFF
--- a/templates/managed-apps/index.html
+++ b/templates/managed-apps/index.html
@@ -124,17 +124,10 @@
           }}
         </li>
         <li class="p-inline-images__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/36aaa31f-MongoDB_Logo_FullColorBlack_RGB.svg",
-            alt="mongo db",
-            width="144",
-            height="39",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
-            ) | safe
-          }}
+          <strong>
+            MongoDB Community Edition<br />
+            (non SSPL)
+          </strong>
         </li>
         <li class="p-inline-images__item">
           {{


### PR DESCRIPTION
## Done

- on managed-apps page, replace MongoDb icon with text 'MongoDB Community Edition
(non SSPL)' per Katherine O

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed-apps
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See really ugly text instead of the logo


## Screenshots

[If relevant, please include a screenshot.]
![image](https://user-images.githubusercontent.com/441217/79379935-98c2b180-7f57-11ea-9940-36a68a29678d.png)
