### PR TITLE
Update links to 20.04 on /azure/pro

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -12,7 +12,7 @@
         <h1>Ubuntu Pro for Azure</h1>
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for Azure is a premium image designed by Canonical to provide the most comprehensive feature set for production environments running on Azure public cloud. Offered as a virtual machine image through Azure Marketplace, it includes a subscription to Canonical's critical security and compliance services by default. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations — no contract necessary.</p>
-        <p><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on Azure</span></a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 20.04 LTS on Azure</span></a></p>
         <p><a href="https://assets.ubuntu.com/v1/27a386bc-Ubuntu_Pro_Azure_03.04.20.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -117,6 +117,11 @@
   </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">Ubuntu Pro 20.04 LTS</h3>
+      <p>The latest LTS release includes the 5.4 kernel out of the box. Ubuntu Pro 20.04 LTS provides extended maintenance through 2030.</p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+    </div>
+    <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Ubuntu Pro 18.04 LTS</h3>
       <p>The latest LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available in Q2. Ubuntu Pro provides extended maintenance through 2028.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
@@ -125,11 +130,6 @@
       <h3 class="p-heading--four">Ubuntu Pro 16.04 LTS</h3>
       <p>The most commonly deployed Ubuntu LTS on the cloud today, Ubuntu 16.04 LTS released in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2024.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Ubuntu Pro 14.04 LTS</h3>
-      <p>Ubuntu 14.04 LTS shipped in 2014 with the 3.13 kernel. Ubuntu Pro extends our security coverage to 2022, giving you plenty of time to prepare and upgrade.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-trusty?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
   </div>
 </section>
@@ -269,7 +269,7 @@
           </tr>
         </tbody>
       </table>
-      <p>For complete pricing, <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=PlansAndPrice" class="p-link--external">see Ubuntu Pro 18.04 LTS on the Azure Marketplace</a></p>
+      <p>For complete pricing, <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=PlansAndPrice" class="p-link--external">see Ubuntu Pro 20.04 LTS on the Azure Marketplace</a></p>
     </div>
   </div>
 </section>
@@ -281,13 +281,18 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four">
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal" class="p-link--external">20.04 LTS</a>
+      </h3>
+    </div>
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-link--external">18.04 LTS</a></h3>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial" class="p-link--external">16.04 LTS</a></h3>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-trusty" class="p-link--external">14.04 LTS</a></h3>
     </div>
   </div>


### PR DESCRIPTION
## Done

Update the copy to reflect the 20.04 release on /azure/pro

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure/pro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that Lech's requested changes in [the copy doc](https://docs.google.com/document/d/1WaQ5n3GxwZzbX0T6rLiRNejFvxIPIHd5V5XgdAwKmSw/edit) have been actioned (please resolve the comments)


## Issue / Card

Fixes #7354 
