### PR TITLE
Correct references to micro USB for Pi 4 to USB-C

### DIFF
--- a/templates/core/build/index.html
+++ b/templates/core/build/index.html
@@ -22,10 +22,10 @@
       <p>If you're using a Raspberry Pi you can use the official <a href="https://www.raspberrypi.org/downloads/" class="p-link--external">Raspberry Pi Imager</a> to flash your image to your SDcard.</p>
       <p>If you are using one of the other Ubuntu certified boards you should use <a href="https://www.balena.io/etcher/" class="p-link--external">Etcher</a>.</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">A micro-USB power cable</li>
+        <li class="p-list__item is-ticked">A micro-USB power cable for the Pi 2 &amp; 3, or a USB-C power cable for the Pi 4</li>
         <li class="p-list__item is-ticked">A microSD card</li>
         <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-        <li class="p-list__item is-ticked">An HDMI cable for the Pi 2 & 3, or a MicroHDMI cable for the Pi 4</li>
+        <li class="p-list__item is-ticked">An HDMI cable for the Pi 2 &amp; 3, or a MicroHDMI cable for the Pi 4</li>
         <li class="p-list__item is-ticked">A USB keyboard</li>
       </ul>
     </div>

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -56,7 +56,7 @@
           <div class="p-stepped-list__content">
             <ul>
               <li class="p-list__item">A Raspberry Pi 2, 3, or 4</li>
-              <li class="p-list__item">A micro-USB power cable</li>
+              <li class="p-list__item">A micro-USB power cable for the Pi 2 &amp; 3, or a USB-C power cable for the Pi 4</li>
               <li class="p-list__item">A microSD card with the Ubuntu Server image</li>
               <li class="p-list__item">A monitor with an HDMI interface</li>
               <li class="p-list__item">An HDMI cable for the Pi 2 &amp; 3 and a MicroHDMI cable for the Pi 4</li>


### PR DESCRIPTION
## Done

- Corrected references to Pi 4 using micro USB

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi/thank-you?version=20.04
- See the correct USB-C reference for the Pi 4
- http://localhost:8001/build
- Select a build
- See the instructions correctly reference USB-C for the Pi 4
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #7515 