### PR TITLE
Improves certification logo alignment; fixes typo

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -9,18 +9,18 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
+    <h1>Security Certifications</h1>
     <div class="col-8">
-      <h1>Security Certifications</h1>
       <p>
         Canonical has achieved FIPS 140-2 Level 1 certification for several cryptographic modules on Ubuntu 18.04 LTS and Ubuntu 16.04 LTS. Canonical has also achieved Common Criteria EAL2 certification for Ubuntu 16.04 LTS. In addition, the Defense Information System Agency (DISA) has published Ubuntu 16.04 LTS and Ubuntu 18.04 LTS Security Technical Implementation Guides (STIGs) which allow Ubuntu to be used by federal agencies. The Center for Internet Security (CIS) also publishes benchmarks for hardening the configuration of Ubuntu systems to make them more secure.
       </p>
       <p>
         Canonical has made its security certification offerings available to all Ubuntu Advantage for Infrastructure customers.
       </p>
-      <p><a class="p-button--neutral js-invoke-modal" href="/support/contact-us?product=support-overview">Contact us with your cerification questions</a></p>
+      <p><a class="p-button--neutral js-invoke-modal" href="/support/contact-us?product=support-overview">Contact us with your certification questions</a></p>
       <p><a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-4 u-vertically-center u-hide--small">
+    <div class="col-4 u-hide--small">
       {{
         image(
           url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
@@ -38,8 +38,8 @@
 
 <section class="p-strip--light" id="fips">
   <div class="row u-equal-height">
+    <h2>FIPS 140-2</h2>
     <div class="col-8">
-      <h2>FIPS 140-2</h2>
       <p>
         FIPS 140-2 is a U.S. Government computer security standard. It defines security requirements related to the design and implementation of a cryptographic module. It is a requirement for U.S. Federal agencies to use FIPS 140-2 validated cryptography to protect sensitive information.
       </p>
@@ -70,7 +70,7 @@
         <li class="p-list__item"><a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/2978">Strongswan validated level 1 July 2017 (#2978)</a></li>
       </ul>
     </div>
-    <div class="col-4 u-vertically-center u-hide--small">
+    <div class="col-4 u-hide--small">
       <img src="https://assets.ubuntu.com/v1/6c2ebd36-fips-validated-140-2-logo.png" alt="" width="150">
     </div>
   </div>
@@ -78,8 +78,8 @@
 
 <section class="p-strip" id="common-criteria">
   <div class="row u-equal-height">
+    <h2>Common Criteria</h2>
     <div class="col-8">
-      <h2>Common Criteria</h2>
       <p>
         Common Criteria (CC) for Information Technology Security Evaluation is an international standard (ISO/IEC IS 15408) for Computer security certification, used by Federal agencies, financial institutions and many other organizations dealing with sensitive data. It validates that a product satisfies a defined set of security requirements.
       </p>
@@ -87,7 +87,7 @@
       </p>
       <p>Ubuntu 18.04 has been submitted and is currently awaiting final certification from CSEC.  The evaluation was performed on Intel x86_64 and IBM Z hardware platforms.</p>
     </div>
-    <div class="col-4 u-vertically-center u-hide--small">
+    <div class="col-4 u-hide--small">
       <img src="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg?w=150" width="150" alt="">
     </div>
   </div>
@@ -95,8 +95,8 @@
 
 <section class="p-strip--light" id="stig">
   <div class="row u-equal-height">
+    <h2>STIG</h2>
     <div class="col-8">
-      <h2>STIG</h2>
       <p>
         Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). They are configuration guidelines for hardening systems to improve security. They contain technical guidance which when implemented, locks down software and systems to mitigate malicious attacks.
       </p>
@@ -108,7 +108,7 @@
         <li class="p-list__item"><a class="p-link--external" href="https://nvd.nist.gov/ncp/checklist/950">STIG checklist for Ubuntu 18.04 LTS</a></li>
       </ul>
     </div>
-    <div class="col-4 u-vertically-center u-hide--small">
+    <div class="col-4 u-hide--small">
       <img src="https://assets.ubuntu.com/v1/ff9e7377-disa-logo.svg" width="150" alt="">
     </div>
   </div>
@@ -116,8 +116,8 @@
 
 <section class="p-strip" id="cis">
   <div class="row u-equal-height">
+    <h2>CIS Benchmark</h2>
     <div class="col-8">
-      <h2>CIS Benchmark</h2>
       <p>
         Center for Internet Security (CIS) is a non-profit organization that uses a consensus process to release benchmarks to safeguard organizations against cyber attacks. The benchmark contains configuration checklists to harden a system making it less vulnerable to malicious attacks. The consensus review process consists of subject matter experts who provide perspective on different backgrounds like audit and compliance, security research, consulting and software development. Each benchmark undergoes two phases of consensus review. In the first phase, a benchmark is drafted with the help of subject matter experts and an initial version of the benchmark is published. In the second phase, feedback from the wider internet community is reviewed and incorporated into the benchmark. Canonical has actively participated in the drafting of Ubuntu 16.04 and Ubuntu 18.04 benchmarks. CIS has also published benchmarks for Ubuntu 12.04 and 14.04 releases.
       </p>
@@ -125,7 +125,7 @@
         <a class="p-link--external" href="https://www.cisecurity.org/partner/canonical/">Read CIS Benchmarks for Ubuntu</a>
       </p>
     </div>
-    <div class="col-4 u-vertically-center u-hide--small">
+    <div class="col-4 u-hide--small">
       <img src="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg?w=150" width="150" alt="">
     </div>
   </div>


### PR DESCRIPTION
## Done

- Realigned certification logos to the top of the body text, rather than the center of the section.
- Fixed “cerification” typo.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the page locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Observe the improved alignment, especially in the FIPS section

## Issue / Card

Fixes #7670.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/19801137/83963156-b4816e80-a89b-11ea-8bf0-3a6681fb0378.png)

After:

![image](https://user-images.githubusercontent.com/19801137/83963178-d844b480-a89b-11ea-9728-1d91e11125d0.png)


