### PR TITLE
Change cta link on /kubeflow/what-is-kubeflow page

### DIFF
--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -11,7 +11,7 @@
     <div class="row u-equal-height">
       <div class="col-7">
         <h1>What is Kubeflow?</h1>
-        <p>Kubeflow is an open source artificial intelligence / machine learning (AI/ML) tool that helps improve deployment, portability and management of AI/ML models. Kubeflow allows users to quickly create, train and tune neural networks within Kubernetes for dynamic resource provisioning.</p>
+        <p>Kubeflow is an open source artificial intelligence/machine learning (AI/ML) tool that helps improve deployment, portability and management of AI/ML models. Kubeflow allows users to quickly create, train and tune neural networks within Kubernetes for dynamic resource provisioning.</p>
         <p>Kubeflow works well with TensorFlow and other modern AI/ML frameworks such as PyTorch, MXNet and Chainer allowing users to enhance their existing code and setup.</p>
       </div>
       <div class="col-4 col-start-large-9 u-vertically-center u-align--center u-hide--small">
@@ -36,7 +36,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p>Governed by the Kubeflow community and originated by Google, the project has over 2,000 community members, more than 180 direct code contributors and over 28,000 contributors. Canonical is an active member of the Kubeflow community and strongly believes in its role in democratising AI/ML by making model training and deployment as frictionless as possible.</p>
+      <p>Governed by the Kubeflow community and originated by Google, the project has over 2,000 community members,  more than 180 direct code contributors and over 28,000 contributors. Canonical is an active member of the Kubeflow community and strongly believes in its role in democratising AI/ML by making model training and deployment as frictionless as possible.</p>
     </div>
   </div>
   <div class="u-fixed-width">
@@ -199,7 +199,7 @@
       <h3 class="p-card__thumbnail">Jupyter notebooks</h3>
       <hr>
       <div class="p-card__description">
-        <p>Kubeflow comes with support for managing Jupyter notebooks, an open-source application that allows users to blend code, equation-style notation, free text and dynamic visualisations to give data scientists a single point of access to their experiment setup and notes.</p>
+        <p>Kubeflow comes with support for managing Jupyter notebooks, an open-source application that allows users to blend code, equation-style notation, free text and dynamic visualisations to give data scientists a single point of access to their experimental setup and notes.</p>
       </div>
     </div>
     <div class="col-6 p-card">
@@ -234,7 +234,7 @@
       <h3 class="p-card__thumbnail">&hellip; and more</h3>
       <hr>
       <div class="p-card__description">
-        <p>Kubeflow is continuously expanding, notable additions are the tracking and managing of metadata of the machine learning workflows as well as Nuclio functions, a high performance serverless solution for data processing, analytics and ML workloads.</p>
+        <p>Kubeflow is continuously expanding, notable additions are the tracking and managing of metadata of the machine learning workflows as well as Nuclio functions, a high-performance serverless solution for data processing, analytics and ML workloads.</p>
       </div>
     </div>
   </div>
@@ -246,7 +246,7 @@
   </div>
   <div class="row u-equal-height ">
     <div class="col-6">
-      <p>There are thousands of individual users of KubeFlow across a broad range of industries with roles varying from data scientist to DevOps engineers. Kubeflow is particularly favoured for its ease of use, software defined MLOps and native execution on Kubernetes.</p>
+      <p>There are thousands of individual users of KubeFlow across a broad range of industries with roles varying from data scientist to DevOps engineers. Kubeflow is particularly favoured for its ease of use, software-defined MLOps and native execution on Kubernetes.</p>
       <p>In addition to <a href="https://home.cern/">CERN</a> and numerous universities around the world, Kubeflow has become a popular choice for transport and logistics companies such as Uber, Lyft and GoJek.</p>
       <p>Use cases are also growing in the media industry with Spotify having already adopted Kubeflow.</p>
       <p>Financial and e-commerce services have been keen adopters, with PayPal and Shopify just some of those that are developing on Kubeflow.</p>
@@ -316,7 +316,7 @@
     <div class="col-7">
       <h2>How to install Kubeflow</h2>
       <p>Kubeflow can easily be setup by installing MicroK8s, a zero-ops Kubernetes provided by Canonical. Kubeflow comes ready to be enabled as part of MicroK8s, making kicking the tyres even easier than before.</p>
-      <p><a class="p-link--external" href="https://microk8s.io">Install Kubeflow in a few easy steps with MicroK8s</a></p>
+      <p><a class="p-button--positive" href="/kubeflow/install">Install Kubeflow in a few easy steps</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Change cta link on /kubeflow/what-is-kubeflow page
- Cleaned up the copy doc
- Fixed some grammar 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/what-is-kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit#) and resolve all comments


## Issue / Card

Fixes #7433


