### PR TITLE
Fail when creating notice that refers nonexistent CVE

### DIFF
--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -65,7 +65,7 @@
       <h2>References</h2>
         <ul class="p-list">
           {% for cve in notice.cves %}
-            <li class="p-list__item"><a href="https://people.canonical.com/~ubuntu-security/cve/CVE-{{cve.id}}">CVE-{{cve.id}}</a></li>
+            <li class="p-list__item"><a href="https://people.canonical.com/~ubuntu-security/cve/{{cve.id}}">{{cve.id}}</a></li>
           {% endfor %}
 
           {% for reference in notice.references %}

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -229,14 +229,14 @@ def create_notice():
             message = f"No release with codename: {release_codename}."
             return (flask.jsonify({"message": message}), 400)
 
-    # Link CVEs, creating them if they don't exist
+    # Link CVEs and other references
     refs = set(data.get("references", []))
     for ref in refs:
         if ref.startswith("CVE-"):
-            cve_id = ref[4:]
-            cve = db_session.query(CVE).get(cve_id)
+            cve = db_session.query(CVE).get(ref)
             if not cve:
-                cve = CVE(id=cve_id)
+                message = f"No CVE with ID: {ref}."
+                return (flask.jsonify({"message": message}), 400)
             notice.cves.append(cve)
         else:
             reference = (


### PR DESCRIPTION
## Done

Change the create notice endpoint to throw an error when the payload refers to a nonexistent CVE.
Also updates the code to consider `CVE-` as part of the ID field.

## QA

- `dotrun clean`
- `dotrun exec alembic upgrade head`
- `dotrun exec python3 webapp/security/fixtures/releases.py`
- `curl https://people.canonical.com/~ubuntu-security/usn/database.json > webapp/security/fixtures/usns.json`
- `dotrun`
- in a separate tab `dotrun exec python3 webapp/security/fixtures/usns.py webapp/security/fixtures/usns.json`
- see errors because we don't have any CVE on the database