### PR TITLE
Post NULL Image build status value initially

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -146,21 +146,20 @@ def post_build():
     context = {}
 
     # Submit user to marketo
-    if opt_in:
-        session.post(
-            "https://pages.ubuntu.com/index.php/leadCapture/save",
-            data={
-                "canonicalUpdatesOptIn": opt_in,
-                "FirstName": " ".join(names[:-1]),
-                "LastName": names[-1] if len(names) > 1 else "",
-                "Email": email,
-                "formid": "3546",
-                "lpId": "2154",
-                "subId": "30",
-                "munchkinId": "066-EOV-335",
-                "imageBuilderStatus": "",
-            },
-        )
+    session.post(
+        "https://pages.ubuntu.com/index.php/leadCapture/save",
+        data={
+            "canonicalUpdatesOptIn": opt_in,
+            "FirstName": " ".join(names[:-1]),
+            "LastName": names[-1] if len(names) > 1 else "",
+            "Email": email,
+            "formid": "3546",
+            "lpId": "2154",
+            "subId": "30",
+            "munchkinId": "066-EOV-335",
+            "imageBuilderStatus": "NULL",
+        },
+    )
 
     # Ensure webhook is created
     try:


### PR DESCRIPTION
## Done
- Removed the opt out conditional as the build is operational and the opt out is for marketing so it should be set in marketo.
- Change the init value of status to Null [which is a special key reserved for this in Marketo](https://nation.marketo.com/t5/Product-Discussions/String-Field-to-Null-Value/m-p/54287#M23509).

## QA
- Go to https://ubuntu.com/core/build
- Fill in the build and ensure you select the checkbox for marketing
- See that you get an email almost straight away with the previous status
- Go to: https://app-sjg.marketo.com/#SL100892270B2LA1
- Click the ID by your name
- Search for "Image Builder Status" and see its what you got in your email. __This is due to empty string not overriding the status value__
- Go to this branches demos at /core/build
- Complete a different build
- Once posted check no email arrives
- Then refresh your info page on marketo
- Jump down to "Image Builder Status" and see that is blank

**Well done** for making it through these QA steps :+1:  