### PR TITLE
Update images on /desktop/features

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -62,7 +62,7 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <ul class="p-matrix isp-strip--suru-half-and-half-reversed is-dark-trisected">
+    <ul class="p-matrix is-trisected">
       <li class="p-matrix__item">
         {{
           image(

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -5,7 +5,7 @@
   @-webkit-keyframes flash-sign {
     22%, 28%, 98%, 100% {
       filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
-      opacity: 0;
+      opacity: 0;p-strip--suru-half-and-half-reversed is-dark
     }
 
     27%, 99% {
@@ -23,7 +23,7 @@
     27%, 99% {
       filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
       opacity: 1;
-    }
+    }p-strip--suru-half-and-half-reversed is-dark
   }
 </style>
 {% endblock %}
@@ -32,26 +32,24 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1nLHJlZ3igDwAAOUDP03wp4iKLxZts8110EA2ZOF5uaU/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip u-no-padding--top u-no-padding--bottom is-bordered">
-  <div class="p-strip--suru-half-and-half">
-    <div class="row">
-      <div class="col-6 col-medium-4">
-        <h1>Features</h1>
-        <p>Enjoy the simplicity of Ubuntu&rsquo;s intuitive interface. Fast, secure and with thousands of apps to choose from &mdash; for everything you want to do, Ubuntu has what you need.</p>
-        <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu</a></p>
-      </div>
-      <div class="col-6 u-vertically-center u-hide--small u-align--center">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/01600134-XPS-touch-notebook.png",
-            alt="",
-            height="233",
-            width="380",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
-      </div>
+<section class="p-strip--suru-half-and-half-reversed is-dark">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 col-medium-4">
+      <h1>Features</h1>
+      <p>Enjoy the simplicity of Ubuntu&rsquo;s intuitive interface. Fast, secure and with thousands of apps to choose from &mdash; for everything you want to do, Ubuntu has what you need.</p>
+      <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu</a></p>
+    </div>
+    <div class="col-6 u-vertically-center u-hide--small u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/3e3f7d1f-hero-laptop.png?w=420",
+          alt="",
+          height="242",
+          width="420",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -64,7 +62,7 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <ul class="p-matrix is-trisected">
+    <ul class="p-matrix isp-strip--suru-half-and-half-reversed is-dark-trisected">
       <li class="p-matrix__item">
         {{
           image(
@@ -97,10 +95,10 @@
           <p class="p-matrix__desc">The free instant messaging, voice or video calling service.</p>
         </div>
       </li>
-      <li class="p-matrix__item last-row">
+      <li class="p-matrix__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/33f5e395-vlc.svg",
+            url="https://assets.ubuntu.com/v1/7b460167-vlc-icon.png",
             alt="VLC icon",
             height="48",
             width="48",
@@ -145,7 +143,7 @@
           <p class="p-matrix__desc">Team communication and collaboration in one place so you can get more done.</p>
         </div>
       </li>
-      <li class="p-matrix__item last-row">
+      <li class="p-matrix__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/ccb8872b-Icon_Atom.svg",
@@ -193,7 +191,7 @@
           <p class="p-matrix__desc">PyCharm provides all the tools you need for productive Python coding.</p>
         </div>
       </li>
-      <li class="p-matrix__item last-row">
+      <li class="p-matrix__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3f3a15ef-logo-telegram.svg",
@@ -223,9 +221,9 @@
     <div class="col-7 col-start-large-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c1471906-libreoffice.jpg",
+          url="https://assets.ubuntu.com/v1/67314cce-libre_cropped.png",
           alt="",
-          height="414",
+          height="422",
           width="556",
           hi_def=True,
           loading="lazy"
@@ -235,14 +233,14 @@
   </div>
 </section>
 
-<section class="p-strip--image is-dark is-deep" style="background-image:url('https://assets.ubuntu.com/v1/0a98afcd-screenshot_desktop.jpg')">
+<section class="p-strip--image is-dark is-deep" style="background-image:url('https://assets.ubuntu.com/v1/d611ea9c-feature-wide3.jpg')">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/849e20c6-news.png",
+          url="https://assets.ubuntu.com/v1/04ea654d-netflix-frankie-gracie-cropped.jpg",
           alt="",
-          height="390",
+          height="310",
           width="500",
           hi_def=True,
           loading="lazy"
@@ -267,9 +265,9 @@
     <div class="col-6 col-start-large-7 u-vertically-center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/04339b8f-emaill+screenshot.jpg",
+          url="https://assets.ubuntu.com/v1/e318e35d-email2.png?w=600",
           alt="",
-          height="398",
+          height="397",
           width="520",
           hi_def=True,
           loading="lazy"
@@ -296,10 +294,10 @@
     <div class="col-8 p-divider__block">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/5ef3d6ca-photogallery.jpg",
+          url="https://assets.ubuntu.com/v1/af19d2f8-shotwell.png?w=550",
           alt="Shotwell screenshot",
-          height="379",
-          width="531",
+          height="417",
+          width="530",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -310,55 +308,42 @@
     <div class="col-4 p-divider__block">
       <h2>Edit and illustrate</h2>
       <p>Edit your photos or create professional illustrations and designs with tools like Gimp and Krita, available in the Ubuntu Software centre.</p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item">
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/b38df947-krita.png",
               alt="Krita icon",
-              height="36",
-              width="36",
+              height="60",
+              width="60",
               hi_def=True,
-
+              attrs={"class": "p-inline-images__logo"},
               loading="lazy"
             ) | safe
           }}
         </li>
-        <li class="p-inline-list__item">
+        <li class="p-inline-images__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/4d47a674-gimp-60x43.svg",
               alt="",
-              height="36",
-              width="36",
+              height="60",
+              width="60",
               hi_def=True,
-
-              loading="lazy"
+              loading="lazy",
+              attrs={"class": "p-inline-images__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-list__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/51ebf780-lightworks.svg",
-              alt="Lightworks icon",
-              height="36",
-              width="36",
-              hi_def=True,
-
-              loading="lazy"
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-list__item">
+        <li class="p-inline-images__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/786ed546-blender.svg",
               alt="Blender icon",
-              height="36",
-              width="36",
+              height="60",
+              width="60",
               hi_def=True,
-
+              attrs={"class": "p-inline-images__logo"},
               loading="lazy"
             ) | safe
           }}
@@ -377,9 +362,9 @@
     <div class="col-7 col-start-large-6 u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/d4f0c4b1-movie.png",
+          url="https://assets.ubuntu.com/v1/c404705c-video-youtube.jpg?w=542",
           alt="",
-          height="336",
+          height="325",
           width="542",
           hi_def=True,
           loading="lazy"

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -379,7 +379,7 @@
     <div class="col-6 col-start-large-7 p-gaming__content">
       <div class="p-card--overlay">
         <h2>Gaming</h2>
-        <p>From Sudoku to shoot-em-ups, we&rsquo;ve got loads of games that&rsquo;ll keep you busy for hours.  There are thousands of games available for Ubuntu, including titles from the Unity and Steam platforms.  Pick from critically acclaimed titles such as Dota 2, Civilization V, Kerbal Space Program, Football Manager 2018 and Borderlands: The Pre-Sequel.</p>
+        <p>From Sudoku to first-person shooters, we’ve got loads of games that’ll keep you busy for hours.  There are thousands of games available for Ubuntu, including titles from the Unity and Steam platforms.  Pick from critically acclaimed titles such as Dota 2, Kerbal Space Program, Counter Strike: Global Offensive and Borderlands: The Pre-Sequel.</p>
       </div>
     </div>
     <div class="u-hide--small p-gaming__flash"></div>


### PR DESCRIPTION
## Done

- Update images on /desktop/features
- redid the wide desktop, email, libre office images.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the images look correct


## Issue / Card

Fixes #7256
