### PR TITLE
Update copy on training page

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -219,7 +219,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-7">
       <h2>Metal as a Service (MAAS)</h2>
@@ -248,6 +248,39 @@
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
       <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered u-no-padding--top">
+  <div class="row">
+    <div class="col-7">
+      <h2>Ceph Operations</h2>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr />
+    <h3>Deployment and Operations training</h3>
+  </div>
+
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>A three-day hands-on course at your premises for up to 15 people that focuses on Ceph storage. The aim of this training is to educate users on Ceph, practice deployment, perform operations and optimisations of Ceph storage, as well as troubleshooting.</p>
+      <p><a href="https://assets.ubuntu.com/v1/28ca49c8-Ceph+Operations+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">3 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises or remote</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/_kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Updated copy on /training

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the changes requested in [the copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit#) have been made
- Resolve the comments


## Issue / Card

Fixes #7526 