### PR TITLE
Add pricing and webinar to /managed

### DIFF
--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -500,7 +500,21 @@
   </div>
 </section>
 
-<div class="p-strip is-deep">
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h2>
+        Fully managed applications pricing
+      </h2>
+      <p>
+        We manage applications at both the host and the guest level.
+      </p>
+    </div>
+  </div>
+  {% include '/shared/pricing/_managed-pricing.html' %}
+</section>
+
+<section class="p-strip--light is-deep">
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">
       <h2>
@@ -528,9 +542,9 @@
       }}
     </div>
   </div>
-</div>
+</section>
 
-<section class="p-strip--light is-deep">
+<section class="p-strip is-deep">
   <div class="u-fixed-width">
     <h3>
       Learn how Canonical deploys and runs Kubernetes and Openstack
@@ -593,7 +607,7 @@
           <h4 class="p-heading-icon__title">Webinar</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/308883">What can you do with Kubernetes?</a></h3>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/410402">Kafka in production - making sure your deployment is fast, reliable and secure</a></h3>
     </div>
   </div>
 </section>

--- a/templates/shared/pricing/_managed-pricing.html
+++ b/templates/shared/pricing/_managed-pricing.html
@@ -1,0 +1,30 @@
+<div class="u-fixed-width">
+  <div style="overflow-x: auto;">
+    <table class="p-table" style="width: auto;">
+      <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th width="200" class="u-align--center">Per VM</th>
+          <th width="200" class="u-align--center">Per Host</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Managed Applications on public clouds, VMware, OpenStack or Kubernetes</td>
+          <td class="u-align--center">$2,447</td>
+          <td class="u-align--center">$5,513<a href="#managed-pricing-fn1"><sup>*</sup></a></td>
+        </tr>
+        <tr>
+          <td>Managed Applications on bare metal</td>
+          <td class="u-align--center">&nbsp;</td>
+          <td class="u-align--center">$7,470</td>
+        </tr>
+      </tbody>
+    </table>
+    <p id="#managed-pricing-fn1">
+      <small>
+        <sup>*</sup> On a VMware, OpenStack or Kubernetes cluster, managed applications on VMs or Containers can be priced per compute host in the cluster as long as the entire cluster is covered.
+      </small>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Add pricing strip and updated a webinar on the /managed page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments on the [copy doc](https://docs.google.com/document/d/17zJ4vTutqVpn0XzUI784BHdJov8cGW1ttDwIjsvcEzE/edit#heading=h.7gedeuoq6tmt)

## Issue / Card

Fixes #7563

