### PR TITLE
Build core and snaps takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1015,6 +1015,13 @@
           type="whitepaper" %}
       {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Solving the software update challenge for IoT devices",
+      description="How Ubuntu Core transforms over-the-air software updates",
+      slug="snapd-whitepaper",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
     </div>
 </section>
 {% endblock content %}

--- a/templates/engage/snapd-whitepaper.md
+++ b/templates/engage/snapd-whitepaper.md
@@ -1,0 +1,32 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Solving the software update challenge for IoT devices"
+  meta_description: "How Ubuntu Core transforms over-the-air software updates"
+  meta_image: https://assets.ubuntu.com/v1/4f290dac-core_and_snaps_meta_image.png
+  meta_copydoc: https://docs.google.com/document/d/1UeqqXVwATZCs_eZu3Wlj6jTGCqR7glnBbnpD0-4Iiu0/
+  header_title: "Solving the software update challenge for IoT devices"
+  header_subtitle: "How Ubuntu Core transforms over-the-air software updates"
+  header_image: "https://assets.ubuntu.com/v1/bd62a456-ubuntucore-snapcraft-logos.svg"
+  header_image_width: "280"
+  header_image_height: "188"
+  header_url: "#register-section"
+  header_cta: Download whitepaper
+  header_cta_class: p-button--positive
+  header_class: p-engage-banner--grad
+  form_include: en
+  form_id: 3480
+  form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/Over-the-air%20software_12.05.20.pdf"
+---
+
+With the modern proliferation of IoT devices, delivering reliable software updates to low-powered, inaccessible, and often remotely administered embedded systems has become a major challenge. With traditional update mechanisms, faulty updates can cause IoT devices to become unstable, and fixing them requires costly manual intervention through on-site engineer visits or device recalls.
+
+Ubuntu Core solves the update problem for IoT devices regardless of fleet scale. Packages on Ubuntu Core are delivered through snaps – a secure, confined, dependency-free, cross-platform Linux packaging system – which enable automated and transactional updates that are either 100% successful, or are not installed.
+
+In this whitepaper, you will learn:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">How the design of snaps makes Ubuntu Core inherently secure and easy to maintain</li>
+  <li class="p-list__item is-ticked">How vendors can deliver automated updates to devices while retaining complete control over which users receive updates, and when</li>
+  <li class="p-list__item is-ticked">How delta updates save bandwidth and reduce cost of ownership for IoT devices</li>
+</ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
   {% include "takeovers/_eu-kubernetes-event.html" %}
   {% include "takeovers/_azure-webinar-takeover.html" %}
   {% include "takeovers/_iot-device-management-whitepaper.html" %}
+  {% include "takeovers/_snapd-takeover.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_snapd-takeover.html
+++ b/templates/takeovers/_snapd-takeover.html
@@ -5,7 +5,7 @@ header_image="https://assets.ubuntu.com/v1/bd62a456-ubuntucore-snapcraft-logos.s
 header_image_width="280",
 header_image_height="188",
 image_hide_small=true,
-primary_url="/engage/snapd-whitepaper",
+primary_url="/engage/snapd-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_IOT_Core_Whitepaper_Snapd",
 primary_cta="Download Whitepaper",
 lang="",
 locale="" %}

--- a/templates/takeovers/_snapd-takeover.html
+++ b/templates/takeovers/_snapd-takeover.html
@@ -1,0 +1,13 @@
+{% with title="Solving the software update challenge for IoT devices",
+subtitle="How Ubuntu Core transforms over-the-air software updates",
+class="",
+header_image="https://assets.ubuntu.com/v1/bd62a456-ubuntucore-snapcraft-logos.svg",
+header_image_width="280",
+header_image_height="188",
+image_hide_small=true,
+primary_url="/engage/snapd-whitepaper",
+primary_cta="Download Whitepaper",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -134,5 +134,7 @@
 {% include "takeovers/_azure-webinar-takeover.html" %}
 <p>13 May 2020</p>
 {% include "takeovers/_iot-device-management-whitepaper.html" %}
+<p>15 May 2020</p>
+{% include "takeovers/_snapd-takeover.html" %}
 
 {% endblock %}


### PR DESCRIPTION
## Done

Built the takeover and engage page for core and snaps whitepaper

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Reload the page until you see the "Solving the software update challenge for IoT devices" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1UYzDr_lRCTESFY9TodAZw_CLqR48ADfdwXmEH9nCZ-w/edit#gid=2113339190)
- Click through to the engage page
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1UYzDr_lRCTESFY9TodAZw_CLqR48ADfdwXmEH9nCZ-w/edit#gid=1271849439)

## Issue / Card

Fixes #7340 