### PR TITLE
Slight copy change and addition of link on /WSL

### DIFF
--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -43,7 +43,8 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Develop cross-platform</h3>
-      <p>Build and debug Linux applications  with Windows tools like Visual Studio Code, Visual Studio, and JetBrains IDE before deploying to the cloud.</p>
+      <p>Build and debug Linux applications  with Windows tools like Visual Studio Code, Visual Studio, and JetBrains IDEs before deploying to the cloud.</p>
+      <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/410412">Register for the “Kubernetes on Windows with WSL2” webinar</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Manage IT infrastructure</h3>


### PR DESCRIPTION

## Done
Updated to ubuntu.com/wsl

1.  Changed IDE -> IDEs

2. Added <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/410412">Register for the “Kubernetes on Windows with WSL2” webinar</a></p>
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the demo against the [copy doc](https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit?ts=5ec21850)


