### PR TITLE
Search based on the selected architecture

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ canonicalwebteam.image-template==1.0.0
 canonicalwebteam.discourse-docs==0.11.1
 python-dateutil==2.8.1
 pytz==2019.3
-canonicalwebteam.store-api==1.0.5
 canonicalwebteam.launchpad==0.4.0
+canonicalwebteam.store-api==2.0.3
 maxminddb-geolite2==2018.703
 Flask-OpenID-Stateless==1.2.6
 feedgen==0.9.0

--- a/static/js/src/imageBuilder.js
+++ b/static/js/src/imageBuilder.js
@@ -268,9 +268,9 @@
       selection.addEventListener("click", function () {
         selectCollection(collection, selection);
         const value = this.querySelector(".js-name").innerText;
-        if (stateIndex == 'board') {
-          state.set('os', [""]);
-          state.get('snaps').reset();
+        if (stateIndex == "board") {
+          state.set("os", [""]);
+          state.get("snaps").reset();
           renderSnapList(state.get("snaps"), preinstallResults, "Remove");
           removeSnapHandler();
         }
@@ -279,7 +279,6 @@
       });
     });
   }
-
 
   function selectCollection(collection, selected) {
     collection.forEach((item) => {
@@ -355,11 +354,23 @@
   function checkDisabled() {
     step2.classList.add("u-disable");
     step3.classList.add("u-disable");
+    archOutput.classList.add("u-hide");
     if (state.get("board") && state.get("board")[0]) {
       step2.classList.remove("u-disable");
     }
     if (state.get("os") && state.get("os")[0]) {
       step3.classList.remove("u-disable");
+      const board = parseSystemValues(state.get("board")[0]);
+      const os = parseSystemValues(state.get("os")[0]);
+      console.log(state.get("board")[0], state.get("os")[0]);
+
+      if (board_architectures[board][os]) {
+        const architecture = board_architectures[board][os]["arch"];
+        archOutput.querySelector(
+          ".js-architecture-detail"
+        ).innerText = architecture;
+        archOutput.classList.remove("u-hide");
+      }
     }
 
     // If snaps is disabled clear all selections and values

--- a/static/js/src/imageBuilder.js
+++ b/static/js/src/imageBuilder.js
@@ -142,6 +142,8 @@
   }, 250);
 
   function clearSearch() {
+    const searchInput = snapSearch.querySelector(".p-search-box__input");
+    searchInput.value = "";
     snapResults.innerHTML = "";
   }
 
@@ -266,11 +268,18 @@
       selection.addEventListener("click", function () {
         selectCollection(collection, selection);
         const value = this.querySelector(".js-name").innerText;
+        if (stateIndex == 'board') {
+          state.set('os', [""]);
+          state.get('snaps').reset();
+          renderSnapList(state.get("snaps"), preinstallResults, "Remove");
+          removeSnapHandler();
+        }
         state.set(stateIndex, [value]);
         updateOSs();
       });
     });
   }
+
 
   function selectCollection(collection, selected) {
     collection.forEach((item) => {
@@ -282,19 +291,22 @@
   function updateOSs() {
     osSelection.forEach((selection) => {
       const osSupport = selection.dataset.supports;
+      const selectedOS = state.get("os")[0];
       const selectedBoard = parseSystemValues(state.get("board")[0]);
+      const selectionValue = selection.querySelector(".js-name").innerText;
+
+      // Update the selected OS based on the state
+      if (selectedOS == selectionValue) {
+        selection.classList.add("is-selected");
+      } else {
+        selection.classList.remove("is-selected");
+      }
 
       // Check if the currently selected OS supports the this board
       if (osSupport.includes(selectedBoard)) {
         selection.closest(".js-selection-container").classList.remove("u-hide");
       } else {
         selection.closest(".js-selection-container").classList.add("u-hide");
-
-        // If current OS selection is not supported by the board reset OS
-        if (selection.classList.contains("is-selected")) {
-          state.set("os", [""]);
-          selection.classList.remove("is-selected");
-        }
       }
     });
   }
@@ -347,19 +359,12 @@
       step2.classList.remove("u-disable");
     }
     if (state.get("os") && state.get("os")[0]) {
-      const board = parseSystemValues(state.get("board")[0]);
-      const os = parseSystemValues(state.get("os")[0]);
-      if (board_architectures[board][os]) {
-        const architecture = board_architectures[board][os]["arch"];
-        if (archOutput.innerText !== architecture) {
-          archOutput.innerText = architecture;
-          state.get("snaps").reset();
-          renderSnapList(state.get("snaps"), preinstallResults, "Remove");
-          removeSnapHandler();
-          clearSearch();
-        }
-      }
       step3.classList.remove("u-disable");
+    }
+
+    // If snaps is disabled clear all selections and values
+    if (!state.get("os")[0]) {
+      clearSearch();
     }
   }
 
@@ -394,5 +399,6 @@
     return parsed;
   }
 
-  renderSummary();
+  // Init
+  render();
 })();

--- a/static/js/src/imageBuilder.js
+++ b/static/js/src/imageBuilder.js
@@ -258,7 +258,9 @@
         render();
       } else {
         results.innerHTML =
-          buttonText == "Add" ? "<p>No matching snaps</p>" : "<p>None</p>";
+          buttonText == "Add"
+            ? "<p>No matching snaps</p>"
+            : "<p>No snaps to preinstall</p>";
       }
     }
   }
@@ -362,7 +364,6 @@
       step3.classList.remove("u-disable");
       const board = parseSystemValues(state.get("board")[0]);
       const os = parseSystemValues(state.get("os")[0]);
-      console.log(state.get("board")[0], state.get("os")[0]);
 
       if (board_architectures[board][os]) {
         const architecture = board_architectures[board][os]["arch"];

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -199,7 +199,6 @@
     <div class="col-10 u-sv3">
       <h2><span class="u-number-circle">3</span> What packages do you want preinstalled?</h2>
       <p>Select the applications that will be pre-installed on the device. For Ubuntu Core this will be snaps, for Ubuntu Classic it will be snaps or packages.</p>
-      <p>Your selected archtecture is <strong class="js-architecture"></strong>. If you are missing a snap its probably not supported by this archtecture.</p>
     </div>
   </div>
   <div class="row">
@@ -218,6 +217,15 @@
       <h4>Your chosen snaps:</h4>
       <div class="p-card has-limited-height--large">
         <div class="js-preinstalled-snaps-list"></div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <div class="p-notification--information js-architecture u-hide">
+        <p class="p-notification__response">
+          <span class="p-notification__status">Information:</span> Your selected architecture is <strong class="js-architecture-detail"></strong>. If you are missing a snap its probably not supported by this architecture.
+        </p>
       </div>
     </div>
   </div>

--- a/templates/core/build.html
+++ b/templates/core/build.html
@@ -143,7 +143,7 @@
   <div class="js-os">
     <div class="row  js-selection-container">
       <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberry-pi2 raspberry-pi3 intel-nuc">
+        <button class="p-button is-wide js-selection" data-supports="raspberrypi2 raspberrypi3 intelnuc">
           <span class="js-name">Core 16</span>
         </button>
       </div>
@@ -153,7 +153,7 @@
     </div>
     <div class="row  js-selection-container">
       <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberry-pi2 raspberry-pi3 raspberry-pi4 intel-nuc">
+        <button class="p-button is-wide js-selection" data-supports="raspberrypi2 raspberrypi3 raspberrypi4 intelnuc">
           <span class="js-name">Core 18</span>
         </button>
       </div>
@@ -163,7 +163,7 @@
     </div>
     <div class="row  js-selection-container">
       <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberry-pi2 raspberry-pi3">
+        <button class="p-button is-wide js-selection" data-supports="raspberrypi2 raspberrypi3">
           <span class="js-name">Classic 16.04</span>
         </button>
       </div>
@@ -173,7 +173,7 @@
     </div>
     <div class="row  js-selection-container">
       <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberry-pi2 raspberry-pi3 raspberry-pi4">
+        <button class="p-button is-wide js-selection" data-supports="raspberrypi2 raspberrypi3 raspberrypi4">
           <span class="js-name">Classic 18.04</span>
         </button>
       </div>
@@ -183,7 +183,7 @@
     </div>
     <div class="row  js-selection-container">
       <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberry-pi3 raspberry-pi4">
+        <button class="p-button is-wide js-selection" data-supports="raspberrypi3 raspberrypi4">
           <span class="js-name">Classic 64-bit 18.04</span>
         </button>
       </div>
@@ -199,6 +199,7 @@
     <div class="col-10 u-sv3">
       <h2><span class="u-number-circle">3</span> What packages do you want preinstalled?</h2>
       <p>Select the applications that will be pre-installed on the device. For Ubuntu Core this will be snaps, for Ubuntu Classic it will be snaps or packages.</p>
+      <p>Your selected archtecture is <strong class="js-architecture"></strong>. If you are missing a snap its probably not supported by this archtecture.</p>
     </div>
   </div>
   <div class="row">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -17,7 +17,7 @@ import talisker.requests
 from ubuntu_release_info.data import Data
 from canonicalwebteam.blog import BlogViews
 from canonicalwebteam.blog.flask import build_blueprint
-from canonicalwebteam.store_api.stores.snapcraft import SnapcraftStoreApi
+from canonicalwebteam.store_api.stores.snapstore import SnapStore
 from canonicalwebteam.launchpad import Launchpad, WebhookExistsError
 from geolite2 import geolite2
 from requests.exceptions import HTTPError
@@ -30,7 +30,7 @@ from webapp.advantage import AdvantageContracts
 
 ip_reader = geolite2.reader()
 session = talisker.requests.get_session()
-store_api = SnapcraftStoreApi(session=talisker.requests.get_session())
+store_api = SnapStore(session=talisker.requests.get_session())
 
 
 def download_thank_you(category):
@@ -282,7 +282,7 @@ def search_snaps():
     """
 
     query = flask.request.args.get("q", "")
-    arch = flask.request.args.get("arch", "amd64")
+    arch = flask.request.args.get("arch", "wide")
     size = flask.request.args.get("size", "100")
     page = flask.request.args.get("page", "1")
 


### PR DESCRIPTION
## Done
- Upgraded the store-api module to the latest.
- Map the board and os to derive the arch and filter snap searches based on it.
- If the selection changes which results in a different arch the snap list is clearer for safety.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core/build
- Sign in and select a board and OS
- You should see a sentence above the search with lets you know the arch you have selected and warn that searches are filtered on this.
- Search for something and add a few snaps
- Then make a different selection, one resulting in different architecture and see that snap lists clear.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/2395

