### PR TITLE
Remove copy implying we're storing renewals payment method details

### DIFF
--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -294,7 +294,8 @@ function enableProcessingState(mode) {
       if (mode === "payment") {
         progressIndicator.querySelector("span").innerHTML = "Making payment...";
       } else if (mode === "payment_method") {
-        progressIndicator.querySelector("span").innerHTML = "Saving details...";
+        progressIndicator.querySelector("span").innerHTML =
+          "Checking details...";
       }
 
       progressTimer3 = setTimeout(() => {

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -188,7 +188,7 @@
       </button>
 
       <button class="js-payment-method p-button--positive u-no-margin--right" disabled type="submit">
-        Save payment details
+        Continue
       </button>
 
       <button class="js-process-payment p-button--positive u-no-margin--right" disabled type="submit">


### PR DESCRIPTION
## Done
- Updated copy in the modal to reflect reality: we aren't storing payment method details.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login in with SSO
- If you don't have test contracts, ask Scott to set you up with one
- Trigger the renewals modal by clicking "Renew..." in the relevant subscription
- Using 4242 4242 4242 4242 as the card number, and any future expiry date, fill out the form
- See that the green CTA reads "Continue"
- Click it, and see that the copy that appears in the bottom left reads "Checking details..."


## Issue / Card

Fixes #7602
