### PR TITLE
Mark renewals as renewable if a user reloads the page during 3DS auth

### DIFF
--- a/static/sass/_pattern_renewal-modal.scss
+++ b/static/sass/_pattern_renewal-modal.scss
@@ -40,6 +40,7 @@
 
     .p-modal__dialog {
       max-width: 50rem;
+      overflow: auto;
       padding: 0;
       position: static;
       width: 100%;

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -530,8 +530,8 @@ def make_renewal(advantage, contract_info):
         invoice = invoices[-1]
         renewal["renewable"] = (
             invoice["pi_status"] == "requires_payment_method"
-            and invoice["subscription_status"] == "incomplete"
-        )
+            or invoice["pi_status"] == "requires_action"
+        ) and invoice["subscription_status"] == "incomplete"
 
     return renewal
 


### PR DESCRIPTION
## Done
- If a user is required to perform 3DS authentication on a renewal payment, but leaves the page for whatever reason, show the "Renew" button, rather than a "Renewal is processing..." message with a disabled button.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Sign in with SSO
- If you don't have any subscriptions, ask Scott to set you up with one
- Proceed through the renewal process by clicking "Renew...", then filling out the details using 4000000000003220 as the card number
  - expiry date can be anything in the future
- Click "Save payment details", and on the next modal screen click "Pay"
- A 3DS modal should appear, when it does, reload the page
- When the page has reloaded, see that you're able to trigger the renewal modal again


## Issue / Card

Fixes #7611 
