### PR TITLE
Updated the UM times and corrected the copy doc.

### DIFF
--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Ubuntu Masters are IT practitioners who are driving revolutionary change in the corporate space. Watch videos from our first Ubuntu Masters Conference, featuring these inspiring doers to hear how they are solving complex industry-wide challenges.{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1BXbsNMORvI7aW3qBgix7-VN7kbc6WizxiraacNFC7_w/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Z63eMCe9o4Onk2ezPFLPDTbI-uJezAOzI-aSpXmZ5lc/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--suru-half-and-half-reversed is-dark">
@@ -49,21 +49,21 @@
           <td><strong>Opening Session</strong></td>
         </tr>
         <tr>
-          <th>11:30 pm ET</th>
+          <th>11:45 pm ET</th>
           <td>
             <strong>Scaling years of growth in one week: Building a high-performance global internet edge using Ubuntu and open source</strong><br />
             <cite><a class="p-link--external" href="https://www.linkedin.com/in/robwc/">Rob Cameron</a>, Technical Director, Cloud Services, Roblox &amp; Adam Mills, Principal Engineer, Roblox</cite>
           </td>
         </tr>
         <tr>
-          <th>12:30 pm ET</th>
+          <th>1 pm ET</th>
           <td>
             <strong>Introduction to edge computing for computer vision and robotics</strong><br />
             <cite><a class="p-link--external" href="https://www.linkedin.com/in/seankellydev/">Sean Kelly</a>, Senior Software Engineer, ifm</cite>
           </td>
         </tr>
         <tr>
-          <th>1:30 pm ET</th>
+          <th>2:15 pm ET</th>
           <td>
             <strong>Building the datacentre: Implementing self-service for large-scale operations</strong><br />
             <cite><a class="p-link--external" href="https://www.linkedin.com/in/joshuamcclintock/">Joshua McClintock</a>, MTS, Systems Design Engineering, T-Mobile</cite>


### PR DESCRIPTION
Fixes #7273 

Updating the UM times and corrected the copy doc.

## Done

Updated the UM times and corrected the copy doc.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the changes against the [copy doc](https://docs.google.com/document/d/1Z63eMCe9o4Onk2ezPFLPDTbI-uJezAOzI-aSpXmZ5lc).

*Note; I have told Katie not to include the secondary time in the copy doc.
