### PR TITLE
Add appliance PC setup page

### DIFF
--- a/templates/appliance/adguard/pc.html
+++ b/templates/appliance/adguard/pc.html
@@ -1,0 +1,14 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_pc.html' %}
+{% include 'appliance/adguard/_start-using.html' %}
+
+{% endblock content %}

--- a/templates/appliance/adguard/pc.html
+++ b/templates/appliance/adguard/pc.html
@@ -2,7 +2,7 @@
 
 {% block title %}Install the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop{% endblock title %}
 
-{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop.{% endblock meta_description %}
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliadotnce on your Ubuntu desktop.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
 

--- a/templates/appliance/plex/pc.html
+++ b/templates/appliance/plex/pc.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_pc.html' %}
+
+{% include 'appliance/plex/_start-using.html' %}
+
+{% endblock content %}

--- a/templates/appliance/shared/_install_instructions_intel-nuc.html
+++ b/templates/appliance/shared/_install_instructions_intel-nuc.html
@@ -11,5 +11,5 @@
   <li class="p-list__item is-ticked">A VGA or HDMI cable</li>
   <li class="p-list__item is-ticked">A USB keyboard and a mouse</li>
   <li class="p-list__item is-ticked">A network connection with Internet access</li>
-  <li class="p-list__item is-ticked">An <a href="/download/desktop">Ubuntu Desktop 20.04 LTS image</a></li>
+  <li class="p-list__item is-ticked">An <a href="/download/desktop">Ubuntu 20.04 LTS desktop image</a></li>
 </ul>

--- a/templates/appliance/shared/_install_instructions_pc.html
+++ b/templates/appliance/shared/_install_instructions_pc.html
@@ -1,0 +1,8 @@
+<div class="p-strip is-shallow u-no-padding--top">
+  <p>We will walk you through the steps of flashing your {{ appliance.name }} Ubuntu Appliance on to your Intel NUC and getting logged in.</p>
+</div>
+<hr>
+<h4>What you&rsquo;ll need</h4>
+<ul class="p-list is-split">
+  <li class="p-list__item is-ticked">An PC running <a href="/download/desktop">Ubuntu desktop</a></li>
+</ul>

--- a/templates/appliance/shared/_install_instructions_pc.html
+++ b/templates/appliance/shared/_install_instructions_pc.html
@@ -1,5 +1,5 @@
 <div class="p-strip is-shallow u-no-padding--top">
-  <p>We will walk you through the steps of flashing your {{ appliance.name }} Ubuntu Appliance on to your Intel NUC and getting logged in.</p>
+  <p>We will walk you through the steps of setting up your {{ appliance.name }} Ubuntu Appliance with KVM on your Ubuntu desktop and getting logged in.</p>
 </div>
 <hr>
 <h4>What you&rsquo;ll need</h4>

--- a/templates/appliance/shared/_pc.html
+++ b/templates/appliance/shared/_pc.html
@@ -6,26 +6,14 @@
   <div class="row u-vertically-center">
     <div class="col-8">
       {% if appliance.iso_url.pc %}
-      <h1>Install the Ubuntu {{ appliance.name }} appliance for Intel NUC</h1>
+      <h1>Install the Ubuntu {{ appliance.name }} appliance with KVM on your Ubuntu desktop</h1>
       <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
         <a href="{{ appliance.iso_url.pc }}">download now</a>.
         {% include "appliance/shared/_verify-checksums-pc.html" %}
       </p>
       {% else %}
-      <h1>Setup your Ubuntu {{ appliance.name }} appliance for Raspberry Pi</h1>
+      <h1>Setup your Ubuntu {{ appliance.name }} appliance with KVM on your Ubuntu desktop</h1>
       {% endif %}
-    </div>
-    <div class="col-4 u-hide--small u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg",
-        alt="",
-        height="227",
-        width="350",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
     </div>
   </div>
 </section>
@@ -56,7 +44,7 @@
       </nav>
 
       <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
-        {% with logo="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        {% with logo="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" %}{% include "appliance/shared/_install_instructions_pc.html" %}{% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_ubuntu.html' %}
           {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
@@ -66,7 +54,7 @@
       </div>
 
       <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
-        {% with logo="https://assets.ubuntu.com/v1/30574235-windows-logo.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        {% with logo="https://assets.ubuntu.com/v1/30574235-windows-logo.svg" %}{% include "appliance/shared/_install_instructions_pc.html" %}{% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_windows.html' %}
           {% with command='type' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
@@ -76,7 +64,7 @@
       </div>
 
       <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
-        {% with logo="https://assets.ubuntu.com/v1/6042056d-MacOS_wordmark.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        {% with logo="https://assets.ubuntu.com/v1/6042056d-MacOS_wordmark.svg" %}{% include "appliance/shared/_install_instructions_pc.html" %}{% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_macos.html' %}
           {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}

--- a/templates/appliance/shared/_pc.html
+++ b/templates/appliance/shared/_pc.html
@@ -1,0 +1,91 @@
+{% if appliance.iso_url.pc %}
+<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
+{% endif %}
+
+<section class="p-strip--suru-topped" style="overflow: visible;">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      {% if appliance.iso_url.pc %}
+      <h1>Install the Ubuntu {{ appliance.name }} appliance for Intel NUC</h1>
+      <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
+        <a href="{{ appliance.iso_url.pc }}">download now</a>.
+        {% include "appliance/shared/_verify-checksums-pc.html" %}
+      </p>
+      {% else %}
+      <h1>Setup your Ubuntu {{ appliance.name }} appliance for Raspberry Pi</h1>
+      {% endif %}
+    </div>
+    <div class="col-4 u-hide--small u-align--center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg",
+        alt="",
+        height="227",
+        width="350",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<hr>
+<section class="p-strip is-bordered">
+  <div class="u-fixed-width">
+    <h2>Installation instructions</h2>
+    <div class="js-tab-container">
+      <nav class="p-tabs">
+        <ul class="p-tabs__list" role="tablist">
+          <li class="p-tabs__item" role="presentation">
+            <a href="#ubuntuos" class="p-tabs__link" id="ubuntuos-tab" role="tab" aria-controls="ubuntuos" aria-selected="true">
+              Ubuntu
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#windows" class="p-tabs__link" tabindex="-1" role="tab" id="windows-tab" aria-controls="windows">
+              Windows
+            </a>
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a href="#macos" class="p-tabs__link" tabindex="-1" role="tab" id="macos-tab" aria-controls="macos">
+              macOS
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
+        {% with logo="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        <ol class="p-stepped-list--detailed">
+          {% include 'appliance/shared/_steps_ssh-keys_ubuntu.html' %}
+          {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_setup-kvm.html' %}
+          {% include 'appliance/shared/_steps_pc_thats-it.html' %}
+        </ol>
+      </div>
+
+      <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
+        {% with logo="https://assets.ubuntu.com/v1/30574235-windows-logo.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        <ol class="p-stepped-list--detailed">
+          {% include 'appliance/shared/_steps_ssh-keys_windows.html' %}
+          {% with command='type' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_setup-kvm.html' %}
+          {% include 'appliance/shared/_steps_pc_thats-it.html' %}
+        </ol>
+      </div>
+
+      <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
+        {% with logo="https://assets.ubuntu.com/v1/6042056d-MacOS_wordmark.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        <ol class="p-stepped-list--detailed">
+          {% include 'appliance/shared/_steps_ssh-keys_macos.html' %}
+          {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_setup-kvm.html' %}
+          {% include 'appliance/shared/_steps_pc_thats-it.html' %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>

--- a/templates/appliance/shared/_steps_pc_thats-it.html
+++ b/templates/appliance/shared/_steps_pc_thats-it.html
@@ -1,0 +1,15 @@
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    That’s it
+  </h4>
+  <div class="p-stepped-list__content">
+    <p>
+      Once setup is done, you can login with SSH into Ubuntu Core, using the following command:
+    </p>
+    <pre><code>ssh -p 8022 &lt;Ubuntu SSO user name&gt;@localhost</code></pre>
+    <p>
+      Your user name is your Ubuntu SSO user name.
+    </p>
+  </div>
+</li>

--- a/templates/appliance/shared/_steps_setup-kvm.html
+++ b/templates/appliance/shared/_steps_setup-kvm.html
@@ -1,0 +1,52 @@
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    Set up and install KVM
+  </h4>
+  <div class="p-stepped-list__content">
+    <ol>
+      <li>
+        <p>Install the qemu-kvm package with the following command:</p>
+        <p><code>sudo apt install qemu-kvm</code></p>
+      </li>
+      <li>
+        <p>Run the kvm-ok command to check KVM status and your hardware:</p>
+        <p><code>Kvm-ok</code></p>
+        <p>The message should say:</p>
+        <pre>INFO: /dev/kvm exists KVM acceleration can be used</pre>
+      </li>
+      <li>
+        <p>You can now launch a virtual machine with KVM, using the following command:</p>
+        <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-16-amd64.img,format=raw</code></pre>
+        <div class="p-notification" id="notification">
+          <div class="p-notification__response">
+            <span class="p-notification__status">Note:</span>
+            <p>This command sets up port redirections:</p>
+            <ul>
+              <li><code>localhost:8022</code> is redirecting to port 22 of the virtual machine for accessing it through SSH</li>
+              <li><code>localhost:8090</code> is redirecting to its port 3000</li>
+            </ul>
+          </div>
+        </div>
+      </li>
+      <li>
+        <p>You should now see a window, with your Appliance virtual machine booting inside it</p>
+      </li>
+      <li>
+        <p>The system will boot then become ready to configure. The device will display the prompt “Press enter to configure”</p>
+      </li>
+      <li>
+        <p>Press <code>Enter</code> then select “Start” to begin configuring your network and an administrator account. Follow the instructions on the screen, you will be asked to configure your network and enter your Ubuntu SSO credentials</p>
+      </li>
+      <li>
+        <p>At the end of the process, you will see your credentials to access your Ubuntu Core machine:</p>
+        <ul>
+          <li>This device is registered to &lt;Ubuntu SSO email address&gt;</li>
+          <li>Remote access was enabled via authentication with the SSO user &lt;Ubuntu SSO user name&gt;</li>
+          <li>Public SSH keys were added to the device for remote access</li>
+        </ul>
+        <p>Your user name is your Ubuntu SSO user name.</p>
+      </li>
+    </ol>
+  </div>
+</li>


### PR DESCRIPTION
## Done

- Created a template for PC install instructions
- Added this to Plex and AdGuard

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/adguard/pc and http://0.0.0.0:8001/appliance/plex/pc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it works for the above pages and the [copy doc](https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#)


## Issue / Card

Fixes #7496
