### PR TITLE
Update logo cloud on desktop page

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -28,7 +28,7 @@
     <div class="col-8 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/48a26da6-logos.png",
+        url="https://assets.ubuntu.com/v1/741b30ec-desktop-logos.png",
         alt="Apps you can use on Ubuntu 20.04.LTS",
         height="235",
         width="510",


### PR DESCRIPTION
## Done

Updated logo cloud on /desktop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the logo cloud under the hero uses [this image](https://assets.ubuntu.com/v1/741b30ec-desktop-logos.png)


## Issue / Card

Fixes #7368 
