### PR TITLE
Update renewed tag logic

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=sqlite:///usn.sqlite3
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.canonical.com/
+CONTRACTS_API_URL=https://contracts.staging.canonical.com/
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -460,7 +460,7 @@ function handleSuccessfulPayment() {
     "Payment complete. One moment...";
   progressIndicator.classList.remove("u-hide");
 
-  location.search = `subscription=${activeRenewal.contractId}&renewed=true`;
+  location.search = `subscription=${activeRenewal.contractId}`;
 }
 
 function hideErrors() {

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -179,7 +179,7 @@
                                       <td class="u-align--right">Ends:</td>
                                       <td class="u-align--left">
                                         <strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>
-                                        {% if open_subscription == contract['contractInfo']['id'] and request.args.get('renewed') %}
+                                        {% if contract["renewal"]["recently_renewed"] %}
                                         <div class="p-label--updated">Renewed</div>
                                         {% endif %}
                                       </td>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -75,7 +75,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.canonical.com"
+    "CONTRACTS_API_URL", "https://contracts.staging.canonical.com"
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -5,10 +5,7 @@ import json
 import math
 import os
 import re
-from datetime import (
-    datetime,
-    timezone,
-)
+from datetime import datetime, timezone, timedelta
 
 # Packages
 import dateutil.parser
@@ -505,6 +502,13 @@ def make_renewal(advantage, contract_info):
         renewal = advantage.get_renewal(renewal["id"])
 
     renewal["renewable"] = False
+
+    if renewal["status"] == "done":
+        renewalModifiedDate = dateutil.parser.parse(renewal["lastModified"])
+        oneHourAgo = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        if oneHourAgo < renewalModifiedDate:
+            renewal["recently_renewed"] = True
 
     # Only actionable renewals are renewable.
     # If "actionable" isn't set, it's not actionable

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -347,7 +347,7 @@ def advantage_view():
     entitlements = {}
     open_subscription = flask.request.args.get("subscription", None)
     stripe_publishable_key = os.getenv(
-        "STRIPE_PUBLISHABLE_KEY", "pk_live_68aXqowUeX574aGsVck8eiIE"
+        "STRIPE_PUBLISHABLE_KEY", "pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46"
     )
 
     if user_info(flask.session):


### PR DESCRIPTION
## Done

- Changed the logic around how we present a "renewed" label when a renewal has completed
  - previously it was based on a query param given by JS, which you wouldn't get if the renewal took > 30 seconds to complete.

**Note:** I've updated contract API and Stripe key variables to use staging values so this can be QAd by anybody - I'll drop that commit before merging.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ask Scott to set you up with a test contract and renewal
- Complete a test purchase using 4242 4242 4242 4242 as the card number, any future expiry date and any zip code
- When the page reloads, see that the "Renewed" tag is there in the expanded row, and that "renewed=true" isn't present in the url
- If you have older contracts with renewals completed in previous tests, expand those rows and see that the "renewed" tag is not there
