### PR TITLE
Add moving to open source whitepaper engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -968,7 +968,7 @@
       type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
-    
+
     {% with title="Managed apps webinar",
       description="Maintaining business focus in a cloud-native world with Managed Apps",
       slug="managed-apps-webinar",
@@ -977,12 +977,19 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
     </div>
-    
+
     <div class="row u-equal-height u-clearfix">
     {% with title="What&rsquo;s new in Ubuntu 20.04 LTS?",
       description="Learn all about the major features introduced as part of the Ubuntu 20.04 LTS release",
       slug="20.04-webinars",
           type="webinar" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+
+    {% with title="Embracing the enterprise open source mandate",
+      description="85% of enterprises report an open source mandate, preference, or exploratory approach ",
+      slug="moving-to-opensource-whitepaper",
+          type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
     </div>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -986,8 +986,8 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
 
-    {% with title="Embracing the enterprise open source mandate",
-      description="85% of enterprises report an open source mandate, preference, or exploratory approach ",
+    {% with title="Embracing the open source mandate",
+      description="85% of enterprises have an open source mandate, preference or are exploring",
       slug="moving-to-opensource-whitepaper",
           type="whitepaper" %}
       {% include "engage/_article-card.html" %}

--- a/templates/engage/moving-to-opensource-whitepaper.md
+++ b/templates/engage/moving-to-opensource-whitepaper.md
@@ -1,12 +1,12 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-     title: "Embracing the enterprise open source mandate"
-     meta_description: "Why 85% of enterprises report an open source mandate, preference, or exploratory approach"
+     title: "Embracing the open source mandate"
+     meta_description: "85% of enterprises have an open source mandate, preference or are exploring"
      meta_image: https://assets.ubuntu.com/v1/4ede4e56-moving-to-open-source-meta.png
      meta_copydoc: https://docs.google.com/document/d/10Pp_AkdhYPfh-edQCq9HngRKVEMUfOCP39E3P5_VXpo/edit
-     header_title: "Embracing the enterprise open source mandate"
-     header_subtitle: "85% of enterprises report an open source mandate, preference, or exploratory approach"
+     header_title: "Embracing the open source mandate"
+     header_subtitle: "85% of enterprises have an open source mandate, preference or are exploring"
      header_image: https://assets.ubuntu.com/v1/f2e4e9fb-slide-opensource.svg
      header_image_width: "400"
      header_image_height: "275"

--- a/templates/engage/moving-to-opensource-whitepaper.md
+++ b/templates/engage/moving-to-opensource-whitepaper.md
@@ -1,0 +1,32 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Embracing the enterprise open source mandate"
+     meta_description: "Why 85% of enterprises report an open source mandate, preference, or exploratory approach"
+     meta_image: https://assets.ubuntu.com/v1/4ede4e56-moving-to-open-source-meta.png
+     meta_copydoc: https://docs.google.com/document/d/10Pp_AkdhYPfh-edQCq9HngRKVEMUfOCP39E3P5_VXpo/edit
+     header_title: "Embracing the enterprise open source mandate"
+     header_subtitle: "85% of enterprises report an open source mandate, preference, or exploratory approach"
+     header_image: https://assets.ubuntu.com/v1/f2e4e9fb-slide-opensource.svg
+     header_image_width: "400"
+     header_image_height: "275"
+     header_url: '#register-section'
+     header_cta: "Download the whitepaper"
+     header_class: "p-engage-banner--grad"
+     header_lang: en
+     form_include: en
+     form_id: 3558
+     form_return_url: https://pages.ubuntu.com/MovingtoOpenSource_TY.html
+---
+
+Open source software is a critical element of today’s enterprise technology landscape. It drives economic benefits, innovation, and competitiveness, while also delivering advantages around agility, stability, and security – which is why it is being prioritised at both the infrastructure and application layers.
+
+Whereas in the past, many businesses displayed an aversion to open source, the reverse is now more often the case. Open source software such as Kubernetes is central to emergent technology trends, and the prominence of open source will only increase over time. However, this increases the need for businesses to require open source support for reliability, security and regulatory compliance.
+
+Read this report from analyst firm, 451 Research, to learn more including:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">A complete breakdown of the attitudes of enterprise decision-makers towards open source software</li>
+  <li class="p-list__item is-ticked">The role of open source software in cloud native and DevOps trends</li>
+  <li class="p-list__item is-ticked">Overcoming open source challenges from skills gaps to day 2 operational concerns</li>
+</ul>


### PR DESCRIPTION
## Done

- Added a new engage page from this [brief](https://docs.google.com/spreadsheets/d/1bkM14vEn8noJcQVphj9B_iGV6suh6NYoJncmG-5e_D4/edit#gid=1271849439)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/moving-to-opensource-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7338 
