### PR TITLE
Copy update for desktop/partners. Add new logos

### DIFF
--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>Ubuntu for partners</h1>
-      <p>We partner with the world’s leading hardware manufacturers and silicon vendors to help deliver an extensive range of Ubuntu certified desktops, notebooks and servers. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimised performance of all your hardware for the life of the OS.</p>
+      <p>We partner with the world’s leading hardware manufacturers to help deliver an extensive range of Ubuntu certified laptops, desktops and workstations for a secure and constantly updated platform. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimised performance of all your hardware for the life of the OS.</p>
       <p><a href="https://partners.ubuntu.com/find-a-partner?service-offered=hardware-manufacturer" class="p-link--external">Learn more about our desktop partners</a></p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
@@ -17,10 +17,10 @@
         <li class="p-inline-images__item u-no-margin--right">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
-              alt="",
-              height="31",
-              width="162",
+              url="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg",
+              alt="Dell",
+              height="100",
+              width="100",
               hi_def=True,
               attrs={"class": "p-inline-images__logo"},
               loading="auto",
@@ -30,10 +30,10 @@
         <li class="p-inline-images__item u-no-margin--right">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/5e92614c-amd-logo.svg",
-              alt="",
-              height="22",
-              width="95",
+              url="https://assets.ubuntu.com/v1/f627fbfb-hp.svg",
+              alt="HP",
+              height="100",
+              width="100",
               hi_def=True,
               attrs={"class": "p-inline-images__logo"},
               loading="auto",
@@ -43,10 +43,10 @@
         <li class="p-inline-images__item u-no-margin--right">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
-              alt="",
-              height="99",
-              width="99",
+              url="https://assets.ubuntu.com/v1/cb3fcdfb-lenovo.svg",
+              alt="Lenovo",
+              height="100",
+              width="144",
               hi_def=True,
               attrs={"class": "p-inline-images__logo"},
               loading="auto",

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -119,7 +119,7 @@
     <div class="col-6 u-vertically-center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/d9105909-Dell_XPS_Laptop_Left-Desktop.png",
+          url="https://assets.ubuntu.com/v1/3e3f7d1f-hero-laptop.png",
           alt="Photo of a laptop running Ubuntu",
           height="311",
           width="502",


### PR DESCRIPTION
## Done

- Updated desktop/partners copy

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/partners
- Check the [copy](https://docs.google.com/document/d/1b4pwQYVHm8-R5_Wqx5zj09Qn8QsrKt3JblteauspmKI/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

*NOTE* The laptop image at the bottom of the page isn't ready yet and will be added in another branch


## Issue / Card

Fixes #7163 