### PR TITLE
Update public cloud page laptop image

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -106,7 +106,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-5">
       <h2>Developers&rsquo; favourite</h2>
@@ -116,10 +116,10 @@
     <div class="col-7 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/79439f53-Dell_XPS_Laptop_Front-Developer.png",
+          url="https://assets.ubuntu.com/v1/b3061ad7-laptop-dev.png",
           alt="",
-          height="272",
-          width="540",
+          height="298",
+          width="500",
           hi_def=True,
           loading="lazy",
         ) | safe


### PR DESCRIPTION
## Done

- Updated the laptop image on the public cloud page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- See the image in the "developers' favourite" section
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #7191 

![image](https://user-images.githubusercontent.com/118614/80527381-307ac380-898c-11ea-81aa-5ebf0451e554.png)
