### PR TITLE
DON'T MERGE Revert https releases for mirrors

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -62,7 +62,6 @@ def download_thank_you(category):
             {"link": mirror["link"], "bandwidth": mirror["mirror_bandwidth"]}
             for mirror in mirrors
             if mirror["mirror_countrycode"] == country_code
-            and mirror["link"].startswith("https")
         ]
     context["mirror_list"] = json.dumps(mirror_list)
 


### PR DESCRIPTION
# Done 

reverts https restriction for mirrors https://github.com/canonical-web-and-design/ubuntu.com/pull/7264
This is in case reverting is necessary to unload some mirrors etc.