### PR TITLE
Handle db migration errors

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -3,7 +3,17 @@
 set -e
 
 # Run migrations
-alembic upgrade head
+{
+    alembic upgrade head
+} || {
+    read -p "Database migration failed. Erase database and try again? " -n 1 -r
+    if [[ $REPLY =~ ^[Yy] ]]; then
+        scripts/clear-database.py
+        alembic upgrade head
+    else
+        exit 1
+    fi
+}
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     echo ""

--- a/scripts/clear-database.py
+++ b/scripts/clear-database.py
@@ -1,0 +1,14 @@
+#! /usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from sqlalchemy import MetaData  # noqa
+from webapp.security.database import db_engine  # noqa
+
+
+metadata = MetaData(db_engine)
+metadata.reflect()
+metadata.drop_all()


### PR DESCRIPTION
DB migration errors have caused a lot of difficulties with
QAing. This should improve things by prompting the user
to erase the database when migration errors are encountered.

QA
--

```
git checkout cve
rm usn.sqlite3
dotrun exec alembic upgrade head
git checkout handle-db-migration-errors  # back to this branch
dotrun serve
```

^ this should now error on DB migration and prompt you to delete your database. If you choose "y", it should successfully run the site.