### PR TITLE
renewals: add terms checkbox before user can complete payment

### DIFF
--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -19,6 +19,7 @@ const form = document.getElementById("details-form");
 const errorDialog = document.getElementById("payment-error-dialog");
 const progressIndicator = document.getElementById("js-progress-indicator");
 
+const termsCheckbox = modal.querySelector(".js-terms");
 const addPaymentMethodButton = modal.querySelector(".js-payment-method");
 const processPaymentButton = modal.querySelector(".js-process-payment");
 const changePaymentMethodButton = modal.querySelector(
@@ -176,11 +177,20 @@ function attachFormEvents() {
       vatContainer.classList.add("u-hide");
     }
   });
+
+  termsCheckbox.addEventListener("change", () => {
+    if (termsCheckbox.checked) {
+      processPaymentButton.disabled = false;
+    } else {
+      processPaymentButton.disabled = true;
+    }
+  });
 }
 
 function attachModalButtonEvents() {
   addPaymentMethodButton.addEventListener("click", (e) => {
     e.preventDefault();
+    changingPaymentMethod = false;
     sendGAEvent("submitted payment details");
     createPaymentMethod();
   });
@@ -285,7 +295,6 @@ function disableProcessingState() {
 function enableProcessingState(mode) {
   addPaymentMethodButton.disabled = true;
   cancelModalButton.disabled = true;
-  processPaymentButton.disabled = true;
 
   // show a progress indicator that evolves over time
   progressTimer = setTimeout(() => {
@@ -587,6 +596,7 @@ function showDetailsMode() {
   modal.classList.add("is-details-mode");
   addPaymentMethodButton.disabled = true;
   processPaymentButton.disabled = true;
+  termsCheckbox.checked = false;
   card.focus();
   validateForm();
 }
@@ -595,8 +605,9 @@ function showDialogMode() {
   disableProcessingState();
   modal.classList.remove("is-pay-mode", "is-details-mode");
   modal.classList.add("is-dialog-mode");
+  addPaymentMethodButton.disabled = true;
   processPaymentButton.disabled = true;
-  processPaymentButton.disabled = true;
+  termsCheckbox.checked = false;
 }
 
 function showPayMode() {
@@ -605,7 +616,8 @@ function showPayMode() {
   modal.classList.remove("is-details-mode", "is-dialog-mode");
   modal.classList.add("is-pay-mode");
   addPaymentMethodButton.disabled = true;
-  processPaymentButton.disabled = false;
+  processPaymentButton.disabled = true;
+  termsCheckbox.checked = false;
 }
 
 function toggleModal() {

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -192,15 +192,15 @@
         <span></span>
       </span>
 
-      <button class="js-cancel-modal">
+      <button class="js-cancel-modal" style="min-width: 5.5rem;">
         Cancel
       </button>
 
-      <button class="js-payment-method p-button--positive u-no-margin--right" disabled type="submit">
+      <button class="js-payment-method p-button--positive u-no-margin--right" disabled type="submit" style="min-width: 5.5rem;">
         Continue
       </button>
 
-      <button class="js-process-payment p-button--positive u-no-margin--right" disabled type="submit">
+      <button class="js-process-payment p-button--positive u-no-margin--right" disabled type="submit" style="min-width: 5.5rem;">
         Pay
       </button>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -168,6 +168,15 @@
               <p class="js-customer-email"></p>
             </div>
           </div>
+
+          <div class="row u-no-padding">
+            <div class="col-12">
+              <form>
+                <input type="checkbox" id="renewal-terms" checked="" class="js-terms">
+                <label class="u-float-left" for="renewal-terms">I agree to the <a href="/legal/ubuntu-advantage-service-terms" target="_blank">Ubuntu Advantage service terms</a></label>
+              </form>
+            </div>
+          </div>
         </div>
 
         <div id="payment-error-dialog">


### PR DESCRIPTION
## Done

- added a t&c checkbox the user needs to check before payment can be processed
- set equal widths on buttons in the modal footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login with SSO
- If you don't have any subscriptions, ask Scott to set you up with one
- On the subscription, click "Renew...", fill out the payment method details and click "Continue"
- See that the "Pay" button is disabled
- Click the t&c checkbox


## Issue / Card

Fixes #7612 
