### PR TITLE
Raspi tutorial notice (focal branch)

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -29,8 +29,17 @@
     </div>
   </div>
 </section>
-
-<section class="p-strip is-bordered u-no-padding--bottom u-hide--small">
+<section class="p-strip is-shallow is-bordered">
+  <div class="u-fixed-width">
+    <div class="p-heading-icon">
+      <div class="p-heading-icon__header">
+        <img alt="Raspberry Pi Ubuntu tutorial" class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg">
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">First time installing Ubuntu on Raspberry Pi? Follow our tutorial &rsaquo;</a></h4>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip u-no-padding--bottom u-hide--small">
   <div class="row u-equal-height u-vertically-center u-sv3">
     <div class="col-3">
       <h2 class="u-no-margin--bottom">Download your Ubuntu Pi image</h2>


### PR DESCRIPTION
## Done

- Adding the raspi tuto notice to the focal branch (duplicate of https://github.com/canonical-web-and-design/ubuntu.com/pull/7270)

## QA

- Notice row on https://ubuntu-com-canonical-web-and-design-pr-7318.run.demo.haus/download/raspberry-pi should match https://ubuntu.com/download/raspberry-pi