### PR TITLE
Add raspi checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -29,6 +29,6 @@ checksums:
   live-server:
     "20.04": "caf3fd69c77c439f162e2ba6040e9c320c4ff0d69aad1340a514319a9264df9f *ubuntu-20.04-live-server-amd64.iso"
   arm64+raspi:
-    "20.04": ""
+    "20.04": "48167067d65c5192ffe041c9cc4958cb7fcdfd74fa15e1937a47430ed7b9de99 *focal-preinstlled-server-arm64+raspi.img.xz"
   armhf+raspi:
-    "20.04": ""
+    "20.04": "e86a9043d5394c4ae3d22d3ba62cd07d400156ec2319270d1e238ba5a0d17d9b *focal-preinstlled-server-armhf+raspi.img.xz"


### PR DESCRIPTION
## Done

- Add raspi checksums to the releases.yaml

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi/thank-you?version=20.04&architecture=armhf+raspi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the checksums are in the verify modal.

