### PR TITLE
Fixed type on pre-Kubecon event subtitle

### DIFF
--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -6,7 +6,7 @@ context:
   meta_image: https://assets.ubuntu.com/v1/baab00bc-pre-kubeconf-meta-image.png
   meta_copydoc: https://docs.google.com/document/d/1VYYmd6kS0eWApEpbVCgTUq0NOHUTEeRWVj7ujtFEsHs/
   header_title: "Streamlined Kubernetes, from Cloud to Edge"
-  header_subtitle: "Innovating and scaling efficiently, with Charmed Kuberenetes and MicroK8s"
+  header_subtitle: "Innovating and scaling efficiently, with Charmed Kubernetes and MicroK8s"
   header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
   header_image_width: "419"
   header_image_height: "172"


### PR DESCRIPTION
## Done

Changed "Innovating and scaling efficiently, with Charmed Kubernetes and MicroK8s" as it was spelt "Kuberenetes"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

