### PR TITLE
Update /aws/pro for 20.04

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -12,7 +12,7 @@
         <h1>Ubuntu Pro for AWS</h1>
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for AWS is a premium image designed by Canonical to provide the most comprehensive feature set for production environments running in the public cloud. Offered as an AMI through AWS Marketplace, it includes a subscription to critical security and compliance services by default. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations &mdash; no contract necessary.</p>
-        <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on AWS</span></a></p>
+        <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 20.04 LTS on AWS</span></a></p>
         <p><a href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -82,7 +82,7 @@
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">The right Ubuntu for you</h3>
             <div class="p-matrix__desc">
-              <p>Canonical brings the three most popular Ubuntu Server distributions to choose from - 14.04 LTS, 16.04 LTS, and 18.04 LTS.</p>
+              <p>Canonical brings the three most popular Ubuntu Server distributions to choose from - 14.04 LTS, 16.04 LTS, 18.04 LTS and 20.04 LTS.</p>
             </div>
           </div>
         </li>
@@ -117,19 +117,19 @@
   </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">Ubuntu Pro 20.04 LTS</h3>
+      <p>The latest LTS release includes the 5.4 kernel out of the box. Ubuntu Pro 20.04 LTS provides extended maintenance through 2030.</p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+    </div>
+    <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Ubuntu Pro 18.04 LTS</h3>
-      <p>The latest LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available soon. Ubuntu Pro provides extended coverage through 2028.</p>
+      <p>Ubuntu 18.04 LTS release includes the 4.15 kernel out of the box, with an optimised 5.3 kernel available in Q2. Ubuntu Pro provides extended maintenance through 2028.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Ubuntu Pro 16.04 LTS</h3>
-      <p>The most commonly deployed Ubuntu LTS on the cloud today, Ubuntu 16.04 LTS released in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2024.</p>
+      <p>Ubuntu 16.04 LTS shipped in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2024.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Ubuntu Pro 14.04 LTS</h3>
-      <p>Ubuntu 14.04 LTS shipped in 2014 with the 3.13 kernel. Ubuntu Pro extends our security coverage to 2022, giving you plenty of time to prepare and upgrade.</p>
-      <p><a href="https://aws.amazon.com/marketplace/pp/B0821V7QJP" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
   </div>
 </section>
@@ -247,7 +247,7 @@
               <td class="u-align--right">$0.088</td>
             </tr>
             <tr>
-              <td>r5d.4xlarge.large</td>
+              <td>r5d.4xlarge</td>
               <td class="u-align--right">$1.152</td>
               <td class="u-align--right">$0.127</td>
             </tr>
@@ -266,13 +266,16 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-link--external">20.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-link--external">18.04 LTS</a></h3>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-link--external">16.04 LTS</a></h3>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821V7QJP" class="p-link--external">14.04 LTS</a></h3>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update /aws/pro for 20.04

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/pro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit#) and resolve all comments


## Issue / Card

Fixes #7381


