### PR TITLE
Updated takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -42,10 +42,10 @@
   {# ALL #}
   {% include "takeovers/_ibm_athena_release.html" %}
   {% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
-  {% include "takeovers/_cloud-cost-analysis.html" %}
   {% include "takeovers/_charmed-openstack-adoption.html" %}
   {% include "takeovers/_rule4-core-cybersecurity.html" %}
   {% include "takeovers/_managed-apps.html" %}
+  {% include "takeovers/_ubuntu-masters-virtual-202004.html" %}
 
 {% endblock takeover_content %}
 


### PR DESCRIPTION
Removed  takeovers/_cloud-cost-analysis.html.

I added takeovers/_ubuntu-masters-virtual-202004.html again so that it appears in the rotation more, although I am unsure if this works?

## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
