### PR TITLE
Update time of /engage/eu-kubernetes-event event

### DIFF
--- a/templates/engage/eu-kubernetes-event.md
+++ b/templates/engage/eu-kubernetes-event.md
@@ -23,7 +23,7 @@ context:
 
 **Date and time**
 May 28, 2020
-[5-7pm BST]
+[4-6pm BST]
 
 **What it is**: A free digital event on Kubernetes, including a live, interactive discussion with a panel of experts, demos, use cases, Q&A, and more.
 


### PR DESCRIPTION
## Done

- Update time of /engage/eu-kubernetes-event event
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/eu-kubernetes-event
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it is 4-6pm not 5-7pm now

