### PR TITLE
Update the default takeover with the LTS

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -14,12 +14,12 @@
     </template>
 
     <!-- Default Takeover: Download the latest Ubuntu -->
-    <section data-lang="all" id="takeover" class="p-strip--image is-dark is-deep" style="background-color: #5E2750; background-image: linear-gradient(110deg, #5E2750 20%, #2C001E 46%, #2C001E 60%);">
+    <section data-lang="all" id="takeover" class="p-strip--image is-dark is-deep" style="background-color: #5E2750; background-image: linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%)">
       <div class="row">
         <div class="col-8">
-          <h1 style="font-weight: 100;">Ubuntu {{ releases.latest.short_version }} is here</h1>
+          <h1 style="font-weight: 100;">Ubuntu {{ releases.lts.short_version }} is here</h1>
           <p>The latest version of the world’s most widely used Linux platform for Kubernetes, multi-cloud and machine learning.</p>
-          <p class="u-no-margin--bottom"><a href="/download" class="p-button--neutral u-no-margin--bottom">Download Ubuntu {{ releases.latest.short_version }} now</a></p>
+          <p class="u-no-margin--bottom"><a href="/download" class="p-button--neutral u-no-margin--bottom">Download Ubuntu {{ releases.lts.short_version }} now</a></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done
Update the default takeover with the LTS with a fresh gradient.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Turn off JS in inspector settings and refresh
- See the takeover says 20.04 LTS instead of 19.10

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7400

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/80799128-f1bc5780-8b9d-11ea-86c1-ebd604f4e897.png)


