### PR TITLE
Update 20.04 desktop and server checksums, handle no checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -25,10 +25,10 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "20.04": "still need the desktop checksum"
+    "20.04": "e5b72e9cfe20988991c9cd87bde43c0b691e3b67b01f76d23f8150615883ce11 *ubuntu-20.04-desktop-amd64.iso"
   live-server:
-    "20.04": "still need the live server checksum"
+    "20.04": "caf3fd69c77c439f162e2ba6040e9c320c4ff0d69aad1340a514319a9264df9f *ubuntu-20.04-live-server-amd64.iso"
   arm64+raspi:
-    "20.04": "still need the arm64+raspi3 checksum"
+    "20.04": ""
   armhf+raspi:
-    "20.04": "still need the armhf+raspi checksum"
+    "20.04": ""

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -3,6 +3,7 @@
   <span class="p-contextual-menu--left">
     <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
+      {% if releases.checksums[system][version] %}
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
         <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
@@ -10,6 +11,9 @@
         <code style="display: block; margin-top: 1rem;">ubuntu-{{ version }}-{% if system != architecture %}{{ system }}-{% else %}preinstalled-server-{% endif %}{{ architecture }}.iso: OK</code><br />
         <small>Or follow this tutorial to learn <a class="p-link--external" href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
+      {% else %}
+        <small>Please check the <a class="p-link--external" href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS">SHA256SUMS page</a> for the numbers and follow the tutorial for help on how to verify your download.</small>
+      {% endif %}
     </span>
   </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.
 </p>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -12,7 +12,7 @@
         <small>Or follow this tutorial to learn <a class="p-link--external" href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
       {% else %}
-        <small>Please check the <a class="p-link--external" href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS">SHA256SUMS page</a> for the numbers and follow the tutorial for help on how to verify your download.</small>
+        <small>Please check the <a class="p-link--external" href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</small>
       {% endif %}
     </span>
   </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.


### PR DESCRIPTION
## Done

- Update 20.04 desktop and server checksums, handle no checksums
- Currently, the raspi images do not have them, so I made the verify partial put instructions on how to get them instead.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - working version - http://0.0.0.0:8001/download/server/thank-you?version=20.04&architecture=amd64
    - alternate message - http://0.0.0.0:8001/download/raspberry-pi/thank-you?version=20.04&architecture=arm64+raspi - which will 404 for now, but you can see what the URL will be
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Partially fixes #7201

## Screenshots

#### good
![image](https://user-images.githubusercontent.com/441217/80110546-b48d0f80-8576-11ea-8ff3-ae9934d263f1.png)

#### missing
![image](https://user-images.githubusercontent.com/441217/80110467-a0491280-8576-11ea-82ff-1c6b6ae1c777.png)

