### PR TITLE
Appliances tutorials

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -21,6 +21,8 @@ appliance:
   children:
     - title: Overview
       path: /appliance
+    - title: Tutorials
+      path: /appliance/tutorials
     - title: Governance
       path: /appliance/governance
     - title: About

--- a/templates/appliance/tutorials.html
+++ b/templates/appliance/tutorials.html
@@ -1,0 +1,37 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Ubuntu Appliances Governance{% endblock %}
+
+{% block meta_description %}Governance ensures that understandable tensions are resolved productively.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1DpU0AzAJ4gBa_au4gELBUD3vLz8l-FnAwFdERBHlvwc/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--suru-blog-hero is-dark">
+  <div class="row">
+    <div class="col-8">
+      <h1 class="u-off-screen">Appliance tutorials</h1>
+      <h2 class="u-sv3">Learn to make appliances by example &mdash; a guided walkthrough</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          iot
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">
+          <a class="p-link--soft" href="/tutorials/how-to-install-ubuntu-core-on-raspberry-pi">How to install Ubuntu Core on your Raspberry Pi</a>
+        </h3>
+        <p class="u-sv3">A complete guide to installing the latest version of Ubuntu Core on your Raspberry Pi 4, 3 or 2.</p>
+      </div>
+      <footer class="blog-p-card__footer">
+        Difficulty: <span class="l-tutorials-meter l-tutorials-meter--2">2 out of 5</span>
+      </footer>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}


### PR DESCRIPTION
## Done
- Built the appliance tutorial page linking to the existing tutorials
- Added the page to the naviagiton

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/tutorials
- Check it matches the [copy doc](https://docs.google.com/document/d/1CgtFLYJqHJIrRbkvqFzvUoIBsgeWUD9o6gV3bbUOdqU/edit#heading=h.c417a2j3hga) _as much as it makes sense_

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7421

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/81486503-1a52ea00-924d-11ea-91ae-f68b13b2d3f1.png)

