### PR TITLE
Add ubuntu masters roblox takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
   {% include "takeovers/_iot-device-management-whitepaper.html" %}
   {% include "takeovers/_snapd-takeover.html" %}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
+  {% include "takeovers/_ubuntu-masters-roblox.html" %}
 
 {% endblock takeover_content %}
 

--- a/templates/takeovers/_ubuntu-masters-roblox.html
+++ b/templates/takeovers/_ubuntu-masters-roblox.html
@@ -1,0 +1,13 @@
+{% with title='From bare metal <br class="u-hide--medium u-hide--small">to the edge:',
+subtitle="Roblox talks about how they rapidly scaled to meet user needs. Years of growth achieved in one week.",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
+image_style="width: 270px; height: 150px;",
+image_hide_small=true,
+equal_cols=true,
+primary_url="https://www.brighttalk.com/webcast/6793/398027?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_UbuntuMasters_EVT_UMq2",
+primary_cta="Watch the session",
+primary_cta_class=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- Created a takeover in the style of the previous Masters one for the Roblox webinar

[copy](https://docs.google.com/document/d/1_xbVloqalCo5di05VDWaLX19HkNuo2L8UoeKk5LI5z8/edit) (I shortened the H1 and moved it into the subtitle)

[Design for last takeover](https://github.com/canonical-web-and-design/web-squad/issues/2017)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Refresh until you see the "From bare metal to the edge" takeover
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #2698

## Screenshots

![image](https://user-images.githubusercontent.com/118614/82576005-20b46080-9b81-11ea-81c3-3c6d4908ed3c.png)
