### PR TITLE
Update server landing page for 20.04

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -42,44 +42,22 @@
     <ul class="p-list is-split">
       <li class="p-list__item is-ticked">Supported by Canonical until 2025 with ESM coverage until 2030</li>
       <li class="p-list__item is-ticked">Runs on all major architectures &ndash; x86-64, ARM v7, ARM64, POWER8, POWER9, IBM s390x (LinuxONE) and introducing initial support for RISC-V</li>
-      <li class="p-list__item is-ticked">Ubuntu Pro cloud images for AWS and Azure, which include hardening, certification, kernel livepatch and more</li>
+      <li class="p-list__item is-ticked">Ubuntu Pro cloud images for <a href="/aws">AWS</a> and <a href="/azure">Azure</a>, which include hardening, certification, kernel livepatch and more</li>
       <li class="p-list__item is-ticked">The Ubuntu Server Live installer is now able to update itself when connected to the internet for the latest features and bug fixes. Initial support for automated installs is now available as well.</li>
-      <li class="p-list__item is-ticked">SSH that supports enabling two factor authorization (2FA)</li>
+      <li class="p-list__item is-ticked">SSH that supports enabling two-factor authorization (2FA)</li>
       <li class="p-list__item is-ticked">Uses nftables as the default engine for UFW which provides easier syntax and achieves better performance results than iptables</li>
       <li class="p-list__item is-ticked">WireGuard<sup>&reg;</sup> &ndash; an innovative VPN technology with modern cryptography defaults and streamlined usability</li>
       <li class="p-list__item is-ticked">AppArmor3 for an even more secure system</li>
       <li class="p-list__item is-ticked">More resilient bootloader that tolerates disk failures</li>
       <li class="p-list__item is-ticked">Greater support for IPv6 on Microsoft Azure</li>
       <li class="p-list__item is-ticked">Support for latest Instance Metadata Service (IMDSv2) on Amazon Web Services (AWS)</li>
-      <li class="p-list__item is-ticked">The latest longterm Linux 5.4 kernel for the latest hardware and security updates</li>
+      <li class="p-list__item is-ticked">The latest long-term Linux 5.4 kernel for the latest hardware and security updates</li>
       <li class="p-list__item is-ticked">Updates to QEMU (v4.2), libvirt (v6.0), PHP (v7.4), Ruby (v2.7), GCC (V9.3), Python (v3.8), MySQL (v8.0), NGINX (v1.17)</li>
     </ul>
     <p>
       <a class="p-link--external"
       href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">
       Read more in the release notes
-      </a>
-    </p>
-  </div>
-</div>
-
-
-<div class="p-strip--light is-bordered">
-  <div class="u-fixed-width">
-    <h2>
-      What&rsquo;s new in {{ releases.latest.short_version }}
-    </h2>
-    <ul class="p-list is-split">
-      <li class="p-list__item is-ticked">Supported by Canonical for 9 months</li>
-      <li class="p-list__item is-ticked">Linux 5.3 kernel</li>
-      <li class="p-list__item is-ticked">Updates to qemu (v4.0), libvirt (v5.4), mysql (v8.0), postgresql (v11) and more</li>
-      <li class="p-list__item is-ticked">Fresh set of fixes and refreshes to the Ubuntu Server installer</li>
-      <li class="p-list__item is-ticked">New Ubuntu Advantage experience</li>
-    </ul>
-    <p>
-      <a class="p-link--external"
-      href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes">
-        Read more in the release notes
       </a>
     </p>
   </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -40,18 +40,19 @@
       What&rsquo;s new in {{ releases.lts.short_version }} LTS
     </h2>
     <ul class="p-list is-split">
-      <li class="p-list__item is-ticked">Supported by Canonical until 2023 with ESM coverage until 2028</li>
-      <li class="p-list__item is-ticked">Runs on all major architectures &ndash; x86, x86-64, ARM v7, ARM64, POWER8 and IBM s390x (LinuxONE)</li>
-      <li class="p-list__item is-ticked">New ubuntu-minimal images that are smaller and boot faster</li>
-      <li class="p-list__item is-ticked">Easily configure networking through <a class="p-link--external" href="https://netplan.io/">netplan</a></li>
-      <li class="p-list__item is-ticked">Fast and accurate time synchronization with chrony</li>
-      <li class="p-list__item is-ticked">A new, default server installer ISO with a new interface and faster install</li>
-      <li class="p-list__item is-ticked">Supports ZFS, the next-generation volume management/ file system ideal for servers and containers</li>
-      <li class="p-list__item is-ticked">LXD 3.0 - Linux containers including clustering, QoS, and resource controls (CPU, memory, block I/O, graphics, and storage quota)</li>
-      <li class="p-list__item is-ticked">Install snaps for simple application installation and release management</li>
-      <li class="p-list__item is-ticked">Linux 4.15 kernel</li>
-      <li class="p-list__item is-ticked">Certification as a guest on AWS, Microsoft Azure, Joyent, IBM, Google Cloud Platform and Rackspace</li>
-      <li class="p-list__item is-ticked">Updates to LXD (v3.0), DPDK (v17.11.1), Postgresql (v10.3), Libvirt (v4.0), NGINX (v1.14), Qemu (v2.11.1), Docker (v17.03), Puppet (v4.10), MySQL (v5.7), PHP (v7.2), and more</li>
+      <li class="p-list__item is-ticked">Supported by Canonical until 2025 with ESM coverage until 2030</li>
+      <li class="p-list__item is-ticked">Runs on all major architectures &ndash; x86-64, ARM v7, ARM64, POWER8, POWER9, IBM s390x (LinuxONE) and introducing initial support for RISC-V</li>
+      <li class="p-list__item is-ticked">Ubuntu Pro cloud images for AWS and Azure, which include hardening, certification, kernel livepatch and more</li>
+      <li class="p-list__item is-ticked">The Ubuntu Server Live installer is now able to update itself when connected to the internet for the latest features and bug fixes. Initial support for automated installs is now available as well.</li>
+      <li class="p-list__item is-ticked">SSH that supports enabling two factor authorization (2FA)</li>
+      <li class="p-list__item is-ticked">Uses nftables as the default engine for UFW which provides easier syntax and achieves better performance results than iptables</li>
+      <li class="p-list__item is-ticked">WireGuard<sup>&reg;</sup> &ndash; an innovative VPN technology with modern cryptography defaults and streamlined usability</li>
+      <li class="p-list__item is-ticked">AppArmor3 for an even more secure system</li>
+      <li class="p-list__item is-ticked">More resilient bootloader that tolerates disk failures</li>
+      <li class="p-list__item is-ticked">Greater support for IPv6 on Microsoft Azure</li>
+      <li class="p-list__item is-ticked">Support for latest Instance Metadata Service (IMDSv2) on Amazon Web Services (AWS)</li>
+      <li class="p-list__item is-ticked">The latest longterm Linux 5.4 kernel for the latest hardware and security updates</li>
+      <li class="p-list__item is-ticked">Updates to QEMU (v4.2), libvirt (v6.0), PHP (v7.4), Ruby (v2.7), GCC (V9.3), Python (v3.8), MySQL (v8.0), NGINX (v1.17)</li>
     </ul>
     <p>
       <a class="p-link--external"
@@ -89,9 +90,7 @@
     <h2 id="performance-and-versatility">
       Performance and versatility
     </h2>
-    <p class="p-heading--three"
-    >Agile, secure, deploy-anywhere technology for fast-moving companies
-    </p>
+    <p class="p-heading--three">Agile, secure, deploy-anywhere technology for fast-moving companies</p>
   </div>
 </div>
 
@@ -219,7 +218,7 @@
       </li>
     </ul>
     <p class="u-align--center u-vertically-spaced"><a href="https://certification.ubuntu.com">
-      View all certified hardware&nbsp;&rsaquo;
+      View all certified hardware partners&nbsp;&rsaquo;
     </a></p>
 
     <ul class="p-inline-images">
@@ -278,7 +277,7 @@
     </ul>
     <p class="u-align--center u-vertically-spaced">
       <a href="https://partners.ubuntu.com/programmes/software">
-        View all certified software&nbsp;&rsaquo;
+        View all certified software partners&nbsp;&rsaquo;
       </a>
     </p>
   </div>


### PR DESCRIPTION
## Done

- Updated /server landing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/server
- Compare with the [copydoc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7193 