### PR TITLE
Update notice package schema to contain package links

### DIFF
--- a/scripts/create-usns.py
+++ b/scripts/create-usns.py
@@ -11,6 +11,52 @@ from http.cookiejar import MozillaCookieJar
 from macaroonbakery import httpbakery
 
 
+def guess_binary_links(binary, version, sources):
+    '''Guess links to the source package based on binary package and version.
+
+    Keyword Arguments:
+    binary -- the name of the binary
+    version -- the version of the binary
+    sources -- a dictionary of source package names to source package versions
+    '''
+    match_first = False
+    source_match = None
+    version_match = None
+    source_link = None
+    version_link = None
+
+    if not sources:
+        # Old USNs may not have any sources listed. We can't make any sort of a
+        # guess in this situation.
+        return (None, None)
+    if len(sources) == 1:
+        # There's a many-to-one mapping of binaries to a source package. Use
+        # the only possible source package for all binaries.
+        match_first = True
+    elif not version:
+        # There are multiple combinations of possible binary to source package
+        # mappings. We can't make an educated guess if we don't have a valid
+        # binary package version so don't attempt to construct a link.
+        return (None, None)
+
+    for source in sources:
+        source_version = sources[source].get('version')
+        if match_first or version == source_version:
+            source_match = source
+            version_match = source_version
+            break
+
+    if source_match:
+        source_link = 'https://launchpad.net/ubuntu/+source/' + source_match
+        if version_match:
+            # Be certain to use the source package version rather than the
+            # binary package version here or the link will be broken for
+            # certain packages
+            version_link = source_link + '/' + version_match
+
+    return (source_link, version_link)
+
+
 parser = argparse.ArgumentParser(description="CLI to post USNs")
 parser.add_argument("file_path", action="store", type=str)
 parser.add_argument("--update", action="store_true", default=False)
@@ -49,9 +95,23 @@ with open(args.file_path) as usn_json:
                         "name": name,
                         "version": info["version"],
                         "description": info["description"],
+                        "is_source": "true"
                     }
                 )
 
+            for name, info in packages["binaries"].items():
+                source_link, version_link = guess_binary_links(
+                    name, info["version"], packages["sources"]
+                )
+                release_packages[codename].append(
+                    {
+                        "name": name,
+                        "version": info["version"],
+                        "is_source": "false",
+                        "source_link": source_link,
+                        "version_link": version_link,
+                    }
+                )
         # format CVEs and references
         cves = []
         references = []

--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -31,7 +31,7 @@
     <div class="col-12">
       <h2>Packages</h2>
       <ul class="p-list">
-        {% for name, package in notice.packages.items() %}
+        {% for package in notice.packages %}
           <li class="p-list__item">{{ package.name }} - {{ package.description }}</li>
         {% endfor %}
       </ul>
@@ -53,8 +53,17 @@
         <ul class="p-list">
           {% for package in notice.release_packages[version] %}
             <li class="p-list__item">
-              <a href="https://launchpad.net/ubuntu/+source/{{ package.name }}">{{ package.name }}</a> -
-              <a href="https://launchpad.net/ubuntu/+source/{{ package.name }}/{{ package.version }}">{{ package.version }}</a>
+              {% if package.source_link %}
+                <a href="{{package.source_link}}">{{ package.name }}</a>
+              {% else %}
+                {{ package.name }}
+              {% endif %}
+              -
+              {% if package.version_link %}
+                <a href="{{package.version_link}}">{{ package.version }}</a>
+              {% else%}
+                {{ package.version }}
+              {% endif %}
             </li>
           {% endfor %}
         </ul>

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -1,6 +1,14 @@
 import dateutil.parser
 from marshmallow import Schema, ValidationError
-from marshmallow.fields import DateTime, Dict, Float, List, Nested, Str
+from marshmallow.fields import (
+    Boolean,
+    DateTime,
+    Dict,
+    Float,
+    List,
+    Nested,
+    Str,
+)
 from marshmallow.validate import Regexp
 
 
@@ -43,7 +51,10 @@ def _validate_release_codenames(release_packages):
 class NoticePackage(Schema):
     name = Str(required=True)
     version = Str(required=True)
-    description = Str(required=True)
+    description = Str()
+    is_source = Boolean(required=True)
+    source_link = Str(allow_none=True)
+    version_link = Str(allow_none=True)
 
 
 class NoticeSchema(Schema):


### PR DESCRIPTION
## Done
Update notice packages schema so we accept package links instead of guessing them.

## QA

- Check out this feature branch
- `docker-compose up -d`
- `dotrun exec alembic upgrade head`
- `wget https://usn.ubuntu.com/usn-db/database.json`
- `snap install jq` if you don't already have it
- `jq '."4363-1" | { (.id): .}' database.json > 4363-1.json`
- dotrun
- dotrun exec ./scripts/create-usns.py 4363-1.json
- Make sure http://localhost:8001/security/notices/4363-1 renders and the packages look similar to https://usn.ubuntu.com/4363-1/


## Issue / Card
Fixes #7542 