### PR TITLE
Add pre-kubecon takeover and engage page

### DIFF
--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -1,0 +1,33 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Kubernetes & MicroK8s virtual event EU"
+  meta_description: "Kubernetes, microK8s, K8s, canonical, ubuntu"
+  meta_image: https://assets.ubuntu.com/v1/baab00bc-pre-kubeconf-meta-image.png
+  meta_copydoc: https://docs.google.com/document/d/1VYYmd6kS0eWApEpbVCgTUq0NOHUTEeRWVj7ujtFEsHs/
+  header_title: "Streamlined Kubernetes, from Cloud to Edge"
+  header_subtitle: "Innovating and scaling efficiently, with Charmed Kuberenetes and MicroK8s"
+  header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
+  header_image_width: "419"
+  header_image_height: "172"
+  header_url: "#register-section"
+  header_cta: Register now
+  header_cta_class: p-button--positive
+  header_class: p-engage-banner--dark
+  header_lang: en
+  webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 406196, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+## About the event
+
+**Date and time**
+May 28, 2020
+[4-6pm GMT]
+
+**What it is**: A free digital event on Kubernetes, including a live, interactive discussion with a panel of experts, demos, use cases, Q&A, and more.
+
+**Who should attend**: Open to IT teams wanting to learn more about how to overcome common enterprise Kubernetes challenges, and the most efficient solutions for executing their Kubernetes strategy.
+
+**What you will learn**: We will discuss the Kubernetes portfolio of Canonical and Ubuntu, as well as how to deploy and leverage MicroK8s and Charmed Kubernetes.
+
+**Takeaways**: Ideas and building blocks for today and the future.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -992,6 +992,13 @@
           type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Streamlined Kubernetes, from Cloud to Edge",
+      description="Innovating and scaling efficiently, with Charmed Kuberenetes and MicroK8s",
+      slug="eu-kubernetes-event",
+      type="event" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
     </div>
 </section>
 {% endblock content %}

--- a/templates/engage/pre-kubecon-event.md
+++ b/templates/engage/pre-kubecon-event.md
@@ -1,20 +1,20 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-    title: "Pre-Kubecon event NL"
-    meta_description: "Kubernetes, microK8s, kubecon, canonical, ubuntu"
-    meta_image: "https://assets.ubuntu.com/v1/7d8a36c9-Meta+data+img+-+Pre-Kubecon+event.jpg"
-    meta_copydoc: "https://docs.google.com/document/d/1Ov_JCaTymV3_OY-_sACJNbfbEUetUjkB28T83kJZZ7U/"
-    header_title: "Virtual event:<br>MicroK8s & Kubernetes"
-    header_subtitle: "Join our virtual event to learn more about MicroK8s, what it is and why you should use it. This event will also include discussions on Kubernetes, an introduction to Canonical and much more!"
-    header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
-    header_image_width: "419"
-    header_image_height: "172"
-    header_url: 'https://primetime.bluejeans.com/a2m/register/daqpkkyc'
-    header_cta: Register
-    header_cta_class: "p-button--positive"
-    header_class: p-engage-banner--dark
-    header_lang: en
+  title: "Pre-Kubecon event NL"
+  meta_description: "Kubernetes, microK8s, kubecon, canonical, ubuntu"
+  meta_image: "https://assets.ubuntu.com/v1/7d8a36c9-Meta+data+img+-+Pre-Kubecon+event.jpg"
+  meta_copydoc: "https://docs.google.com/document/d/1Ov_JCaTymV3_OY-_sACJNbfbEUetUjkB28T83kJZZ7U/"
+  header_title: "Virtual event:<br>MicroK8s & Kubernetes"
+  header_subtitle: "Join our virtual event to learn more about MicroK8s, what it is and why you should use it. This event will also include discussions on Kubernetes, an introduction to Canonical and much more!"
+  header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
+  header_image_width: "419"
+  header_image_height: "172"
+  header_url: "https://primetime.bluejeans.com/a2m/register/daqpkkyc"
+  header_cta: Register
+  header_cta_class: "p-button--positive"
+  header_class: p-engage-banner--dark
+  header_lang: en
 ---
 
 ## About the event
@@ -22,7 +22,6 @@ context:
 **Date and time:**
 March 30, 2020
 [2-5pm]
-
 
 **What it is:** A free digital conference for anyone from the Netherlands. As KubeCon in Amsterdam, we wanted to still bring Kubernetes and MicroK8s to you.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_2004-takeover.html" %}
+  {% include "takeovers/_eu-kubernetes-event.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_eu-kubernetes-event.html
+++ b/templates/takeovers/_eu-kubernetes-event.html
@@ -1,0 +1,14 @@
+{% with title="Kubernetes From<br> Cloud to Edge",
+subtitle="A virtual event on flexible innovation and scaling with Charmed Kuberenetes and MicroK8s ",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg",
+image_style="width: 419px;",
+image_hide_small="true",
+primary_url="/engage/eu-kubernetes-event?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020",
+primary_cta="Register now",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="en" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_eu-kubernetes-event.html
+++ b/templates/takeovers/_eu-kubernetes-event.html
@@ -1,5 +1,5 @@
 {% with title="Kubernetes From<br> Cloud to Edge",
-subtitle="A virtual event on flexible innovation and scaling with Charmed Kuberenetes and MicroK8s ",
+subtitle="A virtual event on flexible innovation and scaling with Charmed Kubernetes and MicroK8s ",
 class="p-takeover--dark",
 header_image="https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg",
 image_style="width: 419px;",

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -128,4 +128,6 @@
 {% include "takeovers/_ibm_athena_release.html" %}
 <p>23 April 2020</p>
 {% include "takeovers/_2004-takeover.html" %}
+<p>11 May 2020</p>
+{% include "takeovers/_eu-kubernetes-event.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Add takeover and engage page for EU kubernetes event

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see the "Kubernetes From Cloud to Edge" takeover
- Check the takeover matches [the brief](https://docs.google.com/spreadsheets/d/1A5DO1jxYXbkQ4Ule1lhxo9s25_UukK3maokZs9c1NCY/edit#gid=1271849439)
- Click through to the engage page and check that it matches [the copy doc](https://docs.google.com/document/d/1VYYmd6kS0eWApEpbVCgTUq0NOHUTEeRWVj7ujtFEsHs/edit#)