### PR TITLE
Update aws link to 20.04

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -134,7 +134,7 @@
       <h2>Ready to get started?</h2>
       <p>Ubuntu Pro for AWS is a premium image designed by Canonical to provide the most comprehensive feature set for production environments running in the public cloud.</p>
       <p>
-        <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">Launch Ubuntu Pro 18.04 LTS for AWS</a>
+        <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">Launch Ubuntu Pro 20.04 LTS for AWS</a>
       </p>
       <p>
         <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview">Launch Ubuntu Pro 20.04 LTS for Azure</a>


### PR DESCRIPTION
## Done

- Updated the aws link from the [copydoc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Check the link and link copy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7383 