### PR TITLE
Make cookie message last 10 seconds

### DIFF
--- a/static/js/src/core.js
+++ b/static/js/src/core.js
@@ -7,9 +7,7 @@ createNav({ showLogins: false });
 // Initalise the cookie policy notification.
 
 var options = {
-  content: `We use cookies to improve your experience. By your continued use of
-  this site you accept such use.<br /> This notice will disappear by
-  itself.`,
-  duration: 1000
+  content: `We use cookies to improve your experience. By your continued use of this site you accept such use.<br /> This notice will disappear by itself.`,
+  duration: 10000
 };
 cookiePolicy(options);


### PR DESCRIPTION
## Done

- Make cookie message last 10 seconds, it was mistakenly 1 second

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in an *incognito* web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the cookie message lasts longer

