### PR TITLE
Fix CVE search redirect

### DIFF
--- a/static/js/src/cve/cve-search.js
+++ b/static/js/src/cve/cve-search.js
@@ -20,22 +20,6 @@ function isValidCveId(value) {
 }
 
 /**
- * Preprends and CVE with `cve-` if not already there
- *
- * @param {string} node
- * @returns {string}
- */
-function constructCveId(value) {
-  const cvePrefixPattern = /^(cve-)/gi;
-
-  if (!value.match(cvePrefixPattern)) {
-    value = `cve-${value}`;
-  }
-
-  return value;
-}
-
-/**
  * isDomNode
  *
  * Checks that the supplied value is a DOM node
@@ -83,4 +67,4 @@ function enableField(field) {
   field.removeAttribute("disabled");
 }
 
-export { isValidCveId, constructCveId, isDomNode, disableField, enableField };
+export { isValidCveId, isDomNode, disableField, enableField };

--- a/static/js/src/cve/cve-search.test.js
+++ b/static/js/src/cve/cve-search.test.js
@@ -1,6 +1,5 @@
 import {
   isValidCveId,
-  constructCveId,
   isDomNode,
   disableField,
   enableField,
@@ -55,16 +54,6 @@ describe("isValidCveId", () => {
     invalidCveIds.forEach((cveId) => {
       expect(isValidCveId(cveId)).toBeFalsy();
     });
-  });
-});
-
-describe("constructCveId", () => {
-  it("prepends `cve-` to ID if missing", () => {
-    expect(constructCveId("1234-1234")).toBe("cve-1234-1234");
-  });
-
-  it("returns full cve ID if in correct format", () => {
-    expect(constructCveId("cve-1234-1234")).toBe("cve-1234-1234");
   });
 });
 

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -1,25 +1,18 @@
-import {
-  isValidCveId,
-  disableField,
-  enableField,
-  constructCveId,
-} from "./cve-search.js";
+import { isValidCveId, disableField, enableField } from "./cve-search.js";
 
 const searchInput = document.querySelector("#q");
 
 function handleCveIdInput(value) {
   const packageInput = document.querySelector("#package");
   const priorityInput = document.querySelector("#priority");
-  const searchButton = document.querySelector("#cve-search-button");
-  const redirectButton = document.querySelector("#cve-redirect-button");
+  const searchButtonText = document.querySelector(".cve-search-text");
+  const searchButtonValidCveText = document.querySelector(
+    ".cve-search-valid-cve-text"
+  );
 
   if (isValidCveId(value)) {
-    const cveId = constructCveId(value);
-
-    redirectButton.setAttribute("href", `/security/${cveId}`);
-
-    redirectButton.classList.remove("u-hide");
-    searchButton.classList.add("u-hide");
+    searchButtonValidCveText.classList.remove("u-hide");
+    searchButtonText.classList.add("u-hide");
 
     disableField(packageInput);
     disableField(priorityInput);
@@ -27,8 +20,8 @@ function handleCveIdInput(value) {
     enableField(packageInput);
     enableField(priorityInput);
 
-    searchButton.classList.remove("u-hide");
-    redirectButton.classList.add("u-hide");
+    searchButtonText.classList.remove("u-hide");
+    searchButtonValidCveText.classList.add("u-hide");
   }
 }
 

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -46,8 +46,10 @@
         </select>
       </div>
       <div class="col-12">
-        <button type="submit" class="p-button--positive" id="cve-search-button">Search</button>
-        <a href="" class="p-button--positive u-hide" id="cve-redirect-button">Go to CVE</a>
+        <button type="submit" class="p-button--positive" id="cve-search-button">
+          <span class="cve-search-text">Search</span>
+          <span class="cve-search-valid-cve-text u-hide">Go to CVE</span>
+        </button>
       </div>
     </div>
   </form>


### PR DESCRIPTION
## Done

Fix CVE search so it doesn't 404 if CVE doesn't exist

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]
- Search for a cve ID that doesn't exist e.g. CVE-1234-1234
- Submit the form and check that the page has 0 results and you don't go to a 404 page