### PR TITLE
Initial addition of the /appliance/nextcloud page

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -29,3 +29,13 @@ appliances:
     checksum:
       raspberrypi: "51799ebbf8e56a2ba2b144438136acbf56ad56950f563729df615c009198be2b *openhab-ubuntu-core-18-pi-arm64.img.xz"
       pc: "19dab5bec3b5d7840b3655cd8b6c2d33d0bd9cb1073dfa6bff5890eaba83fe9d *openhab-ubuntu-core-18-amd64.img.xz"
+  nextcloud:
+    name: "NextCloud"
+    appliance_name: "NextCloud"
+    url_name: "nextcloud"
+    iso_url:
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-pi-arm64.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-amd64.img.xz"
+    checksum:
+      raspberrypi: "51799ebbf8e56a2ba2b144438136acbf56ad56950f563729df615c009198be2b *openhab-ubuntu-core-18-pi-arm64.img.xz"
+      pc: "19dab5bec3b5d7840b3655cd8b6c2d33d0bd9cb1073dfa6bff5890eaba83fe9d *openhab-ubuntu-core-18-amd64.img.xz"

--- a/templates/appliance/nextcloud/_next-steps.html
+++ b/templates/appliance/nextcloud/_next-steps.html
@@ -1,0 +1,30 @@
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h2>
+          Start using your {{ appliance.name }} Ubuntu Appliance
+        </h2>
+        <p>
+          When you start NextCloud for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
+        </p>
+        <p>
+          <a href="http://nextcloud.local">http://nextcloud.local</a>
+        </p>
+        <p>
+          After that, you can start using your new Nextcloud server. For more information and documentation visit the Nextcloud website.
+       </p>
+      </div>
+    </div>
+    <div class="col-6 u-hide--small u-align--center">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/4945963f-nextcloud-screenshot.png ",
+        width="600",
+        alt="",
+        height="337",
+        hi_def=True,
+        loading="lazy",
+        ) | safe}}
+      </div>
+    </div>
+  </section>

--- a/templates/appliance/nextcloud/index.md
+++ b/templates/appliance/nextcloud/index.md
@@ -1,0 +1,47 @@
+---
+wrapper_template: "appliance/shared/_base_appliance_index.html"
+context:
+  name: "NextCloud"
+  short_name: "nextcloud"
+  appliance_name: "NextCloud"
+  company_name: "NextCloud"
+  logo: "https://dashboard.snapcraft.io/site_media/appmedia/2016/06/icon.svg_1.png"
+  category: "Collaboration"
+  meta_description: "Take control of your data with NextCloud, a completely integrated on-premises platform for online content collaboration and data storage out of the box."
+  downloads:
+    raspberrypi: True
+    pc: True
+    intelnuc: True
+  screenshots:
+    1: https://dashboard.snapcraft.io/site_media/appmedia/2018/10/Screenshot_from_2018-10-26_09-49-46.png
+    2: https://dashboard.snapcraft.io/site_media/appmedia/2018/10/Screenshot_from_2018-10-26_09-48-50.png
+  links:
+    1:
+      title: "NextCloud privacy policies"
+      url: "https://nextcloud.com/privacy/"
+    2:
+      title: "NextCloud website"
+      url: "https://nextcloud.com/"
+    3:
+      title: "AdGuard Home license"
+      url: "https://nextcloud.com/faq/"
+  compliance:
+    1: "EU GDPR"
+    2: "California law"
+  base: "core20"
+  published_date: "YYYY-MM-DD"
+  maintenance_date: "2030-06-16"
+  snaps:
+    1:
+      name: "NextCloud"
+      icon: "https://dashboard.snapcraft.io/site_media/appmedia/2016/06/icon.svg_1.png"
+      link: "https://snapcraft.io/nextcloud"
+      publisher: "NextCloud"
+      channel: "latest/stable"
+      version: "18.0.4"
+      published_date: "22 May 2020"
+---
+
+#### Nextcloud Server - A safe home for all your data
+
+Where are your photos and documents? With Nextcloud you pick a server of your choice, at home, in a data center or at a provider. And that is where your files will be. Nextcloud runs on that server, protecting your data and giving you access from your desktop or mobile devices. Through Nextcloud you also access, sync and share your existing data on that FTP drive at school, a Dropbox or a NAS you have at home.

--- a/templates/appliance/nextcloud/intel-nuc.html
+++ b/templates/appliance/nextcloud/intel-nuc.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_intel-nuc.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/nextcloud/pc.html
+++ b/templates/appliance/nextcloud/pc.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on your Ubuntu desktop with KVM.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_pc.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/nextcloud/raspberry-pi.html
+++ b/templates/appliance/nextcloud/raspberry-pi.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install {{ appliance.name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_raspberry-pi.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Initial addition of the /appliance/nextcloud page as well as install pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/nextcloud and the download pages
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- At the bottom of the install instructions see the text is from [this doc](https://docs.google.com/document/d/12m4WT3ZvlfAuBQ6tT-0ARAQeYGFMaSWhBEzs-9l3ww8/edit)
- For the main page, see the data is from [this doc](https://docs.google.com/document/d/1APNIgG9i07O7ZHwgoppi8PQhp1Wbw3PKwP5zA95fZ5I/edit#heading=h.h48ugxmkjc4v)

