### PR TITLE
Add build step for cypress testing

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v2
 
+      - name: Install dependencies and build JS/CSS
+        uses: ./run build
+
       - name: Cypress run
         uses: cypress-io/github-action@v1
         with:


### PR DESCRIPTION
## Done

- Add build step for cypress test
- This will make faster the start of the server handled by the cypress action that was taking too long to start (because of building and installing deps)