### PR TITLE
Provide environment variables for overriding URLs

### DIFF
--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -3,7 +3,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.canonical.com/",
+        api_url="https://contracts.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,
@@ -12,12 +12,12 @@ class AdvantageContracts:
 
         self.session = session
         self.authentication_token = authentication_token
-        self.api_url = api_url
+        self.api_url = api_url.rstrip("/")
 
     def _request(self, method, path, json=None):
         return self.session.request(
             method=method,
-            url=f"{self.api_url}{path}",
+            url=f"{self.api_url}/{path}",
             json=json,
             headers={"Authorization": f"Macaroon {self.authentication_token}"},
         )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -66,6 +66,14 @@ app = FlaskBase(
     static_folder="../static",
 )
 
+# Settings
+app.config["CONTRACTS_API_URL"] = os.getenv(
+    "CONTRACTS_API_URL", "https://contracts.canonical.com"
+).rstrip("/")
+app.config["CANONICAL_LOGIN_URL"] = os.getenv(
+    "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"
+).rstrip("/")
+
 talisker.requests.configure(api_session)
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -344,7 +344,9 @@ def advantage_view():
 
     if user_info(flask.session):
         advantage = AdvantageContracts(
-            session, flask.session["authentication_token"]
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
         )
 
         try:
@@ -471,7 +473,11 @@ def advantage_view():
 
 def post_stripe_method_id():
     if user_info(flask.session):
-        advantage = AdvantageContracts(flask.session["authentication_token"])
+        advantage = AdvantageContracts(
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
+        )
 
         if not flask.request.is_json:
             return flask.jsonify({"error": "JSON required"}), 400
@@ -493,7 +499,11 @@ def post_stripe_method_id():
 
 def post_stripe_invoice_id(renewal_id, invoice_id):
     if user_info(flask.session):
-        advantage = AdvantageContracts(flask.session["authentication_token"])
+        advantage = AdvantageContracts(
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
+        )
 
         return advantage.post_stripe_invoice_id(
             flask.session, invoice_id, renewal_id
@@ -504,7 +514,11 @@ def post_stripe_invoice_id(renewal_id, invoice_id):
 
 def get_renewal(renewal_id):
     if user_info(flask.session):
-        advantage = AdvantageContracts(flask.session["authentication_token"])
+        advantage = AdvantageContracts(
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
+        )
 
         return advantage.get_renewal(flask.session, renewal_id)
     else:
@@ -513,7 +527,11 @@ def get_renewal(renewal_id):
 
 def accept_renewal(renewal_id):
     if user_info(flask.session):
-        advantage = AdvantageContracts(flask.session["authentication_token"])
+        advantage = AdvantageContracts(
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
+        )
 
         return advantage.accept_renewal(flask.session, renewal_id)
     else:


### PR DESCRIPTION
- CONTRACTS_API_URL to override https://contracts.canonical.com
- CANONICAL_LOGIN_URL to override https://login.ubuntu.com

QA
--

Try:

``` bash
CANONICAL_LOGIN_URL=https://login.staging.ubuntu.com dotrun serve
```

Go to http://localhost:8001/advantage, login, see you get sent to `https://login.staging.ubuntu.com` (where you probably don't have an account).

Try:

``` bash
CONTRACTS_API_URL=https://contracts.staging.canonical.com dotrun serve
```

Go to http://localhost:8001/advantage, login, see you are seeing staging data.