### PR TITLE
Fix error in order_by so it works in PostgreSQL

### DIFF
--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -61,7 +61,9 @@ class Notice(Base):
     cves = relationship("CVE", secondary=notice_cves)
     references = relationship("Reference", secondary=notice_references)
     releases = relationship(
-        "Release", secondary=notice_releases, order_by="-Release.release_date"
+        "Release",
+        secondary=notice_releases,
+        order_by="desc(Release.release_date)",
     )
 
 


### PR DESCRIPTION
## Done
Fix the order by so it does not error when the backend is PostgreSQL

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- Make sure the page renders
