### PR TITLE
Update /azure/pro page for 20.04

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -82,7 +82,7 @@
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">The right Ubuntu for you</h3>
             <div class="p-matrix__desc">
-              <p>Canonical brings the three most popular Ubuntu Server distributions to choose from - 14.04 LTS, 16.04 LTS, and 18.04 LTS.</p>
+              <p>Canonical brings the three most popular Ubuntu Server distributions to choose from - 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS.</p>
             </div>
           </div>
         </li>
@@ -123,7 +123,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Ubuntu Pro 18.04 LTS</h3>
-      <p>The latest LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available in Q2. Ubuntu Pro provides extended maintenance through 2028.</p>
+      <p>Ubuntu 18.04  LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available in Q2. Ubuntu Pro provides extended maintenance through 2028.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-4 p-divider__block">

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -123,12 +123,12 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Ubuntu Pro 18.04 LTS</h3>
-      <p>Ubuntu 18.04  LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available in Q2. Ubuntu Pro provides extended maintenance through 2028.</p>
+      <p>Ubuntu 18.04 LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available in Q2. Ubuntu Pro provides extended maintenance through 2028.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Ubuntu Pro 16.04 LTS</h3>
-      <p>The most commonly deployed Ubuntu LTS on the cloud today, Ubuntu 16.04 LTS released in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2024.</p>
+      <p>Ubuntu 16.04 LTS shipped in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2024.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update /azure/pro page for 20.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure/pro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1WaQ5n3GxwZzbX0T6rLiRNejFvxIPIHd5V5XgdAwKmSw/edit#) and resolve all comments


## Issue / Card

Fixes #7380
