### PR TITLE
Removes duplicate “Embedded Linux with Ubuntu” link

### DIFF
--- a/templates/templates/_navigation-enterprise-h.html
+++ b/templates/templates/_navigation-enterprise-h.html
@@ -85,7 +85,6 @@
             <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>
             <li class="p-list__item"><a href="/robotics">Robots and drones with Ubuntu</a></li>
             <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
-            <li class="p-list__item"><a href="/embedded">Embedded Linux with Ubuntu</a></li>
             <li class="p-list__item"><a href="/automotive">Automotive with Ubuntu</a></li>
             <li class="p-list__item"><a href="/internet-of-things/networking">Networking with Ubuntu</a></li>
           </ul>


### PR DESCRIPTION
## Done

- Removes duplicate “Embedded Linux with Ubuntu” link from the “Enterprise” mega-menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Open the “Enterprise” mega-menu
- Look at the “Internet of Things” section

## Issue / Card

None. This issue did not exist in [the copydoc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit).

[Discovered while looking at @lyubomir-popov’s mockups of the new link colour.]