### PR TITLE
Update certs page copy and add contact modal

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -17,6 +17,7 @@
       <p>
         Canonical has made its security certification offerings available to all Ubuntu Advantage for Infrastructure customers.
       </p>
+      <p><a class="p-button--neutral js-invoke-modal" href="/support/contact-us?product=support-overview">Contact us with your cerification questions</a></p>
       <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-vertically-center u-hide--small">
@@ -43,7 +44,7 @@
         FIPS 140-2 is a U.S. Government computer security standard. It defines security requirements related to the design and implementation of a cryptographic module. It is a requirement for U.S. Federal agencies to use FIPS 140-2 validated cryptography to protect sensitive information.
       </p>
       <p>
-        The standard puts stringent requirements on testing and ensuring that the cryptographic implementations meet the standards and work as expected. The testing and validation must be performed by a laboratory, which is accredited under the Cryptographic and Security Testing (CST) Laboratory Accreditation Program (LAP) and is part of NIST’s <a class="p-link--external" href="https://www.nist.gov/nvlap/">National Voluntary Laboratory Accreditation Program (NVLAP)</a>. The validation testing for Ubuntu 16.04 was performed by atsec Information Security, a U.S. Govt and BSI accredited laboratory.
+        The standard puts stringent requirements on testing and ensuring that the cryptographic implementations meet the standards and work as expected. The testing and validation must be performed by a laboratory, which is accredited under the Cryptographic and Security Testing (CST) Laboratory Accreditation Program (LAP) and is part of NIST’s <a class="p-link--external" href="https://www.nist.gov/nvlap/">National Voluntary Laboratory Accreditation Program (NVLAP)</a>. The validation testing for Ubuntu 18.04 LTS and 16.04 LTS was performed by atsec Information Security, a U.S. Government and BSI accredited laboratory.
       </p>
       <p>
         Anyone deploying systems for U.S. Federal government use including the cloud services is required to use FIPS 140-2 compliant systems. FIPS 140-2 is also used commonly outside of U.S. Federal space. It has been adopted in regulated industries like finance, healthcare, legal and manufacturing and a few others where there are Federal regulations on data security.


### PR DESCRIPTION
## Done

- updated the certification page copy and added a contact modal

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Check that the contact modal works and that the [copy] matches
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7478 
