### PR TITLE
Remove invisible duplicated link to webinar

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -466,9 +466,6 @@
         <li class="p-inline-list__item">
           <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us</a>
         </li>
-        <li class="p-inline-list__item">
-          <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/290073">Watch the Ubuntu security webinar</a>
-        </li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Done

Removed duplicate link to webinar which wasn't visible because it was inverted

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that there isn't a link to the webinar next to the "Contact us" button in the "Talk to a member of our team" section at the bottom of the page


## Issue / Card

Fixes #7285
