### PR TITLE
Change order of 20.04 webinars

### DIFF
--- a/templates/engage/20.04-webinars.html
+++ b/templates/engage/20.04-webinars.html
@@ -57,6 +57,32 @@
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
     <div class="col-8">
+      <h2 id="desktop">Desktop</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p>Ubuntu Desktop 20.04 LTS comes out this month and Focal Fossa will boost developer productivity while delivering Ubuntu’s most beautiful look yet. AI developers and gamers alike will look forward to nVIDIA GPUs being supported out of the box, while a new default theme, Yaru, as well as integrated light and dark themes, resulting in Ubuntu getting a fresh new look while maintaining its signature feel.</p>
+      <p>Join Nilay Patel, Product Manager for Ubuntu Desktop, in this webinar to find out more about the tools developers can expect and why we selected them.</p>
+      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/398825?utm_source={{utm_source}}"><span class="p-link--external">Register now</span></a></p>
+    </div>
+    <div class="col-4 u-hide--small">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/7a59d232-20-04-desktop-webinar.png",
+            alt="",
+            width="366",
+            height="206",
+            hi_def=True,
+            loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-8">
       <h2 id="server">Server</h2>
     </div>
   </div>
@@ -71,33 +97,6 @@
       {{
         image(
             url="https://assets.ubuntu.com/v1/d71a7d23-20-04-server-webinar.png",
-            alt="",
-            width="366",
-            height="206",
-            hi_def=True,
-            loading="lazy",
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-shallow is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="desktop">Desktop</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <p>Ubuntu Desktop 20.04 LTS comes out this month and Focal Fossa will boost developer productivity while delivering Ubuntu’s most beautiful look yet. AI developers and gamers alike will look forward to nVIDIA GPUs being supported out of the box, while a new default theme, Yaru, as well as integrated light and dark themes, resulting in Ubuntu getting a fresh new look while maintaining its signature feel.</p>
-      <p>Join Nilay Patel, Product Manager for Ubuntu Desktop, in this webinar to find out more about the tools developers can expect and why we selected them.</p>
-      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/398825?utm_source={{utm_source}}"><span class="p-link--external">Register now</span></a></p>
-    </div>
-    <div class="col-4 u-hide--small">
-      {{
-        image(
-            url="https://assets.ubuntu.com/v1/7a59d232-20-04-desktop-webinar.png",
             alt="",
             width="366",
             height="206",


### PR DESCRIPTION
## Done

- Change order of 20.04 webinars - Desktop on top now

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/20.04-webinars
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that Nilay's is on top and Tytus on the bottom

