### PR TITLE
renewals: add "excluding VAT" note

### DIFF
--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -30,6 +30,7 @@
         <div class="row u-no-padding">
           <div class="col-3 u-text-light">To pay:</div>
           <div class="col-9 js-renewal-total"></div>
+          <div class="col-start-large-4 col-9"><small>Excluding VAT</small></div>
         </div>
       </section>
 


### PR DESCRIPTION
## Done

Added "excluding VAT" to total amount in renewal modal

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login with SSO
- If you don't have any subscriptions, ask Scott to set you up with one
- On the subscription, click "Renew...", see that below the total to pay there is a small piece of text that reads "Excluding VAT"

## Issue / Card

Fixes #7619 

## Screenshots
![Screenshot from 2020-06-02 11-57-47](https://user-images.githubusercontent.com/2376968/83512578-5124c480-a4c8-11ea-841a-b630f57084e1.png)

