### PR TITLE
Renewals ux tweaks

### DIFF
--- a/static/js/src/renewals/set-modal-info.js
+++ b/static/js/src/renewals/set-modal-info.js
@@ -53,12 +53,15 @@ export function getPaymentInformation(paymentMethod) {
   const billingInfo = paymentMethod.billing_details;
   const cardInfo = paymentMethod.card;
 
+  const formattedExpiryMonth = cardInfo.exp_month.toString().padStart(2, "0");
+  const formattedExpiryYear = cardInfo.exp_year.toString().slice(-2);
+
   const cardBrandFormatted =
     cardInfo.brand.charAt(0).toUpperCase() + cardInfo.brand.slice(1);
 
   return {
     cardText: `${cardBrandFormatted} ending ${cardInfo.last4}`,
-    cardExpiry: `${cardInfo.exp_month}/${cardInfo.exp_year}`,
+    cardExpiry: `${formattedExpiryMonth}/${formattedExpiryYear}`,
     cardImage: cardBrandImages[cardInfo.brand] || null,
     email: billingInfo.email,
     name: billingInfo.name,
@@ -79,7 +82,7 @@ export function getRenewalInformation(data) {
 
   return {
     endDate: endDate.toLocaleString("en-GB", dateOptions),
-    name: `Renew "${data.name}"`,
+    name: `Renew &ldquo;${data.name}&rdquo;`,
     products: getProductsString(data.products),
     quantity: `${data.quantity} &#215; ${formattedCurrency(
       data.unitPrice,

--- a/static/js/src/renewals/set-modal-info.js
+++ b/static/js/src/renewals/set-modal-info.js
@@ -75,8 +75,10 @@ export function getRenewalInformation(data) {
     contractEndDate.setMonth(contractEndDate.getMonth() + parseInt(data.months))
   );
 
+  const dateOptions = { year: "numeric", month: "long", day: "numeric" };
+
   return {
-    endDate: endDate.toISOString().split("T", 1)[0],
+    endDate: endDate.toLocaleString("en-GB", dateOptions),
     name: `Renew "${data.name}"`,
     products: getProductsString(data.products),
     quantity: `${data.quantity} &#215; ${formattedCurrency(
@@ -84,7 +86,7 @@ export function getRenewalInformation(data) {
       data.currency,
       "en-CA"
     )}/year`,
-    startDate: startDate.toISOString().split("T", 1)[0],
+    startDate: startDate.toLocaleString("en-GB", dateOptions),
     total: formattedCurrency(data.total, data.currency, "en-US"),
   };
 }

--- a/static/js/src/renewals/tests/fixtures/payment-methods.js
+++ b/static/js/src/renewals/tests/fixtures/payment-methods.js
@@ -14,8 +14,8 @@ export const visa = {
 export const unknownBrand = {
   card: {
     brand: "foo",
-    exp_month: "04",
-    exp_year: "29",
+    exp_month: 4,
+    exp_year: 2029,
     last4: "6789",
   },
   billing_details: {

--- a/static/js/src/renewals/tests/set-modal-info.test.js
+++ b/static/js/src/renewals/tests/set-modal-info.test.js
@@ -37,7 +37,7 @@ describe("getRenewalInformation", () => {
     it("should return an object of appropriate values that can be added to the DOM", () => {
       expect(getRenewalInformation(renewalData.advancedDesktop)).toEqual({
         endDate: "21 May 2021",
-        name: 'Renew "uai-testing"',
+        name: "Renew &ldquo;uai-testing&rdquo;",
         products: "UA Infra Advanced Desktop",
         quantity: "5 &#215; US$25/year",
         startDate: "21 May 2020",

--- a/static/js/src/renewals/tests/set-modal-info.test.js
+++ b/static/js/src/renewals/tests/set-modal-info.test.js
@@ -36,11 +36,11 @@ describe("getRenewalInformation", () => {
   describe("given a renewal data object", () => {
     it("should return an object of appropriate values that can be added to the DOM", () => {
       expect(getRenewalInformation(renewalData.advancedDesktop)).toEqual({
-        endDate: "2021-05-21",
+        endDate: "21 May 2021",
         name: 'Renew "uai-testing"',
         products: "UA Infra Advanced Desktop",
         quantity: "5 &#215; US$25/year",
-        startDate: "2020-05-21",
+        startDate: "21 May 2020",
         total: "$125",
       });
     });

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -13,7 +13,7 @@
         </div>
 
         <div class="row u-no-padding u-sv1">
-          <div class="col-3 u-text-light">Starts:</div>
+          <div class="col-3 u-text-light">Will continue from:</div>
           <div class="col-9 js-renewal-start"></div>
         </div>
 
@@ -104,8 +104,16 @@
               <label class="u-no-padding--top" >VAT number:</label>
             </div>
 
-            <div class="col-9">
+            <div class="col-7">
               <input name="tax" type="text" />
+            </div>
+
+            <div class="col-2">
+              (if required)
+            </div>
+
+            <div class="col-9 col-start-large-4">
+              <span class="p-form-validation__message u-hide"></span>
             </div>
           </div>
 

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -3,7 +3,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.canonical.com",
+        api_url="https://contracts.staging.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -85,4 +85,7 @@ class AdvantageContracts:
             method="post", path=f"v1/renewals/{renewal_id}/acceptance"
         )
 
-        return response.json()
+        if response.ok:
+            return {}
+        else:
+            return response.json()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -75,7 +75,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.canonical.com"
+    "CONTRACTS_API_URL", "https://contracts.staging.canonical.com"
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -546,10 +546,6 @@ def post_stripe_invoice_id(renewal_id, invoice_id):
             api_url=flask.current_app.config["CONTRACTS_API_URL"],
         )
 
-        return advantage.post_stripe_invoice_id(
-            flask.session, invoice_id, renewal_id
-        )
-
         return advantage.post_stripe_invoice_id(invoice_id, renewal_id)
     else:
         return flask.jsonify({"error": "authentication required"}), 401


### PR DESCRIPTION
## Done

- Changed date format in the renewal modal to match what was already in the subscription tables
- Added "(if required)" to VAT field
- Changed "Starts:" to "Will continue from:"

## QA
- Visit /advantage in the demo
- Login
- If you don't have test contracts up for renewal, ask Scott to set you up with one
- Open the renewal modal, see that the points [here](https://github.com/canonical-web-and-design/web-squad/issues/2597#issuecomment-627841020) have been addressed
