### PR TITLE
Add dell webinar takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1037,6 +1037,13 @@
       type="webinar" %}
         {% include "engage/_article-card.html" %}
       {% endwith %}
+
+      {% with title="Standardising machine learning &mdash; from workstation to production", description="Leverage the best tools for AI/ML from workstation to data center",
+      slug="ml-dell-webinar",
+      type="webinar" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
     </div>
+
 </section>
 {% endblock content %}

--- a/templates/engage/ml-dell-webinar.md
+++ b/templates/engage/ml-dell-webinar.md
@@ -1,0 +1,26 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Standardising machine learning - from workstation to production"
+     meta_description: "Leverage the best tools for AI/ML from workstation to data center"
+     meta_image: "https://assets.ubuntu.com/v1/8c99c89e-202006-dell-webinar-social.png"
+     meta_copydoc: "https://docs.google.com/document/d/1Kdbx_bL4R-8BcG69O_Bk_3Lf3GNp9JOcNBnJgnFdiI0/edit"
+     header_title: "Standardising machine learning &mdash; from workstation to production"
+     header_subtitle: ""
+     header_image: "https://assets.ubuntu.com/v1/0b41e7c4-AI+ML_AW_white.svg"
+     header_image_width: "351"
+     header_image_height: "174"
+     header_url: '#register-section'
+     header_cta: Watch the webinar
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--aqua
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 409599, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+In April, we talked about the landscape for Dell’s Data Science Workstation, which is a development enterprise-class workstation for data scientists. Continuing the initial discussion, join Dell and Canonical once again to discover the AI journey from modelling and testing on the desktop to production in the data centre. We will also learn about the foundation of containers in AI - including how to harness the potential of container orchestration of Kubernetes in Machine Learning deployments at scale.
+
+Kyle and Rui will discuss:
+
+- **Dell workstations in AI/ML** - Hear the latest info on the Ubuntu-based Dell Data Science Workstation platform lineup available in the DSW Guided Install Edition - Mobiles, Towers and Racks
+- **Microk8s for lightweight kubernetes** - Learn about “under the desk” clustering (a.k.a. carpet clusters), and testing on a kubernetes cluster
+- **Deploying and using Kubeflow on top of microk8s** - for portability of AI/ML workloads with the best tools for machine learning

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,10 +28,10 @@
 
 {% block takeover_content %}
   {# ALL #}
-  {% include "takeovers/_snapd-takeover.html" %}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_ubuntu-masters-roblox.html" %}
   {% include "takeovers/_kafka-in-production_takeover.html" %}
+  {% include "takeovers/_202006-ml-dell-webinar.html" %}
 
   {# FRENCH #}
   {% include "takeovers/_cio-guide-to-multipass-fr.html" %}

--- a/templates/takeovers/_202006-ml-dell-webinar.html
+++ b/templates/takeovers/_202006-ml-dell-webinar.html
@@ -1,0 +1,18 @@
+{% with title="Machine learning &mdash; from workstation to production",
+subtitle="Streamline the AI journey from modelling to production, with Canonical and Dell",
+class="p-takeover--aqua",
+header_image="https://assets.ubuntu.com/v1/0b41e7c4-AI+ML_AW_white.svg",
+image_style="",
+image_height="174",
+image_width="351",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/ml-dell-webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_DELL_AI_WBN_MLtoProduction",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -140,4 +140,6 @@
 {% include "takeovers/_cio-guide-to-multipass-fr.html" %}
 <p>28 May 2020</p>
 {% include "takeovers/_kafka-in-production_takeover.html" %}
+<p>2 June 2020</p>
+{% include "takeovers/_202006-ml-dell-webinar.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add dell webinar takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/
    - http://0.0.0.0:8001/takeover
    - http://0.0.0.0:8001/engage/ml-dell-webinar
    - http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [design issue](https://github.com/canonical-web-and-design/web-squad/issues/2773) and the [brief](https://docs.google.com/spreadsheets/d/14ijDOFOsUSTfOW7ZiuU92eyezZehEPHDyZfLATuDuu4/edit?ts=5ebe8a0e#gid=2113339190)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7556

