### PR TITLE
Fix bug with blogpost thumbnails not being displayed

### DIFF
--- a/static/js/src/latest-news.js
+++ b/static/js/src/latest-news.js
@@ -43,7 +43,9 @@
       article._embedded &&
       article._embedded["wp:featuredmedia"] &&
       article._embedded["wp:featuredmedia"][0] &&
-      article._embedded["wp:featuredmedia"][0].width
+      article._embedded["wp:featuredmedia"][0].media_details &&
+      article._embedded["wp:featuredmedia"][0].media_details.width &&
+      article._embedded["wp:featuredmedia"][0].media_details.height
     ) {
       let media = article._embedded["wp:featuredmedia"][0];
       articleImage = {


### PR DESCRIPTION
## Done

Fix bug where blog post thumbnails aren't displayed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics/community
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the posts in the "Recent news" section have thumbnails