### PR TITLE
Store session UTMs in localstorage, resurface them on form fills

### DIFF
--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -1,11 +1,11 @@
-(function() {
-  document.addEventListener("DOMContentLoaded", function() {
+(function () {
+  document.addEventListener("DOMContentLoaded", function () {
     var triggeringHash = "#get-in-touch";
     var formContainer = document.getElementById("contact-form-container");
     var contactButtons = document.querySelectorAll(".js-invoke-modal");
 
-    contactButtons.forEach(function(contactButton) {
-      contactButton.addEventListener("click", function(e) {
+    contactButtons.forEach(function (contactButton) {
+      contactButton.addEventListener("click", function (e) {
         e.preventDefault();
         if (contactButton.dataset.formLocation) {
           fetchForm(contactButton.dataset, contactButton);
@@ -17,15 +17,15 @@
     });
 
     // recaptcha submitCallback
-    window.CaptchaCallback = function() {
+    window.CaptchaCallback = function () {
       let recaptchas = [].slice.call(
         document.querySelectorAll("div[class^=g-recaptcha]")
       );
-      recaptchas.forEach(function(field) {
+      recaptchas.forEach(function (field) {
         if (!field.hasAttribute("data-widget-id")) {
           let siteKey = field.getAttribute("data-sitekey");
           const recaptchaWidgetId = grecaptcha.render(field, {
-            sitekey: siteKey
+            sitekey: siteKey,
           });
           field.setAttribute("data-widget-id", recaptchaWidgetId);
         }
@@ -35,10 +35,10 @@
     // Fetch, load and initialise form
     function fetchForm(formData, contactButton) {
       fetch(formData.formLocation)
-        .then(function(response) {
+        .then(function (response) {
           return response.text();
         })
-        .then(function(text) {
+        .then(function (text) {
           formContainer.classList.remove("u-hide");
           formContainer.innerHTML = text
             .replace(/%% formid %%/g, formData.formId)
@@ -50,7 +50,7 @@
           initialiseForm();
           window.CaptchaCallback();
         })
-        .catch(function(error) {
+        .catch(function (error) {
           console.log("Request failed", error);
         });
     }
@@ -88,13 +88,10 @@
       // eg. /kubernetes/install -> kubernetes-install
       // fallbacks to "global"
       var product =
-        window.location.pathname
-          .split("/")
-          .slice(1)
-          .join("-") || "global";
+        window.location.pathname.split("/").slice(1).join("-") || "global";
       // If present, override with product parameter from button URL
       if (contactButton) {
-        contactButton.search.split("&").forEach(function(param) {
+        contactButton.search.split("&").forEach(function (param) {
           if (param.startsWith("product") || param.startsWith("?product")) {
             product = param.split("=")[1];
           }
@@ -109,21 +106,17 @@
     }
 
     function setUTMs() {
-      var params = new URLSearchParams(window.location.search);
-
       var utm_campaign = document.getElementById("utm_campaign");
       if (utm_campaign) {
-        utm_campaign.value = params.get("utm_campaign");
+        utm_campaign.value = localStorage.getItem("utm_campaign");
       }
-
       var utm_source = document.getElementById("utm_source");
       if (utm_source) {
-        utm_source.value = params.get("utm_source");
+        utm_source.value = localStorage.getItem("utm_source");
       }
-
       var utm_medium = document.getElementById("utm_medium");
       if (utm_medium) {
-        utm_medium.value = params.get("utm_medium");
+        utm_medium.value = localStorage.getItem("utm_medium");
       }
     }
 
@@ -140,7 +133,7 @@
       var comment = contactModal.querySelector("#Comments_from_lead__c");
       var otherContainers = document.querySelectorAll(".js-other-container");
 
-      document.onkeydown = function(evt) {
+      document.onkeydown = function (evt) {
         evt = evt || window.event;
         if (evt.keyCode == 27) {
           close();
@@ -148,7 +141,7 @@
       };
 
       if (submitButton) {
-        closeModal.addEventListener("click", function() {
+        closeModal.addEventListener("click", function () {
           ga(
             "send",
             "event",
@@ -160,21 +153,21 @@
       }
 
       if (closeModal) {
-        closeModal.addEventListener("click", function(e) {
+        closeModal.addEventListener("click", function (e) {
           e.preventDefault();
           close();
         });
       }
 
       if (closeModalButton) {
-        closeModalButton.addEventListener("click", function(e) {
+        closeModalButton.addEventListener("click", function (e) {
           e.preventDefault();
           close();
         });
       }
 
       if (contactModal) {
-        contactModal.addEventListener("click", function(e) {
+        contactModal.addEventListener("click", function (e) {
           if (e.target.id == "contact-modal") {
             e.preventDefault();
             close();
@@ -182,8 +175,8 @@
         });
       }
 
-      modalPaginationButtons.forEach(function(modalPaginationButton) {
-        modalPaginationButton.addEventListener("click", function(e) {
+      modalPaginationButtons.forEach(function (modalPaginationButton) {
+        modalPaginationButton.addEventListener("click", function (e) {
           e.preventDefault();
           var button = e.target.closest("a");
           var index = contactIndex;
@@ -211,12 +204,12 @@
         });
       });
 
-      otherContainers.forEach(function(otherContainer) {
+      otherContainers.forEach(function (otherContainer) {
         var checkbox = otherContainer.querySelector(
           ".js-other-container__checkbox"
         );
         var input = otherContainer.querySelector(".js-other-container__input");
-        checkbox.addEventListener("change", function(e) {
+        checkbox.addEventListener("change", function (e) {
           if (e.target.checked) {
             input.style.opacity = 1;
             input.focus();
@@ -266,7 +259,7 @@
         var currentContent = contactModal.querySelector(
           ".js-pagination--" + contactIndex
         );
-        paginationContent.forEach(function(content) {
+        paginationContent.forEach(function (content) {
           content.classList.add("u-hide");
         });
         currentContent.classList.remove("u-hide");
@@ -277,13 +270,13 @@
         var message = "";
 
         var formFields = contactModal.querySelectorAll(".js-formfield");
-        formFields.forEach(function(formField) {
+        formFields.forEach(function (formField) {
           var comma = "";
           var fieldTitle = formField.querySelector(".p-heading--five");
           var inputs = formField.querySelectorAll("input, textarea");
           message += fieldTitle.innerText + "\r\n";
 
-          inputs.forEach(function(input) {
+          inputs.forEach(function (input) {
             switch (input.type) {
               case "radio":
                 if (input.checked) {

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -4,8 +4,8 @@ var navDropdowns = [].slice.call(
 var dropdownWindow = document.querySelector(".dropdown-window");
 var dropdownWindowOverlay = document.querySelector(".dropdown-window-overlay");
 
-navDropdowns.forEach(function(dropdown) {
-  dropdown.addEventListener("click", function(event) {
+navDropdowns.forEach(function (dropdown) {
+  dropdown.addEventListener("click", function (event) {
     event.preventDefault();
 
     var clickedDropdown = this;
@@ -13,7 +13,7 @@ navDropdowns.forEach(function(dropdown) {
     dropdownWindow.classList.remove("slide-animation");
     dropdownWindowOverlay.classList.remove("fade-animation");
 
-    navDropdowns.forEach(function(dropdown) {
+    navDropdowns.forEach(function (dropdown) {
       var dropdownContent = document.getElementById(dropdown.id + "-content");
 
       if (dropdown === clickedDropdown) {
@@ -36,8 +36,8 @@ navDropdowns.forEach(function(dropdown) {
 });
 
 // Close the menu if browser back button is clicked
-window.addEventListener("hashchange", function() {
-  navDropdowns.forEach(function(dropdown) {
+window.addEventListener("hashchange", function () {
+  navDropdowns.forEach(function (dropdown) {
     const dropdownContent = document.getElementById(dropdown.id + "-content");
 
     if (dropdown.classList.contains("is-selected")) {
@@ -47,8 +47,8 @@ window.addEventListener("hashchange", function() {
 });
 
 if (dropdownWindowOverlay) {
-  dropdownWindowOverlay.addEventListener("click", function() {
-    navDropdowns.forEach(function(dropdown) {
+  dropdownWindowOverlay.addEventListener("click", function () {
+    navDropdowns.forEach(function (dropdown) {
       var dropdownContent = document.getElementById(dropdown.id + "-content");
 
       if (dropdown.classList.contains("is-selected")) {
@@ -72,7 +72,7 @@ if (window.location.hash) {
   var tab = document.getElementById(tabId);
 
   if (tab) {
-    setTimeout(function() {
+    setTimeout(function () {
       document.getElementById(tabId).click();
     }, 0);
   }
@@ -95,14 +95,14 @@ addGANavEvents(".p-footer--secondary", "www.ubuntu.com-nav-footer-1");
 function addGANavEvents(target, category) {
   var t = document.querySelector(target);
   if (t) {
-    [].slice.call(t.querySelectorAll("a")).forEach(function(a) {
-      a.addEventListener("click", function() {
+    [].slice.call(t.querySelectorAll("a")).forEach(function (a) {
+      a.addEventListener("click", function () {
         dataLayer.push({
           event: "GAEvent",
           eventCategory: category,
           eventAction: "from:" + origin + " to:" + a.href,
           eventLabel: a.text,
-          eventValue: undefined
+          eventValue: undefined,
         });
       });
     });
@@ -114,7 +114,7 @@ addGAContentEvents("#main-content");
 function addGAContentEvents(target) {
   var t = document.querySelector(target);
   if (t) {
-    [].slice.call(t.querySelectorAll("a")).forEach(function(a) {
+    [].slice.call(t.querySelectorAll("a")).forEach(function (a) {
       let category;
       if (a.classList.contains("p-button--positive")) {
         category = "www.ubuntu.com-content-cta-0";
@@ -124,13 +124,13 @@ function addGAContentEvents(target) {
         category = "www.ubuntu.com-content-link";
       }
       if (!a.href.startsWith("#")) {
-        a.addEventListener("click", function() {
+        a.addEventListener("click", function () {
           dataLayer.push({
             event: "GAEvent",
             eventCategory: category,
             eventAction: "from:" + origin + " to:" + a.href,
             eventLabel: a.text,
-            eventValue: undefined
+            eventValue: undefined,
           });
         });
       }
@@ -143,7 +143,7 @@ addGAImpressionEvents(".js-takeover");
 function addGAImpressionEvents(target) {
   var t = [].slice.call(document.querySelectorAll(target));
   if (t) {
-    t.forEach(function(section) {
+    t.forEach(function (section) {
       if (!section.classList.contains("u-hide")) {
         var a = section.querySelector("a");
         dataLayer.push({
@@ -151,7 +151,7 @@ function addGAImpressionEvents(target) {
           eventCategory: "www.ubuntu.com-impression",
           eventAction: "from:" + origin + " to:" + a.href,
           eventLabel: a.text,
-          eventValue: undefined
+          eventValue: undefined,
         });
       }
     });
@@ -161,13 +161,34 @@ function addGAImpressionEvents(target) {
 addUTMToForms();
 
 function addUTMToForms() {
-  var params = new URLSearchParams(window.location.search);
   const utm_names = ["campaign", "source", "medium"];
   for (let i = 0; i < utm_names.length; i++) {
     var utm_fields = document.getElementsByName("utm_" + utm_names[i]);
     for (let j = 0; j < utm_fields.length; j++) {
       if (utm_fields[j]) {
-        utm_fields[j].value = params.get("utm_" + utm_names[i]);
+        utm_fields[j].value = localStorage.getItem("utm_" + utm_names[i]);
+      }
+    }
+  }
+}
+
+addUTMToLocalStorage();
+
+function addUTMToLocalStorage() {
+  if (window.localStorage && window.sessionStorage) {
+    var params = new URLSearchParams(window.location.search);
+    var utm_campaign = params.get("utm_campaign");
+    var utm_source = params.get("utm_source");
+    var utm_medium = params.get("utm_medium");
+    if (utm_source != "Takeover" && utm_source != "takeover") {
+      if (utm_source) {
+        localStorage.setItem("utm_source", utm_source);
+      }
+      if (utm_campaign) {
+        localStorage.setItem("utm_campaign", utm_campaign);
+      }
+      if (utm_medium) {
+        localStorage.setItem("utm_medium", utm_medium);
       }
     }
   }


### PR DESCRIPTION
## Done

- Keep URL UTM params in localstorage
- Resurface them in forms
- Prevent takeover UTMs from being stored (special case we don't need/want covered for now)
- ...some unintended JS cleanup (thanks vscode?)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the localstorage inspector of your browser
- Add `?utm_source=foo` to any ubuntu.com URL
- Ensure `utm_source` = `foo` is stored in localstorage
- Open a form (/engage page with a whitepaper or a dynamic contact form)
- Ensure the form source loads with hidden fields matching the UTM ones stored in localstorage
- Try overriding stored values with another URL UTM (this should work)
- Try overriding them by clicking on a takeover link with UTMs (this SHOULDN'T override)


