### PR TITLE
Add docs instance for appliance bubble

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -25,6 +25,9 @@ appliance:
       path: /appliance/governance
     - title: About
       path: /appliance/about
+    - title: Docs
+      path: /appliance/docs
+      persist: True
     - title: Contact us
       path: /appliance/contact-us
       hidden: True

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -187,7 +187,22 @@ server_docs_parser = DocParser(
     url_prefix=url_prefix,
 )
 server_docs = DiscourseDocs(
+    blueprint_name="server_docs",
     parser=server_docs_parser,
+    document_template="/docs/document.html",
+    url_prefix=url_prefix,
+)
+
+url_prefix = "/appliance/docs"
+appliance_docs_parser = DocParser(
+    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
+    category_id=46,
+    index_topic_id=16032,
+    url_prefix=url_prefix,
+)
+appliance_docs = DiscourseDocs(
+    blueprint_name="appliance_docs",
+    parser=appliance_docs_parser,
     document_template="/docs/document.html",
     url_prefix=url_prefix,
 )
@@ -203,6 +218,7 @@ app.add_url_rule(
 )
 
 server_docs.init_app(app)
+appliance_docs.init_app(app)
 
 tutorials_path = "/tutorials"
 tutorials_docs_parser = DocParser(


### PR DESCRIPTION
## Done
Initiate a discourse-docs instance for the appliance section.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/docs
- Check that the docs index renders but there is currently no navigation

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7418
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7419

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/81473510-daf9ae80-91f6-11ea-94e8-830f962256cf.png)

