### PR TITLE
Add babelrc to the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 FROM yarn-dependencies AS build-js
 ADD static/js static/js
 ADD webpack.config.js .
+ADD .babelrc .
 RUN yarn run build-js
 
 


### PR DESCRIPTION
## Done
Add babelrc to the docker build

## QA
- Check the code looks right
- Run `docker build --build-arg TALISKER_REVISION_ID=test --tag ubuntu.com .`
- Run `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key --env DATABASE_URL=sqlite:///usn.sqlite3 ubuntu.com`
- Go to http://localhost:8006/static/js/build/renewal-modal.min.js?v=4d60482
- Check that `regeneratorRuntime` appears twice

