### PR TITLE
Build the Adguard appliance page

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -7,3 +7,11 @@ appliances:
     checksum:
       raspberrypi: "8889a56eadef03196ad1f4f9131d21de5c664625751ae3bd3715dc5a04e4aa87 *plexmediaserver-ubuntu-core-18-pi-arm64.img.xz"
       pc: "ea001bde90753b6e7d620a018c6c9e31a196c48009802e177f60fd6751ba979a *plexmediaserver-ubuntu-core-18-amd64.img.xz"
+  adguard:
+    name: "Adguard"
+    iso_url:
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-ubuntu-core-18-pi-arm64.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-ubuntu-core-18-amd64.img.xz"
+    checksum:
+      raspberrypi: "72dfbc102571fd0c465ef87d2fc8cce51d419836712e7dbd5678e62444d132e5 *adguard-home-ubuntu-core-18-pi-arm64.img.xz"
+      pc: "f904ad1ae804c768a8a0a2ab02617a6589c00ca17d764dccaec0d54b19fd4619 *adguard-home-ubuntu-core-18-amd64.img.xz"

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -16,7 +16,7 @@ azure:
 
 appliance:
   title: Appliance
-  path: /Appliance
+  path: /appliance
 
   children:
     - title: Overview
@@ -39,7 +39,10 @@ appliance:
           hidden: True
     - title: Plex
       path: /appliance/plex
-      persist: True
+      hidden: True
+    - title: Adguard
+      path: /appliance/adguard
+      hidden: True
 aws:
   title: AWS
   path: /aws

--- a/templates/appliance/adguard/index.html
+++ b/templates/appliance/adguard/index.html
@@ -1,0 +1,143 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Adguard | Ubuntu Appliance{% endblock %}
+
+{% block meta_description %}AdGuard Home is a network-wide software for blocking ads & tracking. After you set it up, it'll cover ALL your home devices, and you don't need any client-side software for that.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1-OETrr26H36YpewFgSlCxOaSXSf3QoWpKZV5lc8ONbs/{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-8">
+      <div class="p-media-object u-no-margin--bottom">
+        <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png?w=90" alt="" class="p-media-object__image is-round" height="90" width="90">
+        <div class="p-media-object__details">
+          <h1 class="p-heading--three u-no-margin--bottom">
+            Adguard
+          </h1>
+          <p class="p-muted-heading">Ubuntu Appliance</p>
+          <ul class="p-inline-list--middot u-no-margin--bottom">
+            <li class="p-inline-list__item">By AdGuard, (ameshkov)</li>
+            <li class="p-inline-list__item">Security<br class="u-hide--medium"></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-4 u-align--right">
+      <form class="p-form--inline" action="#">
+        <div class="p-form__group">
+          <label for="platform" class="u-off-screen">Platform</label>
+          <select id="platform">
+            <option value="rpi">Raspberry Pi</option>
+            <option value="pc">PC</option>
+            <option value="intel-nuc">Intel NUC</option>
+          </select>
+        </div>
+        <div class="p-form__group">
+          <input type="submit" class="p-button--positive p-form__control" value="Download">
+        </div>
+      </form>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-10">
+      <img src="https://assets.ubuntu.com/v1/1febeddd-adguard-main-image.png" class="p-image--shadowed" alt="Adguard screenshot" />
+    </div>
+    <div class="col-2 u-align--center">
+      <ul class="p-list row">
+        <li class="p-list__item col-small-1 col-medium-1 col-2">
+          <img src="https://assets.ubuntu.com/v1/21176b69-adguard-advert.png?w=200" class="p-image--shadowed" alt="Adguard screenshot" height="150" width="150">
+        </li>
+        <li class="p-list__item col-small-1 col-medium-1 col-2">
+          <img src="https://assets.ubuntu.com/v1/9eb41b64-adguard-advert-1.png?w=200" class="p-image--shadowed" alt="Adguard screenshot" height="150" width="150">
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--four">Network-wide ads & trackers blocking DNS server</h2>
+      <p>AdGuard Home is a network-wide software for blocking ads & tracking. After you set it up, it'll cover ALL your home devices, and you don't need any client-side software for that.</p>
+      <p>It operates as a DNS server that re-routes tracking domains to a &ldquo;black hole,&rdquo; thus preventing your devices from connecting to those servers. It's based on software we use for our public AdGuard DNS servers &mdash; both share a lot of common code.</p>
+    </div>
+    <div class="col-4">
+      <h2 class="p-heading--four">Snaps in the image</h2>
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png?w=75" alt="" class="p-media-object__image is-round" height="75" width="75">
+        <div class="p-media-object__details">
+          <h3 class="p-heading--5 u-no-margin--bottom u-sv-1">
+            <a href="https://snapcraft.io/adguard-home" class="p-link--external">AdGuard Home</a>
+          </h3>
+          <p class="p-muted-text">By Plex, Inc. (plexinc)</p>
+          <p class="u-sv-1"><span class="p-muted-text">Channel: </span>latest/stable</p>
+          <p class="u-sv-1"><span class="p-muted-text">Version: </span>0.101.0</p>
+          <p><span class="p-muted-text">Published: </span>24 April 2020</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Appliance policies</h2>
+      <p>Every Ubuntu appliance publisher is responsible for providing privacy policies and rights to operate with their brand. More information can be found on the governance page.</p>
+      <p><a href="https://github.com/AdguardTeam/AdGuardHome" class="p-link--external">AdGuard policies</a></p>
+      <p><a href="/appliance/governance">Ubuntu appliance governance&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/cb5ac5c9-privacy-policy.svg" alt="" height="200" width="200">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>The developers</h2>
+      <p>The Adguard Ubuntu appliance is a commercial appliance and the software is produced by developers under the Adguard brand.</p>
+      <p><a href="https://adguard.com/en/welcome.html" class="p-link--external">Developer website</a></p>
+      <p><a href="https://github.com/AdguardTeam/AdGuardHome" class="p-link--external">Contact AdGuard</a></p>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/061edebb-developer.svg" alt="" height="200" width="200">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Get started</h2>
+      <p>Once you have installed AdGuard and set up your AdGuard Ubuntu appliance you will be taken through set up in your browser. If you have any more questions or want to go further, the developers of AdGuard have lots of documentation to help you get started.</p>
+      <a href="https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started" class="p-link--external">Get Started</a>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png?w=200" height="200" width="200">
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Build your own appliance</h2>
+      <p>Making it with Ubuntu is easy. If you have an application that you would like to make a part of the Ubuntu appliance portfolio, read our guidelines and get in touch. Soon you will have a page like this.</p>
+      <a href="/appliance/contact-us" class="p-button--neutral js-invoke-modal">Get in touch</a>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/03d1807c-2+-+Build+your+own+stack+and+prototype+your+application.svg" alt="" height="300" width="400">
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/appliance/adguard/raspberry-pi.html
+++ b/templates/appliance/adguard/raspberry-pi.html
@@ -1,0 +1,129 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install {{ appliance.name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+{% if appliance.iso_url.raspberrypi %}
+<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
+{% endif %}
+
+<section class="p-strip--suru-topped" style="overflow: visible;">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      {% if appliance.iso_url.raspberrypi %}
+      <h1>Install the Ubuntu {{ appliance.name }} appliance for Raspberry Pi</h1>
+      <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
+        <a href="{{ appliance.iso_url.raspberrypi }}">download now</a>.
+        {% include "appliance/shared/_verify-checksums.html" %}
+      </p>
+      {% else %}
+      <h1>Setup your Ubuntu {{ appliance.name }} appliance for Raspberry Pi</h1>
+      {% endif %}
+    </div>
+    <div class="col-4 u-hide--small u-align--center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg",
+        alt="",
+        height="227",
+        width="350",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<hr>
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <div class="js-tab-container">
+      <nav class="p-tabs">
+        <ul class="p-tabs__list" role="tablist">
+          <li class="p-tabs__item" role="presentation">
+            <a href="#ubuntuos" class="p-tabs__link" id="ubuntuos-tab" role="tab" aria-controls="ubuntuos" aria-selected="true">
+              Ubuntu
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#windows" class="p-tabs__link" tabindex="-1" role="tab" id="windows-tab" aria-controls="windows">
+              Windows
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#macos" class="p-tabs__link" tabindex="-1" role="tab" id="macos-tab" aria-controls="macos">
+              macOS
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
+        {% with logo="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <h4 class="p-stepped-list__title">
+              Install the Raspberry Pi Imaging Tool
+            </h4>
+            <p class="p-stepped-list__content">
+              <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager_amd64.deb">
+                Download the Imaging Tool for Ubuntu
+              </a>
+            </p>
+          </li>
+          {% include 'appliance/shared/_steps_pi_2.html' %}
+          {% include 'appliance/shared/_steps_pi_3_ubuntu.html' %}
+          {% with command='cat' %}{% include 'appliance/shared/_steps_pi_4567.html' %}{% endwith %}
+        </ol>
+      </div>
+
+      <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
+        {% with logo="https://assets.ubuntu.com/v1/30574235-windows-logo.svg" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <h4 class="p-stepped-list__title">
+              Install the Raspberry Pi Imaging Tool
+            </h4>
+            <p class="p-stepped-list__content">
+              <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager.exe">
+                Download the Imaging Tool for Windows
+              </a>
+            </p>
+          </li>
+          {% include 'appliance/shared/_steps_pi_2.html' %}
+          {% include 'appliance/shared/_steps_pi_3_windows.html' %}
+          {% with command='type' %}{% include 'appliance/shared/_steps_pi_4567.html' %}{% endwith %}
+        </ol>
+      </div>
+
+      <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
+        {% with logo="https://assets.ubuntu.com/v1/6042056d-MacOS_wordmark.svg" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <h4 class="p-stepped-list__title">
+              Install the Raspberry Pi Imaging Tool
+            </h4>
+            <p class="p-stepped-list__content">
+              <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager.dmg">
+                Download the Imaging Tool for macOS
+              </a>
+            </p>
+          </li>
+          {% include 'appliance/shared/_steps_pi_2.html' %}
+          {% include 'appliance/shared/_steps_pi_3_macos.html' %}
+          {% with command='cat' %}{% include 'appliance/shared/_steps_pi_4567.html' %}{% endwith %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>
+
+{% endblock content %}

--- a/templates/appliance/plex/index.html
+++ b/templates/appliance/plex/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Plex magically organizes your media libraries and streams them to any device – including all your video, music, and photo libraries.{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1zgOl4GCK6O6Clv6oxp-DXDSKYIKO2pvpXaYXALiTlpo/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1zgOl4GCK6O6Clv6oxp-DXDSKYIKO2pvpXaYXALiTlpo/{% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -12,15 +12,15 @@
   <div class="row">
     <div class="col-8">
       <div class="p-media-object u-no-margin--bottom">
-        <img src="https://assets.ubuntu.com/v1/402069bd-plex-media-server.png?w=90" class="p-media-object__image is-round" height="90" width="90">
+        <img src="https://assets.ubuntu.com/v1/402069bd-plex-media-server.png?w=90" alt="" class="p-media-object__image is-round" height="90" width="90">
         <div class="p-media-object__details">
           <h1 class="p-heading--three u-no-margin--bottom">
             Plex Media Server
           </h1>
-          <p class="p-muted-heading"">Ubuntu Appliance</p>
+          <p class="p-muted-heading">Ubuntu Appliance</p>
           <ul class="p-inline-list--middot u-no-margin--bottom">
             <li class="p-inline-list__item">By Plex, Inc. (plexinc)</li>
-            <li class="p-inline-list__item">Entertainment<br class="u-hide--medium "></li>
+            <li class="p-inline-list__item">Entertainment<br class="u-hide--medium"></li>
           </ul>
         </div>
       </div>
@@ -87,7 +87,7 @@
     <div class="col-4">
       <h2 class="p-heading--four">Snaps in the image</h2>
       <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/402069bd-plex-media-server.png?w=75" class="p-media-object__image is-round" height="75" width="75">
+        <img src="https://assets.ubuntu.com/v1/402069bd-plex-media-server.png?w=75" alt="" class="p-media-object__image is-round" height="75" width="75">
         <div class="p-media-object__details">
           <h3 class="p-heading--5 u-no-margin--bottom u-sv-1">
             <a href="https://snapcraft.io/plexmediaserver" class="p-link--external">Plex Media Server</a>
@@ -145,7 +145,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Build your own appliance</h2>
-      <p>Making with Ubuntu is easy. If you have an application that you would like to make a part of the Ubuntu appliance portfolio, read our guidelines and get in touch. Soon you will have a page like this.</p>
+      <p>Making it with Ubuntu is easy. If you have an application that you would like to make a part of the Ubuntu appliance portfolio, read our guidelines and get in touch. Soon you will have a page like this.</p>
       <a href="/appliance/contact-us" class="p-button--neutral js-invoke-modal">Get in touch</a>
     </div>
     <div class="col-4 u-align--center u-hide--small">


### PR DESCRIPTION
## Done
- Build the Adguard appliance page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/adguard
- Check it matched the [copy doc](https://docs.google.com/document/d/1-OETrr26H36YpewFgSlCxOaSXSf3QoWpKZV5lc8ONbs/edit#)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7427

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/81981277-febe5980-9627-11ea-864c-fa7d92e5d6d7.png)

