### PR TITLE
Use X-Real-Ip as Ip location

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -63,7 +63,9 @@ def download_thank_you(category):
 
     # Check country code
     country_code = "NO_COUNTRY_CODE"
-    ip_location = ip_reader.get(flask.request.remote_addr)
+    ip_location = ip_reader.get(
+        flask.request.headers.get("X-Real-IP", flask.request.remote_addr)
+    )
     mirror_list = []
 
     if ip_location:


### PR DESCRIPTION
## Done

Fix GeoIp issue when IP behind proxy/content-cache to dispatch users on the ubuntu image mirror list
- Using: `X-Real-IP` with a fallback on remote addr
- This X-Real-IP is provided by nginx

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Find an IP that is in another country and run:

```
curl --request GET \
  --url 'http://127.0.0.1:8001/download/desktop/thank-you?version=20.04&architecture=amd64' \
  --header 'x-real-ip: {{ THE IP }}'
```

make sure that the mirrors that you get are for your country
