### PR TITLE
Remove nftables list item

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -45,7 +45,6 @@
       <li class="p-list__item is-ticked">Ubuntu Pro cloud images for <a href="/aws">AWS</a> and <a href="/azure">Azure</a>, which include hardening, certification, kernel livepatch and more</li>
       <li class="p-list__item is-ticked">The Ubuntu Server Live installer is now able to update itself when connected to the internet for the latest features and bug fixes. Initial support for automated installs is now available as well.</li>
       <li class="p-list__item is-ticked">SSH that supports enabling two-factor authorization (2FA)</li>
-      <li class="p-list__item is-ticked">Uses nftables as the default engine for UFW which provides easier syntax and achieves better performance results than iptables</li>
       <li class="p-list__item is-ticked">WireGuard<sup>&reg;</sup> &ndash; an innovative VPN technology with modern cryptography defaults and streamlined usability</li>
       <li class="p-list__item is-ticked">AppArmor3 for an even more secure system</li>
       <li class="p-list__item is-ticked">More resilient bootloader that tolerates disk failures</li>


### PR DESCRIPTION
## Done

Removed a line from the features list

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/server
- See that the line marked for removal in the [copydoc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit?ts=5e9f41db) is no longer present
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

