### PR TITLE
Remove netboot option from /download/server/arm and /download/server/power

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -51,31 +51,6 @@
         <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
       </div>
     </div>
-    <div class="col-6 p-card is-divided">
-      <h3 class="p-card__title">Ubuntu netboot</h3>
-      <div class="p-card__content">
-        <p>
-          This installer lets you install Ubuntu over the network.
-        </p>
-        <p>
-          <a href="http://cdimage.ubuntu.com/netboot/{{ releases.lts.short_version }}" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-            Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
-          </a>
-        </p>
-        {% if releases.latest.short_version > releases.lts.short_version %}
-        <p>
-          <a href="http://cdimage.ubuntu.com/netboot/{{ releases.latest.short_version }}" class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-            Download Ubuntu {{ releases.latest.full_version }}
-          </a>
-        </p>
-        {% endif %}
-        <p>
-          <a class="p-link--external" href="https://help.ubuntu.com/community/Installation/Netboot">
-            Learn about netboot images
-          </a>
-        </p>
-      </div>
-    </div>
   </div>
 </section>
 

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -38,27 +38,6 @@
         </p>
       </div>
     </div>
-    <div class="col-6 p-card">
-      <h3 class="p-card__title">Netboot image</h3>
-      <div class="p-card__content">
-        <p>This installer lets you install Ubuntu over the network.</p>
-        <p>
-          <a class="p-button--positive is-wide" href="http://cdimage.ubuntu.com/netboot/{{ releases.lts.short_version }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-            Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
-          </a>
-        </p>
-        {% if releases.latest.short_version > releases.lts.short_version %}
-        <p>
-          <a class="p-button--neutral is-wide" href="http://cdimage.ubuntu.com/netboot/{{ releases.latest.short_version }}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER netboot', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-            Download Ubuntu {{ releases.latest.full_version }}
-          </a>
-        </p>
-        {% endif %}
-        <p>
-          <a class="p-link--external" href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images</a>
-        </p>
-      </div>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Remove netboot option from /download/arm and /download/power
- Updated the copy docs
- **Note - we should redesign these pages**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/power and http://0.0.0.0:8001/download/server/arm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the netboot box has been removed
