### PR TITLE
Add live installer to /download/alternative-downloads

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -20,12 +20,10 @@
       <h2 id="network-installer">Network installer</h2>
       <p>The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to start and the rest of the packages are downloaded over the network. Since only current packages are downloaded, there is no need to upgrade packages immediately after installation.</p>
       <p>The network installer is ideal if you have a computer that cannot run the graphical installer, for example, because it does not meet the minimum requirements for the live CD/DVD, or because the computer requires extra configuration before a graphical desktop can be used. The network installer is also useful if you want to install Ubuntu on a large number of computers at once.</p>
+      <p>For 20.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
       <ul class="p-list">
-        {% if releases.latest.short_version > releases.lts.short_version %}
-        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ releases.latest.short_version }}/">Download the network installer for {{ releases.latest.short_version }}</a></li>
-        {% endif %}
-        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ releases.lts.short_version }}/">Download the network installer for {{ releases.lts.short_version }} LTS</a></li>
-        <li class="p-list__item is-ticked"><a class="download-network p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ releases.previous_lts.short_version }}/">Download the network installer for {{ releases.previous_lts.short_version }} LTS</a></li>
+        <li class="p-list__item is-ticked"><a class="p-link--external" href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the {{ releases.lts.short_version }} Ubuntu Live installer</a></li>
+        <li class="p-list__item is-ticked"><a class="p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ releases.previous_lts.short_version }}/">Download the network installer for {{ releases.previous_lts.short_version }} LTS</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add live installer to /download/alternative-downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/alternative-downloads
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit?ts=5ea09cb4#)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/80028306-d20d9b00-84dc-11ea-8a63-459c449f10fc.png)

