### PR TITLE
Remove region-specific takeovers and remove the language attribute fr…

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,18 +27,6 @@
 #}
 
 {% block takeover_content %}
-  {# GERMAN #}
-  {% include "takeovers/de/_vmware-to-charmed-openstack_german.html" %}
-
-  {# SPANISH #}
-  {% include "takeovers/es/_vmware-to-charmed-openstack_spanish.html" %}
-
-  {# DUTCH #}
-  {% include "takeovers/nl/_nl-pre-kubecon.html" %}
-
-  {# FRENCH #}
-  {% include "takeovers/fr/_vmware-to-charmed-openstack_french.html" %}
-
   {# ALL #}
   {% include "takeovers/_2004-takeover.html" %}
 

--- a/templates/takeovers/_2004-takeover.html
+++ b/templates/takeovers/_2004-takeover.html
@@ -12,7 +12,7 @@ primary_cta="Register for the webinars",
 primary_cta_class="",
 secondary_url="/download",
 secondary_cta="Download Ubuntu 20.04 LTS",
-lang="en",
+lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}
 {% endwith %}


### PR DESCRIPTION
## Done

Removed the language-specific takeovers so that all visitors see he release takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Set your language to FR and ensure that you see the 20.04 release takeover
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #7321