### PR TITLE
Add comma to h1 on /openstack/consulting

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -8,7 +8,7 @@
   <section class="p-strip--suru-bottomed is-bordered">
     <div class="row">
       <div class="col-8">
-        <h1>Private cloud design and delivery</h1>
+        <h1>Private cloud, design and delivery</h1>
         <h2 class="p-heading--three">Carrier grade, banking security, government scale. Serious private clouds are our business.</h2>
         <p>Hundreds of successful OpenStack clouds underpin our consulting, training, architecture design, and hardware procurement advice - to help you evaluate and deliver OpenStack.</p>
         <p>


### PR DESCRIPTION
## Done

- Add comma to h1 on /openstack/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare and resolve the comment in the [copy doc](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit#)

## Issue / Card

Fixes #7570

