### PR TITLE
Add phone field to OpenStack modal forms

### DIFF
--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -308,6 +308,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -310,6 +310,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>


### PR DESCRIPTION
## Done

- Added a phone field to OpenStack modal forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the Phone form field is in
  - https://ubuntu-com-canonical-web-and-design-pr-7652.run.demo.haus/openstack#get-in-touch
  - https://ubuntu-com-canonical-web-and-design-pr-7652.run.demo.haus/openstack/managed#get-in-touch
- Submit a form on each, once you've tested, ping davidcalle on IRC to verify outcome
