### PR TITLE
Add port and appliance alias

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -3,52 +3,59 @@ appliances:
     name: "Plex"
     appliance_name: "Plex Media Server"
     url_name: "plex"
+    alias: "plexmediaserver"
     port: 32400
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "8889a56eadef03196ad1f4f9131d21de5c664625751ae3bd3715dc5a04e4aa87 *plexmediaserver-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "ea001bde90753b6e7d620a018c6c9e31a196c48009802e177f60fd6751ba979a *plexmediaserver-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *plexmediaserver-core18-pi.img.xz"
+      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *plexmediaserver-core18-amd64.img.xz"
   adguard:
     name: "Adguard"
     appliance_name: "Adguard"
     url_name: "adguard"
+    alias: "adguard-home"
     port: 3000
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "72dfbc102571fd0c465ef87d2fc8cce51d419836712e7dbd5678e62444d132e5 *adguard-home-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "f904ad1ae804c768a8a0a2ab02617a6589c00ca17d764dccaec0d54b19fd4619 *adguard-home-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *adguard-home-core18-pi.img.xz"
+      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *adguard-home-core18-amd64.img.xz"
   openhab:
     name: "OpenHAB"
     appliance_name: "OpenHAB"
     url_name: "openhab"
+    alias: "openhab"
     port: 8080
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "51799ebbf8e56a2ba2b144438136acbf56ad56950f563729df615c009198be2b *openhab-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "19dab5bec3b5d7840b3655cd8b6c2d33d0bd9cb1073dfa6bff5890eaba83fe9d *openhab-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *openhab-core18-pi.img.xz"
+      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *openhab-core18-amd64.img.xz"
   mosquitto:
     name: "mosquitto"
     appliance_name: "Mosquitto"
     url_name: "mosquitto"
+    alias: "mosquitto"
+    port: 1883
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "51799ebbf8e56a2ba2b144438136acbf56ad56950f563729df615c009198be2b *openhab-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "19dab5bec3b5d7840b3655cd8b6c2d33d0bd9cb1073dfa6bff5890eaba83fe9d *openhab-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *openhab-core18-pi.img.xz"
+      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *openhab-core18-amd64.img.xz"
   nextcloud:
     name: "NextCloud"
     appliance_name: "NextCloud"
     url_name: "nextcloud"
+    alias: "nextcloud"
+    port: 80
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi.img.xz"
+      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "51799ebbf8e56a2ba2b144438136acbf56ad56950f563729df615c009198be2b *openhab-ubuntu-core-18-pi-arm64.img.xz"
-      pc: "19dab5bec3b5d7840b3655cd8b6c2d33d0bd9cb1073dfa6bff5890eaba83fe9d *openhab-ubuntu-core-18-amd64.img.xz"
+      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *openhab-core18-pi.img.xz"
+      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *openhab-core18-amd64.img.xz"

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.pc %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
+<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.pc }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.raspberrypi %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
+<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">

--- a/templates/appliance/shared/_steps-multipass-launch.html
+++ b/templates/appliance/shared/_steps-multipass-launch.html
@@ -1,6 +1,6 @@
 <li>
   <p>Now, launch your appliance image in a vm:</p>
-  <pre><code>multipass launch appliance:&lt;appliance name&gt;</code></pre>
+  <pre><code>multipass launch appliance:{{ appliance.alias }}</code></pre>
 </li>
 <li>
   <p>Find your vm’s IP address:</p>

--- a/templates/appliance/shared/_steps_multipass_macos.html
+++ b/templates/appliance/shared/_steps_multipass_macos.html
@@ -4,12 +4,6 @@
     Set up and install a vm using Multipass
   </h4>
   <div class="p-stepped-list__content">
-    <p>
-      There are two ways to do this, using the downloading and running the Multipass installer or using Brew:
-    </p>
-    <h5>
-      Method 1 - Multipass installer
-    </h5>
     <ol>
       <li>
         <p>
@@ -22,8 +16,14 @@
         </p>
         {{
           image (
-           url="https://assets.ubuntu.com/v1/ac6f638d-multipass-macos-install-screen.png",      alt="",      width="658",      height="475",      hi_def=True,      loading="lazy",
-                ) | safe}}
+          url="https://assets.ubuntu.com/v1/ac6f638d-multipass-macos-install-screen.png",
+          alt="",
+          width="658",
+          height="475",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
       </li>
       <li>
         <p>
@@ -32,30 +32,6 @@
         <pre><code>sudo sh "/Library/Application Support/com.canonical.multipass/uninstall.sh"</code></pre>
       </li>
       {% include "appliance/shared/_steps-multipass-launch.html" %}
-    </ol>
-    <h5>
-      Method 2 - Using Brew
-    </h5>
-    <ol>
-      <li>
-        <p>
-          Look at <a class="p-link--external" href="https://brew.sh/">brew.sh</a> instructions to install Brew itself. Then, it’s simple, run:
-        </p>
-        <p>
-          <pre><code>brew cask install multipass</code></pre>
-        </p>
-      </li>
-      <li>
-        <p>
-          And to uninstall:
-        </p>
-        <pre><code>brew cask uninstall multipass</code></pre>
-        <p>or</p>
-        <pre><code>brew cask zap multipass</code></pre>
-        <p>
-          to destroy all data, too
-        </p>
-      </li>
     </ol>
   </div>
 </li>
@@ -81,7 +57,7 @@
     <p>
       Now, open the Terminal app and launch your appliance image in a vm:
     </p>
-    <pre><code>multipass launch appliance:&lt;appliance name&gt;</code></pre>
+    <pre><code>multipass launch appliance:{{ appliance.alias }}</code></pre>
   </div>
 </li>
 
@@ -93,7 +69,7 @@
     <p>
       To use VirtualBox’s port forwarding feature run:
     </p>
-    <pre><code>sudo VBoxManage modifyvm "&lt;instance name&gt;" --natpf2 "&lt;appliance name&gt;,tcp,,{{ appliance.port }},,&lt;local port&gt;"</code></pre>
+    <pre><code>sudo VBoxManage modifyvm "&lt;instance name&gt;" --natpf2 "{{ appliance.alias }},tcp,,{{ appliance.port }},,{{ appliance.port }}"</code></pre>
     <div class="p-notification" id="notification">
       <div class="p-notification__response">
         <span class="p-notification__status">Note:</span>

--- a/templates/appliance/shared/_steps_multipass_ubuntu.html
+++ b/templates/appliance/shared/_steps_multipass_ubuntu.html
@@ -13,7 +13,7 @@
         <div class="p-notification" id="notification">
           <div class="p-notification__response">
             <span class="p-notification__status">Note:</span>
-            <p>Multipass is about to name your appliance something like ‘cute-emperor’ or ‘prophetic-giraffe’. After this whatever you get will be your <code>&lt;appliance name&gt;</code>. To use a different name simply add <code>--name &lt;your new name&gt;</code> to the end of the next line.</p>
+            <p>Multipass is about to name your appliance something like ‘cute-emperor’ or ‘prophetic-giraffe’. After this whatever you get will be your <code>{{ appliance.alias }}</code>. To use a different name simply add <code>--name &lt;your new name&gt;</code> to the end of the next line.</p>
           </div>
         </div>
       </li>

--- a/templates/appliance/shared/_steps_vm_thats-it.html
+++ b/templates/appliance/shared/_steps_vm_thats-it.html
@@ -5,6 +5,6 @@
   </h4>
   <div class="p-stepped-list__content">
     <p>Your appliance is now running in a Virtual Machine and you can start using it. If you want to access it through the command-line you can also shell into it:</p>
-    <pre><code>multipass shell &lt;appliance name&gt;</code></pre>
+    <pre><code>multipass shell {{ appliance.alias }}</code></pre>
   </div>
 </li>


### PR DESCRIPTION
## Done

- Added ports and alias (for the appliance name) in the yaml
- Used these in the install pages
- Updated links to the downloads and checksums
- Stopped autodownloading for now.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex/vm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the download pages look ok.

