### PR TITLE
Add 20.04 row to RasPi page. Change SHA256SUMS link to cdimages. Add support for patch numbers in download link generation

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -96,7 +96,8 @@
 <section class="p-strip--light is-shallow u-no-padding--bottom {% if releases.latest.short_version < releases.lts.short_version %}is-bordered{% endif %}">
   <div class="row u-equal-height">
     <div class="col-3">
-      <h4>Ubuntu {{ releases.lts.full_version }} LTS</h4>
+      <h4 class="u-no-margin--bottom">Ubuntu {{ releases.lts.full_version }} LTS</h4>
+      <p class="p-muted-heading">Recommended</p>
       <p>The version of Ubuntu with long term support, until {{ releases.lts.eol }}.</p>
     </div>
     <div class="col-3">
@@ -177,6 +178,48 @@
   </div>
 </section>
 {% endif %}
+
+{# 18.04 row #}
+<section class="p-strip is-bordered is-shallow u-no-padding--bottom">
+  <div class="row u-equal-height">
+    <div class="col-3">
+      <h4>Ubuntu 18.04</h4>
+      <p>The previous LTS version of Ubuntu for projects without 20.04 support.</p>
+    </div>
+    <div class="col-3">
+      <p class="u-hide--small u-sv2">&nbsp;</p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-3">
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+          Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
+        </a>
+      </p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
+        </a>
+      </p>
+    </div>
+    <div class="col-3">
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+          Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
+        </a>
+      </p>
+      <p>
+        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+          Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
 
 <section class="p-strip">
   <div class="row">

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {% if start_download %}
-<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">
+<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}{{ versionPatch }}-preinstalled-server-{{ architecture }}.img.xz">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">
@@ -22,7 +22,7 @@
       <h1>Thank you for downloading<br />
         Ubuntu Server {{ version }}<br />
         for Raspberry Pi</h1>
-      <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">download now</a>.</p>
+      <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}{{ versionPatch }}-preinstalled-server-{{ architecture }}.img.xz">download now</a>.</p>
       {% with version=version, system=architecture, architecture=architecture %}{% include "download/shared/_verify-checksums.html" %}{% endwith %}
       {% else %}
       <h1>Thank you</h1>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -3,7 +3,7 @@
   <span class="p-contextual-menu--left">
     <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
-      {% if releases.checksums[system][version] %}
+      {% if releases.checksums[system] and releases.checksums[system][version] %}
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
         <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
@@ -12,7 +12,7 @@
         <small>Or follow this tutorial to learn <a class="p-link--external" href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
       {% else %}
-        <small>Please check the <a class="p-link--external" href="http://releases.ubuntu.com/{{ version }}/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</small>
+        <small>Please check the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</small>
       {% endif %}
     </span>
   </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -37,6 +37,7 @@ def download_thank_you(category):
     context = {"http_host": flask.request.host}
 
     version = flask.request.args.get("version", "")
+    versionPatch = flask.request.args.get("versionPatch", "")
     architecture = flask.request.args.get("architecture", "")
 
     # Sanitise for paths
@@ -48,6 +49,7 @@ def download_thank_you(category):
     if architecture and version_pattern.match(version):
         context["start_download"] = version and architecture
         context["version"] = version
+        context["versionPatch"] = versionPatch
         context["architecture"] = architecture
 
     # Add mirrors


### PR DESCRIPTION
## Done

- Updated copy on the raspi download page
- Added an 18.04 row
- Added support for a patch number in download URL generation
- Changed checksum link to cdimages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi and check the download links work.
- Go through to the thank you page of one of the 18.04 links and ensure that the checksum works
- Check some of the non-pi download pages
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #2758
