### PR TITLE
Moves “Sign out” next to the address

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -22,7 +22,7 @@
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})
-          <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
+          <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral is-inline u-no-margin--bottom" onclick="dataLayer.push({
             'event' : 'GAEvent',
             'eventCategory' : 'Advantage',
             'eventAction' : 'Authentication',

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -21,8 +21,7 @@
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})</p>
-        <p class="u-no-margin--bottom">
+        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})
           <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
             'event' : 'GAEvent',
             'eventCategory' : 'Advantage',


### PR DESCRIPTION
## Done

- Moved the “Sign out” button inline, next to your address

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the UA page at http://0.0.0.0:8001/advantage
- Sign in

## Issue / Card

Partially addresses a couple of comments from the UA workshop:
- [“signout seems very prominent”](https://miro.com/app/board/o9J_ks1W8HE=/?moveToWidget=3074457348194383923&cot=11)
- [“non-standard location for identity, sign-out”](https://miro.com/app/board/o9J_ks1W8HE=/?moveToWidget=3074457348046666018&cot=2)

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/19801137/83250203-a77bc580-a19f-11ea-8869-a5046a6b1265.png)

After:

![image](https://user-images.githubusercontent.com/19801137/83257574-92596380-a1ac-11ea-9ae7-8b6f15499f8c.png)