### PR TITLE
Add the JS to link to the download page

### DIFF
--- a/templates/appliance/adguard/index.html
+++ b/templates/appliance/adguard/index.html
@@ -26,19 +26,9 @@
       </div>
     </div>
     <div class="col-4 u-align--right">
-      <form class="p-form--inline" action="#">
-        <div class="p-form__group">
-          <label for="platform" class="u-off-screen">Platform</label>
-          <select id="platform">
-            <option value="rpi">Raspberry Pi</option>
-            <option value="pc">PC</option>
-            <option value="intel-nuc">Intel NUC</option>
-          </select>
-        </div>
-        <div class="p-form__group">
-          <input type="submit" class="p-button--positive p-form__control" value="Download">
-        </div>
-      </form>
+      {% with app="adguard" %}
+      {% include 'appliance/shared/_download_widget.html' %}
+      {% endwith %}
     </div>
   </div>
 </section>

--- a/templates/appliance/plex/index.html
+++ b/templates/appliance/plex/index.html
@@ -26,19 +26,9 @@
       </div>
     </div>
     <div class="col-4 u-align--right">
-      <form class="p-form--inline" action="#">
-        <div class="p-form__group">
-          <label for="platform" class="u-off-screen">Platform</label>
-          <select id="platform">
-            <option value="rpi">Raspberry Pi</option>
-            <option value="pc">PC</option>
-            <option value="intel-nuc">Intel NUC</option>
-          </select>
-        </div>
-        <div class="p-form__group">
-          <input type="submit" class="p-button--positive p-form__control" value="Download">
-        </div>
-      </form>
+      {% with app="plex" %}
+      {% include 'appliance/shared/_download_widget.html' %}
+      {% endwith %}
     </div>
   </div>
 </section>

--- a/templates/appliance/shared/_download_widget.html
+++ b/templates/appliance/shared/_download_widget.html
@@ -1,0 +1,27 @@
+<form class="p-form--inline js-download">
+  <div class="p-form__group">
+    <label for="platform" class="u-off-screen">Platform</label>
+    <select id="platform" class="js-platform-select">
+      <option value="raspberry-pi">Raspberry Pi</option>
+      <option value="pc">PC</option>
+      <option value="intel-nuc">Intel NUC</option>
+    </select>
+  </div>
+  <div class="p-form__group">
+    <a href="/appliance/{{app}}/raspberry-pi" class="p-button--positive p-form__control js-download-button">Download</a>
+  </div>
+</form>
+<script>
+  (function () {
+    var downloadForm = document.querySelector(".js-download");
+    if (downloadForm) {
+      const linkElement = downloadForm.querySelector('.js-download-button');
+      const selectElement = downloadForm.querySelector('.js-platform-select');
+      if (linkElement && selectElement) {
+        selectElement.addEventListener('change', function() {
+          linkElement.href = window.location.pathname + '/' + selectElement.value;
+        });
+      }
+    }
+  })();
+</script>


### PR DESCRIPTION
## Done
Add the JS to link to the download page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex
- Check that the download button goes to the raspberry-pi thank you page
- Check that when you change the select the link changes
- Try out the /appliance/adguard page

## Issue / Card
Fixes #7497
