### PR TITLE
Update copy on /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -92,7 +92,7 @@
   <div class="row">
     <div class="col-7">
       <h3>Systems management and security at scale</h3>
-      <p>Automate day-to-day management with Landscape, the most cost-effective tool to support and monitor large and rapidly expanding networks of clouds, servers and desktops. Use Landscape for audit reporting, security compliance and patch management at scale. Landscape is available as a service from the cloud or on-premises for compliance with stricter securi&nbsp;&rsaquo;ty requirements.</p>
+      <p>Automate day-to-day management with Landscape, the most cost-effective tool to support and monitor large and rapidly expanding networks of clouds, servers and desktops. Use Landscape for audit reporting, security compliance and patch management at scale. Landscape is available as a service from the cloud or on-premises for compliance with stricter security requirements.</p>
     </div>
   </div>
   <div class="row u-equal-height">

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1,8 +1,9 @@
 {% extends "support/base_support.html" %}
 
-
 {% block title %}Support and management{% endblock %}
+
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -12,6 +13,9 @@
       <h1>Ubuntu Advantage</h1>
       <h4>Open Source for the enterprise</h4>
       <p>Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry. With OpenStack and Kubernetes support included, Ubuntu Advantage for Infrastructure provides everything you need to future-proof your data centre.</p>
+      <p>
+        <a class="p-link--inverted" href="/advantage">Get UA Infrastructure Essential free for personal use</a>, or
+      </p>
       <p>
         <a href="https://buy.ubuntu.com" class="p-button--positive"><span class="p-link--external">Buy online</span></a>
         <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-button--neutral">Read the datasheet</a>
@@ -65,7 +69,7 @@
       <li class="p-matrix__item">
         <div class="p-matrix__content">
           <h3 class="p-matrix__title p-heading--four">Certified technology</h3>
-          <p class="p-matrix__desc">Ubuntu runs everywhere you rely on it to power your mission-critical workloads.</p>
+          <p class="p-matrix__desc">Ubuntu runs everywhere you rely on it to power your mission-critical workloads, with FIPS 140-2 Level 1 and Common Criteria EAL2 certification available.</p>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -88,7 +92,7 @@
   <div class="row">
     <div class="col-7">
       <h3>Systems management and security at scale</h3>
-      <p>Automate day-to-day management with Landscape, the most cost-effective tool to support and monitor large and rapidly expanding networks of clouds, servers and desktops. Use Landscape for audit reporting, security compliance and patch management at scale. Landscape is available as a service from the cloud or on-premises for compliance with stricter security requirements.</p>
+      <p>Automate day-to-day management with Landscape, the most cost-effective tool to support and monitor large and rapidly expanding networks of clouds, servers and desktops. Use Landscape for audit reporting, security compliance and patch management at scale. Landscape is available as a service from the cloud or on-premises for compliance with stricter securi&nbsp;&rsaquo;ty requirements.</p>
     </div>
   </div>
   <div class="row u-equal-height">
@@ -175,9 +179,12 @@
           <p><a href="https://buy.ubuntu.com/" class="p-matrix__link p-link--external">Purchase at buy.ubuntu.com</a></p>
         </div>
         <div class="col-4 p-divider__block">
-          <h4>Buy from the AWS Marketplace</h4>
-          <p>For Amazon AWS, you can purchase Ubuntu Advantage through the AWS Marketplace.</p>
-          <p>Purchase <a href="https://aws.amazon.com/marketplace/pp/B0733NKN6C?qid=1508399270716&sr=0-2&ref_=srh_res_product_title" class="p-link--external">Essential</a>, <a href="https://aws.amazon.com/marketplace/pp/B01MZ1LSBQ?qid=1486382973569&sr=0-1&ref_=srh_res_product_title" class="p-link--external">Standard</a> or <a href="https://aws.amazon.com/marketplace/pp/B01N9JG6EM?qid=1490357851557&sr=0-7&ref_=srh_res_product_title" class="p-link--external">Advanced</a></p>
+          <h4>Buy Ubuntu Pro on AWS or Azure</h4>
+          <p>On Amazon AWS and Azure, you can purchase Ubuntu Pro.</p>
+          <p>
+            <a href="/aws">Learn more about Ubuntu on AWS&nbsp;&rsaquo;</a><br />
+            <a href="/azure">Learn more about Ubuntu on Azure&nbsp;&rsaquo;</a>
+          </p>
         </div>
         <div class="col-4 p-divider__block">
           <h4>Talk to a member of the team</h4>


### PR DESCRIPTION
## Done

- Added link to free Ubuntu Advantage
- Added detail on certifications
- Updated Ubuntu Advantage for AWS and Azure

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit#) and resolve all comments


## Issue / Card

Fixes #7477


