### PR TITLE
Add /appliance/openhab/pc page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -43,6 +43,10 @@ appliance:
     - title: Adguard
       path: /appliance/adguard
       hidden: True
+    - title: OpenHAB
+      path: /appliance/openhab
+      hidden: True
+
 aws:
   title: AWS
   path: /aws

--- a/templates/appliance/adguard/pc.html
+++ b/templates/appliance/adguard/pc.html
@@ -2,13 +2,14 @@
 
 {% block title %}Install the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop{% endblock title %}
 
-{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliadotnce on your Ubuntu desktop.{% endblock meta_description %}
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop with KVM.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 
 {% include 'appliance/shared/_pc.html' %}
+
 {% include 'appliance/adguard/_start-using.html' %}
 
 {% endblock content %}

--- a/templates/appliance/openhab/pc.html
+++ b/templates/appliance/openhab/pc.html
@@ -4,12 +4,12 @@
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop with KVM.{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 
 {% include 'appliance/shared/_pc.html' %}
 
-{% include 'appliance/plex/_start-using.html' %}
+{% include 'appliance/openhab/_start-using.html' %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Add PC install page for openhab
- Add openhab to the navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/openhab/pc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page looks like the others, but with openhab branding

