### PR TITLE
Update copy on /security/certifications

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -12,7 +12,7 @@
     <div class="col-8">
       <h1>Security Certifications</h1>
       <p>
-        Canonical has achieved FIPS 140-2 Level 1 certification for several cryptographic modules on Ubuntu 16.04 LTSand Ubuntu 18.04 LTS. Canonical has also achieved Common Criteria EAL2 certification for Ubuntu 16.04 LTS. In addition, the Defense Information System Agency (DISA) has published Ubuntu 16.04 LTS and Ubuntu 18.04 LTS Security Technical Implementation Guides (STIGs) which allow Ubuntu to be used by Federal agencies. The Center for Internet Security (CIS) also publishes benchmarks for hardening the configuration of Ubuntu systems to make them more secure.
+        Canonical has achieved FIPS 140-2 Level 1 certification for several cryptographic modules on Ubuntu 18.04 LTS and Ubuntu 16.04 LTS. Canonical has also achieved Common Criteria EAL2 certification for Ubuntu 16.04 LTS. In addition, the Defense Information System Agency (DISA) has published Ubuntu 16.04 LTS and Ubuntu 18.04 LTS Security Technical Implementation Guides (STIGs) which allow Ubuntu to be used by federal agencies. The Center for Internet Security (CIS) also publishes benchmarks for hardening the configuration of Ubuntu systems to make them more secure.
       </p>
       <p>
         Canonical has made its security certification offerings available to all Ubuntu Advantage for Infrastructure customers.
@@ -40,13 +40,13 @@
     <div class="col-8">
       <h2>FIPS 140-2</h2>
       <p>
-        FIPS 140-2 is a US government computer security standard. It defines security requirements related to the design and implementation of a cryptographic module. It is a requirement for U.S Federal agencies to use FIPS 140-2 validated cryptography to protect sensitive information.
+        FIPS 140-2 is a U.S. Government computer security standard. It defines security requirements related to the design and implementation of a cryptographic module. It is a requirement for U.S. Federal agencies to use FIPS 140-2 validated cryptography to protect sensitive information.
       </p>
       <p>
         The standard puts stringent requirements on testing and ensuring that the cryptographic implementations meet the standards and work as expected. The testing and validation must be performed by a laboratory, which is accredited under the Cryptographic and Security Testing (CST) Laboratory Accreditation Program (LAP) and is part of NIST’s <a class="p-link--external" href="https://www.nist.gov/nvlap/">National Voluntary Laboratory Accreditation Program (NVLAP)</a>. The validation testing for Ubuntu 16.04 was performed by atsec Information Security, a U.S. Govt and BSI accredited laboratory.
       </p>
       <p>
-        Anyone deploying systems for U.S. Federal government use including the cloud services is required to use FIPS 140-2 compliant systems. FIPS 140-2 is also used commonly outside of US Federal space. It has been adopted in regulated industries like finance, healthcare, legal and manufacturing and a few others where there are Federal regulations on data security.
+        Anyone deploying systems for U.S. Federal government use including the cloud services is required to use FIPS 140-2 compliant systems. FIPS 140-2 is also used commonly outside of U.S. Federal space. It has been adopted in regulated industries like finance, healthcare, legal and manufacturing and a few others where there are Federal regulations on data security.
       </p>
       <p>
         Canonical has validated the following cryptographic modules for Ubuntu 18.04 LTS (the modules are certified on Intel x86_64 and IBM Z hardware platforms):
@@ -80,14 +80,11 @@
     <div class="col-8">
       <h2>Common Criteria</h2>
       <p>
-        Common Criteria (CC) for Information Technology Security Evaluation is an international standard ISO/IEC IS 15408 for Computer security certification. It validates that a product satisfies a defined set of security requirements. Ubuntu 16.04 has been evaluated to assurance level EAL2 through <a class="p-link--external" href="http://www.fmv.se/en/Our-activities/CSEC---The-Swedish-Certification-Body-for-IT-Security/">CSEC &mdash; The Swedish Certification Body for IT Security</a>. The consulting and evaluation was performed by atsec Information Security.
+        Common Criteria (CC) for Information Technology Security Evaluation is an international standard (ISO/IEC IS 15408) for Computer security certification, used by Federal agencies, financial institutions and many other organizations dealing with sensitive data. It validates that a product satisfies a defined set of security requirements.
       </p>
-      <p>
-        Common Criteria is an internationally recognized set of standards used by Federal agencies, financial institutions and many other organizations dealing with sensitive data. The evaluation was performed on Intel x86_64, IBM Power8 and IBM Z hardware platforms.
+      <p>Ubuntu 16.04 has been evaluated to assurance level EAL2 through <a class="p-link--external" href="http://www.fmv.se/en/Our-activities/CSEC---The-Swedish-Certification-Body-for-IT-Security/">CSEC &mdash; The Swedish Certification Body for IT Security</a>. The consulting and evaluation was performed by atsec Information Security. The <a href="https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20Ubuntu%20LTS%2016.04.4.pdf">CSEC certification report</a> is available on the CSEC website for more information. The evaluation was performed on Intel x86_64, IBM Power8 and IBM Z hardware platforms.
       </p>
-      <p>
-        <a class="p-link--external" href="https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20Ubuntu%20LTS%2016.04.4.pdf">Read the CSEC certification report</a>
-      </p>
+      <p>Ubuntu 18.04 has been submitted and is currently awaiting final certification from CSEC.  The evaluation was performed on Intel x86_64 and IBM Z hardware platforms.</p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg?w=150" width="150" alt="">
@@ -100,7 +97,7 @@
     <div class="col-8">
       <h2>STIG</h2>
       <p>
-        Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the US Department of Defense (DoD). They are configuration guidelines for hardening systems to improve security. They contain technical guidance which when implemented, locks down software and systems to mitigate malicious attacks.
+        Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). They are configuration guidelines for hardening systems to improve security. They contain technical guidance which when implemented, locks down software and systems to mitigate malicious attacks.
       </p>
       <p>
         DISA has, in conjunction with Canonical, developed STIGs for Ubuntu 16.04 LTS and Ubuntu 18.04 LTS.


### PR DESCRIPTION
## Done

Update copy on /security/certifications

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the requested changes in [the copy doc](https://docs.google.com/document/d/1CiF-dPqG1Y--h4FWfgKB1ft4G3nC2Boa8NT_JG7D6dQ/edit) have been made and resolve the comments


## Issue / Card

Fixes #7442 
