### PR TITLE
Fix /uasd table of contents

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/_toc.html
+++ b/templates/legal/ubuntu-advantage-service-description/_toc.html
@@ -10,7 +10,10 @@
       <li><a href="#uasd-desktop-support">Desktop support</a></li>
       <li><a href="#uasd-add-ons">Add-Ons</a></li>
       <li><a href="#uasd-maas-support">MAAS Support</a></li>
-      <li><a href="/legal/data-privacy/2016-02-08">08 February 2016&nbsp;&rsaquo;</a></li>
+      <li><a href="#uasd-software">Software</a></li>
+      <li><a href="#uasd-professional-support">Professional Support Services</a></li>
+      <li><a href="#uasd-ua-support-services">Ubuntu Advantage Support Services Process</a></li>
+      <li><a href="#uasd-definitions">Definitions</a></li>
     </ul>
   </nav>
 </div>


### PR DESCRIPTION
## Done

- update the toc on the Ubuntu Advantage Service Description doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/ubuntu-advantage-service-description
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the TOC has all the h2's from the page

## Screenshots

![image](https://user-images.githubusercontent.com/441217/82041850-c27b0f80-96a0-11ea-897c-55fbc8f0b59d.png)
