### PR TITLE
Add cassandra logo and copy in How Canonical Managed Apps work

### DIFF
--- a/templates/managed-apps/index.html
+++ b/templates/managed-apps/index.html
@@ -168,6 +168,19 @@
             ) | safe
           }}
         </li>
+        <li class="p-inline-images__item">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/c530ca79-Cassandra_logo.svg",
+            alt="Apache Cassandra",
+            width="144",
+            height="90",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logos"},
+            ) | safe
+          }}
+        </li>
       </ul>
     </div>
   </div>
@@ -467,7 +480,7 @@
             We support your infrastructure
           </h3>
           <p class="p-stepped-list__content">
-            Canonical offers <a href="/advantage">Ubuntu Advantage for Infrastructure</a>, the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.
+            <a href="/advantage">Ubuntu Advantage for Infrastructure</a>, the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure, is included.
           </p>
         </li>
 


### PR DESCRIPTION
## Done

Add Cassandra logo and copy in "How Canonical Managed Apps work" section

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed-apps
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7369 