### PR TITLE
Update images on /desktop/organisations

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -314,7 +314,7 @@ summary {
 }
 
 .organisations-hero {
-  background-image: url("#{$assets-path}32d95e39-hero-laptop-org.jpg?w=2000");
+  background-image: url("#{$assets-path}32d95e39-hero-laptop-org.jpg?w=1000");
   background-position: right bottom;
   background-size: 1100px auto;
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -314,9 +314,9 @@ summary {
 }
 
 .organisations-hero {
-  background-image: url("#{$assets-path}214648ba-_M8A2368-final.jpg");
+  background-image: url("#{$assets-path}32d95e39-hero-laptop-org.jpg?w=2000");
   background-position: right bottom;
-  background-size: 1200px auto;
+  background-size: 1100px auto;
 
   @media only screen and (min-width: 2000px) {
     background-size: 75%;

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -240,9 +240,9 @@
     <div class="col-6 u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png",
+          url="https://assets.ubuntu.com/v1/3e3f7d1f-hero-laptop.png",
           alt="",
-          height="285",
+          height="327",
           width="567",
           hi_def=True,
           loading="lazy",


### PR DESCRIPTION
## Done

- Update images on /desktop/organisations

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/organisations
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the banner and laptop images are as recommended in the attached issue


## Issue / Card

Fixes #7257
