### PR TITLE
Correct the name of Shotcut from 'Shortcut'

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -357,7 +357,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-4">
       <h2>Videos</h2>
-      <p>Watch HD videos from your browser on Ubuntu, or use the default Movie Player and VLC and OpenShot from the Snap Store. Edit your movies with Shortcut or kdenlive and then watch them in Movie Player.</p>
+      <p>Watch HD videos from your browser on Ubuntu, or use the default Movie Player and VLC and OpenShot from the Snap Store. Edit your movies with Shotcut or kdenlive and then watch them in Movie Player.</p>
     </div>
     <div class="col-7 col-start-large-6 u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Corrected typo: "Shortcut" -> "Shotcut"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/features
- See that "Shotcut" is correctly spelled
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html


## Issue / Card

Fixes #7514 