### PR TITLE
Update /openstack/consulting page copy

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -1,15 +1,14 @@
 {% extends "openstack/_base_openstack.html" %}
 
-
-{% block title %}Consulting | OpenStack{% endblock %}
-{% block meta_description %}Private Cloud Build is a service that builds, supports and manages your cloud for you.{% endblock meta_description %}
+{% block title %}Private cloud design and delivery | OpenStack{% endblock %}
+{% block meta_description %}Let Canonical build, support and manage your cloud for you.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit{% endblock meta_copydoc %}
 
 {% block content %}
   <section class="p-strip--suru-bottomed is-bordered">
     <div class="row">
       <div class="col-8">
-        <h1>OpenStack consulting, design and delivery</h1>
+        <h1>Private cloud design and delivery</h1>
         <h2 class="p-heading--three">Carrier grade, banking security, government scale. Serious private clouds are our business.</h2>
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>


### PR DESCRIPTION
## Done

- Update /openstack/consulting page copy, title, meta description and h1

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit#) and resolve all comments

## Issue / Card

Fixes #7432
