### PR TITLE
Update the cookie policy to version 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "webpack-cli": "3.3.11"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "2.0.3",
+    "@canonical/cookie-policy": "2.1.0",
     "@canonical/global-nav": "2.4.1",
     "@canonical/latest-news": "1.0.1",
     "vanilla-framework": "2.11.0"

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -31,7 +31,8 @@
 
   {% block head_extra %}{% endblock %}
 
-  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2"" crossorigin>
+  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/46ed6870-Ubuntu-L-subset.woff2" crossorigin>
+  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2" crossorigin>
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/6113b69a-Ubuntu-LI-subset.woff2" crossorigin>
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/0c7b8dc0-Ubuntu-R-subset.woff2" crossorigin>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -31,10 +31,9 @@
 
   {% block head_extra %}{% endblock %}
 
-  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2" crossorigin>
-  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2" crossorigin>
-  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
-  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
+  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2"" crossorigin>
+  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/6113b69a-Ubuntu-LI-subset.woff2" crossorigin>
+  <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/0c7b8dc0-Ubuntu-R-subset.woff2" crossorigin>
 
   <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,10 +853,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-2.0.3.tgz#69fd828df9526caa94b2347fbd1544f99d12b7ea"
-  integrity sha512-XdYNqeCYioV48kx3nIR8wNOxzxQk7Iz9rmCDYRQ72/adlz6Soevt1jCs2cVii9ulG2S2I5/UyHrV4ZgQWMFoNA==
+"@canonical/cookie-policy@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-2.1.0.tgz#77b96e3f2e29ba2d6e9d654bdb4729dc21e93612"
+  integrity sha512-Z26080BBDjE2YkQSaP1iDenBwhsiU3jrmvIkZQcE5EgCf+4uqtka3LDZKxwRg7liZQATVxZqDwPV9IYtV8G9XQ==
 
 "@canonical/global-nav@2.4.1":
   version "2.4.1"


### PR DESCRIPTION
## Done
Update the cookie policy to version 2.1.0

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Clear your cookies and refresh
- Check the cookie-policy look the same as you would expect
- Open the inspector hit Network tab and filter for fonts
- Hard refresh the page and see there are only 4 ubuntu subset fonts downloaded
- Check live loads 5 ubuntu fonts, one called: `e8c07df6-Ubuntu-L_W.woff2` 
