### PR TITLE
Redirect those underscore urls

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -839,3 +839,7 @@ internet-of-things/robotics/?: /robotics
 
 # Image builder
 build: /core/build
+
+# Redirect navigation templates
+templates/_(?P<path>.*)/?: /templates/{path}
+shared/forms/interactive/_(?P<path>.*)/?: /shared/forms/interactive/{path}


### PR DESCRIPTION
This [this sentry error](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/8009/).

QA
--

In the demo, or locally, go to `/templates/_navigation-download-h.html`, see it redirects to the proper place.