### PR TITLE
Hide latest news section when no js on homepage

### DIFF
--- a/static/js/src/latest-news.js
+++ b/static/js/src/latest-news.js
@@ -1,4 +1,11 @@
 (function () {
+  function _revealSection() {
+    const latestNewsSection = document.querySelector("[data-js='latest-news']");
+    if (latestNewsSection) {
+      latestNewsSection.classList.remove("u-hide");
+    }
+  }
+
   function _formatDate(date) {
     const parsedDate = new Date(date);
     const monthNames = [
@@ -151,6 +158,8 @@
   function fetchLatestNews(options) {
     let url = "https://ubuntu.com/blog/latest-news";
     let params = [];
+
+    _revealSection();
 
     if (options.limit) {
       params.push("limit=" + options.limit);

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -27,7 +27,14 @@
     {% block notices_content %}
     {% endblock notices_content %}
 
-    <section class="p-strip is-deep is-bordered">
+    <noscript>
+      <section class="p-strip is-bordered">
+        <div class="u-fixed-width">
+          <h3><a href="/blog">Read the latest news on our blog&nbsp;&rsaquo;</a></h3>
+        </div>
+      </section>
+    </noscript>
+    <section class="p-strip is-deep is-bordered u-hide" data-js="latest-news">
       <div class="row p-divider">
         <div class="col-9">
           <h3>Latest news from our blog</h3>
@@ -55,6 +62,14 @@
         </div>
       </template>
 
+      <div class="u-sv3"></div>
+
+      <div class="u-fixed-width">
+        <a href="/blog" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">
+          View more from our blog
+        </a>
+      </div>
+
       <script src="{{ versioned_static('js/src/latest-news.js') }}"></script>
       <script>
         fetchLatestNews(
@@ -67,14 +82,6 @@
           }
         )
       </script>
-
-      <div class="u-sv3"></div>
-
-      <div class="u-fixed-width">
-        <a href="/blog" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">
-          View more from our blog
-        </a>
-      </div>
     </section>
 
     <section class="p-strip--light is-bordered">


### PR DESCRIPTION
## Done

- Hide the latest news section when no js on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the "Latest news sections is there and works fine"
- Disable `js` and reload the page
- See a link to our blog


## Screenshots

![image](https://user-images.githubusercontent.com/40214246/80801072-31397280-8ba3-11ea-8e45-fd3f1c0d0554.png)

