### PR TITLE
CVE page status

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -603,26 +603,23 @@ summary {
   padding-left: $sph-inner--small;
 }
 
-.p-corner-ribbon {
-  background-color: $color-brand;
-  color: $color-x-light;
-  padding-bottom: $spv-inner--x-small;
-  padding-top: $spv-inner--x-small;
-  position: absolute;
-  right: -50px;
-  text-align: center;
-  top: 38px;
-  transform: rotate(45deg);
-  width: 225px;
-}
-
 .is-bordered--top {
   @extend %vf-pseudo-border--top;
 }
 
-.priority-box {
+.cve-status-box,
+.cve-status-box--highlight {
   @extend .p-card;
 
-  background-color: $color-mid-x-light;
   margin-bottom: $sp-small;
+}
+
+.cve-status-box {
+  background-color: $color-mid-x-light;
+}
+
+.cve-status-box--highlight {
+  background-color: $color-brand;
+  border: none;
+  color: $color-x-light;
 }

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -41,18 +41,6 @@
 <section class="p-strip">
 {% endif %}
 
-  {% if cve.status == 'rejected' %}
-  <div class="p-corner-ribbon u-hide--small">
-    Rejected
-  </div>
-  {% endif %}
-
-  {% if cve.status == 'not-for-us' %}
-  <div class="p-corner-ribbon u-hide--small">
-    Not in Ubuntu
-  </div>
-  {% endif %}
-
   <div class="row">
     <div class="col-9">
       <h1>{{ cve.id}}</h1>
@@ -75,14 +63,31 @@
       {% endif %}
     </div>
 
-    {% if cve.status == 'active' and cve.priority %}
     <div class="col-3">
-      <div class="priority-box">
-        <div class="p-heading--four u-no-margin--bottom">Priority {{ cve.priority | capitalize }}</div>
+      {% if cve.status == 'active' and cve.priority %}
+        <div class="cve-status-box">
+          <div class="p-heading--four u-no-margin--bottom">Priority {{ cve.priority | capitalize }}</div>
+        </div>
+        <p>CVSS 3 base score: {{ cve.cvss }}</p>
+      {% endif %}
+
+      {% if cve.status == 'rejected' %}
+        <div class="cve-status-box--highlight">
+          <div class="p-heading--four u-no-margin--bottom">
+            Rejected
+          </div>
+        </div>
+      {% endif %}
+
+      {% if cve.status == 'not-for-us' %}
+      <div class="cve-status-box--highlight">
+        <div class="p-heading--four u-no-margin--bottom">
+          Not in Ubuntu
+        </div>
       </div>
-      <p>CVSS 3 base score: {{ cve.cvss }}</p>
+      {% endif %}
     </div>
-    {% endif %}
+
   </div>
 
   {% if cve.status == 'active' %}


### PR DESCRIPTION
## Done

Replace the CVE status corner ribbon with a card style

## QA

- Check out this feature branch
- Run `dotrun exec python3 webapp/security/fixtures/releases.py`
- Run `dotrun exec python3 webapp/security/fixtures/load_sample_cve.py`
- Run `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/CVE-2019-1010262 and http://0.0.0.0:8001/security/CVE-2020-7629
- Check that the 'Not in Ubuntu' and 'Rejcted' look like the screenshot: https://usercontent.irccloud-cdn.com/file/UIG9Nihs/image.png