### PR TITLE
Use Talisker session for docs calls

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -80,7 +80,11 @@ app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"
 ).rstrip("/")
 
+session = talisker.requests.get_session()
 talisker.requests.configure(api_session)
+discourse_api = DiscourseAPI(
+    base_url="https://discourse.ubuntu.com/", session=session
+)
 
 
 # Error pages
@@ -196,17 +200,17 @@ app.add_url_rule(
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 url_prefix = "/server/docs"
-server_docs_parser = DocParser(
-    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
-    category_id=26,
-    index_topic_id=11322,
-    url_prefix=url_prefix,
-)
 server_docs = DiscourseDocs(
-    parser=server_docs_parser,
+    parser=DocParser(
+        api=discourse_api,
+        category_id=26,
+        index_topic_id=11322,
+        url_prefix=url_prefix,
+    ),
     document_template="/docs/document.html",
     url_prefix=url_prefix,
 )
+server_docs.init_app(app)
 
 # Allow templates to be queried from discourse.ubuntu.com
 app.add_url_rule(
@@ -218,17 +222,14 @@ app.add_url_rule(
     ),
 )
 
-server_docs.init_app(app)
-
 tutorials_path = "/tutorials"
-tutorials_docs_parser = DocParser(
-    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
-    category_id=34,
-    index_topic_id=13611,
-    url_prefix=tutorials_path,
-)
 tutorials_docs = DiscourseDocs(
-    parser=tutorials_docs_parser,
+    parser=DocParser(
+        api=discourse_api,
+        category_id=34,
+        index_topic_id=13611,
+        url_prefix=tutorials_path,
+    ),
     document_template="/tutorials/tutorial.html",
     url_prefix=tutorials_path,
     blueprint_name="tutorials",


### PR DESCRIPTION
Instead of the CachedSession from canonicalwebteam.http.

This is because we're getting timeout errors in Sentry,
because the CachedSession has a timeout of (.5, 3) by default.

We should no longer explicitly time out API calls, as
the combination of the content-cache in front of our sites
and the fact that we use gsync gevent workers in production
should mean that there's no problem with request waiting for
the API calls to complete.

Also, using a Talisker session allows us to get more information
about these API requests in Graylog.

This should fix Sentry errors like this one: https://sentry.is.canonical.com/canonical/ubuntu-com/issues/9582/

## QA

In the demo, or running locally, go to `/tutorials` and `/server/docs` and check they both still work fine.