### PR TITLE
Add open source mandate takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,11 +28,11 @@
 
 {% block takeover_content %}
   {# ALL #}
-  {% include "takeovers/_2004-takeover.html" %}
   {% include "takeovers/_eu-kubernetes-event.html" %}
   {% include "takeovers/_azure-webinar-takeover.html" %}
   {% include "takeovers/_iot-device-management-whitepaper.html" %}
   {% include "takeovers/_snapd-takeover.html" %}
+  {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_moving-to-opensource-whitepaper.html
+++ b/templates/takeovers/_moving-to-opensource-whitepaper.html
@@ -1,0 +1,16 @@
+{% with title="Embracing the open source mandate",
+subtitle="85% of enterprises have an open source mandate, preference or are exploring",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg",
+image_height="116",
+image_width="311",
+image_hide_small=true,
+equal_cols="false",
+primary_url="https://ubuntu.com/engage/moving-to-opensource-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_UAI_Whitepaper_MovingtoOpenSource",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

Add takeover for "Embracing the open source mandate" engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Refresh until you get the "Embracing the open source mandate" takeover
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #2761