### PR TITLE
Remove 'USN-' prefix from templates

### DIFF
--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -1,5 +1,5 @@
 <article class="notice" style="padding-bottom: 32px;">
-  <h3 class="u-no-margin p-heading--four" style="padding-bottom: 8px;"><a href="/security/notices/{{notice.id}}">USN-{{ notice.id }}: {{ notice.title }} ›</a></h3>
+  <h3 class="u-no-margin p-heading--four" style="padding-bottom: 8px;"><a href="/security/notices/{{notice.id}}">{{ notice.id }}: {{ notice.title }} ›</a></h3>
   <p class="u-no-margin u-no-padding--top" style="color: #666; font-size: 14px; padding-bottom: 8px;">{{ notice.published.strftime("%d %B %Y") }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">{{ notice.isummary or notice.summary | safe }}</p>
   <ul class="p-inline-list u-no-margin">

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -1,12 +1,12 @@
 {% extends "templates/one-column.html" %}
 
-{% block title %}USN-{{ notice.id }}: {{ notice.title }} | Ubuntu security notices{% endblock %}
+{% block title %}{{ notice.id }}: {{ notice.title }} | Ubuntu security notices{% endblock %}
 
 {% block content %}
 <section class="p-strip--suru-topped is-bordered">
   <div class="row">
     <div class="col-8">
-	    <h1>USN-{{ notice.id }}: {{ notice.title }}</h1>
+	    <h1>{{ notice.id }}: {{ notice.title }}</h1>
       <p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
       <p>{{ notice.isummary or notice.summary|safe }}</p>
     </div>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -151,7 +151,7 @@ def notices_feed(feed_type):
     feed.link(href=base_url, rel="self")
 
     def feed_entry(notice, url_root):
-        _id = f"USN-{notice.id}"
+        _id = notice.id
         title = f"{_id}: {notice.title}"
         description = notice.details
         published = notice.published


### PR DESCRIPTION
## Done

Remove the `USN-` prefix in templates, since the prefix should actually be part of the ID stored in the database.

## QA

- load notices into the db(ask me for help if you dont know how to)
- dotrun
- go to `localhost:8001/security/notices`
- make sure there it all renders fine
