### PR TITLE
Update public cloud page copy with 20.04 link

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -137,7 +137,7 @@
         <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">Launch Ubuntu Pro 18.04 LTS for AWS</a>
       </p>
       <p>
-        <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview">Launch Ubuntu Pro 18.04 LTS for Azure</a>
+        <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview">Launch Ubuntu Pro 20.04 LTS for Azure</a>
       </p>
       <p>Ubuntu Server {{ releases.lts.short_version }} LTS is a free download that includes five years worth of  security and maintenance updates, guaranteed. Using an Ubuntu partner cloud ensures access to the latest certified Ubuntu cloud images. To run Ubuntu as guest on participating public clouds, the simplest way is to use the image maintained on their server.</p>
       <p>


### PR DESCRIPTION
## Done

Update azure link on /public-cloud from 18.04 to 20.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure the change requested by Lech in [the copy doc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit) has been actioned (please resolve the comment)


## Issue / Card

Fixes #7355 