### PR TITLE
Update CVE icons

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -659,25 +659,25 @@ summary {
 }
 
 .p-icon--unknown-priority {
-  background-image: url("#{$assets-path}e85d00c8-CVE-Priority-icon-Unknown.svg");
+  background-image: url("#{$assets-path}2dff197f-CVE-Priority-icon-Unknown.svg");
 }
 
 .p-icon--negligible-priority {
-  background-image: url("#{$assets-path}f6820eae-CVE-Priority-icon-Negligible.svg");
+  background-image: url("#{$assets-path}ef6c75b8-CVE-Priority-icon-Negligible.svg");
 }
 
 .p-icon--low-priority {
-  background-image: url("#{$assets-path}2c18ab71-CVE-Priority-icon-Low.svg");
+  background-image: url("#{$assets-path}03ac6f86-CVE-Priority-icon-Low.svg");
 }
 
 .p-icon--medium-priority {
-  background-image: url("#{$assets-path}6d25e065-CVE-Priority-icon-Medium.svg");
+  background-image: url("#{$assets-path}8010f9e0-CVE-Priority-icon-Medium.svg");
 }
 
 .p-icon--high-priority {
-  background-image: url("#{$assets-path}a9a5dc21-CVE-Priority-icon-High.svg");
+  background-image: url("#{$assets-path}3887354e-CVE-Priority-icon-High.svg");
 }
 
 .p-icon--critical-priority {
-  background-image: url("#{$assets-path}428a85f3-CVE-Priority-icon-Critical.svg");
+  background-image: url("#{$assets-path}c96f27b9-CVE-Priority-icon-Critical.svg");
 }

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -66,27 +66,27 @@
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
               {% if cve.priority == 'unknown' %}
-                <img src="https://assets.ubuntu.com/v1/e85d00c8-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
+                <img src="https://assets.ubuntu.com/v1/2dff197f-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
               {% endif %}
 
               {% if cve.priority == 'negligible' %}
-                <img src="https://assets.ubuntu.com/v1/f6820eae-CVE-Priority-icon-Negligible.svg" alt="" class="p-heading-icon__img">
+                <img src="https://assets.ubuntu.com/v1/ef6c75b8-CVE-Priority-icon-Negligible.svg" alt="" class="p-heading-icon__img">
               {% endif %}
 
               {% if cve.priority == 'low' %}
-                <img src="https://assets.ubuntu.com/v1/2c18ab71-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
+                <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
               {% endif %}
 
               {% if cve.priority == 'medium' %}
-                <img src="https://assets.ubuntu.com/v1/6d25e065-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
+                <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
               {% endif %}
 
               {% if cve.priority == 'high' %}
-                <img src="https://assets.ubuntu.com/v1/a9a5dc21-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
+                <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
               {% endif %}
 
               {% if cve.priority == 'critical' %}
-                <img src="https://assets.ubuntu.com/v1/428a85f3-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
+                <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
               {% endif %}
               <h4 class="p-heading-icon__title u-no-margin--bottom">
                 {{ cve.priority | capitalize }}


### PR DESCRIPTION
## Done

Update CVE icons

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run DB:

```
docker-compose rm -fs
docker-compose up
```

In another terminal:

```
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec alembic upgrade head
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec python3 scripts/create-releases.py
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres serve
```

In yet another terminal:

```
git clone -b load-cve git@github.com:carkod/ubuntu-cve-tracker
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss
time python3 upload-cve.py ../active
```

Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

- Check that the icons are still visible in the table