### PR TITLE
Update 18.04 links to 20.04 links on azure page

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -87,7 +87,7 @@
           <li class="p-list__item is-ticked">Updates mirrored and images published in all Azure regions worldwide</li>
           <li class="p-list__item is-ticked">5-year lifetime</li>
         </ul>
-        <p>Run Ubuntu 18.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer?tab=Overview" class="p-link--external">Standard</a></p>
+        <p>Run Ubuntu 20.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview" class="p-link--external">Standard</a></p>
       </div>
     </div>
     <div class="col-6 p-card">
@@ -103,7 +103,7 @@
           <li class="p-list__item is-ticked">Integration with Azure security and compliance features</li>
           <li class="p-list__item is-ticked">10-year lifetime</li>
         </ul>
-        <p><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS</span></a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 20.04 LTS</span></a></p>
         <p><a href="/azure/pro">More about Ubuntu Pro for Azure&nbsp;&rsaquo;</a></p>
       </div>
     </div>
@@ -139,13 +139,16 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-link--external">20.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-link--external">18.04 LTS</a></h3>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial" class="p-link--external">16.04 LTS</a></h3>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-trusty" class="p-link--external">14.04 LTS</a></h3>
     </div>
   </div>


### PR DESCRIPTION
## Done

Update links to 18.04 with 20.04 on /azure page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the changes requested by Lech in [the copy doc](https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit#heading=h.rwz46gtc2v3z) have been actioned (please resolve comments)


## Issue / Card

Fixes #7356 