### PR TITLE
Update server guide pdf and thumbnail

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -16,7 +16,16 @@
       <h4>Need a command-line refresher?</h4>
       <p>By subscribing, you also get the "Ubuntu Server CLI pro tips 2020" cheat sheet: learn how to use efficiently the command-line and get started with DevOps &mdash; from basic file management to deploying Kubernetes and OpenStack.</p>
       <div class="p-card--highlighted" style="display: inline-block;">
-        <img src="https://assets.ubuntu.com/v1/927122a9-Ubuntu+Server+CLI+pro+tips.png" alt="" width="440" />
+        {{
+          image(
+              url="https://assets.ubuntu.com/v1/39a8dac8-Ubuntu_Server_CLI_pro_tips_2020-04.jpg",
+              alt="",
+              width="440",
+              height="331",
+              hi_def=True,
+              loading="lazy",
+          ) | safe
+        }}
       </div>
     </div>
 
@@ -59,7 +68,7 @@
               <input type="hidden" name="formVid" class="mktoField" value="3485">
               <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
               <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br><a href='https://assets.ubuntu.com/v1/bb21c0e8-Ubuntu+Server+CLI+pro+tips+06.01.20.pdf' target='_blank' >Here is your CLI cheat sheet.</a>" aria-lable="">
+              <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br><a href='https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf' target='_blank' >Here is your CLI cheat sheet.</a>" aria-lable="">
             </li>
           </ul>
       </fieldset>


### PR DESCRIPTION
## Done

- Update server guide pdf and thumbnail

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the pdf has been updated and there is a new thumbnail

## Issue / Card

Fixes #7298

