### PR TITLE
Fix the gnome version

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -78,7 +78,7 @@
     <div class="u-fixed-width">
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Linux 5.4 kernel</li>
-        <li class="p-list__item is-ticked">The fastest and most responsive GNOME Desktop, running v1.36 by default</li>
+        <li class="p-list__item is-ticked">The fastest and most responsive GNOME Desktop, running v3.36 by default</li>
         <li class="p-list__item is-ticked">A new default theme, Yaru, gives Ubuntu a fresh new look</li>
         <li class="p-list__item is-ticked">Improved settings for WiFi, wallpaper and application groups in the Activities overview</li>
         <li class="p-list__item is-ticked">Change between a light or dark environment directly from system settings</li>


### PR DESCRIPTION
## Done

- Change the Gnome version used by 20.04 LTS.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/developers
-  Check the version is 3.36 instead of 1.36.