### PR TITLE
Add cve priority icons

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -1,0 +1,14 @@
+@mixin ubuntu-p-cve {
+  .cve-status-box,
+  .cve-status-box--highlight {
+    @extend .p-card;
+
+    margin-bottom: $sp-small;
+  }
+
+  .cve-status-box--highlight {
+    background-color: $color-brand;
+    border: none;
+    color: $color-x-light;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -18,9 +18,8 @@
   font-family: "UbtuOverride";
   font-style: normal;
   font-weight: 300;
-  src:
-    url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2")
-    format("woff2"),
+  src: url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2")
+      format("woff2"),
     url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
 }
 
@@ -45,6 +44,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_chart";
 @import "pattern_contact-modal";
 @import "pattern_contextual-footer";
+@import "pattern_cve";
 @import "pattern_desktop-statistics";
 @import "pattern_divider";
 @import "pattern_gaming";
@@ -83,6 +83,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include ubuntu-p-card;
 @include ubuntu-p-contact-modal;
 @include ubuntu-p-contextual-footer;
+@include ubuntu-p-cve;
 @include ubuntu-p-desktop-statistics;
 @include ubuntu-p-divider;
 @include ubuntu-p-footer;
@@ -621,19 +622,62 @@ summary {
   @extend %vf-pseudo-border--top;
 }
 
-.cve-status-box,
-.cve-status-box--highlight {
-  @extend .p-card;
-
-  margin-bottom: $sp-small;
+// Utilities for using icons in table cells
+.icon-container__icon {
+  display: block;
+  float: left;
+  margin-right: 0.5rem;
+  width: 1rem;
 }
 
-.cve-status-box {
-  background-color: $color-mid-x-light;
+.icon-container__text {
+  float: left;
+  width: calc(100% - 1.5rem);
 }
 
-.cve-status-box--highlight {
-  background-color: $color-brand;
-  border: none;
-  color: $color-x-light;
+.p-icon--placeholder {
+  height: 1rem;
+  margin-right: 1rem;
+  width: 1rem;
+}
+
+// Icons introduced in CVE work
+.p-icon--unknown-priority,
+.p-icon--negligible-priority,
+.p-icon--low-priority,
+.p-icon--medium-priority,
+.p-icon--high-priority,
+.p-icon--critical-priority {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  display: inline-block;
+  height: 1rem;
+  position: relative;
+  vertical-align: calc(0.5px + 0.3456em - 0.5em);
+  width: 1rem;
+}
+
+.p-icon--unknown-priority {
+  background-image: url("#{$assets-path}e85d00c8-CVE-Priority-icon-Unknown.svg");
+}
+
+.p-icon--negligible-priority {
+  background-image: url("#{$assets-path}f6820eae-CVE-Priority-icon-Negligible.svg");
+}
+
+.p-icon--low-priority {
+  background-image: url("#{$assets-path}2c18ab71-CVE-Priority-icon-Low.svg");
+}
+
+.p-icon--medium-priority {
+  background-image: url("#{$assets-path}6d25e065-CVE-Priority-icon-Medium.svg");
+}
+
+.p-icon--high-priority {
+  background-image: url("#{$assets-path}a9a5dc21-CVE-Priority-icon-High.svg");
+}
+
+.p-icon--critical-priority {
+  background-image: url("#{$assets-path}428a85f3-CVE-Priority-icon-Critical.svg");
 }

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -65,8 +65,38 @@
 
       <div class="col-3">
         {% if cve.status == 'active' and cve.priority %}
-        <div class="cve-status-box">
-          <div class="p-heading--four u-no-margin--bottom">Priority {{ cve.priority | capitalize }}</div>
+        <div class="cve-status-box u-no-margin--bottom">
+          <div class="p-muted-heading">Priority</div>
+          <div class="p-heading-icon--small">
+            <div class="p-heading-icon__header">
+              {% if cve.priority == 'unknown' %}
+                <img src="https://assets.ubuntu.com/v1/e85d00c8-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
+              {% endif %}
+
+              {% if cve.priority == 'negligible' %}
+                <img src="https://assets.ubuntu.com/v1/f6820eae-CVE-Priority-icon-Negligible.svg" alt="" class="p-heading-icon__img">
+              {% endif %}
+
+              {% if cve.priority == 'low' %}
+                <img src="https://assets.ubuntu.com/v1/2c18ab71-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
+              {% endif %}
+
+              {% if cve.priority == 'medium' %}
+                <img src="https://assets.ubuntu.com/v1/6d25e065-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
+              {% endif %}
+
+              {% if cve.priority == 'high' %}
+                <img src="https://assets.ubuntu.com/v1/a9a5dc21-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
+              {% endif %}
+
+              {% if cve.priority == 'critical' %}
+                <img src="https://assets.ubuntu.com/v1/428a85f3-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
+              {% endif %}
+              <h4 class="p-heading-icon__title u-no-margin--bottom">
+                {{ cve.priority | capitalize }}
+              </h4>
+            </div>
+          </div>
         </div>
         <p>CVSS 3 base score: {{ cve.cvss }}</p>
         {% endif %}
@@ -104,18 +134,18 @@
         <tbody>
           {% for package in cve.packages %}
           <tr>
-            <td rowspan="{{ package.releases | length }}">{{ package.name }}</td>
-            <td>{{ package.releases[0].name }}</td>
-            <td>{{ package.releases[0].status }}</td>
+            <td rowspan="{{ package.package_statuses | length }}">{{ package.name }}</td>
+            <td>{{ package.package_statuses[0].release.name }}</td>
+            <td>{{ package.package_statuses[0].status }}</td>
           </tr>
-          {% for n in range(package.releases | length) %}
-          {% if n > 0 %}
-          <tr>
-            <td>{{ package.releases[n].name }}</td>
-            <td>{{ package.releases[n].status }}</td>
-          </tr>
-          {% endif %}
-          {% endfor %}
+            {% for n in range(package.package_statuses | length) %}
+            {% if n > 0 %}
+            <tr>
+              <td>{{ package.package_statuses[n].release.name }}</td>
+              <td>{{ package.package_statuses[n].status }}</td>
+            </tr>
+            {% endif %}
+            {% endfor %}
           {% endfor %}
         </tbody>
       </table>

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -76,7 +76,14 @@
           <th>CVE</th>
           <th>Package</th>
           {% for release in releases %}
-            <th>Ubuntu {{ release.name }} {{ release.version }} {{ release.support_tag }}</th>
+            <th>
+              <div class="icon-container__icon">
+                <i class="p-icon--placeholder"></i>
+              </div>
+              <div class="icon-container__text">
+                Ubuntu {{ release.name }} {{ release.version }} {{ release.support_tag }}
+              </div>
+            </th>
           {% endfor %}
         </tr>
       </thead>
@@ -89,7 +96,32 @@
               {% endif %}
               <td>{{ package.name }}</td>
               {% for release in releases %}
-                <td>{{ package.get_status_by_codename(release.codename) }}</td>
+                <td>
+                  <div class="icon-container__icon">
+                    {% if release.status == 'DNE' or release.status == 'not-affected' %}
+                      <i class="p-icon--placeholder"></i>
+                    {% else %}
+                      {% if cve.priority == 'unknown' %}
+                        <i class="p-icon--unknown-priority"></i>
+                      {% elif cve.priority == 'negligible' %}
+                        <i class="p-icon--negligible-priority"></i>
+                      {% elif cve.priority == 'low' %}
+                        <i class="p-icon--low-priority"></i>
+                      {% elif cve.priority == 'medium' %}
+                        <i class="p-icon--medium-priority"></i>
+                      {% elif cve.priority == 'high' %}
+                        <i class="p-icon--high-priority"></i>
+                      {% elif cve.priority == 'critical' %}
+                        <i class="p-icon--critical-priority"></i>
+                      {% else %}
+                        <i class="p-icon--placeholder"></i>
+                      {% endif %}
+                    {% endif %}
+                  </div>
+                  <div class="icon-container__text">
+                    {{ package.get_status_by_codename(release.codename) }}
+                  </div>
+                </td>
               {% endfor %}
             </tr>
           {% endfor %}


### PR DESCRIPTION
## Done

Add priority icons to CVE pages and CVE table

## QA

- Check out this feature branch
- Delete the `usn.sqlite3` file
- Run the site using the command `./run serve` or `dotrun`
- Run `dotrun exec python3 webapp/security/fixtures/releases.py`
- Clone [the CVE tracker repo](https://github.com/carkod/ubuntu-cve-tracker/tree/load-cve) and checkout the `load-cve` branch
- Create a virtual environment: `python3 -m venv venv`
- Activate the virtual environment: `. venv/bin/activate`
- Install dependencies: `pip install requests cvss macaroonbakery`
- In the `ubuntu-cve-tracker` repo change into the `scripts` directory
- Run: `python upload-cve.py ../active`
- You will be asked to authenticate via a browser and be presented with a link
- The CVEs will then be uploaded which may take a few minutes
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Check that priority icons are present on some of the CVEs in the table (not all will have them)
- Click through to a CVE page and check that there is a priority icon in the priority box on the top right

## Issue / Card

Fixes #7474

## Screenshots

### Critical priority CVE
![cve_priority_critical](https://user-images.githubusercontent.com/501889/81816385-2aa3e700-9523-11ea-9906-d7e46a5ca466.png)

### High priority CVE
![cve_priority_high](https://user-images.githubusercontent.com/501889/81816389-2bd51400-9523-11ea-9b51-1650af000959.png)

### Low priority CVE
![cve_priority_low](https://user-images.githubusercontent.com/501889/81816390-2bd51400-9523-11ea-85cf-a139b5925377.png)

### Medium priority CVE
![cve_priority_medium](https://user-images.githubusercontent.com/501889/81816393-2d064100-9523-11ea-9f84-52ca40c2f2e0.png)

### Negligible priority CVE
![cve_priority_negligible](https://user-images.githubusercontent.com/501889/81816396-2d9ed780-9523-11ea-80bd-1d439568e703.png)

### Unknown priority CVE
![cve_priority_unknown](https://user-images.githubusercontent.com/501889/81816397-2d9ed780-9523-11ea-92ff-eeee38e1ccb9.png)


### CVE table
![cve_table](https://user-images.githubusercontent.com/501889/81922143-99407d80-95d3-11ea-8d72-6a23e7760940.png)

