### PR TITLE
Remove autocomplete and reset from the search field

### DIFF
--- a/templates/build/index.html
+++ b/templates/build/index.html
@@ -207,8 +207,7 @@
     <div class="col-6">
       <h4>Available snaps:</h4>
       <form class="p-search-box js-snap-search">
-        <input type="search" class="p-search-box__input" name="search">
-        <button type="reset" class="p-search-box__reset" alt="reset"><i class="p-icon--close"></i></button>
+        <input type="search" class="p-search-box__input" name="search" automplete="off">
         <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
       </form>
       <div class="p-card has-limited-height">

--- a/templates/build/index.html
+++ b/templates/build/index.html
@@ -248,7 +248,7 @@
         {% endif %}
         <p>
           <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-          <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+          <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">Also send me information about Canonical’s products and services.</label>
         </p>
         <input type="hidden" name="board" value="" />
         <input type="hidden" name="system" value="" />


### PR DESCRIPTION
## Done
Remove autocomplete and reset from the search field

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/build
- Sign in
- Select and board and OS
- Search for something and see you do not see a autocomplete popover
- See that the reset or clear is not there. 

## Issue / Card
Fixes the comments here: https://github.com/canonical-web-and-design/ubuntu.com/pull/6695#issuecomment-620590768
