### PR TITLE
Added multipass to download menu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN yarn run build-css
 FROM ubuntu:focal
 
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev gpg
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-setuptools python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev gpg
 COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
 COPY --from=python-dependencies /root/.local/bin /root/.local/bin
 ENV PATH="/root/.local/bin:${PATH}"

--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -23,7 +23,7 @@ context:
 
 **Date and time**
 May 28, 2020
-[5-7pm BST]
+[4-6pm BST]
 
 **What it is**: A free digital event on Kubernetes, including a live, interactive discussion with a panel of experts, demos, use cases, Q&A, and more.
 

--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -1,8 +1,8 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-  title: "Kubernetes & MicroK8s virtual event EU"
-  meta_description: "Kubernetes & MicroK8s virtual event EMEA"
+  title: "Kubernetes from Cloud to Edge: A Virtual Event"
+  meta_description: "From public cloud, to containers, and even lightweight devices, discover strategies for optimising your Kubernetes deployment and operations. Join us live on 28 May 2020."
   meta_image: https://assets.ubuntu.com/v1/baab00bc-pre-kubeconf-meta-image.png
   meta_copydoc: https://docs.google.com/document/d/1VYYmd6kS0eWApEpbVCgTUq0NOHUTEeRWVj7ujtFEsHs/
   header_title: "Streamlined Kubernetes, from Cloud to Edge"

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -16,6 +16,10 @@
       <p>
         Ubuntu is the reference platform for Kubernetes on all major public clouds, including official support in Google’s GKE, Microsoft’s AKS and Amazon’s EKS CAAS offerings. We deliver pure upstream Kubernetes tested across the widest range of clouds &mdash; from public clouds to private data centres, from bare metal to virtualised infrastructure.
       </p>
+      <p>
+        <a class="p-button--positive" href="/kubernetes/install">Try it now</a>
+        <a class="js-invoke-modal" href="/kubernetes/contact-us">Contact us&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
@@ -40,7 +44,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <h2 class="p-heading--four">MicroK8s</h2>
-      <p><em>Workstations and appliances</em></p>
+      <p><em>Workstations, DevOps, edge &amp; IoT</em></p>
       <hr class="u-sv1" />
       <ul class="p-list">
         <li class="p-list__item is-ticked">Single-package install</li>
@@ -50,7 +54,7 @@
         <li class="p-list__item is-ticked">Local registry support</li>
         <li class="p-list__item is-ticked">Host storage</li>
       </ul>
-      <p>Developers love MicroK8s as a fast, lean upstream K8s for rapid iteration. It&rsquo;s also popular as a secure and robust K8s for IoT and appliances.</p>
+      <p>Developers love MicroK8s as a simple, conformant Kubernetes for rapid iteration and CI/CD testing. It’s also popular as a secure and robust K8s for IoT and appliances.</p>
       <p><a href="https://microk8s.io/" class="p-link--external">Learn more and install MicroK8s</a></p>
     </div>
 
@@ -405,7 +409,7 @@
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a href="/blog/webinar-how-to-get-started-with-your-kubernetes-strategy">How to get started with your Kubernetes strategy&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four p-link--external"><a href="https://www.brighttalk.com/webcast/6793/383698">A decision maker's guide to Kubernetes deployment in your data centre</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
@@ -424,7 +428,7 @@
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a href="/blog/kubernetes-for-the-enterprise-1-2-3-go">Kubernetes for the Enterprise: 1, 2, 3, Go!&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four p-link--external"><a href="https://www.brighttalk.com/webcast/6793/347227">Moving to Production-Ready, Fast, Affordable Kubernetes</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
@@ -443,7 +447,7 @@
           <h4 class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a href="/blog/the-no-nonsense-way-to-accelerate-your-business-with-containers">The no-nonsense way to accelerate your business with containers&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--four"><a href="/engage/whitepaper-containers">The no-nonsense way to accelerate your business with containers&nbsp;&rsaquo;</a></h3>
     </div>
   </div>
 </section>

--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -14,6 +14,9 @@
           <a href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" class="p-button--positive p-button--small" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ releases.lts.short_version }} LTS', 'eventValue' : undefined });">{{ releases.lts.short_version }} LTS</a>
           {% if releases.latest.short_version > releases.lts.short_version %}<a href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64" class="p-button--neutral p-button--small" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">{{ releases.latest.short_version }}</a>{% endif %}
           <ul class='p-text-list--small is-bordered' >
+            <li class='p-list__item'><a class='p-link' href='https://multipass.run'>
+              Mac and Windows
+            </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/server/arm'>
               ARM
             </a></li>


### PR DESCRIPTION
## Done

- Added a "Mac and Windows" entry to the download mega menu, server section.
- Copy doc updated

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the [menu item](https://ubuntu-com-canonical-web-and-design-pr-7575.run.demo.haus/#download) is present and links to multipass.run
