### PR TITLE
Added appliance to the menus

### DIFF
--- a/templates/templates/_navigation-developer-h.html
+++ b/templates/templates/_navigation-developer-h.html
@@ -122,7 +122,7 @@
               <a href="/internet-of-things/digital-signage">The leading OS for digital signage&nbsp;&rsaquo;</a>
             </li>
             <li class="p-list__item">
-              <a href="/internet-of-things/robotics">Drones and autopilots&nbsp;&rsaquo;</a>
+              <a href="/appliance">Free appliance images for your PC or Raspberry Pi&nbsp;&rsaquo;</a>
             </li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/internet-of-things/contact-us">Accelerate to market</a></p>

--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -79,6 +79,7 @@
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/internet-of-things">Build your IoT on Ubuntu</a></li>
             <li class="p-list__item"><a href="/core">Ubuntu Core - embedded &amp; secure</a></li>
+            <li class="p-list__item"><a href="/appliance">Appliance images</a></li>
             <li class="p-list__item"><a href="/embedded">Embedded Linux with Ubuntu</a></li>
             <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure packages for IoT</a></li>
             <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>


### PR DESCRIPTION
## Done
Added appliance to the menus based on the information from Rhys:
> rhys-davies: ant for the moment let's list it under Enterprise/IoT and Developer/make-devices with the intention of giving it its own place later

Removed "Drones and autopilots" based on @matthewpaulthomas request.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Open both menus and see the links work

## Issue / Card
Fixes #7431
