### PR TITLE
Update Google Cloud Platform logo

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -125,10 +125,10 @@
       <li class="p-inline-images__item">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/4f54c31c-Google-Cloud-Platform.png?w=144",
+          url="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=144",
           alt="Google Cloud Platform",
           width="144",
-          height="47",
+          height="88",
           hi_def=True,
           loading="lazy",
           attrs={"class": "p-inline-images__logos"},

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -278,10 +278,10 @@
       <li class="p-inline-images__item">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/4f54c31c-Google-Cloud-Platform.png?w=144",
+          url="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=144",
           alt="Google Cloud Platform",
           width="144",
-          height="47",
+          height="88",
           hi_def=True,
           loading="lazy",
           attrs={"class": "p-inline-images__logos"},

--- a/templates/managed-apps/index.html
+++ b/templates/managed-apps/index.html
@@ -217,10 +217,10 @@
       <li class="p-inline-images__item">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/4f54c31c-Google-Cloud-Platform.png?w=144",
+          url="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=144",
           alt="Google Cloud Platform",
           width="144",
-          height="47",
+          height="88",
           hi_def=True,
           loading="lazy",
           attrs={"class": "p-inline-images__logos"},


### PR DESCRIPTION
## Done

- Updated https://ubuntu.com/managed-apps and https://ubuntu.com/kubernetes to use the correct Google Cloud Platform logo.

(The correct logo is already used on https://ubuntu.com/download/cloud, so I am using that asset.)