### PR TITLE
Revert the tempalte image dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.flask_base==0.6.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==5.0.0
 canonicalwebteam.search==0.2.1
-canonicalwebteam.templatefinder==0.2.5
+canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.image-template==1.1.0
 canonicalwebteam.discourse-docs==0.11.1
 canonicalwebteam.launchpad==0.7.2


### PR DESCRIPTION
## Done
Revert the tempalte image dep

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
- Click the green contact button

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7544
