### PR TITLE
7466 azure webinar and engage page

### DIFF
--- a/templates/engage/azure-webinar.md
+++ b/templates/engage/azure-webinar.md
@@ -1,0 +1,35 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Leveraging open source with Ubuntu Pro on Azure"
+  meta_description: "How Microsoft and Canonical are partnering to ensure every organisation can achive more through open source software in a trusted way"
+  meta_image: "https://assets.ubuntu.com/v1/be09312f-azure-webinar-meta-image.png"
+  meta_copydoc: "https://docs.google.com/document/d/1cUNpZbCoBCPknnUSWF9I3pf7PdyEi8u-RoeGPY_vs3A"
+  header_title: "Leveraging open source with Ubuntu Pro on Azure:"
+  header_subtitle: "Economics, Velocity and Security"
+  header_image: "https://assets.ubuntu.com/v1/9e4df13f-ubuntu-azure-logos.svg"
+  header_image_width: "220"
+  header_image_height: "219"
+  header_class: p-engage-banner--grad
+  header_url: "#register-section"
+  header_cta: Learn morew
+  header_cta_class: p-button--positive
+  webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 406236, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Every day, organizations of all kinds and sizes choose to harness open source innovation as part
+of their development and operations. Many have embraced Linux and are now adopting open
+source beyond the core platform, as evidenced by the widespread adoption of ecosystems like
+Python, Node.js and Go, and workloads like Kafka, Redis and Elasticsearch. From retailers to
+financial services enterprises running on Microsoft Azure, Ubuntu has rapidly become a
+preferred platform to harness that innovation.
+
+But how can organizations balance the fast pace of community-driven open source innovation
+with their own imperatives of security, compliance and support? And what does an open source
+security strategy mean for enterprise environments?
+
+In this webinar, you&rsquo;ll learn how Microsoft and Canonical are partnering to ensure every
+organization can achieve more through open source software in a trusted way &mdash; with no
+compromises on security and support. In addition to covering features of Ubuntu Pro for Azure
+such as Livepatch, Extended Security Maintenance and FIPS/Common Criteria, we’ll share our
+roadmap and joint vision for open source security and compliance in the cloud.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1000,5 +1000,14 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
     </div>
+
+    <div class="row u-equal-height u-clearfix">
+      {% with title="Leveraging open source with Ubuntu Pro on Azure",
+        description="How Microsoft and Canonical are partnering to ensure every organisation can achive more through open source software in a trusted way",
+        slug="azure-webinar",
+        type="webinar" %}
+        {% include "engage/_article-card.html" %}
+    {% endwith %}
+    </div>
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
   {# ALL #}
   {% include "takeovers/_2004-takeover.html" %}
   {% include "takeovers/_eu-kubernetes-event.html" %}
+  {% include "takeovers/_azure-webinar-takeover.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_azure-webinar-takeover.html
+++ b/templates/takeovers/_azure-webinar-takeover.html
@@ -1,0 +1,13 @@
+{% with title="Leveraging open source<br> with Ubuntu Pro on Azure:",
+subtitle="Economics, Velocity and Security",
+class="",
+header_image="https://assets.ubuntu.com/v1/9e4df13f-ubuntu-azure-logos.svg",
+image_height="219",
+image_width="220",
+image_hide_small=true,
+primary_url="/engage/azure-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Azure_WBN_UbuntuProAzure",
+primary_cta="Learn more",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -130,4 +130,6 @@
 {% include "takeovers/_2004-takeover.html" %}
 <p>11 May 2020</p>
 {% include "takeovers/_eu-kubernetes-event.html" %}
+<p>12 May 2020</p>
+{% include "takeovers/_azure-webinar-takeover.html" %}
 {% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -68,6 +68,7 @@ app = FlaskBase(
 
 talisker.requests.configure(api_session)
 
+
 # Error pages
 @app.errorhandler(404)
 def not_found_error(error):

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -189,7 +189,7 @@ def notices_feed(feed_type):
 @authorization_required
 def create_notice():
     if not flask.request.json:
-        return (flask.jsonify({"message": f"No payload received"}), 400)
+        return (flask.jsonify({"message": "No payload received"}), 400)
 
     notice_schema = NoticeSchema()
     try:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -104,7 +104,7 @@ def releasenotes_redirect():
                 f"https://wiki.ubuntu.com/{release_slug}/ReleaseNotes"
             )
 
-    return flask.redirect(f"https://wiki.ubuntu.com/Releases")
+    return flask.redirect("https://wiki.ubuntu.com/Releases")
 
 
 def build():


### PR DESCRIPTION
## Done

Add takeover and engage page for Azure webinar

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see the "Leveraging open source with Ubuntu Pro on Azure:" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1QH2O8NiiJnRYSYnOQz4IOZLK83hx-bAptwzJL_FJ2ko/edit#gid=2113339190)
- Click through to the engage page and check that it matches [the brief]
- Test the engage page on [https://socialdebug.com/](https://socialdebug.com/) or [http://debug.iframely.com/](http://debug.iframely.com/) and [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)


## Issue / Card

Fixes #7466 