### PR TITLE
WIP: Add appliance base and first pass of about page

### DIFF
--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block outer_content %}
+    {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/appliance/about.html
+++ b/templates/appliance/about.html
@@ -39,7 +39,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Security first</h2>
-      <p>Ubuntu Appliances are designed to make your devices worry-free. Each benefits from the advanced security features of <a href="/core">Ubuntu Core</a>. Served applications are packaged as <a href="https://docs.ubuntu.com/core/en/guides/intro/security" class="p-link--external">snaps</a> &mdash; a format that strictly confines and monitors software to mitigate cybersecurity risks. Ubuntu Appliances provide the highest level of endpoint security even for the most casual use cases.</p>
+      <p>Ubuntu Appliances are designed to make your devices worry-free. Each benefits from the advanced security features of <a href="/core">Ubuntu Core</a>. Served applications are packaged as <a href="https://docs.ubuntu.com/core/en/coresnaps" class="p-link--external">snaps</a> &mdash; a format that strictly confines and monitors software to mitigate cybersecurity risks. Ubuntu Appliances provide the highest level of endpoint security even for the most casual use cases.</p>
     </div>
   </div>
 </section>

--- a/templates/appliance/about.html
+++ b/templates/appliance/about.html
@@ -12,7 +12,43 @@
   <div class="row">
     <div class="col-8">
       <h2>What is an Ubuntu Appliance?</h2>
-      <p>An Ubuntu Appliance is an official system image which blends a single application with Ubuntu Core. Ubuntu Appliances are certified to run flawlessly on Raspberry Pi and PC boards. They are free, privacy-friendly and come with maintenance guarantees.</p>
+      <p>An Ubuntu Appliance Image turns a PC or board into an appliance that does a specific thing for home or work. It is an official system disk image, built on Ubuntu Core for security and updates. Almost all Ubuntu Appliances are certified to run flawlessly on a PC or Raspberry Pi, as well as a wide range of additional boards. Some Ubuntu Appliances will require specific hardware and are only certified on a subset of the standard hardware platforms. They are free, privacy-friendly and come with long term security maintenance guarantees.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Free to download and use</h2>
+      <p>Most Ubuntu Appliances are entirely open source, but there are also some Ubuntu Appliances for proprietary software. All of them are free to download and install.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Securely built on trusted infrastructure</h2>
+      <p>All Ubuntu Appliance images are assembled on the same secure infrastructure that builds the Ubuntu operating system. The underlying open source applications that perform the appliance-specific functions are also built on that infrastructure. Ubuntu Appliances for proprietary applications are either built on that same infrastructure or built by the official vendor for that application, just like the software you would download directly from them. Since an Ubuntu Appliance is made up of a collection of digitally signed packages, you always know exactly where each component comes from.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Easy to install</h2>
+      <p>Each Ubuntu Appliance image is a boot disk image - simply write it onto a disk using a standard disk imaging tool and boot the board or box from that disk. We provide recommended disk imaging tools for all the standard platforms. On first boot, you have the opportunity to customise the appliance and register it to yourself so you can keep track of it.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Automatic system updates for ten years</h2>
+      <p>The underlying operating system of all Ubuntu Appliance images is Ubuntu Core, the highly secure, fully containerised Linux platform that uses transactional update mechanisms to ensure it can always roll back to a known-good state. The platform elements of Ubuntu Core are maintained for ten years, so Ubuntu Appliances can meet enterprise security and longevity requirements.</p>
     </div>
   </div>
 </section>
@@ -21,7 +57,7 @@
   <div class="row">
     <div class="col-8">
       <h2>A single-minded system</h2>
-      <p>Ubuntu Appliances provide software foundations that anybody may use to create secure and reliable smart devices. You will enrich your personal computing estate with self-made appliances that carry out single jobs perfectly. The catalogue of Ubuntu Appliances will provide a broad selection of applications encompassing home automation, gaming, media centres, networking, storage, security, 3d printing, robots and drones. </p>
+      <p>Ubuntu Appliances provide software foundations that anybody may use to create secure and reliable smart devices. You will enrich your personal computing estate with self-made appliances that carry out single jobs perfectly. The catalogue of Ubuntu Appliances will provide a broad selection of applications encompassing home automation, gaming, media centres, networking, storage, security, 3d printing, robots and drones.</p>
     </div>
   </div>
 </section>
@@ -30,7 +66,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Clear privacy policy</h2>
-      <p>Ubuntu Appliances comply with established privacy policies. Users should be able to trust in the devices they use at home, in the office or in the factory. They deserve total transparency regarding what happens with their data. Publishers of Ubuntu Appliances will disclose their use of data, should their users require the information. Detailed information can be found on the governance page or in Canonical’s own <a href="/legal/data-privacy">privacy documentation.</a></p>
+      <p>Ubuntu Appliances comply with established privacy policies. Users should be able to trust in the devices they use at home, in the office or in the factory. They deserve total transparency regarding what happens with their data. Publishers of Ubuntu Appliances will disclose their use of data, should their users require the information. Detailed information can be found on the <a href="/appliance/governance">governance page</a> or in Canonical’s own <a href="/legal/data-privacy">privacy documentation</a>. </p>
     </div>
   </div>
 </section>
@@ -39,7 +75,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Security first</h2>
-      <p>Ubuntu Appliances are designed to make your devices worry-free. Each benefits from the advanced security features of <a href="/core">Ubuntu Core</a>. Served applications are packaged as <a href="https://docs.ubuntu.com/core/en/coresnaps" class="p-link--external">snaps</a> &mdash; a format that strictly confines and monitors software to mitigate cybersecurity risks. Ubuntu Appliances provide the highest level of endpoint security even for the most casual use cases.</p>
+      <p>Ubuntu Appliances are designed to make your devices worry-free. Each benefits from the advanced security features of <a href="/core">Ubuntu Core</a>. Served applications are packaged as <a href="https://docs.ubuntu.com/core/en/coresnaps" class="p-link--external">snaps</a> - a format that strictly confines and monitors software to mitigate cybersecurity risks. Ubuntu Appliances provide the highest level of endpoint security even for the most casual use cases.</p>
     </div>
   </div>
 </section>
@@ -49,6 +85,7 @@
     <div class="col-8">
       <h2>Always fresh</h2>
       <p>Ubuntu Appliances are always synced with the latest stable application release, thanks to automatic updates. You can opt-in to sync on beta and candidate releases. Your device will fetch and install software updates at a regular frequency. Leveraging Ubuntu Core’s resilient software update mechanism, Ubuntu Appliances self-heal in case of failed updates.</p>
+      <p>Open source appliances are also maintained for the same length of time by Canonical, the company behind Ubuntu. Proprietary appliances will follow the commercial maintenance plan of the vendor behind the software on the appliance.</p>
     </div>
   </div>
 </section>
@@ -66,7 +103,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Community and commercial</h2>
-      <p>Commercial software can be both good and popular. Limiting Ubuntu Appliances to open-source, community-driven software only would limit users in the appliances they can create. In the portfolio, whether an appliance is commercial or community-driven is clearly marked. If a user would prefer to only have open-source or commercial Ubuntu appliances the option is available. </p>
+      <p>Commercial software can be both good and popular. Limiting Ubuntu Appliances to open-source, community-driven software only would limit users in the appliances they can create. In the portfolio, whether an appliance is commercial or community-driven is clearly marked. If a user would prefer to only have open-source or commercial Ubuntu appliances the option is available.</p>
     </div>
   </div>
 </section>

--- a/templates/appliance/about.html
+++ b/templates/appliance/about.html
@@ -1,0 +1,83 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}About Ubuntu Appliances{% endblock %}
+
+{% block meta_description %}An Ubuntu Appliance is an official system image which blends a single application with Ubuntu Core. Ubuntu Appliances are certified to run flawlessly on Raspberry Pi and PC boards. They are free, privacy-friendly and come with maintenance guarantees.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1UM4K9n9SFNiWdmKIBnPGCsjLQrPSOnqZHMNIMwQ2CZI/edit#heading=h.mhr3ck1sv2v4{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col-8">
+      <h2>What is an Ubuntu Appliance?</h2>
+      <p>An Ubuntu Appliance is an official system image which blends a single application with Ubuntu Core. Ubuntu Appliances are certified to run flawlessly on Raspberry Pi and PC boards. They are free, privacy-friendly and come with maintenance guarantees.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>A single-minded system</h2>
+      <p>Ubuntu Appliances provide software foundations that anybody may use to create secure and reliable smart devices. You will enrich your personal computing estate with self-made appliances that carry out single jobs perfectly. The catalogue of Ubuntu Appliances will provide a broad selection of applications encompassing home automation, gaming, media centres, networking, storage, security, 3d printing, robots and drones. </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Clear privacy policy</h2>
+      <p>Ubuntu Appliances comply with established privacy policies. Users should be able to trust in the devices they use at home, in the office or in the factory. They deserve total transparency regarding what happens with their data. Publishers of Ubuntu Appliances will disclose their use of data, should their users require the information. Detailed information can be found on the governance page or in Canonical’s own <a href="/legal/data-privacy">privacy documentation.</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Security first</h2>
+      <p>Ubuntu Appliances are designed to make your devices worry-free. Each benefits from the advanced security features of <a href="/core">Ubuntu Core</a>. Served applications are packaged as <a href="https://docs.ubuntu.com/core/en/guides/intro/security" class="p-link--external">snaps</a> &mdash; a format that strictly confines and monitors software to mitigate cybersecurity risks. Ubuntu Appliances provide the highest level of endpoint security even for the most casual use cases.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Always fresh</h2>
+      <p>Ubuntu Appliances are always synced with the latest stable application release, thanks to automatic updates. You can opt-in to sync on beta and candidate releases. Your device will fetch and install software updates at a regular frequency. Leveraging Ubuntu Core’s resilient software update mechanism, Ubuntu Appliances self-heal in case of failed updates.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Standardised experience</h2>
+      <p>Users can expect the same great things for every Ubuntu Appliance: frictionless experience, software reliability, state-of-the-art endpoint security, and predictable application performance. Ubuntu Appliances are continuously tested to work flawlessly on certified boards.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Community and commercial</h2>
+      <p>Commercial software can be both good and popular. Limiting Ubuntu Appliances to open-source, community-driven software only would limit users in the appliances they can create. In the portfolio, whether an appliance is commercial or community-driven is clearly marked. If a user would prefer to only have open-source or commercial Ubuntu appliances the option is available. </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Widely compatible</h2>
+      <p>Ubuntu Appliances are made to work the same on Raspberry Pi’s or PC boards. All of which are accessible, affordable, popular bases for personal smart devices.</p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Added base template for /appliance
- Added first pass of /appliance/about

[COPYDOC](https://docs.google.com/document/d/1UM4K9n9SFNiWdmKIBnPGCsjLQrPSOnqZHMNIMwQ2CZI/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/about
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #7412 