### PR TITLE
Install gpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN yarn run build-css
 FROM ubuntu:bionic
 
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev gpg
 COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
 COPY --from=python-dependencies /root/.local/bin /root/.local/bin
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
We need gpg installed to be able to encrypt the user's
data to attach to the build.

## QA

``` bash
docker build -t ib .
docker run -ti -p 8888:80--env DATABASE_URL=sqlite:///something --env LAUNCHPAD_TOKEN={thetoken} --env LAUNCHPAD_SECRET={thesecret} ib
```

Go to http://localhost:8888/build, kick off a build, check it successfully is kicked off.