### PR TITLE
Set name when passing customer info to UA contracts service

### DIFF
--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -127,6 +127,7 @@ function attachCustomerInfoToStripeAccount(paymentMethod) {
     paymentMethod.id,
     activeRenewal.accountId,
     stripeAddressObject,
+    customerInfo.name,
     stripeTaxObject
   )
     .then((data) => {

--- a/static/js/src/renewals/contracts-api.js
+++ b/static/js/src/renewals/contracts-api.js
@@ -39,6 +39,7 @@ export async function postCustomerInfoToStripeAccount(
   paymentMethodID,
   accountID,
   address,
+  name,
   taxID
 ) {
   let response = await fetch("/advantage/customer-info", {
@@ -53,6 +54,7 @@ export async function postCustomerInfoToStripeAccount(
       payment_method_id: paymentMethodID,
       account_id: accountID,
       address: address,
+      name: name,
       tax_id: taxID,
     }),
   });

--- a/static/js/src/renewals/contracts-api.js
+++ b/static/js/src/renewals/contracts-api.js
@@ -41,7 +41,7 @@ export async function postCustomerInfoToStripeAccount(
   address,
   taxID
 ) {
-  let response = await fetch("/advantage/payment-method", {
+  let response = await fetch("/advantage/customer-info", {
     method: "POST",
     cache: "no-store",
     credentials: "include",

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -53,7 +53,7 @@ class AdvantageContracts:
         return response.json()
 
     def put_customer_info(
-        self, account_id, payment_method_id, address, tax_id
+        self, account_id, payment_method_id, address, name, tax_id
     ):
         response = self._request(
             method="put",
@@ -61,6 +61,7 @@ class AdvantageContracts:
             json={
                 "paymentMethodID": payment_method_id,
                 "address": address,
+                "name": name,
                 "taxID": tax_id,
             },
         )

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -52,7 +52,9 @@ class AdvantageContracts:
 
         return response.json()
 
-    def put_method_id(self, account_id, payment_method_id, address, tax_id):
+    def put_customer_info(
+        self, account_id, payment_method_id, address, tax_id
+    ):
         response = self._request(
             method="put",
             path=f"v1/accounts/{account_id}/customer-info/stripe",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,7 +41,7 @@ from webapp.views import (
     build_tutorials_index,
     download_thank_you,
     get_renewal,
-    post_stripe_method_id,
+    post_customer_info,
     post_stripe_invoice_id,
     post_build,
     releasenotes_redirect,
@@ -129,9 +129,7 @@ def utility_processor():
 # Simple routes
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule(
-    "/advantage/payment-method",
-    view_func=post_stripe_method_id,
-    methods=["POST"],
+    "/advantage/customer-info", view_func=post_customer_info, methods=["POST"],
 )
 app.add_url_rule(
     "/advantage/renewals/<renewal_id>/invoices/<invoice_id>",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -556,10 +556,11 @@ def post_customer_info():
             return flask.jsonify({"error": "account_id required"}), 400
 
         address = flask.request.json.get("address")
+        name = flask.request.json.get("name")
         tax_id = flask.request.json.get("tax_id")
 
         return advantage.put_customer_info(
-            account_id, payment_method_id, address, tax_id
+            account_id, payment_method_id, address, name, tax_id
         )
     else:
         return flask.jsonify({"error": "authentication required"}), 401

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -536,7 +536,7 @@ def make_renewal(advantage, contract_info):
     return renewal
 
 
-def post_stripe_method_id():
+def post_customer_info():
     if user_info(flask.session):
         advantage = AdvantageContracts(
             session,
@@ -558,7 +558,7 @@ def post_stripe_method_id():
         address = flask.request.json.get("address")
         tax_id = flask.request.json.get("tax_id")
 
-        return advantage.put_method_id(
+        return advantage.put_customer_info(
             account_id, payment_method_id, address, tax_id
         )
     else:


### PR DESCRIPTION
## Done

- Pass name value to the ua contracts service when posting to customer info endpoint

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Sign in with SSO
- If you don't have any subscriptions, ask Scott to set you up with one
- Proceed through the renewal process by clicking "Renew...", then filling out the details using 4242 4242 4242 4242 as the card number
  - expiry date can be anything in the future
- Open the network tab in your browser's dev tools
- Click "Save payment details", and see that a post request to "customer-info" occurs
- Check the params of that request, and see that the name value is included


## Issue / Card

Fixes #7609
