### PR TITLE
Remove reference to the ubuntu-support-status command

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -235,11 +235,6 @@
     <div class="row">
       <div class="col-8">
         <p>Ubuntu LTS releases transition into Extended Security Maintenance (ESM) phase as the standard, five-year public support window comes to a close. It is recommended for users and organisations to upgrade to the latest LTS release or <a href="/esm">subscribe to ESM</a> for continued security coverage.</p>
-        <p>This command will print the exact status of your system:</p>
-        <div class="p-code-copyable" style="margin-top: .5rem;">
-          <input class="p-code-copyable__input" value="ubuntu-support-status" readonly="readonly">
-          <button class="p-code-copyable__action">Copy to clipboard</button>
-        </div>
         <p>The <a class="p-link--external" href="https://wiki.ubuntu.com/Releases">Ubuntu Releases wiki</a> has current information on previous and upcoming versions.</p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Remove reference to the `ubuntu-support-status` command. This has been removed from Ubuntu 20.04 LTS, per [LP: #1873362](https://pad.lv/1873362)

## Issue / Card

Fixes #7663 
