### PR TITLE
Sentence case Pi on /download/raspberry-pi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -13,7 +13,7 @@
   <div class="row u-vertically-center">
     <div class="col-8">
       <h1>Install Ubuntu Server on a Raspberry Pi 2, 3 or 4</h1>
-      <p>Running Ubuntu Server on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your pi and away you go.</p>
+      <p>Running Ubuntu Server on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your Pi and away you go.</p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Sentence case Pi on /download/raspberry-pi
- Updated the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu.com/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- `s/it onto your pi and away you go./it onto your Pi and away you go./`


