### PR TITLE
Update raspberry pi install instructions

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -1,6 +1,7 @@
 appliances:
   plex:
     name: "Plex"
+    appliance_name: "Plex Media Server"
     url_name: "plex"
     iso_url:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-ubuntu-core-18-pi-arm64.img.xz"
@@ -10,6 +11,7 @@ appliances:
       pc: "ea001bde90753b6e7d620a018c6c9e31a196c48009802e177f60fd6751ba979a *plexmediaserver-ubuntu-core-18-amd64.img.xz"
   adguard:
     name: "Adguard"
+    appliance_name: "Adguard"
     url_name: "adguard"
     iso_url:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-ubuntu-core-18-pi-arm64.img.xz"
@@ -19,6 +21,7 @@ appliances:
       pc: "f904ad1ae804c768a8a0a2ab02617a6589c00ca17d764dccaec0d54b19fd4619 *adguard-home-ubuntu-core-18-amd64.img.xz"
   openhab:
     name: "OpenHAB"
+    appliance_name: "OpenHAB"
     url_name: "openhab"
     iso_url:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-pi-arm64.img.xz"

--- a/templates/appliance/shared/_install_instructions_raspberry-pi.html
+++ b/templates/appliance/shared/_install_instructions_raspberry-pi.html
@@ -1,5 +1,5 @@
 <div class="p-strip is-shallow u-no-padding--top">
-  <p>We will walk you through the steps of flashing your {{ appliance.name }} Ubuntu appliance on to your Raspberry Pi and getting logged in.</p>
+  <p>We will walk you through the steps of flashing your {{ appliance.appliance_name }} Ubuntu Appliance on to your Raspberry Pi and getting logged in.</p>
 </div>
 <hr>
 <h4>What you&rsquo;ll need</h4>

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.raspberrypi %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
+<meta http-equiv="r efresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">

--- a/templates/appliance/shared/_steps_pi_boot-raspberry-pi.html
+++ b/templates/appliance/shared/_steps_pi_boot-raspberry-pi.html
@@ -14,7 +14,7 @@
       Power up the Pi by connecting it to your USB power supply.
     </p>
     <p>
-      Your Pi will boot, and present you with a series of configuration choices. You need to ensure that the Pi has Internet access so that it can get updates and verify your SSH keys.
+      Your Pi will boot, and present you with a series of configuration choices. You need to ensure that the Pi has internet access so that it can get updates and verify your SSH keys.  If you need more help there is a <a href="/tutorials/how-to-install-ubuntu-core-on-raspberry-pi#4-boot-ubuntu-core">tutorial</a> that goes through these steps in more detail. 
     </p>
     <p>
       Next, you will need to enter your Ubuntu cloud account email address.

--- a/templates/appliance/shared/_steps_ssh-keys_ubuntu.html
+++ b/templates/appliance/shared/_steps_ssh-keys_ubuntu.html
@@ -5,15 +5,13 @@
   </h4>
   <div class="p-stepped-list__content">
     <p>
-      The ‘Secure Shell’ protocol provides access to your Ubuntu Appliance and uses cryptographic keys to authenticate you to the device. You will need SSH software and keys.
+      The ‘Secure Shell’ protocol provides access to your Ubuntu Appliance and uses cryptographic keys to authenticate you to the device. You need SSH software and keys.
     </p>
     <p>
       Run the following commands:
     </p>
 
-    <pre><code>mkdir ~/.ssh
-chmod 700 ~/.ssh
-ssh-keygen -t rsa</code></pre>
+    <pre><code>ssh-keygen -t rsa</code></pre>
 
     <ol>
       <li>
@@ -27,7 +25,7 @@ ssh-keygen -t rsa</code></pre>
       </li>
     </ol>
     <p>
-      You now have a public and private key that you can use to authenticate. Next place the public key on your Raspberry Pi so that you can use SSH-key-based authentication to log in.
+      You now have a public and private key that you can use to authenticate.
     </p>
     </div>
   </li>

--- a/templates/appliance/shared/_steps_ssh-keys_windows.html
+++ b/templates/appliance/shared/_steps_ssh-keys_windows.html
@@ -34,7 +34,7 @@
     <pre><code>Name  : OpenSSH.Client~~~~0.0.1.0
 State : NotPresent</code></pre>
     <p>
-      Then, install the server and/or client features:
+      Then, install the client features:
     </p>
     <pre><code>Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0</code></pre>
     <p>

--- a/templates/appliance/shared/_steps_sso.html
+++ b/templates/appliance/shared/_steps_sso.html
@@ -14,7 +14,7 @@
       <code>{{ command }} ~/.ssh/id_rsa.pub</code>
     </p>
     <p>
-      Copy the result into the text field on the website. Click import and will have the key set up.
+      Copy the result into the text field on the website. Click <code>import</code> and will have the key set up.
     </p>
   </div>
 </li>


### PR DESCRIPTION
## Done

- Update raspberry pi install instructions


**I turned off automatic downloads for the review**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit) and resolve comments

