### PR TITLE
Update /tco-calculator page title

### DIFF
--- a/templates/tco-calculator/index.html
+++ b/templates/tco-calculator/index.html
@@ -1,6 +1,6 @@
 {% extends "tco-calculator/_base_tco_calculator.html" %}
 
-{% block title %}TCO calculator{% endblock %}
+{% block title %}Private cloud TCO calculator{% endblock %}
 
 {% block meta_description %}{% endblock meta_description %}
 


### PR DESCRIPTION
## Done

- "TCO calculator" -> "Private cloud TCO calculator"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the [page](https://ubuntu-com-canonical-web-and-design-pr-7516.run.demo.haus/tco-calculator) matches the [copy doc](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit#heading=h.c6wjbvvp8mcm)
