### PR TITLE
Update partner programme name

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -16,7 +16,7 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="u-fixed-width">
-    {% with title="A selection of our certified public cloud partners", json_feed_url="https://partners.ubuntu.com/partners.json?programme__name=Certified%20Public%20Cloud&featured=true", feed_item_limit=10 %}{% include "shared/_partner-logos.html" %}{% endwith %}
+    {% with title="A selection of our certified public cloud partners", json_feed_url="https://partners.ubuntu.com/partners.json?programme__name=Public%20Cloud&featured=true", feed_item_limit=10 %}{% include "shared/_partner-logos.html" %}{% endwith %}
     <p class="u-align--center"><a class="p-link--external" href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud ">View all certified public cloud partners</a></p>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updating the programme name from 'Certified Public Cloud' to 'Public Cloud'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the logo cloud still loads

