### PR TITLE
Added the French VM to OS to FR takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,7 @@
 
   {# FRENCH #}
   {% include "takeovers/_cio-guide-to-multipass-fr.html" %}
+  {% include "takeovers/fr/_french_vmware-to-os.html" %}
 
 {% endblock takeover_content %}
 


### PR DESCRIPTION
Added  {% include "takeovers/fr/_french_vmware-to-os.html" %}

## Done
- Added the French VM to OS to FR takeovers
- Added  {% include "takeovers/fr/_french_vmware-to-os.html" %}


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Change browser language to FR and make sure takeover appears in rotation.
