### PR TITLE
Added Ubuntu masters to "Learn" of Community menu

### DIFF
--- a/templates/templates/navigation-community-h.html
+++ b/templates/templates/navigation-community-h.html
@@ -11,6 +11,7 @@
             <li class="p-list__item"><a href="https://help.ubuntu.com/">Ubuntu documentation</a></li>
             <li class="p-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Ubuntu events on Youtube</a></li>
             <li class="p-list__item"><a href="https://www.youtube.com/channel/UCSsoSZBAZ3Ivlbt_fxyjIkw">The Juju Cloud Operations Show</a></li>
+            <li class="p-list__item"><a href="/masters-conference">Get inspired by Ubuntu Masters</a></li>
           </ul>
         </div>
         <div class="col-4">


### PR DESCRIPTION
## Done

- Added Ubuntu masters to "Learn" of Community menu.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the demo [against the copy doc ](https://docs.google.com/document/d/1TgsBJdGgsP4KrGiz5kU5QYkdGSlKqhAVnZGnCJgshYY/edit#)and accepts correct changes.


## Issue / Card
Fixes #7607 


