### PR TITLE
Build new /kubernetes/what-is-kubernetes page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -148,6 +148,8 @@ kubernetes:
   children:
     - title: Overview
       path: /kubernetes
+    - title: What is Kubernetes
+      path: /kubernetes/what-is-kubernetes
     - title: Features
       path: /kubernetes/features
     - title: Managed

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -576,6 +576,14 @@ summary {
   }
 }
 
+.is-ticked__cross {
+  background-image: url("https://assets.ubuntu.com/v1/9cdb5b1e-cross-darkaubergine.svg");
+  background-position-y: 0.65rem;
+  background-repeat: no-repeat;
+  background-size: 0.875rem;
+  padding-left: 2rem;
+}
+
 .u-inline {
   display: inline;
 }

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -97,20 +97,18 @@
       <p>
         Containers are a technology that allows the user to divide up a machine so that it can run more than one application (in the case of process containers) or operating system instance (in the case of system containers) on the same kernel and hardware, and in so doing maintain isolation between these workloads. Containers are a modern way to virtualise infrastructure and provide a more lightweight approach than traditional virtual machines: they all share a single host OS, require less memory space, ensure greater resource utilisation and have several orders of magnitude shorter startup time.
       </p>
-      <p class="u-sv3">
-
+      <p>
         {{
           image(
-          url="https://assets.ubuntu.com/v1/0a04f36f-diagram-machine-virtualization-vs-containers.svg",
+          url="https://assets.ubuntu.com/v1/3d57842f-diagram-machine-virtualization-vs-containers.svg",
           alt="",
           width="681",
-          height="360",
+          height="416",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "", "id": ""},
+          attrs={"style": "padding: 2rem 0;"},
           ) | safe
         }}
-
       </p>
       <p>
         Inside Google alone, at least <a class="p-link--external" href="https://cloud.google.com/containers/">two billion containers are generated each week</a> to manage its vast operations.
@@ -152,8 +150,8 @@
           image(
           url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
           alt="Canonical",
-          height="30",
-          width="216",
+          height="20",
+          width="149",
           hi_def=True,
           loading="lazy",
           ) | safe
@@ -162,9 +160,9 @@
       <li class="p-inline-images__item">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/7dd7bfaf-2018-logo-huawei.svg",
+          url="https://assets.ubuntu.com/v1/80fe0ebe-Huawei-logo.svg",
           alt="Huawei",
-          height="144",
+          height="33",
           width="144",
           hi_def=True,
           loading="lazy",
@@ -187,10 +185,10 @@
       <li class="p-inline-images__item">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/3abbe38f-zte_logo_en.png",
+          url="https://assets.ubuntu.com/v1/3abbe38f-zte_logo_en.png?w=65",
           alt="ZTE",
-          height="45",
-          width="98",
+          height="30",
+          width="65",
           hi_def=True,
           attrs={"class": "p-inline-images__logo"},
           loading="lazy",
@@ -202,10 +200,10 @@
           image(
           url="https://assets.ubuntu.com/v1/82c62241-red-hat-2019-primary.svg",
           alt="RedHat",
-          height="45",
-          width="190",
+          height="40",
+          width="169",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-inline-images__logo", "style": "width:169px;"},
           loading="lazy",
           ) | safe
         }}
@@ -215,10 +213,10 @@
           image(
           url="https://assets.ubuntu.com/v1/9c276e79-mirantis-logo-horizontal.svg",
           alt="Mirantis",
-          height="35",
-          width="315",
+          height="30",
+          width="270",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-inline-images__logo", "style": "width:270px;"},
           loading="lazy",
           ) | safe
         }}
@@ -449,11 +447,11 @@
           </li>
           <li class="p-list__item is-ticked__cross">Require applications to be written in a specific programming language nor does it dictate a specific configuration language/system.
           </li>
+          <li class="p-list__item is-ticked__cross">Deploy source code and does not build applications, although it can be used to build CI/CD pipelines
+          </li>
           <li class="p-list__item is-ticked__cross">Provide application-level services, such as middleware, databases and storage clusters out-of-the box. Such components can be integrated with k8s through add-ons.
           </li>
           <li class="p-list__item is-ticked__cross">Provide nor dictate specific logging, monitoring and alerting components
-          </li>
-          <li class="p-list__item is-ticked__cross">Deploy source code and does not build applications, although it can be used to build CI/CD pipelines
           </li>
         </ul>
       </div>
@@ -470,9 +468,10 @@
     </div>
     <div class="row">
       <div class="col-4 p-card">
-        <h3 class="p-card__title">
+        <h4 class="p-card__title">
           Run Kubernetes locally and at the edge
-        </h3>
+        </h4>
+        <hr>
         <div class="p-card__content">
           <p>
             MicroK8s is a production-grade lightweight Kubernetes that deploys a single-node cluster with a single-install command. It’s a CNCF-certified Linux snap that runs all Kubernetes services natively on Ubuntu, or any operating system that supports snaps, Windows and macOS.
@@ -488,9 +487,10 @@
         </div>
       </div>
       <div class="col-4 p-card">
-        <h3 class="p-card__title">
+        <h4 class="p-card__title">
           Run Kubernetes on your infrastructure of choice
-        </h3>
+        </h4>
+        <hr>
         <div class="p-card__content">
           <p>
             Deploy Canonical’s Charmed Kubernetes, a highly available, pure upstream, multi-node Kubernetes cluster. It’s a fully automated, model-driven approach to Kubernetes that takes care of logging, monitoring and alerting and provides application lifecycle automation capabilities.
@@ -506,9 +506,10 @@
         </div>
       </div>
       <div class="col-4 p-card">
-        <h3 class="p-card__title">
-          Have us run Kubernetes for you
-        </h3>
+        <h4 class="p-card__title">
+          Have us run Kubernetes <br class="u-hide--small">for you
+        </h4>
+        <hr>
         <div class="p-card__content">
           <p>
             Don't want the hassle and cost of hiring your own K8s team of experts? Get peace of mind and focus on  your business, by leveraging our proven experience in Kubernetes deployments and operations.
@@ -654,14 +655,14 @@
     <div class="row">
       <div class="col-8">
         <h4>
-          We’re here to revolutionise the way you think about Kubernetes clusters.
+          We’re here to revolutionise the way you think about Kubernetes&nbsp;clusters.
         </h4>
         <p>
           <a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us">Schedule a Kubernetes demo</a>
         </p>
       </div>
-
     </div>
+  </section>
 
   {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -8,41 +8,654 @@
 
 {% block content %}
 
-<section class="p-strip is-bordered u-no-padding--top u-no-padding--bottom">
+<section class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-topped">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h1>
-        What is Kubernetes?
-      </h1>
-      <p>
-        Kubernetes, or k8s for short, is an open source platform, pioneered by Google, which started as a simple container orchestration tool but has grown into a cloud-native platform.  It’s one of the most significant advancements in IT since the public cloud came to being in 2009 and has an unparalleled <a class="p-link--external" href="https://451research.com/451-research-says-application-containers-market-will-grow-to-reach-4-3bn-by-2022">5-year 30% growth rate</a> in both market revenue and overall adoption.
-      </p>
+    <div class="row u-equal-height">
+      <div class="col-7">
+        <h1>
+          What is Kubernetes?
+        </h1>
+        <p>
+          Kubernetes, or k8s for short, is an open source platform, pioneered by Google, which started as a simple container orchestration tool but has grown into a cloud-native platform.  It’s one of the most significant advancements in IT since the public cloud came to being in 2009 and has an unparalleled <a class="p-link--external" href="https://451research.com/451-research-says-application-containers-market-will-grow-to-reach-4-3bn-by-2022">5-year 30% growth rate</a> in both market revenue and overall adoption.
+        </p>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
+          alt="",
+          width="250",
+          height="195",
+          hi_def=True,
+          loading="auto",
+          ) | safe
+        }}
+      </div>
     </div>
-    <div class="col-5 u-align--center u-vertically-center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
-        alt="",
-        width="250",
-        height="195",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}
-    </div>
-  </div>
   </div>
 </section>
 
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-4">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9fa25e69-Design+and+build.svg",
+        alt="",
+        width="63",
+        height="50",
+        hi_def=True,
+        loading="auto|lazy",
+        attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
+      <p>
+        Kubernetes has risen to popularity as a result of its appealing architecture, development teams needing to deliver and maintain software at scale, a large and active community and the continuous need for extensibility.  It reduces many of the manual tasks traditionally associated with co-ordinating containers in production by automating their deployment, scheduling and management.
+      </p>
+    </div>
+    <div class="col-4">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/061edebb-developer.svg",
+        alt="",
+        width="50",
+        height="50",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
+      <p>
+        Kubernetes maps out how applications should work and how they should interact with other applications. Due to its elasticity, it can scale services up and down as required, perform rolling updates, switch traffic between different versions of your applications to test features or rollback problematic deployments.
+      </p>
+    </div>
+    <div class="col-4">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/a33638f0-public-cloud.svg",
+        alt="",
+        width="66",
+        height="50",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
+      <p>
+        The technology has emerged as a leading choice for organisations looking to build their multi-cloud environments, thanks to the widespread adoption of its APIs. All public clouds have adopted Kubernetes and offer their own distributions, such as AWS Elastic Container Service for Kubernetes, Google Kubernetes Engine and Azure Kubernetes Service.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>
+        What are containers?
+      </h2>
+      <p>
+        Containers are a technology that allows the user to divide up a machine so that it can run more than one application (in the case of process containers) or operating system instance (in the case of system containers) on the same kernel and hardware, and in so doing maintain isolation between these workloads. Containers are a modern way to virtualise infrastructure and provide a more lightweight approach than traditional virtual machines: they all share a single host OS, require less memory space, ensure greater resource utilisation and have several orders of magnitude shorter startup time.
+      </p>
+      <p class="u-sv3">
+
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/0a04f36f-diagram-machine-virtualization-vs-containers.svg",
+          alt="",
+          width="681",
+          height="360",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "", "id": ""},
+          ) | safe
+        }}
+
+      </p>
+      <p>
+        Inside Google alone, at least <a class="p-link--external" href="https://cloud.google.com/containers/">two billion containers are generated each week</a> to manage its vast operations.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <h2>
+      Kubernetes history and ecosystem
+    </h2>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <p>
+        Kubernetes (from the Greek ‘κυβερνήτης’ meaning ‘helmsman’) was developed by Google, its design has been heavily influenced by Google’s ‘Borg’ project – a similar system used by Google to run much of its infrastructure. Kubernetes has since been donated to the Cloud Native Computing Foundation, a collaborative project between the Linux Foundation and Google, Cisco, IBM, Docker, Microsoft, AWS and VMware.
+      </p>
+    </div>
+    <div class="col-4 u-align--center">
+      <div style="background-color:#fff; border: 1px solid #eee; padding: 1rem;">
+        <p class="p-heading--four u-align--left">
+          Did you know? The font used in the Kubernetes logo is the Ubuntu font!
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="u-fixed-width">
+    <h2 class="p-muted-heading u-align--center">
+      KEY CONTRIBUTORS TO KUBERNETES
+    </h2>
+    <ul class="p-inline-images">
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
+          alt="Canonical",
+          height="30",
+          width="216",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/7dd7bfaf-2018-logo-huawei.svg",
+          alt="Huawei",
+          height="144",
+          width="144",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/5bd692e3-partner-logo-fujitsu.svg",
+          alt="Fujutsu",
+          height="57",
+          width="122",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/3abbe38f-zte_logo_en.png",
+          alt="ZTE",
+          height="45",
+          width="98",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/82c62241-red-hat-2019-primary.svg",
+          alt="RedHat",
+          height="45",
+          width="190",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/9c276e79-mirantis-logo-horizontal.svg",
+          alt="Mirantis",
+          height="35",
+          width="315",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/bc96d94b-CoreOS-logo.png",
+          alt="Core OS",
+          height="57",
+          width="150",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy",
+          ) | safe
+        }}
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>
+        How does Kubernetes work?
+      </h2>
+      <p>
+        Kubernetes works by joining a group of physical or virtual host machines referred to as “nodes”, into a cluster to manage containers. This creates a “supercomputer” that has greater processing speed, more storage capacity and increased network capabilities than any single machine would have on its own. The nodes include all necessary services to run “pods”, which in turn run single or multiple containers. A pod corresponds to a single instance of an application in Kubernetes.
+      </p>
+      <p>
+        One (or more for larger clusters, or High Availability) node of the cluster is designated as the "master". The master node then assumes responsibility for the cluster as the orchestration layer - scheduling and allocating tasks to the other "worker" nodes in a way which maximises the resources of the cluster. All operator interaction with the cluster goes through this master node, whether that is changes to the configuration, executing or terminating workloads, or controlling ingress and egress on the network.
+      </p>
+      <p>
+        The master node is also responsible for monitoring all aspects of the cluster, enabling it to perform additional useful functions such as automatically reallocating workloads in case of failure, scaling up tasks which need more resources and otherwise ensuring that the assigned workloads are always operating correctly.
+      </p>
+      <p>
+        <a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Download Enterprise Kubernetes datasheet&nbsp;&rsaquo;</a>
+      </p>
+      <p>
+        <img class="u-hide--small" src="https://assets.ubuntu.com/v1/26a8de44-diagram-enterprise-kubernetes.svg" alt="">
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12">
+      <h2>
+        Speaking Kubernetes
+      </h2>
+      <ul class="p-matrix">
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Cluster
+            </h3>
+            <p class="p-matrix__desc">
+              A set of nodes that run containerized applications managed by Kubernetes.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Pod
+            </h3>
+            <p class="p-matrix__desc">
+              The smallest unit in the Kubernetes object model that is used to host containers.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Master node
+            </h3>
+            <p class="p-matrix__desc">
+              <em>a.k.a. control plane</em><br />
+              The orchestration layer that provides interfaces to define, deploy, and manage the lifecycle of containers.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Worker Node
+            </h3>
+            <p class="p-matrix__desc">
+              Every worker node can host applications as containers. A Kubernetes cluster usually has multiple worker nodes (at least one).
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              API server
+            </h3>
+            <p class="p-matrix__desc">
+              The primary control plane component, that exposes the Kubernetes API, enabling communications between cluster components.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Controller-manager
+            </h3>
+            <p class="p-matrix__desc">
+              A control plane daemon that monitors the state of the cluster and makes all necessary changes for the cluster to reach its desired state.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Container runtime
+            </h3>
+            <p class="p-matrix__desc">
+              The software responsible for running containers by coordinating the use of system resources across containers.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Kubelet
+            </h3>
+            <p class="p-matrix__desc">
+              An agent that runs on each worker node in the cluster and ensures that containers are running in a pod.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Kubectl
+            </h3>
+            <p class="p-matrix__desc">
+              A command-line tool for controlling Kubernetes clusters.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              Kubeproxy
+            </h3>
+            <p class="p-matrix__desc">
+              Enables communication between worker nodes, by maintaining network rules on the nodes.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              CNI
+            </h3>
+            <p class="p-matrix__desc">
+              The Container Network Interface is a specification and a set of tools to define networking interfaces between network providers and Kubernetes.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div class="p-matrix__content">
+            <h3 class="p-matrix__title">
+              CSI
+            </h3>
+            <p class="p-matrix__desc">
+              The Container Storage Interface is a specification for data storage tools and applications to integrate with Kubernetes clusters.
+            </p>
+          </div>
+        </li>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-12">
+        <h2>
+          Why use Kubernetes?
+        </h2>
+        <p>
+          Kubernetes is a platform to run your applications and services. It’s cloud-native, provides operational cost savings, faster time-to-market and is maintained by a large community. Developers like container-based development, as it helps break up monolithic applications into more maintainable microservices. Kubernetes allows their work to move seamlessly from development to production and results in faster-time-to-market for a businesses’ applications.
+        </p>
+        <p>
+          Kubernetes works by:
+        </p>
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked">Orchestrating containers across multiple hosts
+          </li>
+          <li class="p-list__item is-ticked">Ensures that containerised apps behave in the same way in all environments, from testing to production
+          </li>
+          <li class="p-list__item is-ticked">Controlling and automating application deployments and updates
+          </li>
+          <li class="p-list__item is-ticked">Making more efficient use of hardware to minimise resources needed to run containerised applications
+          </li>
+          <li class="p-list__item is-ticked">Mounting and adding storage to run stateful apps
+          </li>
+          <li class="p-list__item is-ticked">Scaling containerised applications and their resources on the fly
+          </li>
+          <li class="p-list__item is-ticked">Declaratively managing services, which guarantees that applications are always running as intended
+          </li>
+          <li class="p-list__item is-ticked">Health-checking and self-healing applications with auto-placement, autorestart, auto-replication and autoscaling
+          </li>
+          <li class="p-list__item is-ticked">Being open source (<a href="https://github.com/kubernetes/kubernetes">all Kubernetes code is on GitHub</a>) and maintained by a large, active community</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-12">
+        <h2>
+          What Kubernetes is not
+        </h2>
+        <p>
+          Kubernetes is a platform that enables configuration, automation and management capabilities around containers. It has a vast tooling ecosystem and can address complex use cases, and this is the reason why many confuse it for a traditional Platform-as-a-Service (PaaS).
+        </p>
+        <p>
+          It is important to distinguish between the two solutions. Kubernetes, as opposed to PaaS does not:
+        </p>
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked__cross">Limit the types of supported applications or require a dependency handling framework
+          </li>
+          <li class="p-list__item is-ticked__cross">Require applications to be written in a specific programming language nor does it dictate a specific configuration language/system.
+          </li>
+          <li class="p-list__item is-ticked__cross">Provide application-level services, such as middleware, databases and storage clusters out-of-the box. Such components can be integrated with k8s through add-ons.
+          </li>
+          <li class="p-list__item is-ticked__cross">Provide nor dictate specific logging, monitoring and alerting components
+          </li>
+          <li class="p-list__item is-ticked__cross">Deploy source code and does not build applications, although it can be used to build CI/CD pipelines
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-8">
+        <h2>
+          Using Kubernetes for development
+        </h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">
+          Run Kubernetes locally and at the edge
+        </h3>
+        <div class="p-card__content">
+          <p>
+            MicroK8s is a production-grade lightweight Kubernetes that deploys a single-node cluster with a single-install command. It’s a CNCF-certified Linux snap that runs all Kubernetes services natively on Ubuntu, or any operating system that supports snaps, Windows and macOS.
+          </p>
+          <p>
+            MicroK8s is the simplest distribution of Kubernetes, that lowers the barrier of entry to container orchestration and cloud-native development. Because of its small footprint it is ideal for clusters, workstations, CI/CD pipelines, IoT devices, and small edge clouds.
+          </p>
+          <p>
+            <a href="/kubernetes/install#single-node">
+              Install MicroK8s&nbsp;&rsaquo;
+            </a>
+          </p>
+        </div>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">
+          Run Kubernetes on your infrastructure of choice
+        </h3>
+        <div class="p-card__content">
+          <p>
+            Deploy Canonical’s Charmed Kubernetes, a highly available, pure upstream, multi-node Kubernetes cluster. It’s a fully automated, model-driven approach to Kubernetes that takes care of logging, monitoring and alerting and provides application lifecycle automation capabilities.
+          </p>
+          <p>
+            It’s tested across the widest range of infrastructure and deploys on bare-metal, private and public clouds. Along with our Kubernetes, Canonical supports a rich ecosystem of different pieces of software that can be integrated from the stack up. Canonical is one of Microsoft’s primary development partners as Ubuntu is the operating system of choice on AKS.
+          </p>
+          <p>
+            <a href="/kubernetes/docs/quickstart">
+              Deploy Charmed Kubernetes&nbsp;&rsaquo;
+            </a>
+          </p>
+        </div>
+      </div>
+      <div class="col-4 p-card">
+        <h3 class="p-card__title">
+          Have us run Kubernetes for you
+        </h3>
+        <div class="p-card__content">
+          <p>
+            Don't want the hassle and cost of hiring your own K8s team of experts? Get peace of mind and focus on  your business, by leveraging our proven experience in Kubernetes deployments and operations.
+          </p>
+          <p>
+            Canonical offers a fully managed service which manages the complex operations that many may lack the skills to do, such as installing, patching, scaling, monitoring, and upgrading with zero downtime.
+          </p>
+          <p>
+            If you have clusters built, we can manage them for you.  We can also build and manage them for you, handing the keys over when and if you’re ready to take full control.
+          </p>
+          <p>
+            <a href="/kubernetes/managed">
+              Learn about our Managed Kubernetes service&nbsp;&rsaquo;
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-12">
+        <h2>
+          What's new in Kubernetes 1.18
+        </h2>
+        <p>
+          Kubernetes 1.18, which is the latest stable version, was released in March 2020. Canonical provides full enterprise support for Kubernetes. 1.18.
+        </p>
+        <p>
+          Here are highlights from the latest- version of Kubernetes 1.18 (released March 2020):
+        </p>
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked">
+            <strong>Kubectl debug</strong> -  the cli now provides a way to do interactive troubleshooting and to run an ephemeral container alongside the Pod being investigated
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>OIDC discovery for service accounts tokens</strong> - Kubernetes API tokens can be used as a general authentication mechanism, simplifying service integration
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Node Topology Manager</strong> - enables <a class="p-link--external" href="https://www.kernel.org/doc/html/v4.18/vm/numa.html">NUMA</a> alignment of CPU and devices, such as SR-IOV VFs, allowing workloads to run in low-latency optimised environments
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>ContainerD support on Windows</strong> - the container runtime is now supported on Windows, a big step to ensure Kubernetes compatibility on Windows nodes
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>Ingress extensions</strong> - Ingress is enhanced with the pathType field and IngressClass resource
+          </li>
+          <li class="p-list__item is-ticked">
+            <strong>CertificateSigningRequest API</strong> - extending the Certificate API capabilities to provision certificates for non-core components of a Kubernetes cluster
+          </li>
+        </ul>
+        <p>
+          <a href="/blog/kubernetes-1-18-available-from-canonical">
+            Learn more about Kubernetes 1.18 features&nbsp;&rsaquo;
+          </a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light is-deep">
+    <div class="u-fixed-width">
+      <h3>
+        Other Kubernetes resources
+      </h3>
+    </div>
+
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Data sheet</h4>
+          </div>
+        </div>
+        <h3 class="p-heading--four">
+          <a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">
+            Kubernetes for the enterprise
+          </a>
+        </h3>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Webinar</h4>
+          </div>
+        </div>
+        <h3 class="p-heading--four">
+          <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/362200">
+            Kubernetes at the edge: Why use Kubernetes as part of your edge strategy?
+          </a>
+        </h3>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Whitepaper</h4>
+          </div>
+        </div>
+        <h3 class="p-heading--four">
+          <a class="p-link--external" href="https://pages.ubuntu.com/container-whitepaper.html">
+            The no-nonsense way to accelerate your business with containers
+          </a>
+        </h3>
+      </div>
+    </div>
+  </section>
+
+  {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
 
 
-{% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-
-
-
-{% endblock content %}
+  {% endblock content %}

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -1,0 +1,48 @@
+{% extends "kubernetes/base_kubernetes.html" %}
+
+{% block title %}What is Kubernetes{% endblock %}
+
+{% block meta_description %}What is Kubernetes? How does Kubernetes work and why use it for your business? Learn the Kubernetes terminology, benefits, get release information and the essentials of Canonical’s Kubernetes solutions.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/19ZAsyujRHjOBIKP15F-4Z9L24KpfoYrx0YpL-0gO6sE/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-topped">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>
+        What is Kubernetes?
+      </h1>
+      <p>
+        Kubernetes, or k8s for short, is an open source platform, pioneered by Google, which started as a simple container orchestration tool but has grown into a cloud-native platform.  It’s one of the most significant advancements in IT since the public cloud came to being in 2009 and has an unparalleled <a class="p-link--external" href="https://451research.com/451-research-says-application-containers-market-will-grow-to-reach-4-3bn-by-2022">5-year 30% growth rate</a> in both market revenue and overall adoption.
+      </p>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
+        alt="",
+        width="192",
+        height="150",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </div>
+  </div>
+  </div>
+</section>
+
+
+
+{% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+
+
+{% endblock content %}

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<section class="p-strip u-no-padding--top u-no-padding--bottom">
+<section class="p-strip is-bordered u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-topped">
   <div class="row u-equal-height">
     <div class="col-7">
@@ -24,8 +24,8 @@
         image(
         url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
         alt="",
-        width="192",
-        height="150",
+        width="250",
+        height="195",
         hi_def=True,
         loading="auto",
         ) | safe

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -265,7 +265,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-deep">
   <div class="row">
     <div class="col-12">
       <h2>
@@ -460,7 +460,7 @@
     </div>
   </section>
 
-  <section class="p-strip--light">
+  <section class="p-strip--light is-deep">
     <div class="row">
       <div class="col-8">
         <h2>
@@ -649,6 +649,19 @@
       </div>
     </div>
   </section>
+
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-8">
+        <h4>
+          We’re here to revolutionise the way you think about Kubernetes clusters.
+        </h4>
+        <p>
+          <a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us">Schedule a Kubernetes demo</a>
+        </p>
+      </div>
+
+    </div>
 
   {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 


### PR DESCRIPTION
## Done

- Build new /kubernetes/what-is-kubernetes page
- Added it to the navigation
- **NOTE** - needs update of top diagram

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/what-is-kubernetes page
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [design](#7551) and the [copy doc](https://docs.google.com/document/d/19ZAsyujRHjOBIKP15F-4Z9L24KpfoYrx0YpL-0gO6sE/edit#)


## Issue / Card

Fixes #7552 

