### PR TITLE
Fix if IP has no linked country

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -68,7 +68,7 @@ def download_thank_you(category):
     )
     mirror_list = []
 
-    if ip_location:
+    if ip_location and "country" in ip_location:
         country_code = ip_location["country"]["iso_code"]
 
         mirror_list = [


### PR DESCRIPTION
## Done

https://sentry.is.canonical.com/canonical/ubuntu-com/issues/10208/
- Fix issue if ip has no country linked. Redirect to releases.ubuntu.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Try to access with the header: x-real-ip set to what is in the sentry error
