### PR TITLE
Update title and meta description on /engage/eu-kubernetes-event

### DIFF
--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -1,8 +1,8 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-  title: "Kubernetes & MicroK8s virtual event EU"
-  meta_description: "Kubernetes & MicroK8s virtual event EMEA"
+  title: "Kubernetes from Cloud to Edge: A Virtual Event"
+  meta_description: "From public cloud, to containers, and even lightweight devices, discover strategies for optimising your Kubernetes deployment and operations. Join us live on 28 May 2020."
   meta_image: https://assets.ubuntu.com/v1/baab00bc-pre-kubeconf-meta-image.png
   meta_copydoc: https://docs.google.com/document/d/1VYYmd6kS0eWApEpbVCgTUq0NOHUTEeRWVj7ujtFEsHs/
   header_title: "Streamlined Kubernetes, from Cloud to Edge"


### PR DESCRIPTION
## Done

- Updated the title and meta description of the eu-kubernetes-event engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/eu-kubernetes-event
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the title and meta description match the [brief](https://docs.google.com/spreadsheets/d/1A5DO1jxYXbkQ4Ule1lhxo9s25_UukK3maokZs9c1NCY/edit?ts=5ec78e52#gid=1271849439)

