### PR TITLE
Remove classic os from the selection

### DIFF
--- a/templates/build/index.html
+++ b/templates/build/index.html
@@ -163,36 +163,6 @@
         <p>Recommended for the most advanced security.</p>
       </div>
     </div>
-    <div class="row  js-selection-container">
-      <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberrypi2 raspberrypi3">
-          <span class="js-name" data-value="classic16.04">16.04 LTS</span>
-        </button>
-      </div>
-      <div class="col-9">
-        <p>Use if your apps or existing devices require it.</p>
-      </div>
-    </div>
-    <div class="row  js-selection-container">
-      <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberrypi2 raspberrypi3 raspberrypi4">
-          <span class="js-name" data-value="classic18.04">18.04 LTS 32-bit</span>
-        </button>
-      </div>
-      <div class="col-9">
-        <p>Recommended for best memory efficiency.</p>
-      </div>
-    </div>
-    <div class="row  js-selection-container">
-      <div class="col-3">
-        <button class="p-button is-wide js-selection" data-supports="raspberrypi3 raspberrypi4">
-          <span class="js-name" data-value="classic6418.04">18.04 LTS 64-bit</span>
-        </button>
-      </div>
-      <div class="col-9">
-        <p>Recommended for best maths performance.</p>
-      </div>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done
Remove classic os from the build selection

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/build
- See there is no classic os options
- I have left the logic there for the future
