### PR TITLE
Add new Kafka webinar takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1033,7 +1033,7 @@
       {% endwith %}
 
       {% with title="Kafka in production", description="Learn how to plan and operate a fast, reliable and secure Kafka deployment",
-      slug="/engage/kafka-in-production",
+      slug="kafka-in-production",
       type="webinar" %}
         {% include "engage/_article-card.html" %}
       {% endwith %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1029,8 +1029,14 @@
       description="Choisir une architecture cloud rentable",
       slug="fr/guide-du-DSI-pour-les-operations-multicloud",
       type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
-    {% endwith %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
+
+      {% with title="Kafka in production", description="Learn how to plan and operate a fast, reliable and secure Kafka deployment",
+      slug="/engage/kafka-in-production",
+      type="webinar" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
     </div>
 </section>
 {% endblock content %}

--- a/templates/engage/kafka-in-production.md
+++ b/templates/engage/kafka-in-production.md
@@ -1,0 +1,28 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Kafka deployment, management and operations webinar"
+     meta_description: "Learn how to plan and operate a fast, reliable and secure Kafka deployment"
+     meta_image: "https://assets.ubuntu.com/v1/faada17e-kafka-webinar-meta-image.png"
+     meta_copydoc: "https://docs.google.com/document/d/1K0qdFarxwnUCt4AUA9if6KdQ35hjE-s6o6bEy6H_4bY/edit"
+     header_title: "Kafka in production"
+     header_subtitle: "Making sure your deployment is fast, reliable and secure"
+     header_image: "https://assets.ubuntu.com/v1/a70bfab2-Managed-apps_wht.svg"
+     header_url: '#register-section'
+     header_cta: "Register for the webinar"
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--grad
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 410402, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+Many organisations utilise Kafka to enable data pipelines between applications and micro-services. With its wide adoption, DevOps teams often face challenges ensuring that this open source application is deployed at scale in a secure and reliable way.
+
+For example, configuring the correct amount of replicas and topic partitions to achieve the throughput and resilience an organisation needs can be difficult. Further, organisations that deploy Kafka for the first time want to make sure it's done correctly, whether that be on-premise or in AWS, Azure or Google Cloud.
+
+In this webinar you will learn:
+
+- Architecture, configuration and security recommendations for Kafka deployments on private cloud, container and public cloud environments
+- The challenges with Kafka operations around topic management, upgrading and scaling
+- A management solution to reduce strain, complexity and costs for DevOps teams
+
+Watch this webinar to understand the key design decisions in creating a resilient and secure Kafka streaming pipeline and options to achieve operations at scale.

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
   {% include "takeovers/_snapd-takeover.html" %}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_ubuntu-masters-roblox.html" %}
+  {% include "takeovers/_kafka-in-production_takeover.html" %}
 
   {# FRENCH #}
   {% include "takeovers/_cio-guide-to-multipass-fr.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,9 +28,6 @@
 
 {% block takeover_content %}
   {# ALL #}
-  {% include "takeovers/_eu-kubernetes-event.html" %}
-  {% include "takeovers/_azure-webinar-takeover.html" %}
-  {% include "takeovers/_iot-device-management-whitepaper.html" %}
   {% include "takeovers/_snapd-takeover.html" %}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_ubuntu-masters-roblox.html" %}

--- a/templates/takeovers/_kafka-in-production_takeover.html
+++ b/templates/takeovers/_kafka-in-production_takeover.html
@@ -1,0 +1,16 @@
+{% with title="Kafka in production",
+subtitle="Making sure your deployment is fast, reliable and secure",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/a70bfab2-Managed-apps_wht.svg",
+image_style="width: 297px; height: 150px;",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/kafka-in-production?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_ManagedApps_WBN_KafkainProd",
+primary_cta="Register for the webinar",
+primary_cta_class="p-button--positive",
+secondary_url="",
+secondary_cta="",
+lang="",
+locale="" %}
+  {% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -138,5 +138,6 @@
 {% include "takeovers/_snapd-takeover.html" %}
 <p>22 May 2020</p>
 {% include "takeovers/_cio-guide-to-multipass-fr.html" %}
-
+<p>%script:name=28 May 2020</p>
+{% include "takeovers/_kafka-in-production_takeover.html" %}
 {% endblock %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -138,6 +138,6 @@
 {% include "takeovers/_snapd-takeover.html" %}
 <p>22 May 2020</p>
 {% include "takeovers/_cio-guide-to-multipass-fr.html" %}
-<p>%script:name=28 May 2020</p>
+<p>28 May 2020</p>
 {% include "takeovers/_kafka-in-production_takeover.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add new Kafka webinar takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/
    - http://0.0.0.0:8001/engage/kafka-in-production
    - http://0.0.0.0:8001/engage
    - http://0.0.0.0:8001/takeovers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [brief](https://docs.google.com/spreadsheets/d/1yKQdNwBwL_c41SSjekkZu823FEKEuvnIeIvqzEs0hMY/edit) and [design](https://github.com/canonical-web-and-design/web-squad/issues/2775)

## Issue / Card

Fixes #7557

## Screenshots

![image](https://user-images.githubusercontent.com/441217/83164797-8dd97000-a104-11ea-8932-bf492e766b1b.png)

