### PR TITLE
Update design of appliance index pages

### DIFF
--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -24,26 +24,35 @@
         </div>
       </div>
     </div>
-    <div class="col-4 u-align--right">
-      <form class="p-form--inline js-download">
-        <div class="p-form__group">
-          <label for="platform" class="u-off-screen">Platform</label>
-          <select id="platform" class="js-platform-select">
-            {% if downloads.raspberrypi %}
-            <option value="raspberry-pi">Raspberry Pi</option>
-            {% endif %}
-            {% if downloads.pc %}
-            <option value="pc">PC</option>
-            {% endif %}
-            {% if downloads.intelnuc %}
-            <option value="intel-nuc">Intel NUC</option>
-            {% endif %}
-          </select>
+    <div class="col-4">
+      <div class="row">
+        {% if downloads.raspberrypi %}
+        <div class="col-2">
+          <a href="/appliance/{{ short_name }}/raspberry-pi">
+            <div class="u-align--center">
+              <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=100" alt="" style="width: 50%;">
+              <p>Raspberry&nbsp;Pi&nbsp;&rsaquo;</p>
+            </div>
+          </a>
         </div>
-        <div class="p-form__group">
-          <a href="/appliance/{{ short_name }}/raspberry-pi" class="p-button--positive p-form__control js-download-button">Download</a>
+        {% endif %}
+        {% if downloads.pc %}
+        <div class="col-2">
+          <a href="/appliance/{{ short_name }}/intel-nuc">
+            <div class="u-align--center">
+              <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=100" style="width: 50%;">
+              <p>NUC&nbsp;&rsaquo;</p>
+            </div>
+          </a>
         </div>
-      </form>
+        {% endif %}
+      </div>
+      {% if downloads.pc %}
+      <p>
+        <strong>Don’t have a device?</strong><br />
+        <a href="/appliance/{{ short_name }}/vm">Try {{ appliance_name }} on your Ubuntu, Windows or Mac machine&nbsp;&rsaquo;</a>
+      </p>
+      {% endif %}
     </div>
   </div>
 </section>
@@ -57,7 +66,7 @@
         {% else %}
         <img src="{{ screenshots.1 }}" class="p-image--shadowed" alt="{{ appliance_name }} screenshots">
         {% endif %}
-     </div>
+      </div>
     </div>
     <div class="col-2 u-align--center">
       <ul class="p-list row">
@@ -81,6 +90,13 @@
       {{ content | safe }}
     </div>
     <div class="col-4">
+      {% if maintenance_date %}
+      <div class="p-label--new">Certified</div>
+      <p>Maintained until {{ maintenance_date }}<br />
+        {% if downloads.raspberrypi %}ARM{% endif %}{% if downloads.pc and downloads.raspberrypi %}, {% endif %}{% if downloads.pc %}x86{% endif %}
+      </p>
+      {% endif %}
+
       <h5 class="u-no-margin--bottom u-no-padding--top">Relevant links</h5>
       <ul class="p-list">
         {% for link in links.values() %}
@@ -97,30 +113,43 @@
       <p>{{ base }}</p>
       <h5 class="u-no-margin--bottom u-no-padding--top">Date published</h5>
       <p>{{ published_date }}</p>
-      <h5 class="u-no-margin--bottom u-no-padding--top">Security maintenance until</h5>
-      <p>{{ maintenance_date }}</p>
     </div>
   </div>
 </section>
 
 <section class="p-strip u-no-padding--top">
   <div class="row">
-    <div class="col-6">
+    <div class="col-10">
       <h2 class="p-heading--four">Snaps in the image</h2>
-      {% for snap in snaps.values() %}
-      <div class="p-media-object">
-        <img src="{{ snap.icon }}?w=75" alt="" class="p-media-object__image is-round" height="75" width="75">
-        <div class="p-media-object__details">
-          <h3 class="p-heading--5 u-no-margin--bottom u-sv-1">
-            <a href="{{ snap.link }}" class="p-link--external">{{ snap.name }}</a>
-          </h3>
-          <p class="p-muted-text">By {{ snap.publisher }}</p>
-          <p class="u-sv-1"><span class="p-muted-text">Channel: </span>{{ snap.channel }}</p>
-          <p class="u-sv-1"><span class="p-muted-text">Version: </span>{{ snap.version }}</p>
-          <p><span class="p-muted-text">Published: </span>{{ snap.published_date }}</p>
-        </div>
-      </div>
-      {% endfor %}
+      <table>
+        <thead>
+          <tr>
+            <td style="width: 33%;">&nbsp;</td>
+            <th>PUBLISHER</th>
+            <th>VERSION</th>
+            <th>UPDATED</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for snap in snaps.values() %}
+          <tr>
+            <td>
+              <div class="p-media-object">
+                <img src="{{ snap.icon }}?w=50" alt="" class="p-media-object__image is-round" height="50" width="50">
+                <div class="p-media-object__details">
+                  <p>
+                    <a href="{{ snap.link }}" class="p-link--external">{{ snap.name }}</a>
+                  </p>
+                </div>
+              </div>
+            </td>
+            <td><p>{{ snap.publisher }}</p></td>
+            <td><p>{{ snap.version }}</p></td>
+            <td><p>{{ snap.published_date }}</p></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
   </div>
 </section>
@@ -128,33 +157,31 @@
 <section class="p-strip u-no-padding--top">
   <div class="row">
     <div class="col-6">
-      <h4>This appliance works on:</h4>
+      {% if downloads.pc %}
+      <h3>Try it out!</h3>
+      <p>
+        Grab a spare board, PC or NUC. We also have <a href="/appliance/{{ short_name }}/vm">instructions for virtual machine</a> testing of appliances.
+      </p>
+      {% endif %}
     </div>
-  </div>
-
-  <div class="row">
     {% if downloads.raspberrypi %}
-    <div class="col-2">
-      <a href="/appliance/{{ short_name }}/raspberry-pi" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">Raspberry Pi</h3>
-        <hr />
+    <div class="col-3">
+      <a href="/appliance/{{ short_name }}/raspberry-pi">
         <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=200" alt="" style="margin:1rem 0; width: 85%;">
+          <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=100" alt="" style="width: 50%;">
+          <p>Install on Raspberry&nbsp;Pi&nbsp;&rsaquo;</p>
         </div>
       </a>
-      <p><a href="/appliance/{{ short_name }}/raspberry-pi">Install on Raspberry&nbsp;Pi</a></p>
     </div>
     {% endif %}
     {% if downloads.pc %}
-    <div class="col-2">
-      <a href="/appliance/{{ short_name }}/intel-nuc" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">NUC</h3>
-        <hr />
+    <div class="col-3">
+      <a href="/appliance/{{ short_name }}/intel-nuc">
         <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=200" style="margin:1rem 0; width: 85%;">
+          <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=100" style="width: 50%;">
+          <p>Install on NUC&nbsp;&rsaquo;</p>
         </div>
       </a>
-      <p><a href="/appliance/{{ short_name }}/intel-nuc">Install on NUC</a></p>
     </div>
     {% endif %}
   </div>
@@ -163,12 +190,44 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
+      <h2>
+        Join the community
+      </h2>
+      <p>
+        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place for news and views.
+      </p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
       <h2>Build your own appliance</h2>
       <p>Making it with Ubuntu is easy. If you have an application that you would like to make a part of the Ubuntu appliance portfolio, read our guidelines and get in touch. Soon you will have a page like this.</p>
       <a href="/appliance/contact-us" class="p-button--neutral js-invoke-modal">Get in touch</a>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/03d1807c-2+-+Build+your+own+stack+and+prototype+your+application.svg" alt="" height="300" width="400">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/03d1807c-2+-+Build+your+own+stack+and+prototype+your+application.svg",
+        alt="",
+        width="400",
+        height="300",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update design of appliance index pages based on the latest copy
- Left in the bottom 'Build your own appliance' strip for now

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/14sEgchP6BUjnUtJt67XJ-fKl7k8dAevaf5EJac9Pmyc/edit#)



