### PR TITLE
Updated the datasheet on /openstack/consulting

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -137,7 +137,7 @@
       </div>
 
       <div class="col-4 p-card u-align--center">
-        <a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf">
+        <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf">
           {{
             image(
               url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
@@ -150,7 +150,7 @@
             ) | safe
           }}
         </a>
-        <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
+        <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
 
       <div class="col-4 p-card u-align--center">
@@ -389,7 +389,7 @@
       <div class="col-9">
         <h2>Build your OpenStack cloud with Canonical</h2>
         <p><a href="/openstack/features">Find out how</a> Canonical delivers the world’s favourite enterprise OpenStack. The choice of the largest operators in telco, finance, media, pharma, retail and government sectors, Canonical’s OpenStack on Ubuntu offers a flexible architecture and enables integration of GPGPUs, FPGAs and cloud network accelerators.</p>
-        <p class="u-no-margin--top"><a href="https://assets.ubuntu.com/v1/3ef1aad9-Datasheet_Private-Cloud-Build.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
+        <p class="u-no-margin--top"><a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--positive">Read the datasheet</a>&#8195;<a href="/openstack/contact-us?product=foundation-cloud" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us ', 'eventLabel' : 'Talk to us  - Bottom CTA', 'eventValue' : undefined });">Talk to us </a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
I changed the datasheet on [/openstack/consulting](https://ubuntu.com/openstack/consulting) in two places to https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf.


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the demo page to the [copy doc](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit#)

## Issue / Card #7291