### PR TITLE
Add the appliance homepage

### DIFF
--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -1,0 +1,172 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Ubuntu Appliance{% endblock %}
+
+{% block meta_description %}An Ubuntu Appliance is an official system image which blends a single application with Ubuntu Core. Ubuntu Appliances are certified to run flawlessly on Raspberry Pi and PC boards. They are free, privacy-friendly and come with maintenance guarantees.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Fcr5b5Rn06AB89D6DGPmoIgXLxLalijMhwnu_IyUxV4/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru is-dark">
+  <div class="row">
+    <h1>Ubuntu Appliance portfolio</h1>
+    <p class="p-heading--four">Free appliance images for your PC or Raspberry Pi</p>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-2">
+      <h2 class="p-muted-heading">Featured today</h2>
+    </div>
+    <div class="col-2">
+      <a href="/appliance/openhab" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">OpenHab</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png" style="height:32px; margin-top:2rem;">
+        </div>
+      </a>
+    </div>
+    <div class="col-2">
+      <a href="/appliance/plex" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">Plex</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" style="height:32px; margin-top:2rem;">
+        </div>
+      </a>
+    </div>
+    <div class="col-2">
+      <a href="/appliance/nextcloud" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">NextCloud</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png" style="height:62px; margin-top:1.25rem;">
+        </div>
+      </a>
+    </div>
+    <div class="col-2">
+      <a href="/appliance/adguard" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">Adguard</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png" style="height:62px; margin-top:1.25rem;">
+        </div>
+      </a>
+    </div>
+    <div class="col-2">
+      <a href="/appliance/frrouting" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">FRRouting</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/6111e099-FRR.png" style="height:72px; margin-top:1rem;">
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Single-minded systems</h2>
+      <p class="p-heading--four">Do one thing perfectly</p>
+      <p>Transform any PC or certified board into a smart device.</p>
+      <p>Ubuntu Appliances will broaden your personal computing estate with appliances that do one job well.</p>
+      <p>Our appliance images turn generic boxes into highly secure and single-purpose devices. They will run quietly and they won’t break.</p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Clear Privacy Policy</h2>
+      <p class="p-heading--four">Be sure about your data</p>
+      <p>Transparency is the rule.</p>
+      <p>Every appliance in the catalogue complies with the established privacy policy guidelines. You will be given full visibility on the use of your personal data.</p>
+      <p><a href="/appliance/governance">Learn about your privacy protection guarantees&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Security first</h2>
+      <p class="p-heading--four">Crisp. Clean. Core.</p>
+      <p>We believe that security is everything. That’s why Ubuntu Appliances meet state-of-the-art standards of endpoint security.</p>
+      <p>Security capabilities like strict software isolation and software immutability are provided out-of-the-box with each appliance, thanks to Ubuntu Core.</p>
+      <p>To keep your device secure, CVE patches and bug fixes will be delivered over the long term and in a timely manner, the Canonical way.</p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Always fresh</h2>
+      <p class="p-heading--four">Self-healing software</p>
+      <p>Keeping up with upstream, automatically!</p>
+      <p>Whether it is stable, candidate or beta releases that you want to run on your box, the system will autonomously fetch and install software updates.</p>
+      <p>What’s more, failed updates will be reversed without your intervention.</p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Standardised experience</h2>
+      <p>These things are guaranteed across all Ubuntu appliances:</p>
+      <ul>
+        <li>Frictionless user experience</li>
+        <li>Tight security</li>
+        <li>Data privacy</li>
+        <li>Application performance</li>
+      </ul>
+      <p>Various applications but same quality expectations.</p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Community and Commercial</h2>
+      <p class="p-heading--four">Consistent policies and operations</p>
+      <p>Welcome! This is an open community where tinkerers meet open-source developers, where IT leaders can discover start-up appliances.</p>
+      <p>Whether community-driven or commercially minded, all contributions are welcome.</p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6">
+      <h2>Widely compatible</h2>
+      <p class="p-heading--four">Choose your certified board or box</p>
+      <p>We test and fix every Ubuntu appliance, to make sure they work perfectly across all certified boards and boxes.</p>
+      <p>Ubuntu Appliances work the same on ARM and PC architectures. Board peripherals and accessories are fully supported with each appliance.</p>
+      <p>We make it just work!</p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -71,7 +71,7 @@
     <hr class="p-separator" />
   </div>
 
-  <div class="row">
+  <div class="row u-equal-height">
     <div class="col-6">
       <h2>Single-minded systems</h2>
       <p class="p-heading--four">Do one thing perfectly</p>
@@ -79,19 +79,43 @@
       <p>Ubuntu Appliances will broaden your personal computing estate with appliances that do one job well.</p>
       <p>Our appliance images turn generic boxes into highly secure and single-purpose devices. They will run quietly and they won’t break.</p>
     </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+          alt="",
+          height="171",
+          width="300",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 
   <div class="u-fixed-width">
     <hr class="p-separator" />
   </div>
 
-  <div class="row">
+  <div class="row u-equal-height">
     <div class="col-6">
       <h2>Clear Privacy Policy</h2>
       <p class="p-heading--four">Be sure about your data</p>
       <p>Transparency is the rule.</p>
       <p>Every appliance in the catalogue complies with the established privacy policy guidelines. You will be given full visibility on the use of your personal data.</p>
       <p><a href="/appliance/governance">Learn about your privacy protection guarantees&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -107,6 +131,18 @@
       <p>Security capabilities like strict software isolation and software immutability are provided out-of-the-box with each appliance, thanks to Ubuntu Core.</p>
       <p>To keep your device secure, CVE patches and bug fixes will be delivered over the long term and in a timely manner, the Canonical way.</p>
     </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 
   <div class="u-fixed-width">
@@ -121,6 +157,18 @@
       <p>Whether it is stable, candidate or beta releases that you want to run on your box, the system will autonomously fetch and install software updates.</p>
       <p>What’s more, failed updates will be reversed without your intervention.</p>
     </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 
   <div class="u-fixed-width">
@@ -131,13 +179,25 @@
     <div class="col-6">
       <h2>Standardised experience</h2>
       <p>These things are guaranteed across all Ubuntu appliances:</p>
-      <ul>
-        <li>Frictionless user experience</li>
-        <li>Tight security</li>
-        <li>Data privacy</li>
-        <li>Application performance</li>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Frictionless user experience</li>
+        <li class="p-list__item is-ticked">Tight security</li>
+        <li class="p-list__item is-ticked">Data privacy</li>
+        <li class="p-list__item is-ticked">Application performance</li>
       </ul>
       <p>Various applications but same quality expectations.</p>
+    </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/69aaa876-compliance.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 
@@ -152,6 +212,18 @@
       <p>Welcome! This is an open community where tinkerers meet open-source developers, where IT leaders can discover start-up appliances.</p>
       <p>Whether community-driven or commercially minded, all contributions are welcome.</p>
     </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+          alt="",
+          height="200",
+          width="200",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 
   <div class="u-fixed-width">
@@ -164,7 +236,19 @@
       <p class="p-heading--four">Choose your certified board or box</p>
       <p>We test and fix every Ubuntu appliance, to make sure they work perfectly across all certified boards and boxes.</p>
       <p>Ubuntu Appliances work the same on ARM and PC architectures. Board peripherals and accessories are fully supported with each appliance.</p>
-      <p>We make it just work!</p>
+      <p><a href="https://certification.ubuntu.com/iot" class="p-link--external">See all Canonical certified hardware </a></p>
+    </div>
+    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
+          alt="",
+          height="171",
+          width="300",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Add the appliance homepage

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/applance
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check it matches [the copy doc](https://docs.google.com/document/d/1Fcr5b5Rn06AB89D6DGPmoIgXLxLalijMhwnu_IyUxV4/edit#)
- Check it matches [the design](https://app.zeplin.io/project/5eb3d16a91c4117789940141/screen/5eb40ad3e0674e7503f6ce42)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7411

