### PR TITLE
Update /download/alternative-downloads with named older releases

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,11 +1,13 @@
 latest:
   slug: EoanErmine
+  name: "Eoan Ermine"
   short_version: "19.10"
   full_version: "19.10"
   release_date: "October 2019"
   eol: July 2020
 lts:
   slug: FocalFossa
+  name: "Focal Fossa"
   short_version: "20.04"
   full_version: "20.04"
   release_date: "April 2020"
@@ -13,8 +15,13 @@ lts:
 openstack_lts:
   slug: Ussuri
 previous_lts:
+  name: "Bionic Beaver"
   short_version: "18.04"
   full_version: "18.04.4"
+previous_previous_lts:
+  name: "Xenial Xerus"
+  short_version: "16.04"
+  full_version: "16.04.6"
 
 checksums:
   desktop:

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -74,6 +74,13 @@
     <div class="col-6 p-divider__block">
       <h2 id="past-releases-and-other-flavours">Past releases and other flavours</h2>
       <p>Looking for an older release of Ubuntu? Whether you need an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.previous_lts.full_version }}/">Ubuntu {{ releases.previous_lts.short_version }} LTS ({{ releases.previous_lts.name }})</a></li>
+        {% if releases.latest.short_version < releases.lts.short_version %}
+        <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.latest.full_version }}/">Ubuntu {{ releases.latest.short_version }} ({{ releases.latest.name }})</a></li>
+        {% endif %}
+        <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.previous_previous_lts.full_version }}/">Ubuntu {{ releases.previous_previous_lts.short_version }} LTS ({{ releases.previous_previous_lts.name }})</a></li>
+      </ul>
       <p><a class="p-link--external" href="https://releases.ubuntu.com/">Past releases</a></p>
     </div>
   </div>

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -73,7 +73,7 @@
     </div>
     <div class="col-6 p-divider__block">
       <h2 id="past-releases-and-other-flavours">Past releases and other flavours</h2>
-      <p>Looking for an older release of Ubuntu? Whether you need an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
+      <p>Looking for an older release of Ubuntu? Whether you need a POWER, IBMz (s390x), ARM, an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.previous_lts.full_version }}/">Ubuntu {{ releases.previous_lts.short_version }} LTS ({{ releases.previous_lts.name }})</a></li>
         {% if releases.latest.short_version < releases.lts.short_version %}


### PR DESCRIPTION
## Done

- Update /download/alternative-downloads with named older releases to help POWER, ARM and LinuxONE people file older releases more easily

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/alternative-downloads
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the 'Past releases and other flavours' mentions these other release types and lists the main older releases.


## Issue / Card

Fixes #7319

## Screenshots

![image](https://user-images.githubusercontent.com/441217/80089850-77188a00-8556-11ea-848e-dafdbd4df463.png)

