### PR TITLE
Update copy on /aws/pro

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -75,7 +75,7 @@
         <li class="p-matrix__item">
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">AWS-integrated</h3>
-            <p class="p-matrix__desc">Starting in Q1 2020, Ubuntu Pro will include integrations with AWS services including Security Hub, CloudWatch and CloudTrail.</p>
+            <p class="p-matrix__desc">Starting in 2020, Ubuntu Pro will include integrations with AWS services including Security Hub, CloudWatch and CloudTrail.</p>
           </div>
         </li>
         <li class="p-matrix__item">


### PR DESCRIPTION
## Done

- Remove 'Q1' from text

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/pro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that 'Q1' has been removed as in the [copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit#)


## Issue / Card

Fixes #7625

