### PR TITLE
SEO updates to /managed/kafka

### DIFF
--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -164,7 +164,7 @@
       <tr>
         <td><strong>On-premise</strong></td>
         <td colspan="2">Any OpenStack, bare metal and key third-party providers such as VMWare.<br />
-          We can support your specific cloud provider - <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>.</td>
+          We can support your specific cloud provider - <a href="/managed/contact-us" class="js-invoke-modal">Contact us</a>.</td>
         </tr>
         <tr>
           <td><strong>Hybrid-cloud</strong></td>
@@ -273,7 +273,7 @@
         <tr>
           <td><strong>SLA</strong></td>
           <td colspan="2">Yes, 99.9% up-time.<br />
-            We can support your specific requirements - <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>.</td>
+            We can support your specific requirements - <a href="/managed/contact-us" class="js-invoke-modal">Contact us</a>.</td>
           </tr>
           <tr>
             <td><strong>ISO270001/2 certified</strong></td>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -164,7 +164,7 @@
       <tr>
         <td><strong>On-premise</strong></td>
         <td colspan="2">Any OpenStack, bare metal and key third-party providers such as VMWare.<br />
-          We can support your specific cloud provider - <a href="/managed/contact-us" class="js-invoke-modal">Contact us</a>.</td>
+          We can support your specific cloud provider - <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>.</td>
         </tr>
         <tr>
           <td><strong>Hybrid-cloud</strong></td>
@@ -273,7 +273,7 @@
         <tr>
           <td><strong>SLA</strong></td>
           <td colspan="2">Yes, 99.9% up-time.<br />
-            We can support your specific requirements - <a href="/managed/contact-us" class="js-invoke-modal">Contact us</a>.</td>
+            We can support your specific requirements - <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>.</td>
           </tr>
           <tr>
             <td><strong>ISO270001/2 certified</strong></td>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -10,21 +10,26 @@
 <section class="p-strip--suru-topped is-bordered">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Apache Kafka, managed by the open source experts on Ubuntu</h1>
+      <h1>
+        Managed Apache Kafka on Ubuntu
+      </h1>
       <p>Canonical is uniquely positioned to manage the open source software and applications that run your cloud.</p>
       <p>Our app engineers provide full operational management of Apache Kafka across any conformant Kubernetes, public cloud and on-premise environments. Deploy Kafka with agility, and conserve your teams&rsquo; resources from ongoing deployments and operations.</p>
       <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+      <p>
+        <a href="/engage/kafka-in-production">Watch the webinar - “Kafka in production”&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-5 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/fac9a1bf-201509-kafka-logo-wb-en.svg",
-          alt="",
-          height="178",
-          width="320",
-          hi_def=True,
-          attrs={"class": ""},
-          loading="auto",
+        url="https://assets.ubuntu.com/v1/fac9a1bf-201509-kafka-logo-wb-en.svg",
+        alt="",
+        height="178",
+        width="320",
+        hi_def=True,
+        attrs={"class": ""},
+        loading="auto",
         ) | safe
       }}
     </div>
@@ -34,7 +39,9 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
-      <h2>No limits Kafka</h2>
+      <h2>
+        Kafka as a service, on any infrastructure
+      </h2>
       <p>We&rsquo;ve deployed thousands of clouds with OpenStack and Kubernetes and managed it across all infrastructure types. Canonical&rsquo;s leadership across open source cloud &mdash; both on-premise and in the public cloud &mdash; lets us offer the most complete Managed Kafka service.</p>
     </div>
   </div>
@@ -49,7 +56,7 @@
       <h4>Any cloud</h4>
       <p>The only Managed Kafka service that covers hybrid and multi-clouds across GCP, AWS and Azure, on-premise vendors and
         OpenStack.
-        </p>
+      </p>
     </div>
     <div class="col-4 p-divider__block">
       <h4>Any scale</h4>
@@ -111,7 +118,9 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
-      <h2>Kafka management &mdash; architecture and operations</h2>
+      <h2>
+        Kafka management, architecture and operation
+      </h2>
       <p>Canonical offers a <a href="/managed">fully managed service</a> for open source software and applications, including support for Apache Kafka, anywhere you can run Ubuntu.</p>
       <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
     </div>
@@ -125,7 +134,7 @@
         <td><strong>Versions managed</strong></td>
         <td colspan="2">
           Kafka 2.3 by default<br/>
-          We can support your specific version &mdash; <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>
+          We can support your specific version &mdash; <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>.
         </td>
       </tr>
       <tr>
@@ -154,151 +163,182 @@
       </tr>
       <tr>
         <td><strong>On-premise</strong></td>
-        <td colspan="2">Any OpenStack, bare metal and key third-party providers such as VMWare.</td>
-      </tr>
-      <tr>
-        <td><strong>Hybrid-cloud</strong></td>
-        <td colspan="2">Persistent streaming between all cloud types and management across all</td>
-      </tr>
-      <tr>
-        <td><strong>Multi-cloud</strong></td>
-        <td colspan="2">Persistent streaming between all cloud types and management across all</td>
-      </tr>
-    </table>
+        <td colspan="2">Any OpenStack, bare metal and key third-party providers such as VMWare.<br />
+          We can support your specific cloud provider - <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>.</td>
+        </tr>
+        <tr>
+          <td><strong>Hybrid-cloud</strong></td>
+          <td colspan="2">Persistent streaming between all cloud types and management across all</td>
+        </tr>
+        <tr>
+          <td><strong>Multi-cloud</strong></td>
+          <td colspan="2">Persistent streaming between all cloud types and management across all</td>
+        </tr>
+      </table>
 
-    <h3>Data</h3>
-    <table>
-      <tr>
-        <td><strong>High Availability</strong></td>
-        <td colspan="2">Yes, minimum of 3 replications to ensure availability and consensus</td>
-      </tr>
-      <tr>
-        <td><strong>Number of partitions</strong></td>
-        <td colspan="2">No limits &mdash; we will implement and manage the optimal number of partitions for your configuration</td>
-      </tr>
-      <tr>
-        <td><strong>Number of replications</strong></td>
-        <td colspan="2">No limits &mdash; we will implement and manage the optimal number of replications for your configuration</td>
-      </tr>
-      <tr>
-        <td><strong>Throughput</strong></td>
-        <td colspan="2">No limits &mdash; we will support any throughput your cloud can achieve</td>
-      </tr>
-      <tr>
-        <td><strong>Node size</strong></td>
-        <td colspan="2">No restrictions on the size of the node</td>
-      </tr>
-      <tr>
-        <td><strong>Latency</strong></td>
-        <td colspan="2">Managed Kafka will match the latency your cloud can achieve</td>
-      </tr>
-      <tr>
-        <td><strong>KSQL</strong></td>
-        <td colspan="2">KSQL can integrate with Managed Kafka</td>
-      </tr>
-    </table>
+      <h3>Data</h3>
+      <table>
+        <tr>
+          <td><strong>High Availability</strong></td>
+          <td colspan="2">Yes, minimum of 3 replications to ensure availability and consensus</td>
+        </tr>
+        <tr>
+          <td><strong>Number of partitions</strong></td>
+          <td colspan="2">No limits &mdash; we will implement and manage the optimal number of partitions for your configuration</td>
+        </tr>
+        <tr>
+          <td><strong>Number of replications</strong></td>
+          <td colspan="2">No limits &mdash; we will implement and manage the optimal number of replications for your configuration</td>
+        </tr>
+        <tr>
+          <td><strong>Throughput</strong></td>
+          <td colspan="2">No limits &mdash; we will support any throughput your cloud can achieve</td>
+        </tr>
+        <tr>
+          <td><strong>Node size</strong></td>
+          <td colspan="2">No restrictions on the size of the node</td>
+        </tr>
+        <tr>
+          <td><strong>Latency</strong></td>
+          <td colspan="2">Managed Kafka will match the latency your cloud can achieve</td>
+        </tr>
+        <tr>
+          <td><strong>KSQL</strong></td>
+          <td colspan="2">KSQL can integrate with Managed Kafka</td>
+        </tr>
+      </table>
 
-    <h3>App Operations</h3>
-    <table>
-      <tr>
-        <td><strong>Updates</strong></td>
-        <td colspan="2">All future updates included</td>
-      </tr>
-      <tr>
-        <td><strong>Managed updates</strong></td>
-        <td colspan="2">Schedule updates during specific time windows to minimize downtime</td>
-      </tr>
-      <tr>
-        <td><strong>New nodes</strong></td>
-        <td colspan="2">On-request</td>
-      </tr>
-      <tr>
-        <td><strong>Load balancing</strong></td>
-        <td colspan="2">Automatic load balancing by default</td>
-      </tr>
-      <tr>
-        <td><strong>Schema Registry deployment</strong></td>
-        <td colspan="2">Yes, support in deploying your organisation's Schema Registry</td>
-      </tr>
-      <tr>
-        <td><strong>Metrics and Visualisation</strong></td>
-        <td colspan="2">Yes, Managed Kafka includes Graylog, Prometheus and Grafana monitoring and dashboard tools, to ensure transparency and visibility on all vital metrics</td>
-      </tr>
-    </table>
+      <h3>App Operations</h3>
+      <table>
+        <tr>
+          <td><strong>Updates</strong></td>
+          <td colspan="2">All future updates included</td>
+        </tr>
+        <tr>
+          <td><strong>Managed updates</strong></td>
+          <td colspan="2">Schedule updates during specific time windows to minimize downtime</td>
+        </tr>
+        <tr>
+          <td><strong>New nodes</strong></td>
+          <td colspan="2">On-request</td>
+        </tr>
+        <tr>
+          <td><strong>Load balancing</strong></td>
+          <td colspan="2">Automatic load balancing by default</td>
+        </tr>
+        <tr>
+          <td><strong>Schema Registry deployment</strong></td>
+          <td colspan="2">Yes, support in deploying your organisation's Schema Registry</td>
+        </tr>
+        <tr>
+          <td><strong>Metrics and Visualisation</strong></td>
+          <td colspan="2">Yes, Managed Kafka includes Graylog, Prometheus and Grafana monitoring and dashboard tools, to ensure transparency and visibility on all vital metrics</td>
+        </tr>
+      </table>
 
-    <h3>Interoperability</h3>
-    <table>
-      <tr>
-        <td><strong>Connectors</strong></td>
-        <td colspan="2">Yes, open source Kafka Connectors for applications</td>
-      </tr>
-      <tr>
-        <td><strong>REST API</strong></td>
-        <td colspan="2">Yes, administrate Kafka without accessing the underlying Kafka client</td>
-      </tr>
-      <tr>
-        <td><strong>Direct</strong></td>
-        <td colspan="2">Hostname and IP visibility, to connect with your other cloud infrastructure</td>
-      </tr>
-    </table>
+      <h3>Interoperability</h3>
+      <table>
+        <tr>
+          <td><strong>Connectors</strong></td>
+          <td colspan="2">Yes, open source Kafka Connectors for applications</td>
+        </tr>
+        <tr>
+          <td><strong>REST API</strong></td>
+          <td colspan="2">Yes, administrate Kafka without accessing the underlying Kafka client</td>
+        </tr>
+        <tr>
+          <td><strong>Direct</strong></td>
+          <td colspan="2">Hostname and IP visibility, to connect with your other cloud infrastructure</td>
+        </tr>
+      </table>
 
-    <h3>Security and reliability</h3>
-    <table>
-      <tr>
-        <td><strong>Security Patches</strong></td>
-        <td colspan="2">Yes. Canonical provides all security patches.</td>
-      </tr>
-      <tr>
-        <td><strong>Kernel</strong></td>
-        <td colspan="2">Kernel Livepatch</td>
-      </tr>
-      <tr>
-        <td><strong>24/7 Monitoring</strong></td>
-        <td colspan="2">Yes &mdash; Canonical&rsquo;s Kafka experts cover all geographic regions and time-zones</td>
-      </tr>
-      <tr>
-        <td><strong>Break/Fix response</strong></td>
-        <td colspan="2">Yes</td>
-      </tr>
-      <tr>
-        <td><strong>SLA</strong></td>
-        <td colspan="2">Yes, 99.9% up-time.</td>
-      </tr>
-      <tr>
-        <td><strong>ISO270001/2 certified</strong></td>
-        <td colspan="2">Yes</td>
-      </tr>
-      <tr>
-        <td><strong>SOC2 Type 2 certified</strong></td>
-        <td colspan="2">Yes</td>
-      </tr>
-      <tr>
-        <td><strong>GDPR Compliance tested</strong></td>
-        <td colspan="2">Yes</td>
-      </tr>
-    </table>
+      <h3>Security and reliability</h3>
+      <table>
+        <tr>
+          <td><strong>Security Patches</strong></td>
+          <td colspan="2">Yes. Canonical provides all security patches.</td>
+        </tr>
+        <tr>
+          <td><strong>Kernel</strong></td>
+          <td colspan="2">Kernel Livepatch</td>
+        </tr>
+        <tr>
+          <td><strong>24/7 Monitoring</strong></td>
+          <td colspan="2">Yes &mdash; Canonical&rsquo;s Kafka experts cover all geographic regions and time-zones</td>
+        </tr>
+        <tr>
+          <td><strong>Break/Fix response</strong></td>
+          <td colspan="2">Yes</td>
+        </tr>
+        <tr>
+          <td><strong>SLA</strong></td>
+          <td colspan="2">Yes, 99.9% up-time.<br />
+            We can support your specific requirements - <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>.</td>
+          </tr>
+          <tr>
+            <td><strong>ISO270001/2 certified</strong></td>
+            <td colspan="2">Yes</td>
+          </tr>
+          <tr>
+            <td><strong>SOC2 Type 2 certified</strong></td>
+            <td colspan="2">Yes</td>
+          </tr>
+          <tr>
+            <td><strong>GDPR Compliance tested</strong></td>
+            <td colspan="2">Yes</td>
+          </tr>
+        </table>
 
-    <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
-  </div>
-</section>
+        <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+      </div>
+    </section>
 
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Learn how Managed Apps help organisations maintain business focus</h2>
-      <p>Managed Apps frees DevOps teams to focus on the value their apps can deliver and away from time-consuming cloud-management tasks, at a predictable price.</p>
-      <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/394568">Watch on-demand</a></p>
+
+    <section class="p-strip p-engage-banner--grad">
+      <div class="row u-equal-height">
+        <div class="col-7">
+          <h2>
+            Plan and optimise your Kafka deployment
+          </h2>
+          <p>
+            Watch this webinar to understand the key design decisions in creating a resilient and secure Kafka streaming pipeline, and options to achieve operations at scale.
+          </p>
+          <p>
+            <a class="p-button--positive" href="/engage/kafka-in-production">Watch the webinar</a>
+          </p>
+        </div>
+        <div class="col-5 u-hide--small u-vertically-center u-align--center">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/a70bfab2-Managed-apps_wht.svg",
+            alt="",
+            width="297",
+            height="150",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+      </div>
+    </section>
+
+    <section class="p-strip">
+      <div class="row u-equal-height">
+        <div class="col-7">
+          <h2>Learn how Managed Apps help organisations maintain business focus</h2>
+          <p>Managed Apps frees DevOps teams to focus on the value their apps can deliver and away from time-consuming cloud-management tasks, at a predictable price.</p>
+          <p><a class="p-button--positive" href="https://www.brighttalk.com/webcast/6793/394568">Watch on-demand</a></p>
+        </div>
+        <div class="col-5 u-vertically-center">
+          <blockquote class="p-pull-quote">
+            <p class="p-pull-quote__quote">With Managed Apps, DevOps becomes a strategic edge, not just a requirement for others to perform their jobs.</p>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+
+    {% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-kafka.html" data-form-id="3592" data-lp-id="3828" data-return-url="https://www.ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
-    <div class="col-5 u-vertically-center">
-      <blockquote class="p-pull-quote">
-        <p class="p-pull-quote__quote">With Managed Apps, DevOps becomes a strategic edge, not just a requirement for others to perform their jobs.</p>
-      </blockquote>
-    </div>
-  </div>
-</section>
-
-{% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-kafka.html" data-form-id="3592" data-lp-id="3828" data-return-url="https://www.ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-{% endblock content %}
+    {% endblock content %}


### PR DESCRIPTION
## Done

- SEO updates to /managed/kafka
- Add webinar

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/kafka
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/15c89-PyMc-QnSHglG1hf_Tub5lMkEcVYALL0rm5-LvA/edit#) and resolve comments


## Issue / Card

Fixes #2782


