### PR TITLE
Revert template finder version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==5.0.0
 canonicalwebteam.search==0.2.1
-canonicalwebteam.templatefinder==0.2.5
+canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.image-template==1.1.0
 canonicalwebteam.discourse-docs==0.11.1
 canonicalwebteam.launchpad==0.7.2


### PR DESCRIPTION
## Done

Revert template finder to fix contact us modals

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check http://0.0.0.0:8001/shared/forms/interactive/_general loads
- Click contact us and see modal


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
