### PR TITLE
Fix the inclusion of _ibm_athena_release.html on takeovers

### DIFF
--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -125,5 +125,5 @@
 <p>17 Apr 2020</p>
 {% include "takeovers/_managed-apps.html" %}
 <p>17 April 2020</p>
-{% include "templates/takeovers/_ibm_athena_release.html" %}
+{% include "takeovers/_ibm_athena_release.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done
Fix the inclusion of _ibm_athena_release.html on takeovers

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers
- Check the page does not 500

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7288
