### PR TITLE
Undo text change on /managed-apps

### DIFF
--- a/templates/managed-apps/index.html
+++ b/templates/managed-apps/index.html
@@ -480,7 +480,7 @@
             We support your infrastructure
           </h3>
           <p class="p-stepped-list__content">
-            <a href="/advantage">Ubuntu Advantage for Infrastructure</a>, the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure, is included.
+            Canonical offers <a href="/advantage">Ubuntu Advantage for Infrastructure</a>, the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.
           </p>
         </li>
 


### PR DESCRIPTION
## Done

- Undo today's text change on /managed-apps

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed-apps
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it matches the [copy doc](https://docs.google.com/document/d/17zJ4vTutqVpn0XzUI784BHdJov8cGW1ttDwIjsvcEzE/edit?ts=5ea9ad20#)

## Issue / Card

Fixes #7376

