### PR TITLE
Add a property for the release support tag

### DIFF
--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -5,7 +5,7 @@
   <ul class="p-inline-list u-no-margin">
     {% for release in notice.releases %}
       <li class="p-inline-list__item">
-        <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {% if release.lts %} LTS {% endif %}</a>
+        <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {{ release.support_tag }}</a>
       </li>
     {% endfor %}
   </ul>

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -20,7 +20,7 @@
       <ul class="p-inline-list u-no-margin--bottom">
         {% for release in notice.releases %}
           <li class="p-inline-list__item">
-            <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {% if release.lts %} LTS {% endif %}</a>
+            <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {{ release.support_tag }}</a>
           </li>
         {% endfor %}
       </ul>

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -37,7 +37,7 @@
           {% for release in releases %}
           <option value="{{ release.codename }}"
             {% if request.args.get('release') == release.codename %}selected{% endif %}>
-            Ubuntu {{ release.version }} {% if release.lts %} LTS {% endif %}
+            Ubuntu {{ release.version }} {{ release.support_tag }}
           </option>
           {% endfor %}
         </select>

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sqlalchemy import (
     Boolean,
     Column,
@@ -9,6 +11,7 @@ from sqlalchemy import (
     Table,
 )
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
 
@@ -81,3 +84,14 @@ class Release(Base):
     release_date = Column(DateTime)
     esm_expires = Column(DateTime)
     support_expires = Column(DateTime)
+
+    @hybrid_property
+    def support_tag(self):
+        now = datetime.now()
+
+        if self.lts and self.support_expires > now:
+            return "LTS"
+        elif self.lts and self.esm_expires > now:
+            return "ESM"
+
+        return ""


### PR DESCRIPTION
## Done

Add a property to the model that returns the current support tag for an ubuntu release.

## QA

- dotrun clean
- dotrun
- dotrun ./webapp/security/fixtures/releases.py
- go to security/notices and see that the dropdwon shows the right support tag for each release