### PR TITLE
Add clear filter button to CVE search

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -811,8 +811,9 @@ security:
     - title: Notices
       path: https://usn.ubuntu.com
       persist: True
-    - title: CVEs
-      path: /security/cve
+    # Hidden for soft launch
+    # - title: CVEs
+    # path: /security/cve
 
 licensing:
   title: Licensing

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -43,9 +43,14 @@
           </option>
         </select>
       </div>
-      <div class="col-3">
-        <label>&nbsp;</label> <!-- required for layout -->
-        <button type="submit">Search</button>
+      <div class="col-3 u-align--right">
+        <div class="p-form__group">
+          <label class="p-form__label">&nbsp;</label> <!-- required for layout -->
+          <div class="p-form__control">
+            <a href="/security/cve" class="p-button--neutral">Clear filters</a>
+            <button type="submit" class="p-button--positive">Search</button>
+          </div>
+        </div>
       </div>
     </div>
   </form>

--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -307,9 +307,10 @@
           <li class="p-inline-list__item">
             <a class="p-link--external" href="https://usn.ubuntu.com">Notices</a>
           </li>
-          <li class="p-inline-list__item">
+          <!-- Hidden for soft launch -->
+          <!-- <li class="p-inline-list__item">
             <a href="/security/cve">CVEs</a>
-          </li>
+          </li> -->
           <li class="p-inline-list__item">
             <a href="/esm">Extended Security Maintenance</a>
           </li>


### PR DESCRIPTION
## Done

- Added a "Clear filters" button to the CVE search
- Commented out links to /security/cve for soft launch

## QA

- Check out this feature branch
- Run the following commands
- `docker-compose up -d`
- If you get an error saying something is already running on that port: `sudo kill -9 `sudo lsof -t -i :5432``
- `dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres`
- `export DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres`
- `alembic upgrade head`
- `dotrun exec python3 webapp/security/fixtures/load_sample_cve.py`
- If you have an error here you may need to drop the database schema. To do that follow the steps in this comment: https://github.com/canonical-web-and-design/ubuntu.com/pull/7242#issuecomment-616435249
- `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve 
- Use the search form and submit it
- Click the "Clear filters" button and check that the form fields have been cleared


## Issue / Card

Fixes #7268