### PR TITLE
add renewals invoice endpoint

### DIFF
--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -26,9 +26,12 @@ def _prepare_request(method, path, data=None, session=None):
     return request.prepare()
 
 
-def _send(request, timeout=3):
+def _send(request, timeout=5, raise_http_errors=True):
     response = api_session.send(request, timeout=timeout)
-    response.raise_for_status()
+
+    if raise_http_errors:
+        response.raise_for_status()
+
     return response
 
 
@@ -100,7 +103,21 @@ def put_method_id(session, account_id, payment_method_id):
             path=f"v1/accounts/{account_id}/payment-method/stripe",
             data={"paymentMethodID": payment_method_id},
             session=session,
-        )
+        ),
+        raise_http_errors=False,
+    )
+
+    return response.json()
+
+
+def post_stripe_invoice_id(session, invoice_id, renewal_id):
+    response = _send(
+        _prepare_request(
+            method="post",
+            path=f"v1/renewals/{renewal_id}/payment/stripe/{invoice_id}",
+            session=session,
+        ),
+        raise_http_errors=False,
     )
 
     return response.json()
@@ -122,7 +139,9 @@ def accept_renewal(session, renewal_id):
             method="post",
             path=f"v1/renewals/{renewal_id}/acceptance",
             session=session,
-        )
+        ),
+        timeout=30,
+        raise_http_errors=False,
     )
 
     return response.json()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,6 +41,7 @@ from webapp.views import (
     download_thank_you,
     get_renewal,
     post_stripe_method_id,
+    post_stripe_invoice_id,
     releasenotes_redirect,
 )
 from webapp.login import login_handler, logout
@@ -121,7 +122,12 @@ app.add_url_rule(
     methods=["POST"],
 )
 app.add_url_rule(
-    "/advantage/renewals/{renewal_id}", view_func=get_renewal, methods=["GET"]
+    "/advantage/renewals/invoice",
+    view_func=post_stripe_invoice_id,
+    methods=["POST"],
+)
+app.add_url_rule(
+    "/advantage/renewals/<renewal_id>", view_func=get_renewal, methods=["GET"],
 )
 
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -122,7 +122,7 @@ app.add_url_rule(
     methods=["POST"],
 )
 app.add_url_rule(
-    "/advantage/renewals/invoice",
+    "/advantage/renewals/<renewal_id>/invoices/<invoice_id>",
     view_func=post_stripe_invoice_id,
     methods=["POST"],
 )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -258,6 +258,26 @@ def post_stripe_method_id():
         return flask.jsonify({"error": "authentication required"}), 401
 
 
+def post_stripe_invoice_id():
+    if auth.is_authenticated(flask.session):
+        if not flask.request.is_json:
+            return flask.jsonify({"error": "JSON required"}), 400
+
+        invoice_id = flask.request.json.get("invoice_id")
+        if not invoice_id:
+            return flask.jsonify({"error": "invoice_id required"}), 400
+
+        renewal_id = flask.request.json.get("renewal_id")
+        if not renewal_id:
+            return flask.jsonify({"error": "renewal_id required"}), 400
+
+        return advantage.post_stripe_invoice_id(
+            flask.session, invoice_id, renewal_id
+        )
+    else:
+        return flask.jsonify({"error": "authentication required"}), 401
+
+
 def get_renewal(renewal_id):
     if auth.is_authenticated(flask.session):
         return advantage.get_renewal(flask.session, renewal_id)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -258,19 +258,8 @@ def post_stripe_method_id():
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def post_stripe_invoice_id():
+def post_stripe_invoice_id(renewal_id, invoice_id):
     if auth.is_authenticated(flask.session):
-        if not flask.request.is_json:
-            return flask.jsonify({"error": "JSON required"}), 400
-
-        invoice_id = flask.request.json.get("invoice_id")
-        if not invoice_id:
-            return flask.jsonify({"error": "invoice_id required"}), 400
-
-        renewal_id = flask.request.json.get("renewal_id")
-        if not renewal_id:
-            return flask.jsonify({"error": "renewal_id required"}), 400
-
         return advantage.post_stripe_invoice_id(
             flask.session, invoice_id, renewal_id
         )


### PR DESCRIPTION
When a payment fails, the user can attempt to pay with updated payment method details, in which case we need to post to this endpoint in order for the ua-contracts service to use the new payment method on the current payment.