### PR TITLE
Update /appliance overview text and layout

### DIFF
--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -72,20 +72,19 @@
   </div>
 
   <div class="row u-equal-height">
-    <div class="col-6">
-      <h2>Single-minded systems</h2>
-      <p class="p-heading--four">Do one thing perfectly</p>
-      <p>Transform any PC or certified board into a smart device.</p>
-      <p>Ubuntu Appliances will broaden your personal computing estate with appliances that do one job well.</p>
-      <p>Our appliance images turn generic boxes into highly secure and single-purpose devices. They will run quietly and they won’t break.</p>
+    <div class="col-7">
+      <h2>Make something great today</h2>
+      <p class="p-heading--four">We’ve got just the thing for you</p>
+      <p>Transform a spare PC or Pi into a smart, secure, and ultra-simple box that does exactly what you want. Brilliantly.</p>
+      <p>Open or commercial. Enterprise or home. Entertainment. Automation. Gaming. Network. Storage. Fun. Come and play with something new today.</p>
     </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
           alt="",
-          height="171",
-          width="300",
+          height="114",
+          width="200",
           hi_def=True,
           loading="auto"
         ) | safe
@@ -98,19 +97,44 @@
   </div>
 
   <div class="row u-equal-height">
-    <div class="col-6">
-      <h2>Clear Privacy Policy</h2>
-      <p class="p-heading--four">Be sure about your data</p>
-      <p>Transparency is the rule.</p>
-      <p>Every appliance in the catalogue complies with the established privacy policy guidelines. You will be given full visibility on the use of your personal data.</p>
-      <p><a href="/appliance/governance">Learn about your privacy protection guarantees&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
           alt="",
-          height="200",
+          height="180",
+          width="180",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>Try before you Pi</h2>
+      <p class="p-heading--four">Test drive them safely on your laptop</p>
+      <p>Just for fun, you can run a Virtual Ubuntu Appliance on any PC without affecting your existing system. Most of our appliances have a virtual version unless they really do depend on special hardware.</p>
+      <p>No need for a spare disk or board, just follow the steps  and you’ll be up and running quickly. Virtual Ubuntu Appliances work on Ubuntu, Windows and macOS.</p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-7">
+      <h2>App store easy</h2>
+      <p class="p-heading--four">An app or two for extra foo</p>
+      <p>Upgrade your appliance with extra apps. Try out a new autopilot. Add an extra game. Each appliance starts with just the right stuff for everyone. Add the sauce you like.</p>
+      <p>Enjoy the same <a class="p-link--external" href="https://snapcraft.io/store">huge app selection as Ubuntu</a>, or get a dedicated store with unique apps for that specific thing. Publishers will shape the store you see.</p>
+      <p>Ubuntu Appliances get apps and updates from our global backbone, just like millions of Ubuntu workstations, laptops and servers every day.</p>
+    </div>
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/22f88d02-apps.svg",
+          alt="",
+          height="114",
           width="200",
           hi_def=True,
           loading="auto"
@@ -124,133 +148,148 @@
   </div>
 
   <div class="row">
-    <div class="col-6">
-      <h2>Security first</h2>
-      <p class="p-heading--four">Crisp. Clean. Core.</p>
-      <p>We believe that security is everything. That’s why Ubuntu Appliances meet state-of-the-art standards of endpoint security.</p>
-      <p>Security capabilities like strict software isolation and software immutability are provided out-of-the-box with each appliance, thanks to Ubuntu Core.</p>
-      <p>To keep your device secure, CVE patches and bug fixes will be delivered over the long term and in a timely manner, the Canonical way.</p>
-    </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
           alt="",
-          height="200",
-          width="200",
+          height="180",
+          width="180",
           hi_def=True,
           loading="auto"
         ) | safe
       }}
     </div>
+    <div class="col-7">
+      <h2>Secure by design</h2>
+      <p class="p-heading--four">Crisp. Clean. Carrier-grade. Core.</p>
+      <p>SecureBoot. Full disk encryption. Hardware crypto keys. An ironclad commitment to your peace of mind.</p>
+      <p>We toughened Ubuntu to harden these things. They bring their magic, we bring our mettle. Community or business-backed, they both enjoy <a href="/core">the same robust, secure Ubuntu Core</a>.</p>
+      <p>Strict confinement and read-only packages keep bad code locked down. Certs and signatures make for tamper proof provenance. Full containerisation for no loose ends. And we’ve got your back for critical jobs with ten year updates, guaranteed.</p>
+    </div>
+  </div>
+</section>
+
+{# 2 by 2 section #}
+<section class="p-strip--light is-deep">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
+          alt="",
+          height="85",
+          width="149",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"}
+        ) | safe
+      }}
+      <h2>Clear privacy policies</h2>
+      <p>Every Ubuntu Appliance complies with EU data protection or California privacy law. Your personal data is precious. Your privacy even more so. Our mission is to defend them in this new world of ever-present sensor-driven software.</p>
+      <p>Voice-activated software and computer vision are amazing tools. We ensure those microphones and cameras only work for you.</p>
+      <p><a href="/appliance/governance">Learn about your privacy protection&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
+          alt="",
+          height="85",
+          width="85",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+      <h2>Enterprise-grade control</h2>
+      <p class="p-heading--four">Define the flow of fixes across your whole estate.</p>
+      <p>Imagine a world where every firmware update was instantly available on any device. Imagine you could determine exactly when and where it rolled out. Imagine you knew the CVE status of everything you care about, everywhere, all the time.</p>
+      <p>That’s the precision of every Ubuntu Appliance. Made for mission-critical. One dashboard, one practice, one process for your entire multi-vendor estate. With a universal Ubuntu Core, your updates and security align from edge to cloud, no matter which hardware, no matter which appliance.</p>
+    </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr class="p-separator" />
+    <p class="u-sv3">
+      &nbsp;
+    </p>
   </div>
 
-  <div class="row">
+  <div class="row u-equal-height">
     <div class="col-6">
-      <h2>Always fresh</h2>
-      <p class="p-heading--four">Self-healing software</p>
-      <p>Keeping up with upstream, automatically!</p>
-      <p>Whether it is stable, candidate or beta releases that you want to run on your box, the system will autonomously fetch and install software updates.</p>
-      <p>What’s more, failed updates will be reversed without your intervention.</p>
-    </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
           alt="",
-          height="200",
-          width="200",
+          height="85",
+          width="85",
           hi_def=True,
           loading="auto"
         ) | safe
       }}
+      <h2>Future proven</h2>
+      <p class="p-heading--four">Stable. Beta. RC. Edge. Get future fixes faster here.</p>
+      <p>Every piece of software on your Ubuntu Appliance is offered in a set of streams. These channels offer all the current builds and if the publisher allows, early access versions too.</p>
+      <p>Set your appliance to preview channels for a taste of future change before it’s fully done. Choose a safe canary box, and catch the issues there. Switch software streams at any time, for any system, anywhere.</p>
+    </div>
+    <div class="col-6">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
+          alt="",
+          height="85",
+          width="63",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+      <h2>Certified, Maintained or Experimental</h2>
+      <p>Some appliances are serious things, and you want to know that Canonical will keep them reliable, year after year, on a certified device. Those are marked ‘certified’, and they get constant testing and security coverage.</p>
+      <p>Other appliances have a company to keep the updates coming, for at least a certain time. Those ones are tagged ‘maintained’ and you can always see the minimum time assured of maintenance.</p>
+      <p>And then there are the crazy things, the community things, the experimental things. Enjoy those, but don’t get too attached to them. If enough people love them then they’ll get maintenance commitments too.</p>
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr class="p-separator" />
+    <p class="u-sv3">
+      &nbsp;
+    </p>
   </div>
 
-  <div class="row">
-    <div class="col-6">
-      <h2>Standardised experience</h2>
-      <p>These things are guaranteed across all Ubuntu appliances:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Frictionless user experience</li>
-        <li class="p-list__item is-ticked">Tight security</li>
-        <li class="p-list__item is-ticked">Data privacy</li>
-        <li class="p-list__item is-ticked">Application performance</li>
-      </ul>
-      <p>Various applications but same quality expectations.</p>
-    </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/69aaa876-compliance.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row">
-    <div class="col-6">
-      <h2>Community and Commercial</h2>
-      <p class="p-heading--four">Consistent policies and operations</p>
-      <p>Welcome! This is an open community where tinkerers meet open-source developers, where IT leaders can discover start-up appliances.</p>
-      <p>Whether community-driven or commercially minded, all contributions are welcome.</p>
-    </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row">
-    <div class="col-6">
-      <h2>Widely compatible</h2>
-      <p class="p-heading--four">Choose your certified board or box</p>
-      <p>We test and fix every Ubuntu appliance, to make sure they work perfectly across all certified boards and boxes.</p>
-      <p>Ubuntu Appliances work the same on ARM and PC architectures. Board peripherals and accessories are fully supported with each appliance.</p>
-      <p><a href="https://certification.ubuntu.com/iot" class="p-link--external">See all Canonical certified hardware </a></p>
-    </div>
-    <div class="col-5 col-start-large-8 u-align--center u-hide--small u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
-          alt="",
-          height="171",
-          width="300",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
+    <div class="row u-equal-height">
+      <div class="col-6">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+            alt="",
+            height="85",
+            width="85",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
+        <h2>Community and Commercial</h2>
+        <p>Our open source community appliances get all the updates, benefits and care that goes into our mission-critical customers. That’s Ubuntu. That’s Canonical.</p>
+        <p>Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.</p>
+        <p><a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a></p>
+      </div>
+        <div class="col-6">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
+              alt="",
+              height="85",
+              width="149",
+              hi_def=True,
+              loading="auto"
+            ) | safe
+          }}
+          <h2>Confidently compatible</h2>
+          <p class="p-heading--four">Choose your certified board or box</p>
+          <p>It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.</p>
+          <p>We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. That’s to be sure you can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.</p>
+          <p><a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a></p>
+        </div>
+      </div>
 </section>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Update /appliance overview text and layout

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Updated based on the revised [copy doc](https://docs.google.com/document/d/1Fcr5b5Rn06AB89D6DGPmoIgXLxLalijMhwnu_IyUxV4/edit#heading=h.oq1bqfd7kna3)
