### PR TITLE
Create the OpenHab appliance pages

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -15,3 +15,11 @@ appliances:
     checksum:
       raspberrypi: "72dfbc102571fd0c465ef87d2fc8cce51d419836712e7dbd5678e62444d132e5 *adguard-home-ubuntu-core-18-pi-arm64.img.xz"
       pc: "f904ad1ae804c768a8a0a2ab02617a6589c00ca17d764dccaec0d54b19fd4619 *adguard-home-ubuntu-core-18-amd64.img.xz"
+  openhab:
+    name: "OpenHAB"
+    iso_url:
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-pi-arm64.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-amd64.img.xz"
+    checksum:
+      raspberrypi: "51799ebbf8e56a2ba2b144438136acbf56ad56950f563729df615c009198be2b *openhab-ubuntu-core-18-pi-arm64.img.xz"
+      pc: "19dab5bec3b5d7840b3655cd8b6c2d33d0bd9cb1073dfa6bff5890eaba83fe9d *openhab-ubuntu-core-18-amd64.img.xz"

--- a/templates/appliance/adguard/index.html
+++ b/templates/appliance/adguard/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Adguard | Ubuntu Appliance{% endblock %}
 
-{% block meta_description %}AdGuard Home is a network-wide software for blocking ads & tracking. After you set it up, it'll cover ALL your home devices, and you don't need any client-side software for that.{% endblock %}
+{% block meta_description %}Build your Adgaurd appliance with Ubuntu Appliance images with preinstalled snaps. AdGuard Home is a network-wide software for blocking ads & tracking.{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1-OETrr26H36YpewFgSlCxOaSXSf3QoWpKZV5lc8ONbs/{% endblock meta_copydoc %}
 
@@ -69,6 +69,33 @@
       <p>It operates as a DNS server that re-routes tracking domains to a &ldquo;black hole,&rdquo; thus preventing your devices from connecting to those servers. It's based on software we use for our public AdGuard DNS servers &mdash; both share a lot of common code.</p>
     </div>
     <div class="col-4">
+      <h5 class="u-no-margin--bottom u-no-padding--top">Relevant links</h5>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="https://adguard.com/en/privacy.html">AdGuard Home Privacy Policies</a></li>
+        <li class="p-list__item"><a href="https://adguard.com">AdGuard Home website</a></li>
+        <li class="p-list__item"><a href="https://adguard.com/en/rewards.html">AdGuard Home developer license</a></li>
+        <li class="p-list__item"><a href="https://github.com/AdguardTeam/AdGuardHome/issues">AdGuard Home issue tracker</a></li>
+        <li class="p-list__item"><a href="/appliance/governance">Ubuntu appliance governance</a></li>
+      </ul>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Privacy compliance</h5>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">EU GDPR</li>
+        <li class="p-list__item is-ticked">California law</li>
+      </ul>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Base</h5>
+      <p>core20</p>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Date published</h5>
+      <p>YYYY-MM-DD</p>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Security maintenance until</h5>
+      <p>YYYY-MM-DD</p>
+    </div>
+  </div>
+</section>
+
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <div class="col-6">
       <h2 class="p-heading--four">Snaps in the image</h2>
       <div class="p-media-object">
         <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png?w=75" alt="" class="p-media-object__image is-round" height="75" width="75">
@@ -76,7 +103,7 @@
           <h3 class="p-heading--5 u-no-margin--bottom u-sv-1">
             <a href="https://snapcraft.io/adguard-home" class="p-link--external">AdGuard Home</a>
           </h3>
-          <p class="p-muted-text">By Plex, Inc. (plexinc)</p>
+          <p class="p-muted-text">By AdGuard, (ameshkov)</p>
           <p class="u-sv-1"><span class="p-muted-text">Channel: </span>latest/stable</p>
           <p class="u-sv-1"><span class="p-muted-text">Version: </span>0.101.0</p>
           <p><span class="p-muted-text">Published: </span>24 April 2020</p>
@@ -86,48 +113,39 @@
   </div>
 </section>
 
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <div class="col-6">
+      <h4>This appliance works on:</h4>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
+      <a href="/appliance/adguard/raspberry-pi" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">Raspberry Pi</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=200" alt="" style="margin:1rem 0; width: 85%;">
+        </div>
+      </a>
+      <p><a href="/appliance/adguard/raspberry-pi">Install on Raspberry&nbsp;Pi</a></p>
+    </div>
+
+    <div class="col-2">
+      <a href="/appliance/adguard/intel-nuc" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">NUC</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=200" style="margin:1rem 0; width: 85%;">
+        </div>
+      </a>
+      <p><a href="/appliance/adguard/intel-nuc">Install on NUC</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2>Appliance policies</h2>
-      <p>Every Ubuntu appliance publisher is responsible for providing privacy policies and rights to operate with their brand. More information can be found on the governance page.</p>
-      <p><a href="https://github.com/AdguardTeam/AdGuardHome" class="p-link--external">AdGuard policies</a></p>
-      <p><a href="/appliance/governance">Ubuntu appliance governance&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/cb5ac5c9-privacy-policy.svg" alt="" height="200" width="200">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h2>The developers</h2>
-      <p>The Adguard Ubuntu appliance is a commercial appliance and the software is produced by developers under the Adguard brand.</p>
-      <p><a href="https://adguard.com/en/welcome.html" class="p-link--external">Developer website</a></p>
-      <p><a href="https://github.com/AdguardTeam/AdGuardHome" class="p-link--external">Contact AdGuard</a></p>
-    </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/061edebb-developer.svg" alt="" height="200" width="200">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2>Get started</h2>
-      <p>Once you have installed AdGuard and set up your AdGuard Ubuntu appliance you will be taken through set up in your browser. If you have any more questions or want to go further, the developers of AdGuard have lots of documentation to help you get started.</p>
-      <a href="https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started" class="p-link--external">Get Started</a>
-    </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png?w=200" height="200" width="200">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Build your own appliance</h2>

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -34,7 +34,7 @@
         <h3 class="p-heading--five u-no-padding--top">Plex</h3>
         <hr />
         <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" style="height:32px; margin-top:2rem;">
+          <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" alt="" style="height:32px; margin-top:2rem;">
         </div>
       </a>
     </div>
@@ -43,7 +43,7 @@
         <h3 class="p-heading--five u-no-padding--top">NextCloud</h3>
         <hr />
         <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png" style="height:62px; margin-top:1.25rem;">
+          <img src="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png" alt="" style="height:62px; margin-top:1.25rem;">
         </div>
       </a>
     </div>
@@ -52,7 +52,7 @@
         <h3 class="p-heading--five u-no-padding--top">Adguard</h3>
         <hr />
         <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png" style="height:62px; margin-top:1.25rem;">
+          <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png" alt="" style="height:62px; margin-top:1.25rem;">
         </div>
       </a>
     </div>
@@ -61,7 +61,7 @@
         <h3 class="p-heading--five u-no-padding--top">FRRouting</h3>
         <hr />
         <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/6111e099-FRR.png" style="height:72px; margin-top:1rem;">
+          <img src="https://assets.ubuntu.com/v1/6111e099-FRR.png" alt="" style="height:72px; margin-top:1rem;">
         </div>
       </a>
     </div>

--- a/templates/appliance/openhab/_start-using.html
+++ b/templates/appliance/openhab/_start-using.html
@@ -1,0 +1,30 @@
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h2>
+          Start using your {{ appliance.name }} Ubuntu Appliance
+        </h2>
+        <p>
+          When you start openHAB for the first time, it only starts the dashboard. So let's have a look at it: open a browser and browse to your openHAB dashboard:
+        </p>
+        <p>
+          <code>http://&lt;IP-of-your-machine&gt;:8080</code>
+        </p>
+        <p>
+          Now you can follow the instructions on the screen to get started using your new openHAB Ubuntu Appliance. For more information or more documentation on what to do next, the <a href="https://www.openhab.org/">openHAB website</a> is the best place to go next.
+        </p>
+      </div>
+    </div>
+    <div class="col-6 u-hide--small u-align--center">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/5727f492-openhab-first-screen.jpg",
+        alt="Openhab wizard screen",
+        width="988",
+        height="704",
+        hi_def=True,
+        loading="lazy",
+        ) | safe}}
+      </div>
+    </div>
+  </section>

--- a/templates/appliance/openhab/index.html
+++ b/templates/appliance/openhab/index.html
@@ -1,0 +1,175 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}OpenHAB | Ubuntu Appliance{% endblock %}
+
+{% block meta_description %}Build your OpenHAB appliance with Ubuntu Appliance images with preinstalled snaps. The open Home Automation Bus is technology agnostic home automation platform which runs as the center of your smart home.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/14sEgchP6BUjnUtJt67XJ-fKl7k8dAevaf5EJac9Pmyc/{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-8">
+      <div class="p-media-object u-no-margin--bottom">
+        <img src="https://assets.ubuntu.com/v1/f4632e06-openhab-logo.png?w=90" alt="" class="p-media-object__image is-round" height="90" width="90">
+        <div class="p-media-object__details">
+          <h1 class="p-heading--three u-no-margin--bottom">
+            OpenHAB
+          </h1>
+          <p class="p-muted-heading">Ubuntu Appliance</p>
+          <ul class="p-inline-list--middot u-no-margin--bottom">
+            <li class="p-inline-list__item">By openHAB Foundation e.V. (openhab)</li>
+            <li class="p-inline-list__item">Smart Home<br class="u-hide--medium"></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-4 u-align--right">
+      <form class="p-form--inline" action="#">
+        <div class="p-form__group">
+          <label for="platform" class="u-off-screen">Platform</label>
+          <select id="platform">
+            <option value="rpi">Raspberry Pi</option>
+            <option value="pc">PC</option>
+            <option value="intel-nuc">Intel NUC</option>
+          </select>
+        </div>
+        <div class="p-form__group">
+          <input type="submit" class="p-button--positive p-form__control" value="Download">
+        </div>
+      </form>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-10">
+      <img src="https://assets.ubuntu.com/v1/8d38f054-openhab-screenshot-4.png" class="p-image--shadowed" alt="OpenHAB screenshot" />
+    </div>
+    <div class="col-2 u-align--center">
+      <ul class="p-list row">
+        <li class="p-list__item col-small-1 col-medium-1 col-2">
+          <img src="https://assets.ubuntu.com/v1/07b4d31f-openhab-screenshot-2.png?w=200" class="p-image--shadowed" alt="OpenHAB screenshot" height="150" width="150">
+        </li>
+        <li class="p-list__item col-small-1 col-medium-1 col-2">
+          <img src="https://assets.ubuntu.com/v1/a0d79df1-openhab-screenshot-3.png?w=200" class="p-image--shadowed" alt="OpenHAB screenshot" height="150" width="150">
+        </li>
+        <li class="p-list__item col-small-1 col-medium-1 col-2">
+          <img src="https://assets.ubuntu.com/v1/56268be0-openhab-screenshot-1.png?w=200" class="p-image--shadowed" alt="OpenHAB screenshot" height="150" width="150">
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--four">Empowering the smart home</h2>
+      <p>The open Home Automation Bus (openHAB, pronounced ˈəʊpənˈhæb) is an open source, technology agnostic home automation platform which runs as the center of your smart home!</p>
+      <p>Some of openHAB's strengths are:</p>
+      <ul>
+        <li>Its ability to integrate a multitude of other devices and systems. openHAB includes other home automation systems, (smart) devices and other technologies into a single solution</li>
+        <li>To provide a uniform user interface and a common approach to automation rules across the entire system, regardless of the number of manufacturers and sub-systems involved</li>
+        <li>Giving you the most flexible tool available to make almost any home automation wish come true; if you can think it, odds are that you can implement it with openHAB</li>
+      </ul>
+      <p>When home automation just seems to work, it is always the result of hard work. Home automation is fascinating and requires a considerable investment of your time. Here are some key considerations especially for new users. To be successful, you will need to:</p>
+      <ul>
+        <li>Start slowly and one step at a time</li>
+        <li>Be prepared to learn</li>
+        <li>Remain flexible in how you want to achieve your goal</li>
+        <li>Celebrate all the small successes</li>
+      </ul>
+      <p>Remember, openHAB is just a computer program. The computer will only do what you tell it to do. openHAB can provide many default solutions that are easy to setup. On the flip side, the more you insist that everything should look and work exactly as you want it, the more work you will have to do. openHAB is fully customizable, but doing so will require substantial effort on your part.</p>
+    </div>
+    <div class="col-4">
+      <h5 class="u-no-margin--bottom u-no-padding--top">Relevant links</h5>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="https://www.openhab.org/privacy.html">OpenHAB Privacy Policies</a></li>
+        <li class="p-list__item"><a href="https://www.openhab.org/">OpenHAB website</a></li>
+        <li class="p-list__item"><a href="https://github.com/openhab">OpenHAB source code</a></li>
+        <li class="p-list__item"><a href="/appliance/governance">Ubuntu appliance governance</a></li>
+      </ul>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Privacy compliance</h5>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">EU GDPR</li>
+        <li class="p-list__item is-ticked">California law</li>
+      </ul>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Base</h5>
+      <p>core20</p>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Date published</h5>
+      <p>YYYY-MM-DD</p>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Security maintenance until</h5>
+      <p>YYYY-MM-DD</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-heading--four">Snaps in the image</h2>
+      <div class="p-media-object">
+        <img src="https://assets.ubuntu.com/v1/f4632e06-openhab-logo.png?w=75" alt="" class="p-media-object__image is-round" height="75" width="75">
+        <div class="p-media-object__details">
+          <h3 class="p-heading--5 u-no-margin--bottom u-sv-1">
+            <a href="https://snapcraft.io/openhab" class="p-link--external">openhab</a>
+          </h3>
+          <p class="p-muted-text">By openHAB Foundation e.V. (openhab)</p>
+          <p class="u-sv-1"><span class="p-muted-text">Channel: </span>latest/stable</p>
+          <p class="u-sv-1"><span class="p-muted-text">Version: </span>2.5.4</p>
+          <p><span class="p-muted-text">Published: </span>4 May 2020</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <div class="col-6">
+      <h4>This appliance works on:</h4>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
+      <a href="/appliance/openhab/raspberry-pi" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">Raspberry Pi</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=200" alt="" style="margin:1rem 0; width: 85%;">
+        </div>
+      </a>
+      <p><a href="/appliance/openhab/raspberry-pi">Install on Raspberry&nbsp;Pi</a></p>
+    </div>
+
+    <div class="col-2">
+      <a href="/appliance/openhab/intel-nuc" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">NUC</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=200" style="margin:1rem 0; width: 85%;">
+        </div>
+      </a>
+      <p><a href="/appliance/openhab/intel-nuc">Install on NUC</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Build your own appliance</h2>
+      <p>Making it with Ubuntu is easy. If you have an application that you would like to make a part of the Ubuntu appliance portfolio, read our guidelines and get in touch. Soon you will have a page like this.</p>
+      <a href="/appliance/contact-us" class="p-button--neutral js-invoke-modal">Get in touch</a>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/03d1807c-2+-+Build+your+own+stack+and+prototype+your+application.svg" alt="" height="300" width="400">
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/appliance/openhab/intel-nuc.html
+++ b/templates/appliance/openhab/intel-nuc.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_intel-nuc.html' %}
+
+{% include 'appliance/openhab/_start-using.html' %}
+
+{% endblock content %}

--- a/templates/appliance/openhab/raspberry-pi.html
+++ b/templates/appliance/openhab/raspberry-pi.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install {{ appliance.name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_raspberry-pi.html' %}
+
+{% include 'appliance/openhab/_start-using.html' %}
+
+{% endblock content %}

--- a/templates/appliance/plex/index.html
+++ b/templates/appliance/plex/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Plex Media Server | Ubuntu Appliance{% endblock %}
 
-{% block meta_description %}Plex magically organizes your media libraries and streams them to any device – including all your video, music, and photo libraries.{% endblock %}
+{% block meta_description %}Build your Plex appliance with Ubuntu Appliance images with preinstalled snaps. Plex magically organizes your media libraries and streams them to any device – including all your video, music, and photo libraries.{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1zgOl4GCK6O6Clv6oxp-DXDSKYIKO2pvpXaYXALiTlpo/{% endblock meta_copydoc %}
 
@@ -73,9 +73,9 @@
   <div class="row">
     <div class="col-8">
       <h2 class="p-heading--four">Plex magically organizes your media libraries and streams them to any device</h2>
-      <p>Plex magically organizes your media libraries and streams them to any device – including all your video, music, and photo libraries. With a Plex Pass, supported tuner, and digital antenna, you can also watch and record FREE over-the-air broadcast TV, including major networks. You can also enjoy podcasts Plus Plex News – the most balanced and comprehensive personalized video newsfeed out there. </p>
+      <p>Plex magically organizes your media libraries and streams them to any device &mdash; including all your video, music, and photo libraries. With a Plex Pass, supported tuner, and digital antenna, you can also watch and record FREE over-the-air broadcast TV, including major networks. You can also enjoy podcasts Plus Plex News &mdash; the most balanced and comprehensive personalized video newsfeed out there. </p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Magically organize all your personal media – photos, music, movies, shows, even DVR-ed TV – and stream it to any device in a beautiful, simple interface, and Plex adds rich descriptions, artwork, and other related information</li>
+        <li class="p-list__item is-ticked">Magically organize all your personal media &mdash; photos, music, movies, shows, even DVR-ed TV &mdash; and stream it to any device in a beautiful, simple interface, and Plex adds rich descriptions, artwork, and other related information</li>
         <li class="p-list__item is-ticked">Podcasts are here! Search for your favorites or discover new ones through personalized recommendations. Plus: 30-second skip, variable speed playback, rich discovery, and full Plex-style support for cross-device playback status (including On Deck, so you can pick back up where you left off on any device)</li>
         <li class="p-list__item is-ticked">Get personalized and trusted video news from over 190 global publisher partners (and growing!), including CBS, Financial Times, Euronews, and top local news sources for over 80% of markets in the US</li>
         <li class="p-list__item is-ticked">Cut the cord! Go premium with a Plex Pass and use Plex Live TV & DVR so you can watch and record free over-the-air HD TV, like NBC, ABC, CBS, and FOX, with any supported digital antenna and tuner</li>
@@ -85,6 +85,31 @@
       </ul>
     </div>
     <div class="col-4">
+      <h5 class="u-no-margin--bottom u-no-padding--top">Relevant links</h5>
+      <ul class="p-list">
+        <li class="p-list__item"><a href="https://www.plex.tv/en-gb/about/privacy-legal/">Plex Media Server Policies</a></li>
+        <li class="p-list__item"><a href="https://www.plex.tv/">Plex Media Server website</a></li>
+        <li class="p-list__item"><a href="https://support.plex.tv/articles/204096476-license-information/">Plex Media Server license</a></li>
+        <li class="p-list__item"><a href="/appliance/governance">Ubuntu appliance governance</a></li>
+      </ul>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Privacy compliance</h5>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">EU GDPR</li>
+        <li class="p-list__item is-ticked">California law</li>
+      </ul>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Base</h5>
+      <p>core20</p>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Date published</h5>
+      <p>YYYY-MM-DD</p>
+      <h5 class="u-no-margin--bottom u-no-padding--top">Security maintenance until</h5>
+      <p>YYYY-MM-DD</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <div class="col-6">
       <h2 class="p-heading--four">Snaps in the image</h2>
       <div class="p-media-object">
         <img src="https://assets.ubuntu.com/v1/402069bd-plex-media-server.png?w=75" alt="" class="p-media-object__image is-round" height="75" width="75">
@@ -102,46 +127,39 @@
   </div>
 </section>
 
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <div class="col-6">
+      <h4>This appliance works on:</h4>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-2">
+      <a href="/appliance/plex/raspberry-pi" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">Raspberry Pi</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=200" alt="" style="margin:1rem 0; width: 85%;">
+        </div>
+      </a>
+      <p><a href="/appliance/plex/raspberry-pi">Install on Raspberry&nbsp;Pi</a></p>
+    </div>
+
+    <div class="col-2">
+      <a href="/appliance/plex/intel-nuc" class="p-link--soft">
+        <h3 class="p-heading--five u-no-padding--top">NUC</h3>
+        <hr />
+        <div class="u-align--center">
+          <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=200" style="margin:1rem 0; width: 85%;">
+        </div>
+      </a>
+      <p><a href="/appliance/plex/intel-nuc">Install on NUC</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2>Appliance policies</h2>
-      <p>Every Ubuntu appliance publisher is responsible for providing privacy policies and rights to operate with their brand. More information can be found on the governance page.</p>
-      <a href="https://www.plex.tv/en-gb/about/privacy-legal/" class="p-link--external">Plex Media Server Policies</a>
-    </div>
-    <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/cb5ac5c9-privacy-policy.svg" alt="" height="200" width="200">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h2>The developers</h2>
-      <p>The Plex media Ubuntu appliance is a commercial appliance and the software is produced by developers at Plexinc.</p>
-      <a href="https://plex.tv" class="p-link--external">Plex.tv</a>
-    </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" alt="" height="100" width="250">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2>Get started</h2>
-      <p>Once you have installed and set up your Plex Media Server Ubuntu appliance you will be taken through set up in your browser. If you have any more questions or want to go further, the developers of Plex Media Server have lots of documentation to help you get started.</p>
-      <a href="https://snapcraft.io/plexmediaserver" class="p-link--external">Get Started</a>
-    </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/402069bd-plex-media-server.png?w=200" height="200" width="200">
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Build your own appliance</h2>


### PR DESCRIPTION
## Done
Create the OpenHab appliance pages.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/openhab
- Check it matches the [copy doc](https://docs.google.com/document/d/14sEgchP6BUjnUtJt67XJ-fKl7k8dAevaf5EJac9Pmyc/edit#)
- Go to the instructions page: http://0.0.0.0:8001/appliance/openhab/raspberry-pi
- Check it matches the [copy doc](https://docs.google.com/document/d/19BL4l1m7F_jE-GkMGxg19KG1SsZtqzjLAFuyLngSy9Y/edit)
- Check it matches [the design](https://app.zeplin.io/project/5eb3d16a91c4117789940141/screen/5ebd0f192d60fe1b8e8aa73c)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7426