### PR TITLE
Add /core/build/notify endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ canonicalwebteam.discourse-docs==0.11.1
 python-dateutil==2.8.1
 pytz==2019.3
 canonicalwebteam.store-api==1.0.5
-canonicalwebteam.launchpad==0.3.1
+canonicalwebteam.launchpad==0.4.0
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedgen==0.9.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -37,6 +37,7 @@ from webapp.views import (
     blog_custom_group,
     blog_custom_topic,
     blog_press_centre,
+    build_tutorials_index,
     download_thank_you,
     get_renewal,
     post_stripe_method_id,
@@ -44,7 +45,7 @@ from webapp.views import (
     post_build,
     releasenotes_redirect,
     search_snaps,
-    build_tutorials_index,
+    notify_build,
 )
 from webapp.login import login_handler, logout
 from webapp.security.views import (
@@ -180,6 +181,9 @@ template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/snaps", view_func=search_snaps)
 app.add_url_rule("/core/build", view_func=post_build, methods=["POST"])
+app.add_url_rule(
+    "/core/build/notify", view_func=notify_build, methods=["POST"]
+)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 url_prefix = "/server/docs"


### PR DESCRIPTION
**Depends on https://github.com/canonical-web-and-design/canonicalwebteam.launchpad/pull/18**

This submits the form to Marketo to send the email to the user.

Also:

- Add secrets to webhooks when creating them
- Verify the secret when triggering the webhook
- Change metadata on builds: Store "_board" and "_name" instead of
  "_full_name"

Marketo expects a `imageBuilderDownloadlink`, but I can't see any way
to get this download URL from
[the build object in the API](https://launchpad.net/+apidoc/devel.html#build).

QA
--

```bash
dotrun clean
dotrun
```

Now try triggering the build endpoint:

```bash
$ curl -i -X POST --data '{"action": "created", "livefs": "/~imagebuild/+livefs/ubuntu/bionic/ubuntu-cpc", "livefs_build": "/~imagebuild/+livefs/ubuntu/bionic/ubuntu-cpc/+build/211926", "status": "Needs building"}' -H "Content-Type: application/json" http://localhost:8001/core/build/notify
HTTP/1.1 403 FORBIDDEN
...
No X-Hub-Signature provided

$ curl -i -X POST -H 'X-Hub-Signature: sha1=4db21d3e2d2e246e64172248f92997752601ed09' --data '{"action": "created", "livefs": "/~imagebuild/+livefs/ubuntu/bionic/ubuntu-cpc", "livefs_build": "/~imagebuild/+livefs/ubuntu/bionic/ubuntu-cpc/+build/211926", "status": "Fake status"}' -H "Content-Type: application/json" http://localhost:8001/core/build/notify
HTTP/1.1 400 BAD REQUEST
...
X-Hub-Signature does not match

$ curl -i -X POST -H 'X-Hub-Signature: sha1=a3dc19b497f8229bd3c6d2b619e186f23eeb9d82' --data '{"action": "created", "livefs": "/~imagebuild/+livefs/ubuntu/bionic/ubuntu-cpc", "livefs_build": "/~imagebuild/+livefs/ubuntu/bionic/ubuntu-cpc/+build/212425", "status": "Needs building"}' -H "Content-Type: application/json" http://localhost:8001/core/build/notify
HTTP/1.1 202 ACCEPTED
...
Submitted
```

After a while, I will receive an email. Lol. I guess you could ask me to make sure that happened?