### PR TITLE
Show contact numbers if renewal is not actionable

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -353,12 +353,10 @@ summary {
 // Advantage section
 .p-table--advantage-contract {
   margin: 0 auto;
-  table-layout: fixed;
   width: auto;
 
   td {
     display: table-cell;
-    width: 50%;
   }
 
   tr {
@@ -405,6 +403,17 @@ summary {
   @extend %vf-has-round-corners;
 
   margin-bottom: 0;
+}
+
+.p-table--advantage-contact {
+  @media only screen and (min-width: $breakpoint-large) {
+    width: 66%;
+  }
+
+  th,
+  td {
+    flex: 1 !important;
+  }
 }
 
 .p-table--advantage {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -18,8 +18,8 @@
   font-family: "UbtuOverride";
   font-style: normal;
   font-weight: 300;
-  src:
-    url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2") format("woff2"),
+  src: url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2")
+      format("woff2"),
     url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
 }
 
@@ -353,10 +353,12 @@ summary {
 // Advantage section
 .p-table--advantage-contract {
   margin: 0 auto;
+  table-layout: fixed;
   width: auto;
 
   td {
     display: table-cell;
+    width: 50%;
   }
 
   tr {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -406,10 +406,6 @@ summary {
 }
 
 .p-table--advantage-contact {
-  @media only screen and (min-width: $breakpoint-large) {
-    width: 66%;
-  }
-
   th,
   td {
     flex: 1 !important;

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -215,21 +215,23 @@
                                 {% elif contract["renewal"]["actionable"] == false %}
                                   </table>
                                   
-                                  <div class="p-notification--information" style="margin-top: 1rem; width: 100%;">
-                                    <p class="p-notification__response">
-                                      Sorry, this subscription can't be renewed online. Please call us.
-                                    </p>
+                                  <div class="row">
+                                    <div class="p-notification--information col-8 col-start-large-3" style="margin-top: 1rem;">
+                                      <p class="p-notification__response">
+                                        Sorry, this subscription can't be renewed online. Please call us.
+                                      </p>
+                                    </div>
                                   </div>
                                     
                                   <table class="p-table--advantage-contact row">
-                                    <thead class="col-8">
+                                    <thead class="col-8 col-start-large-3">
                                       <tr>
                                         <th>Country</th>
                                         <th>Phone number</th>
                                       </tr>
                                     </thead>
 
-                                    <tbody class="col-8">
+                                    <tbody class="col-8 col-start-large-3">
                                       <tr>
                                         <td>United States:</td>
                                         <td><a href="tel:+1 737 2040291">+1 737 2040291</a></td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -212,6 +212,46 @@
                                       <span>Renewal in progress...</span>
                                     </td>
                                   </tr>
+                                {% elif contract["renewal"]["actionable"] == false %}
+                                  </table>
+                                  
+                                  <table class="u-no-margin--bottom">
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--center">
+                                        <div class="p-notification--information u-no-margin--bottom">
+                                          <p class="p-notification__response">
+                                            Sorry, this subscription can't be renewed online. Please call us.
+                                          </p>
+                                        </div>
+                                      </td>
+                                    </tr>
+                                  </table>
+
+                                  <table class="p-table--advantage-contract">
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">United States:</td>
+                                      <td class="u-align--left"><a href="tel:+1 737 2040291">+1 737 2040291</a></td>
+                                    </tr>
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">United Kingdom:</td>
+                                      <td class="u-align--left"><a href="tel:+44 203 656 5291">+44 203 656 5291</a></td>
+                                    </tr>
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">Germany:</td>
+                                      <td class="u-align--left"><a href="tel:+49 61512746816">+49 61512746816</a></td>
+                                    </tr>
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">Spain:</td>
+                                      <td class="u-align--left"><a href="tel:+34 932201131">+34 932201131</a></td>
+                                    </tr>
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">France:</td>
+                                      <td class="u-align--left"><a href="tel:+33 184889319">+33 184889319</a></td>
+                                    </tr>
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">Japan:</td>
+                                      <td class="u-align--left"><a href="tel:+81-3 6205 3075">+81-3 6205 3075</a></td>
+                                    </tr>
                                 {% endif %}
                               {% endif %}
                             </table>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -215,29 +215,21 @@
                                 {% elif contract["renewal"]["actionable"] == false %}
                                   </table>
                                   
-                                  <table class="u-no-margin--bottom">
-                                    <tbody>
-                                      <tr style="border-top: 0;">
-                                        <td class="u-align--center">
-                                          <div class="p-notification--information u-no-margin--bottom" style="width: 100%;">
-                                            <p class="p-notification__response">
-                                              Sorry, this subscription can't be renewed online. Please call us.
-                                            </p>
-                                          </div>
-                                        </td>
-                                      </tr>
-                                    </tbody>
-                                  </table>
-
-                                  <table class="p-table--advantage-contact">
-                                    <thead>
+                                  <div class="p-notification--information" style="margin-top: 1rem; width: 100%;">
+                                    <p class="p-notification__response">
+                                      Sorry, this subscription can't be renewed online. Please call us.
+                                    </p>
+                                  </div>
+                                    
+                                  <table class="p-table--advantage-contact row">
+                                    <thead class="col-8">
                                       <tr>
                                         <th>Country</th>
                                         <th>Phone number</th>
                                       </tr>
                                     </thead>
 
-                                    <tbody>
+                                    <tbody class="col-8">
                                       <tr>
                                         <td>United States:</td>
                                         <td><a href="tel:+1 737 2040291">+1 737 2040291</a></td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -216,42 +216,53 @@
                                   </table>
                                   
                                   <table class="u-no-margin--bottom">
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--center">
-                                        <div class="p-notification--information u-no-margin--bottom">
-                                          <p class="p-notification__response">
-                                            Sorry, this subscription can't be renewed online. Please call us.
-                                          </p>
-                                        </div>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr style="border-top: 0;">
+                                        <td class="u-align--center">
+                                          <div class="p-notification--information u-no-margin--bottom" style="width: 100%;">
+                                            <p class="p-notification__response">
+                                              Sorry, this subscription can't be renewed online. Please call us.
+                                            </p>
+                                          </div>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
 
-                                  <table class="p-table--advantage-contract">
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--right">United States:</td>
-                                      <td class="u-align--left"><a href="tel:+1 737 2040291">+1 737 2040291</a></td>
-                                    </tr>
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--right">United Kingdom:</td>
-                                      <td class="u-align--left"><a href="tel:+44 203 656 5291">+44 203 656 5291</a></td>
-                                    </tr>
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--right">Germany:</td>
-                                      <td class="u-align--left"><a href="tel:+49 61512746816">+49 61512746816</a></td>
-                                    </tr>
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--right">Spain:</td>
-                                      <td class="u-align--left"><a href="tel:+34 932201131">+34 932201131</a></td>
-                                    </tr>
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--right">France:</td>
-                                      <td class="u-align--left"><a href="tel:+33 184889319">+33 184889319</a></td>
-                                    </tr>
-                                    <tr style="border-top: 0;">
-                                      <td class="u-align--right">Japan:</td>
-                                      <td class="u-align--left"><a href="tel:+81-3 6205 3075">+81-3 6205 3075</a></td>
-                                    </tr>
+                                  <table class="p-table--advantage-contact">
+                                    <thead>
+                                      <tr>
+                                        <th>Country</th>
+                                        <th>Phone number</th>
+                                      </tr>
+                                    </thead>
+
+                                    <tbody>
+                                      <tr>
+                                        <td>United States:</td>
+                                        <td><a href="tel:+1 737 2040291">+1 737 2040291</a></td>
+                                      </tr>
+                                      <tr>
+                                        <td>United Kingdom:</td>
+                                        <td><a href="tel:+44 203 656 5291">+44 203 656 5291</a></td>
+                                      </tr>
+                                      <tr>
+                                        <td>Germany:</td>
+                                        <td><a href="tel:+49 61512746816">+49 61512746816</a></td>
+                                      </tr>
+                                      <tr>
+                                        <td>Spain:</td>
+                                        <td><a href="tel:+34 932201131">+34 932201131</a></td>
+                                      </tr>
+                                      <tr>
+                                        <td>France:</td>
+                                        <td><a href="tel:+33 184889319">+33 184889319</a></td>
+                                      </tr>
+                                      <tr>
+                                        <td>Japan:</td>
+                                        <td><a href="tel:+81-3 6205 3075">+81-3 6205 3075</a></td>
+                                      </tr>
+                                    </tbody>
                                 {% endif %}
                               {% endif %}
                             </table>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -507,7 +507,12 @@ def make_renewal(advantage, contract_info):
     renewal["renewable"] = False
 
     # Only actionable renewals are renewable.
-    if not renewal["actionable"]:
+    # If "actionable" isn't set, it's not actionable
+    # If "actionable" IS set, but not true, it's not actionable
+    if "actionable" not in renewal:
+        renewal["actionable"] = False
+        return renewal
+    elif not renewal["actionable"]:
         return renewal
 
     # The renewal is renewable only during its time window.


### PR DESCRIPTION
## Done

- Added a list of contact numbers for cases where a renewal is present but not actionable

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Sign in with SSO
- Ask Scott to set you up with test data
- Find the subscription, expand the row and see that you are presented with a notification and a list of contact numbers


## Issue / Card

Fixes #7605

## Screenshots
![Screenshot from 2020-06-03 12-50-48](https://user-images.githubusercontent.com/2376968/83633489-f4dda580-a598-11ea-8bc2-cf9eb9767db1.png)



