### PR TITLE
handle payment success response from ua-contract service

### DIFF
--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -144,7 +144,7 @@ def accept_renewal(session, renewal_id):
         raise_http_errors=False,
     )
 
-    if response.status_code == 200:
+    if response.ok:
         return {}
     else:
         return response.json()

--- a/webapp/api/advantage.py
+++ b/webapp/api/advantage.py
@@ -144,4 +144,7 @@ def accept_renewal(session, renewal_id):
         raise_http_errors=False,
     )
 
-    return response.json()
+    if response.status_code == 200:
+        return {}
+    else:
+        return response.json()


### PR DESCRIPTION


## Done

A successful payment returns a 200 response with no body from the ua-contracts service, which was causing a 500 on our side when we tried to parse the body.
