### PR TITLE
Update enterprise k8s datasheet links

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -71,7 +71,7 @@
 
       <p><a href="/kubernetes/install">Install instructions&nbsp;&rsaquo;</a></p>
       <p><a href="/kubernetes/managed">Fully managed Kubernetes options&nbsp;&rsaquo;</a></p>
-      <p><a href="https://assets.ubuntu.com/v1/8db65a1e-Kubernetes-for-the-Enterprise.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">Charmed Kubernetes datasheet&nbsp;&rsaquo;</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">Charmed Kubernetes datasheet&nbsp;&rsaquo;</a></p>
     </div>
 
     <div class="col-4 p-card">
@@ -371,7 +371,7 @@
 
   <div class="u-fixed-width">
     <p>
-      <a href="https://assets.ubuntu.com/v1/8db65a1e-Kubernetes-for-the-Enterprise.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">
+      <a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Download the Services datasheet', 'eventLabel' : 'Download the Services datasheet' : undefined });">
         Download the Enterprise Kubernetes datasheet&nbsp;&rsaquo;
       </a>
     </p>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -16,7 +16,7 @@
       <p class="p-heading--four">Cost effective. Pure upstream.</p>
       <p>Focus on your business while Canonical builds and manages your Kubernetes clusters. Take advantage of your on-premises assets and leverage public clouds for your multi-cloud strategy.</p>
       <div>
-        <a href="https://assets.ubuntu.com/v1/8db65a1e-Kubernetes-for-the-Enterprise.pdf" class="p-button--positive">Read the datasheet</a>
+        <a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf" class="p-button--positive">Read the datasheet</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-hide--small">
@@ -90,7 +90,7 @@
             }}
             <h4 class="p-heading-icon__title">Datasheet</h4>
           </div>
-          <h3 class="p-heading--four"><a class="p-link--external" href="https://assets.ubuntu.com/v1/8db65a1e-Kubernetes-for-the-Enterprise.pdf">Kubernetes for the enterprise</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Kubernetes for the enterprise</a></h3>
         </div>
       </div>
       <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that the datasheet URL is updated to `https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf` on:
  - /kubernetes: 
   - in 'Upstream K8s options...' > Charmed Kubernetes > 'Charmed Kubernetes Datasheet'
   - in 'AI/ML add-on...' > 'Download the Enterprise Kubernetes datasheet' at bottom
  - /kubernetes/managed
   - in hero section
   - in Resources section
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #7292 