### PR TITLE
Update copy on /tco-calculator

### DIFF
--- a/templates/tco-calculator/index.html
+++ b/templates/tco-calculator/index.html
@@ -227,7 +227,7 @@
   <div class="u-fixed-width">
     <p class="p-heading--six"><em>NOTE: This calculator is for informational purposes only. Actual numbers may vary depending on your requirements. Also, discounts may apply for bigger clusters. For more detailed pricing, please contact Canonical’s sales team.</em></p>
     <p>
-      <a class="p-button--positive js-invoke-modal" href="/openstack/managed#get-in-touch">
+      <a class="p-button--positive js-invoke-modal" href="/openstack/contact-us?product=openstack-managed-cloud">
         Get in touch
       </a>
     </p>
@@ -244,5 +244,10 @@
   </div>
 </section>
 
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
 <script src="{{ versioned_static('js/build/tco-calculator.min.js') }}"></script>
+
 {% endblock content %}

--- a/templates/tco-calculator/index.html
+++ b/templates/tco-calculator/index.html
@@ -10,8 +10,12 @@
 <section class="p-strip--suru is-dark">
   <div class="row">
     <div class="col-8">
-      <h1>Private cloud TCO calculator</h1>
-      <p>One of the biggest promises behind the private cloud infrastructure is better economics compared to proprietary hardware and public clouds. Use the TCO (total cost of ownership) calculator below to estimate the cost of your private cloud infrastructure with Canonical.</p>
+      <h1>
+        Private cloud TCO calculator
+      </h1>
+      <p>
+        One of the biggest promises behind the private cloud infrastructure is better economics compared to proprietary hardware and public clouds. Use the TCO (total cost of ownership) calculator below to estimate the cost of your private cloud infrastructure with Canonical or <a class="p-link--inverted" href="/openstack/compare">learn more about differences between various OpenStack distributions</a>.
+      </p>
     </div>
   </div>
 </section>
@@ -221,7 +225,12 @@
   </div>
 
   <div class="u-fixed-width">
-    <p class="p-heading--six"><em>NOTE: This calculator is for informational purposes only. Actual numbers may vary depending on your requirements. Also, discounts may apply for bigger clusters. For more detailed pricing, <a href="/openstack/managed#get-in-touch">contact Canonical’s sales team</a>.</em></p>
+    <p class="p-heading--six"><em>NOTE: This calculator is for informational purposes only. Actual numbers may vary depending on your requirements. Also, discounts may apply for bigger clusters. For more detailed pricing, please contact Canonical’s sales team.</em></p>
+    <p>
+      <a class="p-button--positive js-invoke-modal" href="/openstack/managed#get-in-touch">
+        Get in touch
+      </a>
+    </p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Update copy on /tco-calculator with a link in the banner and a button for contact after the caclulator

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/tco-calculator
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit#)


## Issue / Card

Fixes #7579