### PR TITLE
Create the appliance modal contact

### DIFF
--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -220,15 +220,6 @@
         });
       });
 
-      // Hack for now but updates the styling based on the thank you panel
-      function checkThankYou() {
-        if (contactIndex == 4) {
-          contactModal.classList.add("thank-you");
-        } else {
-          contactModal.classList.remove("thank-you");
-        }
-      }
-
       // Updates the index and renders the changes
       function setState(index) {
         contactIndex = index;
@@ -252,8 +243,6 @@
 
       // Update the content of the modal based on the current index
       function render() {
-        checkThankYou();
-
         comment.value = createMessage();
 
         var currentContent = contactModal.querySelector(

--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -4,4 +4,5 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_appliance" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/appliance/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 {% endblock %}

--- a/templates/appliance/governance.html
+++ b/templates/appliance/governance.html
@@ -89,10 +89,10 @@
       <p>The majority of Ubuntu appliances will exist at this grade. A maintained appliance has a commitment from the snap maintainers to update the appliance snaps regularly according to a declared cadence. That cadence is up to the publisher but it must include scope and time. I.e What they will commit to maintaining over what period of time.</p>
       <h3 id="experimental" class="p-heading--four">Experimental</h3>
       <p>This grade can indicate a few things:
-      <ul class="p-link">
-        <li class="p-link__item is-ticked">The snaps included in the image are not all considered to be properly maintained</li>
-        <li class="p-link__item is-ticked">The appliance image itself is undergoing testing by Canonical or by the maintainers</li>
-        <li class="p-link__item is-ticked">The snaps that make up the appliance image are being pulled from the ‘candidate’ or ‘edge’ channels</li>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">The snaps included in the image are not all considered to be properly maintained</li>
+        <li class="p-list__item is-ticked">The appliance image itself is undergoing testing by Canonical or by the maintainers</li>
+        <li class="p-list__item is-ticked">The snaps that make up the appliance image are being pulled from the ‘candidate’ or ‘edge’ channels</li>
       </ul>
       <p>In the docs section, you will find access to the image builder. A tool where anyone can build appliance images out of whichever snaps they please to test on their own. Any images this way are not guaranteed to work and are also considered experimental.</p>
     </div>
@@ -124,7 +124,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Commercial terms</h2>
-      <p>In order to use an Ubuntu appliance image in a commercial product, you must <a href="/appliance/contact-us?product=commercial-product">contact Canonical</a> so that we can talk to the developer about the use of their work and Ubuntu Core in your product. You must see the appliances and Canonical’s licensing terms before using the image in any commercial product.</p>
+      <p>In order to use an Ubuntu appliance image in a commercial product, you must <a href="/appliance/contact-us?product=commercial-product" class="js-invoke-modal">contact Canonical</a> so that we can talk to the developer about the use of their work and Ubuntu Core in your product. You must see the appliances and Canonical’s licensing terms before using the image in any commercial product.</p>
       <p>
     </div>
   </div>

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -1,0 +1,207 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <hr />
+      <h2 class="p-modal__title" id="modal-title">Let’s create a new Ubuntu appliance</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <p id="modal-description" class="u-no-max-width u-no-margin--bottom">Canonical partners with developers, open-source and otherwise, to merge software-defined applications with readily available popular hardware in a secure, easily updatable and deployable way. Tell us about your project so we can bring the right team to the conversation.</p>
+
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Is your application packaged as a snap?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="radio" id="application-snap-yes" name="application-snap" value="Yes">
+            <label for="application-snap-yes">Yes</label>
+          </div>
+          <div class="col-5 u-sv3">
+            <input type="radio" id="application-snap-no" name="application-snap" value="No">
+            <label for="application-snap-no">No, I’m looking for help with this</label>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <div class="u-sv3">
+          <h3 class="p-heading--five">Link to your package</h3>
+          <textarea id="package-link" aria-label="Link to your package" rows="3" placeholder="Can you provide us with a link to your snap or your development repo so we can start looking for the best way to help you and for your next steps in creating an Ubuntu appliance?"></textarea>
+        </div>
+        <div class="pagination">
+          <a class="p-button--positive pagination__link--next" href="">Next</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Have you tested your application as a full image using the <a href="/core/build">image-builder tool</a>?</h3>
+        <div class="u-sv3">
+          <input type="radio" id="tested-image-builder-yes" name="tested-image-builder" value="Yes, it works">
+          <label for="tested-image-builder-yes" class="u-no-margin--bottom">Yes, it works</label>
+          <input type="radio" id="tested-image-builder-yes-but" name="tested-image-builder" value="Yes, but it doesn’t work, I’m looking for help with this">
+          <label for="tested-image-builder-yes-but" class="u-no-margin--bottom">Yes, but it doesn’t work, I’m looking for help with this</label>
+          <input type="radio" id="tested-image-builder-no" name="tested-image-builder" value="No">
+          <label for="tested-image-builder-no">No</label>
+        </div>
+      </div>
+
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Have you tested your applications on <a href="https://certification.ubuntu.com/iot">certified hardware</a>? (e.g Raspberry Pi, Intel NUC, etc.)</h3>
+        <div class="u-sv3">
+          <input type="radio" id="tested-certified-hardware-yes" name="tested-certified-hardware" value="Yes, it works">
+          <label for="tested-certified-hardware-yes" class="u-no-margin--bottom">Yes, it works</label>
+          <input type="radio" id="tested-certified-hardware-yes-but" name="tested-certified-hardware" value="Yes, but it doesn’t work, I’m looking for help with this">
+          <label for="tested-certified-hardware-yes-but" class="u-no-margin--bottom">Yes, but it doesn’t work, I’m looking for help with this</label>
+          <input type="radio" id="tested-certified-hardware-no" name="tested-certified-hardware" value="No, I’m looking for help testing on hardware I don’t have">
+          <label for="tested-certified-hardware-no">No, I’m looking for help testing on hardware I don’t have</label>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <div class="u-sv3">
+          <h3 class="p-heading--five">Which hardware have you tested your image on?</h3>
+          <textarea id="package-link" aria-label="Which hardware have you tested your image on?" rows="3" placeholder="Which hardware have you tested your image on? Which have you not been able to test your image on and would like us to test?"></textarea>
+        </div>
+        <div class="pagination">
+          <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+          <a class="pagination__link--next p-button--positive" href="">Next</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Looking to the future, once we have reviewed your application, snaps and image, what information can you give us to help us publicise the launch of your appliance?</h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="future-graphics">
+            <label for="future-graphics">Official logos/graphics</label>
+            <input type="checkbox" id="future-contributions">
+            <label for="future-contributions">Repo for contributions</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="future-tutorials">
+            <label for="future-tutorials">Tutorials</label>
+            <input type="checkbox" id="future-licensing">
+            <label for="future-licensing">Licensing information</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="future-documentation">
+            <label for="future-documentation">Documentation</label>
+            <input type="checkbox" id="future-privacy-policy">
+            <label for="future-privacy-policy">Privacy Policy</label>
+          </div>
+        </div>
+      </div>
+
+      <div class="js-formfield">
+        <div class="u-sv3">
+          <h3 class="p-heading--five">Please leave links to anything you have listed here</h3>
+          <textarea id="other-links" aria-label="Please leave links to anything you have listed here" rows="3" placeholder=""></textarea>
+        </div>
+      </div>
+
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Are you open to collaborating with Canonical in creating marketing content for your appliance?</h3>
+        <div class="u-sv3">
+          <input type="radio" id="collaborating-yes" name="collaborating" value="Yes">
+          <label for="collaborating-yes" class="u-no-margin--bottom">Yes</label>
+          <input type="radio" id="collaborating-no" name="collaborating" value="No">
+          <label for="collaborating-no">No</label>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+        <a class="pagination__link--next p-button--positive" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--4 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Work email:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--5 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about embedded Ubuntu</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done
- Create the appliance modal contact
- Add the invoke class to the link in the governance page
- Remove the thank you hack

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance#get-in-touch
- Check that the modal matches the [copy doc](https://docs.google.com/document/d/1DLkSZGAuOQYZqBg02r2pVGT6rfXK_0aBpoEEMrngnDk/edit#heading=h.s5zvgb70wqn)
- Clicking the contact Canonical link in the governance page invoked to modal

## Issue / Card
Fixes #7458
