### PR TITLE
CVE search form

### DIFF
--- a/static/js/src/cve/cve-search.js
+++ b/static/js/src/cve/cve-search.js
@@ -1,0 +1,86 @@
+/**
+ * isValidCveId
+ *
+ * Checks if the supplied value is a valid CVE ID in the format
+ *
+ * A CVE ID consists consists of `cve-` (case-insensitive)
+ * followed by 4 integers, follwed by `-`, followed by 4 to 7 integers
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isValidCveId(value) {
+  if (!value) {
+    return;
+  }
+
+  const cveIdPattern = /^(cve-)?\d{4}-\d{4,7}$/gi;
+
+  return value.match(cveIdPattern);
+}
+
+/**
+ * Preprends and CVE with `cve-` if not already there
+ *
+ * @param {string} node
+ * @returns {string}
+ */
+function constructCveId(value) {
+  const cvePrefixPattern = /^(cve-)/gi;
+
+  if (!value.match(cvePrefixPattern)) {
+    value = `cve-${value}`;
+  }
+
+  return value;
+}
+
+/**
+ * isDomNode
+ *
+ * Checks that the supplied value is a DOM node
+ *
+ * @param {HTMLElement} node
+ * @returns {boolean}
+ */
+function isDomNode(node) {
+  try {
+    return node instanceof HTMLElement;
+  } catch (e) {
+    return;
+  }
+}
+
+/**
+ * disableField
+ *
+ * Sets the `disabled` attribute on the supplied DOM node
+
+ * @param {HTMLElement} field
+ * @returns {undefined}
+ */
+function disableField(field) {
+  if (!isDomNode(field)) {
+    return;
+  }
+
+  field.setAttribute("disabled", true);
+}
+
+/**
+ * enableField
+ *
+ * Removes the `disabled` attribute from the supplied DOM node
+ *
+ * @param {*} field
+ * @returns {undefined}
+ */
+function enableField(field) {
+  if (!isDomNode(field)) {
+    return;
+  }
+
+  field.removeAttribute("disabled");
+}
+
+export { isValidCveId, constructCveId, isDomNode, disableField, enableField };

--- a/static/js/src/cve/cve-search.test.js
+++ b/static/js/src/cve/cve-search.test.js
@@ -1,0 +1,113 @@
+import {
+  isValidCveId,
+  constructCveId,
+  isDomNode,
+  disableField,
+  enableField,
+} from "./cve-search.js";
+
+describe("isValidCveId", () => {
+  it("returns falsy if given no value", () => {
+    expect(isValidCveId()).toBeFalsy();
+  });
+
+  it("returns truthy if given a valid CVE ID", () => {
+    const validCveIds = [
+      "cve-1234-1324",
+      "CVE-1234-1234",
+      "cve-1234-12345",
+      "CVE-1234-12345",
+      "cve-1234-123456",
+      "CVE-1234-123456",
+      "cve-1234-1234567",
+      "CVE-1234-1234567",
+      "1234-1234",
+      "1234-12345",
+      "1234-123456",
+      "1234-1234567",
+    ];
+
+    validCveIds.forEach((cveId) => {
+      expect(isValidCveId(cveId)).toBeTruthy();
+    });
+  });
+
+  it("returns falsy if given an invalid CVE ID", () => {
+    const invalidCveIds = [
+      "cve-123-1234",
+      "CVE-123-1234",
+      "cve-123-12345",
+      "CVE-123-12345",
+      "cve-123-123456",
+      "CVE-123-1234567",
+      "cve-1234-123",
+      "CVE-1234-123",
+      "cve-1234-12345678",
+      "CVE-1234-12345678",
+      "123-1234",
+      "123-12345",
+      "123-123456",
+      "123-1234567",
+      "1234-123",
+      "1234-12345678",
+    ];
+
+    invalidCveIds.forEach((cveId) => {
+      expect(isValidCveId(cveId)).toBeFalsy();
+    });
+  });
+});
+
+describe("constructCveId", () => {
+  it("prepends `cve-` to ID if missing", () => {
+    expect(constructCveId("1234-1234")).toBe("cve-1234-1234");
+  });
+
+  it("returns full cve ID if in correct format", () => {
+    expect(constructCveId("cve-1234-1234")).toBe("cve-1234-1234");
+  });
+});
+
+describe("isDomNode", () => {
+  it("returns falsy if no argument is given", () => {
+    expect(isDomNode()).toBeFalsy();
+  });
+
+  it("returns truthy if argument is a DOM node", () => {
+    const input = document.createElement("input");
+    expect(isDomNode(input)).toBeTruthy();
+  });
+
+  it("returns falsy if argument is not a DOM node", () => {
+    const input = '<input type="text">';
+    expect(isDomNode(input)).toBeFalsy();
+  });
+});
+
+describe("disableField", () => {
+  it("returns falsy if no argument given", () => {
+    expect(disableField()).toBeFalsy();
+  });
+
+  it("sets the `disabled` attribute to `true` on the field", () => {
+    const input = document.createElement("input");
+    disableField(input);
+    expect(input.getAttribute("disabled")).toBeTruthy();
+
+    input.setAttribute("disabled", false);
+    expect(input.getAttribute("disabled")).toBe("false");
+  });
+});
+
+describe("enableField", () => {
+  it("returns falsy if no argument given", () => {
+    expect(enableField()).toBeFalsy();
+  });
+
+  it("removes the `disabled` attribte from the field", () => {
+    const input = document.createElement("input");
+    input.setAttribute("disabled", true);
+    enableField(input);
+    expect(input.getAttribute("disabled")).toBeFalsy();
+  });
+});

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -1,0 +1,41 @@
+import {
+  isValidCveId,
+  disableField,
+  enableField,
+  constructCveId,
+} from "./cve-search.js";
+
+const searchInput = document.querySelector("#q");
+
+function handleCveIdInput(value) {
+  const packageInput = document.querySelector("#package");
+  const priorityInput = document.querySelector("#priority");
+  const searchButton = document.querySelector("#cve-search-button");
+  const redirectButton = document.querySelector("#cve-redirect-button");
+
+  if (isValidCveId(value)) {
+    const cveId = constructCveId(value);
+
+    redirectButton.setAttribute("href", `/security/${cveId}`);
+
+    redirectButton.classList.remove("u-hide");
+    searchButton.classList.add("u-hide");
+
+    disableField(packageInput);
+    disableField(priorityInput);
+  } else {
+    enableField(packageInput);
+    enableField(priorityInput);
+
+    searchButton.classList.remove("u-hide");
+    redirectButton.classList.add("u-hide");
+  }
+}
+
+handleCveIdInput(searchInput.value);
+
+function handleSearchInput(event) {
+  handleCveIdInput(event.target.value);
+}
+
+searchInput.addEventListener("keyup", handleSearchInput);

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -2,9 +2,9 @@
 {% block title %}{{ cve.id  }}{% endblock %}
 
 {% block head_extra %}
-  {% if cve.status == 'rejected' or cve.status == 'not-for-us' %}
-  <meta name="robots" content="noindex">
-  {% endif %}
+{% if cve.status == 'rejected' or cve.status == 'not-for-us' %}
+<meta name="robots" content="noindex">
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -37,117 +37,117 @@
 
 {% if cve.status == 'rejected' or cve.status == 'not-for-us' %}
 <section class="p-strip--light is-bordered--top">
-{% else %}
-<section class="p-strip">
-{% endif %}
+  {% else %}
+  <section class="p-strip">
+    {% endif %}
 
-  <div class="row">
-    <div class="col-9">
-      <h1>{{ cve.id}}</h1>
+    <div class="row">
+      <div class="col-9">
+        <h1>{{ cve.id }}</h1>
 
-      {% if cve.public_date %}
-      <p>Published {{ cve.public_date }}</p>
-      {% endif %}
+        {% if cve.public_date %}
+        <p>Published: <strong>{{ cve.public_date.strftime("%d %B %Y") }}</strong></p>
+        {% endif %}
 
-      {% if cve.status == 'active' and cve.last_updated_date and cve.last_updated_date != cve.public_date %}
-      <p>Last updated {{ cve.last_updated_date }}</p>
-      {% endif %}
+        {% if cve.status == 'active' and cve.last_updated_date and cve.last_updated_date != cve.public_date %}
+        <p>Last updated: <strong>{{ cve.last_updated_date.strftime("%d %B %Y") }}</strong></p>
+        {% endif %}
 
-      {% if cve.description %}
-      <p>{{ cve.description }}</p>
-      {% endif %}
+        {% if cve.description %}
+        <p>{{ cve.description }}</p>
+        {% endif %}
 
-      {% if cve.ubuntu_description %}
-      <h2>From the Ubuntu security team</h2>
-      <p>{{ cve.ubuntu_description }}</p>
-      {% endif %}
-    </div>
+        {% if cve.ubuntu_description %}
+        <h2>From the Ubuntu security team</h2>
+        <p>{{ cve.ubuntu_description }}</p>
+        {% endif %}
+      </div>
 
-    <div class="col-3">
-      {% if cve.status == 'active' and cve.priority %}
+      <div class="col-3">
+        {% if cve.status == 'active' and cve.priority %}
         <div class="cve-status-box">
           <div class="p-heading--four u-no-margin--bottom">Priority {{ cve.priority | capitalize }}</div>
         </div>
         <p>CVSS 3 base score: {{ cve.cvss }}</p>
-      {% endif %}
+        {% endif %}
 
-      {% if cve.status == 'rejected' %}
+        {% if cve.status == 'rejected' %}
         <div class="cve-status-box--highlight">
           <div class="p-heading--four u-no-margin--bottom">
             Rejected
           </div>
         </div>
-      {% endif %}
+        {% endif %}
 
-      {% if cve.status == 'not-for-us' %}
-      <div class="cve-status-box--highlight">
-        <div class="p-heading--four u-no-margin--bottom">
-          Not in Ubuntu
+        {% if cve.status == 'not-for-us' %}
+        <div class="cve-status-box--highlight">
+          <div class="p-heading--four u-no-margin--bottom">
+            Not in Ubuntu
+          </div>
         </div>
+        {% endif %}
       </div>
-      {% endif %}
+
     </div>
 
-  </div>
-
-  {% if cve.status == 'active' %}
-  <div class="u-fixed-width">
-    <h2>Status</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Package</th>
-          <th>Release</th>
-          <th>Status</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for package in cve.packages %}
+    {% if cve.status == 'active' %}
+    <div class="u-fixed-width">
+      <h2>Status</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Package</th>
+            <th>Release</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for package in cve.packages %}
           <tr>
             <td rowspan="{{ package.releases | length }}">{{ package.name }}</td>
             <td>{{ package.releases[0].name }}</td>
             <td>{{ package.releases[0].status }}</td>
           </tr>
           {% for n in range(package.releases | length) %}
-            {% if n > 0 %}
-            <tr>
-              <td>{{ package.releases[n].name }}</td>
-              <td>{{ package.releases[n].status }}</td>
-            </tr>
-            {% endif %}
+          {% if n > 0 %}
+          <tr>
+            <td>{{ package.releases[n].name }}</td>
+            <td>{{ package.releases[n].status }}</td>
+          </tr>
+          {% endif %}
           {% endfor %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
+
+    <div class="u-fixed-width">
+      {% if cve.status == 'active' and cve.notes %}
+      <h2>Notes</h2>
+      <p>{{ cve.notes }}</p>
+      {% endif %}
+
+      <h2>References</h2>
+      {% if cve.references %}
+      <ul>
+        {% for reference in cve.references %}
+        <li><a href="{{ reference.uri }}">{{ reference.uri }}</a></li>
         {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% endif %}
+      </ul>
+      {% else %}
+      <ul>
+        <li>
+          <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
+            MITRE
+          </a>
+        </li>
+      </ul>
+      {% endif %}
 
-  <div class="u-fixed-width">
-    {% if cve.status == 'active' and cve.notes %}
-    <h2>Notes</h2>
-    <p>{{ cve.notes }}</p>
-    {% endif %}
+    </div>
+  </section>
 
-    <h2>References</h2>
-    {% if cve.references %}
-    <ul>
-    {% for reference in cve.references %}
-      <li><a href="{{ reference.uri }}">{{ reference.uri }}</a></li>
-    {% endfor %}
-    </ul>
-    {% else %}
-    <ul>
-      <li>
-        <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
-          MITRE
-        </a>
-      </li>
-    </ul>
-    {% endif %}
-
-  </div>
-</section>
-
-{% with first_item="_security_discussion", second_item="_security_esm",
+  {% with first_item="_security_discussion", second_item="_security_esm",
 third_item="_security_further_reading" %}{% include
 "shared/contextual_footers/_contextual_footer.html" %}{% endwith %} {% endblock %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -3,24 +3,26 @@
 {% block title %}CVEs{% endblock %}
 
 {% block content %}
-<section class="p-strip--suru-topped">
+
+<section class="p-strip--suru-topped u-no-padding--bottom">
   <div class="u-fixed-width">
     <h1>CVE reports</h1>
   </div>
+</section>
 
+<section class="p-strip is-shallow">
   <div class="u-fixed-width">
     <h2>Search</h2>
   </div>
-
   <form>
     <div class="row">
-      <div class="col-3">
-        <label for="q">CVE ID:</label>
-        <input type="text" name="q" id="q" value="{{query or '' }}">
+      <div class="col-6">
+        <label for="q">CVE ID or description contains:</label>
+        <input type="text" name="q" id="q" value="{{ query or '' }}">
       </div>
       <div class="col-3">
         <label for="package">Package:</label>
-        <input type="text" name="package" id="package" value="{{package or '' }}">
+        <input type="text" name="package" id="package" value="{{ package or '' }}">
       </div>
       <div class="col-3">
         <label for="priority">Priority:</label>
@@ -43,38 +45,26 @@
           </option>
         </select>
       </div>
-      <div class="col-3 u-align--right">
-        <div class="p-form__group">
-          <label class="p-form__label">&nbsp;</label> <!-- required for layout -->
-          <div class="p-form__control">
-            <a href="/security/cve" class="p-button--neutral">Clear filters</a>
-            <button type="submit" class="p-button--positive">Search</button>
-          </div>
-        </div>
+      <div class="col-12">
+        <button type="submit" class="p-button--positive" id="cve-search-button">Search</button>
+        <a href="" class="p-button--positive u-hide" id="cve-redirect-button">Go to CVE</a>
       </div>
     </div>
   </form>
+</section>
 
+<section class="p-strip is-shallow">
   <div class="u-fixed-width">
-    {% if query %}
-      <h2>
-        {% if total_results > 1 %}
-          {{ offset + 1 }} &ndash; {{ offset + limit  }} of
-        {% endif %}
-        {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-      </h2>
+    {% if query or package or priority %}
+    <h2>
+      {% if total_results > 1 %}
+      {{ offset + 1 }} &ndash; {{ offset + limit  }} of
+      {% endif %}
+      {{ total_results }} result{% if total_results != 1 %}s{% endif %}
+    </h2>
     {% else %}
-      <h2>Recent CVEs affecting Ubuntu</h2>
+    <h2>Recent CVEs affecting Ubuntu</h2>
     {% endif %}
-
-    <ul class="p-inline-list">
-      <li class="p-inline-list__item">
-        <a href="?{{ modify_query({'order-by': 'oldest'}) }}">Oldest first</a>
-      </li>
-      <li class="p-inline-list__item">
-        <a href="?{{ modify_query({'order-by': 'newest'}) }}">Newest first</a>
-      </li>
-    </ul>
   </div>
 
   <div class="u-fixed-width">
@@ -84,7 +74,7 @@
           <th>CVE</th>
           <th>Package</th>
           {% for release in releases %}
-            <th>{{ release.name }}</th>
+          <th>{{ release.name }}</th>
           {% endfor %}
         </tr>
       </thead>
@@ -93,37 +83,39 @@
         <tr>
           <td rowspan="{{ cve.packages | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
           {% for package in cve.packages %}
-            {% if loop.index == 1 %}
-            <td>{{ package.name }}</td>
-              {% for rel in package.releases %}
-                {% if rel.name != 'Upstream' %}
-                <td>{{ rel.status }}</td>
-                {% endif %}
-              {% endfor %}
-            {% endif %}
+          {% if loop.index == 1 %}
+          <td>{{ package.name }}</td>
+          {% for rel in package.releases %}
+          {% if rel.name != 'Upstream' %}
+          <td>{{ rel.status }}</td>
+          {% endif %}
+          {% endfor %}
+          {% endif %}
           {% endfor %}
         </tr>
-          {% for package in cve.packages %}
-            {% if loop.index > 1 %}
-            <tr>
-              <td>{{ package.name }}</td>
-              {% for rel in package.releases %}
-                {% if rel.name != 'Upstream' %}
-                  <td>{{ rel.status }}</td>
-                {% endif %}
-              {% endfor %}
-            {% endif %}
-            </tr>
+        {% for package in cve.packages %}
+        {% if loop.index > 1 %}
+        <tr>
+          <td>{{ package.name }}</td>
+          {% for rel in package.releases %}
+          {% if rel.name != 'Upstream' %}
+          <td>{{ rel.status }}</td>
+          {% endif %}
           {% endfor %}
+          {% endif %}
+        </tr>
+        {% endfor %}
         {% endfor %}
       </tbody>
     </table>
 
     {% with %}
-      {% include "security/cve/_pagination.html" %}
+    {% include "security/cve/_pagination.html" %}
     {% endwith %}
   </div>
 </section>
+
+<script src="{{ versioned_static('js/build/cve.min.js') }}" defer></script>
 
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
 {% include "shared/contextual_footers/_contextual_footer.html" %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     "desktop-statistics": "./static/js/src/desktop-statistics.js",
     tutorials: [
       "./static/js/src/tutorial-list.js",
-      "./static/js/src/tutorial.js"
+      "./static/js/src/tutorial.js",
     ],
     forms: "./static/js/src/forms.js",
     "image-download": "./static/js/src/image-download.js",
@@ -15,17 +15,18 @@ module.exports = {
       "./static/js/src/core.js",
       "./static/js/src/navigation.js",
       "./static/js/src/form-validation.js",
-      "./static/js/src/scratch.js"
+      "./static/js/src/scratch.js",
     ],
     "release-chart": "./static/js/src/release-chart.js",
     tabotronic: "./static/js/src/tabotronic.js",
     "tco-calculator": "./static/js/src/tco-calculator.js",
-    "sticky-nav": "./static/js/src/sticky-nav.js"
+    "sticky-nav": "./static/js/src/sticky-nav.js",
+    cve: "./static/js/src/cve/cve.js",
   },
   mode: process.env.ENVIRONMENT === "devel" ? "development" : "production",
   output: {
     filename: "[name].min.js",
-    path: __dirname + "/static/js/build"
+    path: __dirname + "/static/js/build",
   },
   module: {
     rules: [
@@ -35,10 +36,10 @@ module.exports = {
         use: {
           loader: "babel-loader",
           options: {
-            presets: ["@babel/preset-env"]
-          }
-        }
-      }
-    ]
-  }
+            presets: ["@babel/preset-env"],
+          },
+        },
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## Done

Made CVE search form work as intended
Drive by: formatted the date strings on a CVE page

## QA

``` bash
rm usn.sqlite3
dotrun exec alembic upgrade head
dotrun exec python3 webapp/security/fixtures/releases.py
dotrun exec python3 webapp/security/fixtures/load_sample_cve.py
dotrun
```

- Go to `/security/cve` and put a valid CVE ID (e.g. CVE-2020-10535) in the search field
- Check that the package and priority fields are disabled
- Check that the search button has turned into a button which takes you to the CVE page
- Enter a term from the CVE description into the search field e.g. any part of the following string assuming you used the example CVE ID above:

> GitLab 12.8.x before 12.8.6, when sign-up is enabled, allows remote attackers to bypass email domain

- Check that the CVE containing that description is returned as a result

### Check that the tests pass
```bash
dotrun exec yarn run test-js static/js/src/cve/cve-search.test.js
```