### PR TITLE
Add CIO french engage page

### DIFF
--- a/templates/engage/fr/guide-du-DSI-pour-les-operations-multicloud.md
+++ b/templates/engage/fr/guide-du-DSI-pour-les-operations-multicloud.md
@@ -1,0 +1,53 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Choisir une architecture cloud rentable"
+  meta_description: "Découvrez les différentes architectures clouds et comment choisir une architecture rentable"
+  meta_image: "https://assets.ubuntu.com/v1/8770be8d-french_meta_image.png"
+  meta_copydoc: https://docs.google.com/document/d/1SapWacMi5UHALRIkK3WE2j5OS9NbHBzLLmt7XZkejtA
+  header_title: "GUIDE DU DSI pour les opérations multicloud"
+  header_subtitle: "Choisir une architecture cloud rentable"
+  header_image: "https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg"
+  header_image_width: "393"
+  header_image_height: "345"
+  header_url: "#register-section"
+  header_cta: Lire le whitepaper
+  header_cta_class: p-button--positive
+  header_class: p-engage-banner--dark
+  form_include: fr
+  form_id: 3580
+  form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/CIO_MultiCloud_WP_French_28.01.20%20%283%29.pdf"
+---
+
+Le cloud computing, bien qu’étant une technologie mature, reste complexe. L’avènement du serverless computing, de Kubernetes, des conteneurs et un grand nombre de scénarios de déploiement possibles laissent de nombreuses entreprises mal informées quant à la façon dont elles devraient progresser avec leur stratégie cloud.
+
+Quelle est la bonne stratégie cloud pour votre entreprise ?
+
+<div class="col-12 u-equal-height">
+  <div class="col-3">
+    <p><img src="https://assets.ubuntu.com/v1/90010d3d-Screenshot+from+2018-09-03+10-33-04.png" alt="Choosing a cost effective cloud architecture"></p>
+  </div>
+  <div class="col-9 u-vertically-center">
+    <ul class="p-list--divided is-split">
+      <li class="p-list__item">Cloud public</li>
+      <li class="p-list__item">Cloud privé</li>
+      <li class="p-list__item">Cloud géré</li>
+      <li class="p-list__item">Cloud hybride</li>
+      <li class="p-list__item">Multi-Cloud</li>
+      <li class="p-list__item">Pas de cloud</li>
+    </ul>
+  </div>
+</div>
+
+Dans ce whitepaper, vous trouverez une discussion objective des différentes approches de cloud computing disponibles aujourd’hui, une explication de la façon dont le cloud s’intègrent aux technologies comme les conteneurs et le serverless computing ainsi que les facteurs que les organisations doivent prendre en compte lors du processus décisionnaire de leur stratégie cloud.
+
+Ce document est parfait si vous voulez apprendre comment choisir une architecture cloud rentable, en savoir plus sur les stratégies cloud et les technologies émergentes.
+
+Points clés du livre blanc:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Apprenez en plus sur tous les types d'architecture cloud</li>
+  <li class="p-list__item is-ticked">Comprendre pourquoi aucun type d'architecture ou d'infrastructure cloud n'est idéal pour tout le monde</li>
+  <li class="p-list__item is-ticked">Découvrir comment évaluer les besoins de votre entreprise et les aligner sur différentes solutions cloud</li>
+  <li class="p-list__item is-ticked">Tout ce que vous devez savoir sur les produits cloud, Kubernetes et AI / ML de Canonical</li>
+</ul>

--- a/templates/engage/fr/guide-du-DSI-pour-les-operations-multicloud.md
+++ b/templates/engage/fr/guide-du-DSI-pour-les-operations-multicloud.md
@@ -43,7 +43,7 @@ Dans ce whitepaper, vous trouverez une discussion objective des différentes app
 
 Ce document est parfait si vous voulez apprendre comment choisir une architecture cloud rentable, en savoir plus sur les stratégies cloud et les technologies émergentes.
 
-Points clés du livre blanc:
+Points clés du whitepaper :
 
 <ul class="p-list">
   <li class="p-list__item is-ticked">Apprenez en plus sur tous les types d'architecture cloud</li>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1023,5 +1023,14 @@
       {% include "engage/_article-card.html" %}
     {% endwith %}
     </div>
+
+    <div class="row u-equal-height u-clearfix">
+      {% with title="GUIDE DU DSI pour les opérations multicloud",
+      description="Choisir une architecture cloud rentable",
+      slug="fr/guide-du-DSI-pour-les-operations-multicloud",
+      type="whitepaper" %}
+      {% include "engage/_article-card.html" %}
+    {% endwith %}
+    </div>
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,9 @@
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_ubuntu-masters-roblox.html" %}
 
+  {# FRENCH #}
+  {% include "takeovers/_cio-guide-to-multipass-fr.html" %}
+
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_cio-guide-to-multipass-fr.html
+++ b/templates/takeovers/_cio-guide-to-multipass-fr.html
@@ -1,0 +1,15 @@
+{% with title="Choisir une architecture cloud rentable",
+subtitle="Découvrez les différentes architectures clouds et comment choisir une architecture rentable",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg",
+image_style="",
+image_height="345",
+image_width="393",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001GHleAAG",
+primary_cta="Lire le whitepaper",
+primary_cta_class="",
+lang="fr" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -136,5 +136,7 @@
 {% include "takeovers/_iot-device-management-whitepaper.html" %}
 <p>15 May 2020</p>
 {% include "takeovers/_snapd-takeover.html" %}
+<p>22 May 2020</p>
+{% include "takeovers/_cio-guide-to-multipass-fr.html" %}
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Built takeover and added to /takovers
- Built engage page and added to /engage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Change your browsers language settings to French
- Refresh until you see the "Choisir une architecture cloud rentable" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1GdeDl3mV-8RyqknFRZ0Kk8dbKzSKxHyL5qQyNcWy0gg/edit#gid=2113339190)
- Click through to the engage page
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1GdeDl3mV-8RyqknFRZ0Kk8dbKzSKxHyL5qQyNcWy0gg/edit#gid=1271849439)

## Issue / Card

Fixes #7451 