### PR TITLE
Fix board architectures search

### DIFF
--- a/static/js/src/imageBuilder.js
+++ b/static/js/src/imageBuilder.js
@@ -1,4 +1,4 @@
-window.renderImageBuilder = function (boardArchitectures) {
+window.renderImageBuilder = function () {
   // State management
   class StateArray extends Array {
     push(item) {
@@ -88,22 +88,22 @@ window.renderImageBuilder = function (boardArchitectures) {
   let triggerSearch = debounce(function () {
     const board = state.get("board")[0];
     const os = state.get("os")[0];
-    const architecture = boardArchitectures[board][os]["arch"];
     snapResults.innerHTML =
       '<p><i class="p-icon--spinner u-animation--spin"></i></p>';
     const searchInput = snapSearch.querySelector(".p-search-box__input");
     if (searchInput) {
       const searchValue = encodeURI(searchInput.value);
-      fetch(`/snaps?q=${searchValue}&size=12&architecture=${architecture}`)
+      fetch(`/snaps?q=${searchValue}&size=12&board=${board}&system=${os}`)
         .then((response) => {
           return response.json();
         })
         .then((json) => {
-          snapSearchResults = json["_embedded"]
-            ? json["_embedded"]["clickindex:package"]
-            : {};
+          snapSearchResults = json["results"];
           renderSnapList(snapSearchResults, snapResults, "Add");
           addSnapHandler();
+          archOutput.querySelector(".js-architecture-detail").innerText =
+            json["architecture"];
+          archOutput.classList.remove("u-hide");
         });
     }
   }, 250);
@@ -327,14 +327,11 @@ window.renderImageBuilder = function (boardArchitectures) {
     }
     if (state.get("os") && state.get("os")[0]) {
       step3.classList.remove("u-disable");
-      const board = state.get("board")[0];
-      const os = state.get("os")[0];
 
-      if (boardArchitectures[board][os]) {
-        const architecture = boardArchitectures[board][os]["arch"];
-        archOutput.querySelector(
-          ".js-architecture-detail"
-        ).innerText = architecture;
+      if (
+        snapResults.hasChildNodes() &&
+        archOutput.querySelector(".js-architecture-detail").innerHTML.trim()
+      ) {
         archOutput.classList.remove("u-hide");
       }
     }

--- a/templates/build/index.html
+++ b/templates/build/index.html
@@ -224,7 +224,7 @@
     <div class="col-6">
       <div class="p-notification--information js-architecture u-hide">
         <p class="p-notification__response">
-          Your selected architecture is <strong class="js-architecture-detail"></strong>. If you are missing a snap it's probably not supported by this architecture.
+          Only showing snaps compatible with your system's architecture (<strong class="js-architecture-detail"></strong>). If a snap you expected to see is missing, it may not be compatible with your system.
         </p>
       </div>
     </div>
@@ -260,10 +260,7 @@
   </div>
 </section>
 <script src="{{ versioned_static('js/build/imageBuilder.min.js') }}"></script>
-<script>
-  const boardArchitectures = {{ board_architectures | safe }};
-  renderImageBuilder(boardArchitectures);
-</script>
+<script>renderImageBuilder();</script>
 
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -293,15 +293,29 @@ def search_snaps():
     """
 
     query = flask.request.args.get("q", "")
-    arch = flask.request.args.get("arch", "wide")
+    architecture = flask.request.args.get("architecture", "wide")
+    board = flask.request.args.get("board")
+    system = flask.request.args.get("system")
     size = flask.request.args.get("size", "100")
     page = flask.request.args.get("page", "1")
+
+    if board and system:
+        architecture = Launchpad.board_architectures[board][system]["arch"]
 
     if not query:
         return flask.jsonify({"error": "Query parameter 'q' empty"}), 400
 
+    search_response = store_api.search(
+        query, size=size, page=page, arch=architecture
+    )
+
     return flask.jsonify(
-        store_api.search(query, size=size, page=page, arch=arch)
+        {
+            "results": search_response.get("_embedded", {}).get(
+                "clickindex:package", {}
+            ),
+            "architecture": architecture,
+        }
     )
 
 


### PR DESCRIPTION
- The search wasn't filtering by architecture at all (it was using the wrong parameter name)
- Remove the need for the client-side to have the whole architectures mapping
- Improve the wording for the architecture warning notice

QA
--

`dotrun`, go to `/build`, play around with searching for snaps, changing boards etc. Try to break the state of the page.