### PR TITLE
Added link to download/server/provisioning

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -19,7 +19,7 @@
   <div class="row u-equal-height p-divider">
     <div class="col-4 p-divider__block">
       <h2>Install MAAS on your&nbsp;hardware</h2>
-      <p>Follow the instructions at <a href="https://maas.io/install" class="p-link--external">https://maas.io/install</a> to download, configure and install MAAS.</p>
+      <p>Follow the <a href="https://maas.io/install" class="p-link--external">instructions to download, configure and install MAAS</a>.</p>
     </div>
     <div class="col-8 p-divider__block">
       <h3>Requirements</h3>

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -19,7 +19,7 @@
   <div class="row u-equal-height p-divider">
     <div class="col-4 p-divider__block">
       <h2>Install MAAS on your&nbsp;hardware</h2>
-      <p>Follow the instructions at https://maas.io/install to download, configure and install MAAS.</p>
+      <p>Follow the instructions at <a href="https://maas.io/install" class="p-link--external">https://maas.io/install</a> to download, configure and install MAAS.</p>
     </div>
     <div class="col-8 p-divider__block">
       <h3>Requirements</h3>


### PR DESCRIPTION


## Done

I added <a href="https://maas.io/install" class="p-link--external">https://maas.io/install</a> to the copy.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the demo(/download/server/provisioning) to the [copy doc](https://docs.google.com/document/d/12GXYcP9WrOgoso6Sf3bQql6nALRUzpdlcRW3Gbu-npM/edit) and accept the correct changes.


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
