### PR TITLE
Add Raspberry Pi tutorial notice to /download/raspberry-pi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -29,7 +29,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-shallow notice">
+<section class="p-strip is-shallow is-bordered">
   <div class="u-fixed-width">
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -14,7 +14,6 @@
     <div class="col-8">
       <h1>Install Ubuntu Server on a Raspberry Pi 2, 3 or 4</h1>
       <p>Running Ubuntu Server on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your pi and away you go.</p>
-
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -39,7 +39,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered u-no-padding--bottom u-hide--small">
+<section class="p-strip u-no-padding--bottom u-hide--small">
   <div class="row u-equal-height u-vertically-center u-sv3">
     <div class="col-3">
       <h2 class="u-no-margin--bottom">Download your Ubuntu Pi image</h2>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -14,6 +14,7 @@
     <div class="col-8">
       <h1>Install Ubuntu Server on a Raspberry Pi 2, 3 or 4</h1>
       <p>Running Ubuntu Server on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your pi and away you go.</p>
+
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{
@@ -29,7 +30,16 @@
     </div>
   </div>
 </section>
-
+<section class="p-strip is-shallow notice">
+  <div class="u-fixed-width">
+    <div class="p-heading-icon">
+      <div class="p-heading-icon__header">
+        <img alt="Raspberry Pi Ubuntu tutorial" class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg">
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">First time installing Ubuntu on Raspberry Pi? Follow our tutorial &rsaquo;</a></h4>
+      </div>
+    </div>
+  </div>
+</section>
 <section class="p-strip is-bordered u-no-padding--bottom u-hide--small">
   <div class="row u-equal-height u-vertically-center u-sv3">
     <div class="col-3">


### PR DESCRIPTION
## Done

- Add Raspberry Pi tutorial notice to /download/raspberry-pi
- Updated copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Got to [/download/raspberry-pi](https://ubuntu-com-canonical-web-and-design-pr-7270.run.demo.haus/download/raspberry-pi), ensure the notice works well on desktop/mobile

## Screenshots

![Screenshot_2020-04-17 Install Ubuntu Server on a Raspberry Pi 2, 3 or 4 Ubuntu(1)](https://user-images.githubusercontent.com/18480003/79556002-bfd8ca80-80a0-11ea-9c8b-2a2e7d92d461.png)

