### PR TITLE
Add kafka page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -31,12 +31,14 @@ aws:
       hidden: True
 
 managedapps:
-  title: Managed apps
+  title: Managed
   path: /managed
 
   children:
     - title: Overview
       path: /managed
+    - title: Kafka
+      path: /managed/kafka
     - title: Contact us
       path: /managed/contact-us
       hidden: True

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -7,7 +7,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/15c89-PyMc-QnSHglG1hf_Tub5lMkEcVYALL0rm5-LvA/{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-bottomed is-deep">
+<section class="p-strip--suru-topped is-bordered">
   <div class="row u-vertically-center">
     <div class="col-7">
       <h1>Apache Kafka, managed by the open source experts on Ubuntu</h1>
@@ -39,7 +39,6 @@
     </div>
   </div>
 </section>
-
 <section class="p-strip u-no-padding--top">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
@@ -67,11 +66,10 @@
     </div>
   </div>
 </section>
-
 <section class="p-strip--light u-no-padding--top">
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Secure by default</h3>
+      <h4 class="p-card__title">Secure by default</h4>
       <hr class="u-sv1">
       <ul class="p-list">
         <li class="p-list__item is-ticked">Data is encrypted at-rest and in-transit</li>
@@ -81,7 +79,7 @@
       </ul>
     </div>
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Integrate with your infrastructure</h3>
+      <h4 class="p-card__title">Integrate with your infrastructure</h4>
       <hr class="u-sv1">
       <ul class="p-list">
         <li class="p-list__item is-ticked">Transparent hostname and IP addresses to connect with other services</li>
@@ -90,7 +88,7 @@
       </ul>
     </div>
     <div class="col-6 p-card">
-      <h2 class="p-card__title">Reliable, mission-critical clouds</h2>
+      <h4 class="p-card__title">Reliable, mission-critical clouds</h4>
       <hr class="u-sv1">
       <ul class="p-list">
         <li class="p-list__item is-ticked">Load balancing and data replication allow failure without downtime</li>
@@ -99,7 +97,7 @@
       </ul>
     </div>
     <div class="col-6 p-card">
-      <h2 class="p-card__title">Tailored to your specific needs</h2>
+      <h4 class="p-card__title">Tailored to your specific needs</h4>
       <hr class="u-sv1">
       <ul class="p-list">
         <li class="p-list__item is-ticked">Control the version of Kafka your cloud runs</li>
@@ -119,7 +117,6 @@
     </div>
   </div>
 </section>
-
 <section class="p-strip u-no-padding--top">
   <div class="row">
     <h3>App information</h3>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -1,0 +1,306 @@
+{% extends "managed/_base_managed-apps.html" %}
+
+{% block title %}Canonical's managed apps{% endblock %}
+
+{% block meta_description %}Our app and cloud experience lets you maintain business focus in a complex tech landscape. Rely on our expert engineers to set-up and operate your apps, with full lifecycle coverage.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/15c89-PyMc-QnSHglG1hf_Tub5lMkEcVYALL0rm5-LvA/{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--suru-bottomed is-deep">
+  <div class="row u-vertically-center">
+    <div class="col-7">
+      <h1>Apache Kafka, managed by the open source experts on Ubuntu</h1>
+      <p>Canonical is uniquely positioned to manage the open source software and applications that run your cloud.</p>
+      <p>Our app engineers provide full operational management of Apache Kafka across any conformant Kubernetes, public cloud and on-premise environments. Deploy Kafka with agility, and conserve your teams&rsquo; resources from ongoing deployments and operations.</p>
+      <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+    </div>
+    <div class="col-5 u-hide--small u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/fac9a1bf-201509-kafka-logo-wb-en.svg",
+          alt="",
+          height="178",
+          width="320",
+          hi_def=True,
+          attrs={"class": ""},
+          loading="auto",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h2>No limits Kafka</h2>
+      <p>We&rsquo;ve deployed thousands of clouds with OpenStack and Kubernetes and managed it across all infrastructure types. Canonical&rsquo;s leadership across open source cloud &mdash; both on-premise and in the public cloud &mdash; lets us offer the most complete Managed Kafka service.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <h4>Any conformant Kubernetes</h4>
+      <p>Canonical will manage Kafka on any conformant Kubernetes. We handle the deployment of Kafka on Kubernetes so you don&rsquo;t have to.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>Any cloud</h4>
+      <p>The only Managed Kafka service that covers hybrid and multi-clouds across GCP, AWS and Azure, on-premise vendors and
+        OpenStack.
+        </p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>Any scale</h4>
+      <p>Canonical&rsquo;s Managed Kafka does not put limits on data transfer or cluster size. Additionally, We will support any throughput speed your cloud infrastructure can achieve.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2>Why Managed Kafka?</h2>
+      <p>While Kafka simplifies microservice communications, it creates complexity in its management across different infrastructures and as a layer between different microservices. Offloading the complexity of managing Kafka to Canonical open source experts removes operations as a blocker to team agility and innovation.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light u-no-padding--top">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title">Secure by default</h3>
+      <hr class="u-sv1">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Data is encrypted at-rest and in-transit</li>
+        <li class="p-list__item is-ticked">Data-plane authorisation with Kafka ACLS</li>
+        <li class="p-list__item is-ticked">Encrypted client-broker transfer with Transport Layer Security (TLS)</li>
+        <li class="p-list__item is-ticked">Data security assurance with SOC2 and ISO27001/2 certification</li>
+      </ul>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title">Integrate with your infrastructure</h3>
+      <hr class="u-sv1">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Transparent hostname and IP addresses to connect with other services</li>
+        <li class="p-list__item is-ticked">Access and support for open source Kafka Connector</li>
+        <li class="p-list__item is-ticked">Kafka REST Proxy exposed, to access the cluster with HTTP calls</li>
+      </ul>
+    </div>
+    <div class="col-6 p-card">
+      <h2 class="p-card__title">Reliable, mission-critical clouds</h2>
+      <hr class="u-sv1">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Load balancing and data replication allow failure without downtime</li>
+        <li class="p-list__item is-ticked">High availability and throughput through Kafka&rsquo;s distributed cluster architecture</li>
+        <li class="p-list__item is-ticked">Support in deploying your organisation&rsquo;s Schema Registry</li>
+      </ul>
+    </div>
+    <div class="col-6 p-card">
+      <h2 class="p-card__title">Tailored to your specific needs</h2>
+      <hr class="u-sv1">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Control the version of Kafka your cloud runs</li>
+        <li class="p-list__item is-ticked">Schedule updates to downtime windows</li>
+        <li class="p-list__item is-ticked">Understand key metrics with an integrated  web-based dashboard and logging, monitoring and alerting (Graylog-Prometheus-Grafana) stack</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h2>Kafka management &mdash; architecture and operations</h2>
+      <p>Canonical offers a <a href="/managed">fully managed service</a> for open source software and applications, including support for Apache Kafka, anywhere you can run Ubuntu.</p>
+      <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <h3>App information</h3>
+    <table>
+      <tr>
+        <td><strong>Versions managed</strong></td>
+        <td colspan="2">
+          Kafka 2.3 by default<br/>
+          We can support your specific version &mdash; <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Zookeeper</strong></td>
+        <td colspan="2">Fully supported and managed</td>
+      </tr>
+    </table>
+
+    <h3>Cloud architecture</h3>
+    <table>
+      <tr>
+        <td><strong>Kubernetes</strong></td>
+        <td colspan="2">Any conformant Kubernetes (Charmed Kubernetes, RKE, OpenShift, AKS, EKS, GKE and more)</td>
+      </tr>
+      <tr>
+        <td><strong>Public Clouds</strong></td>
+        <td colspan="2">AWS, Azure and GCP</td>
+      </tr>
+      <tr>
+        <td><strong>Data Center Regions</strong></td>
+        <td colspan="2">Single or multiple supported</td>
+      </tr>
+      <tr>
+        <td><strong>Data Centre Availability Zones</strong></td>
+        <td colspan="2">Single or multiple supported</td>
+      </tr>
+      <tr>
+        <td><strong>On-premise</strong></td>
+        <td colspan="2">Any OpenStack, bare metal and key third-party providers such as VMWare.</td>
+      </tr>
+      <tr>
+        <td><strong>Hybrid-cloud</strong></td>
+        <td colspan="2">Persistent streaming between all cloud types and management across all</td>
+      </tr>
+      <tr>
+        <td><strong>Multi-cloud</strong></td>
+        <td colspan="2">Persistent streaming between all cloud types and management across all</td>
+      </tr>
+    </table>
+
+    <h3>Data</h3>
+    <table>
+      <tr>
+        <td><strong>High Availability</strong></td>
+        <td colspan="2">Yes, minimum of 3 replications to ensure availability and consensus</td>
+      </tr>
+      <tr>
+        <td><strong>Number of partitions</strong></td>
+        <td colspan="2">No limits &mdash; we will implement and manage the optimal number of partitions for your configuration</td>
+      </tr>
+      <tr>
+        <td><strong>Number of replications</strong></td>
+        <td colspan="2">No limits &mdash; we will implement and manage the optimal number of replications for your configuration</td>
+      </tr>
+      <tr>
+        <td><strong>Throughput</strong></td>
+        <td colspan="2">No limits &mdash; we will support any throughput your cloud can achieve</td>
+      </tr>
+      <tr>
+        <td><strong>Node size</strong></td>
+        <td colspan="2">No restrictions on the size of the node</td>
+      </tr>
+      <tr>
+        <td><strong>Latency</strong></td>
+        <td colspan="2">Managed Kafka will match the latency your cloud can achieve</td>
+      </tr>
+      <tr>
+        <td><strong>KSQL</strong></td>
+        <td colspan="2">KSQL can integrate with Managed Kafka</td>
+      </tr>
+    </table>
+
+    <h3>App Operations</h3>
+    <table>
+      <tr>
+        <td><strong>Updates</strong></td>
+        <td colspan="2">All future updates included</td>
+      </tr>
+      <tr>
+        <td><strong>Managed updates</strong></td>
+        <td colspan="2">Schedule updates during specific time windows to minimize downtime</td>
+      </tr>
+      <tr>
+        <td><strong>New nodes</strong></td>
+        <td colspan="2">On-request</td>
+      </tr>
+      <tr>
+        <td><strong>Load balancing</strong></td>
+        <td colspan="2">Automatic load balancing by default</td>
+      </tr>
+      <tr>
+        <td><strong>Schema Registry deployment</strong></td>
+        <td colspan="2">Yes, support in deploying your organisation's Schema Registry</td>
+      </tr>
+      <tr>
+        <td><strong>Metrics and Visualisation</strong></td>
+        <td colspan="2">Yes, Managed Kafka includes Graylog, Prometheus and Grafana monitoring and dashboard tools, to ensure transparency and visibility on all vital metrics</td>
+      </tr>
+    </table>
+
+    <h3>Interoperability</h3>
+    <table>
+      <tr>
+        <td><strong>Connectors</strong></td>
+        <td colspan="2">Yes, open source Kafka Connectors for applications</td>
+      </tr>
+      <tr>
+        <td><strong>REST API</strong></td>
+        <td colspan="2">Yes, administrate Kafka without accessing the underlying Kafka client</td>
+      </tr>
+      <tr>
+        <td><strong>Direct</strong></td>
+        <td colspan="2">Hostname and IP visibility, to connect with your other cloud infrastructure</td>
+      </tr>
+    </table>
+
+    <h3>Security and reliability</h3>
+    <table>
+      <tr>
+        <td><strong>Security Patches</strong></td>
+        <td colspan="2">Yes. Canonical provides all security patches.</td>
+      </tr>
+      <tr>
+        <td><strong>Kernel</strong></td>
+        <td colspan="2">Kernel Livepatch</td>
+      </tr>
+      <tr>
+        <td><strong>24/7 Monitoring</strong></td>
+        <td colspan="2">Yes &mdash; Canonical&rsquo;s Kafka experts cover all geographic regions and time-zones</td>
+      </tr>
+      <tr>
+        <td><strong>Break/Fix response</strong></td>
+        <td colspan="2">Yes</td>
+      </tr>
+      <tr>
+        <td><strong>SLA</strong></td>
+        <td colspan="2">Yes, 99.9% up-time.</td>
+      </tr>
+      <tr>
+        <td><strong>ISO270001/2 certified</strong></td>
+        <td colspan="2">Yes</td>
+      </tr>
+      <tr>
+        <td><strong>SOC2 Type 2 certified</strong></td>
+        <td colspan="2">Yes</td>
+      </tr>
+      <tr>
+        <td><strong>GDPR Compliance tested</strong></td>
+        <td colspan="2">Yes</td>
+      </tr>
+    </table>
+
+    <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>Learn how Managed Apps help organisations maintain business focus</h2>
+      <p>Managed Apps frees DevOps teams to focus on the value their apps can deliver and away from time-consuming cloud-management tasks, at a predictable price.</p>
+      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/394568">Watch on-demand</a></p>
+    </div>
+    <div class="col-5 u-vertically-center">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">With Managed Apps, DevOps becomes a strategic edge, not just a requirement for others to perform their jobs.</p>
+        <cite class="p-pull-quote__citation">Canonical</cite>
+      </blockquote>
+    </div>
+  </div>
+</section>
+
+{% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+{% endblock content %}

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -292,7 +292,6 @@
     <div class="col-5 u-vertically-center">
       <blockquote class="p-pull-quote">
         <p class="p-pull-quote__quote">With Managed Apps, DevOps becomes a strategic edge, not just a requirement for others to perform their jobs.</p>
-        <cite class="p-pull-quote__citation">Canonical</cite>
       </blockquote>
     </div>
   </div>


### PR DESCRIPTION
## Done

Built /managed/kafka page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/kafka
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that it matches [the copy doc](https://docs.google.com/document/d/15c89-PyMc-QnSHglG1hf_Tub5lMkEcVYALL0rm5-LvA/) and [the design](https://camo.githubusercontent.com/dfa9acbc9e0cd45b918d11b26b655981cc3e5424/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3565623933333839653062346366643037636136326232362f34313765656466342d633565362d346562652d393935382d353635323331373734376665)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2755