### PR TITLE
Update eu k8s event page

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -62,8 +62,14 @@
         {% if header_date %}<p>
           {{ header_date }}
         </p>{% endif %}
-        {% if header_cta %}<br class="u-hide--medium u-hide--large" />
-        <p class="u-hide--medium u-hide--large">
+        {% if header_cta %}
+          {% if header_cta_all_sizes %}
+            <br />
+            <p>
+          {% else %}
+            <br class="u-hide--medium u-hide--large" />
+            <p class="u-hide--medium u-hide--large">
+          {% endif %}
           <a href="{{ header_url }}" class="{% if header_cta_class %}{{ header_cta_class }}{% else %}p-button--neutral{% endif %}">
             {{ header_cta }}
           </a>

--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -2,7 +2,7 @@
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
   title: "Kubernetes & MicroK8s virtual event EU"
-  meta_description: "Kubernetes, microK8s, K8s, canonical, ubuntu"
+  meta_description: "Kubernetes & MicroK8s virtual event EMEA"
   meta_image: https://assets.ubuntu.com/v1/baab00bc-pre-kubeconf-meta-image.png
   meta_copydoc: https://docs.google.com/document/d/1VYYmd6kS0eWApEpbVCgTUq0NOHUTEeRWVj7ujtFEsHs/
   header_title: "Streamlined Kubernetes, from Cloud to Edge"
@@ -13,6 +13,7 @@ context:
   header_url: "https://www.brighttalk.com/webcast/6793/406196"
   header_cta: Register now
   header_cta_class: p-button--positive
+  header_cta_all_sizes: true
   header_class: p-engage-banner--dark
   header_lang: en
   webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 406196, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'


### PR DESCRIPTION
## Done

- Updated the meta description of /engage/eu-kubernetes-event
- Show the cta button on all sizes on /engage/eu-kubernetes-event

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001engage/eu-kubernetes-event
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the cta button is visible on desktop sized viewports


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2763#issuecomment-631515275