### PR TITLE
Remove traditional installer from server downloads

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -68,27 +68,12 @@
 
 <div class="p-strip--light">
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h2 id="alternate-ubuntu-server-installer">Alternative Ubuntu Server installer</h2>
-      <p>If you want to reuse your existing partitions, you will need to use the alternate installer.</p>
-      {% if releases.latest.short_version > releases.lts.short_version %}
-      <p>
-        <a href="http://cdimage.ubuntu.com/releases/{{ releases.latest.full_version }}/release/" class="p-link--external">Ubuntu {{ releases.latest.full_version }} alternative installer</a>
-      </p>
-      {% endif %}
-      <p>
-        <a href="http://cdimage.ubuntu.com/releases/{{ releases.lts.full_version }}/release/" class="p-link--external">Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr> alternative installer</a>
-      </p>
-      <p>
-        <a href="http://cdimage.ubuntu.com/releases/{{ releases.previous_lts.full_version }}/release/" class="p-link--external">Ubuntu {{ releases.previous_lts.full_version }} <abbr title="Long-term support">LTS</abbr> alternative installer</a>
-      </p>
-    </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h2 id="other-images-and-mirrors">Other images and mirrors</h2>
       <p>For the full list of available Ubuntu images, we recommend you select a mirror local to you.</p>
       <p><a href="https://launchpad.net/ubuntu/+cdmirrors" class="p-link--external">See all Ubuntu mirrors</a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-6 p-divider__block">
       <h2 id="past-releases-and-other-flavours">Past releases and other flavours</h2>
       <p>Looking for an older release of Ubuntu? Whether you need an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
       <p><a class="p-link--external" href="https://releases.ubuntu.com/">Past releases</a></p>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -20,9 +20,6 @@
         The long-term support version of Ubuntu Server, including the {{ releases.openstack_lts.slug }} release of OpenStack and support guaranteed until {{ releases.lts.eol }}.
       </p>
       <p>
-        This release uses our simplified installer, Subiquity. If you need complex functions such as encrypted filesystems, use the <a href="/download/alternative-downloads#alternate-ubuntu-server-installer">traditional installer</a>.
-      </p>
-      <p>
         <a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a>
       </p>
     </div>

--- a/templates/templates/_navigation-download-h.html
+++ b/templates/templates/_navigation-download-h.html
@@ -14,7 +14,6 @@
           <a href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" class="p-button--positive p-button--small" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ releases.lts.short_version }} LTS', 'eventValue' : undefined });">{{ releases.lts.short_version }} LTS</a>
           {% if releases.latest.short_version > releases.lts.short_version %}<a href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64" class="p-button--neutral p-button--small" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">{{ releases.latest.short_version }}</a>{% endif %}
           <ul class='p-text-list--small is-bordered' >
-            <li class="p-list__item"><a href="/download/alternative-downloads#alternate-ubuntu-server-installer">Use the traditional installer</a></li>
             <li class='p-list__item'><a class='p-link' href='/download/server/arm'>
               ARM
             </a></li>


### PR DESCRIPTION
## Done

- Remove traditional installer from server downloads
- The copy docs have been updated as well

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/download/server
    - http://0.0.0.0:8001/download/alternative-downloads
    - http://0.0.0.0:8001/download/alternative-downloads#download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it no longer mentions the traditional installer

## Issue / Card

Fixes #7308


