### PR TITLE
Add Ubuntu Masters takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
-  {% include "takeovers/_ubuntu-masters-roblox.html" %}
+  {% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
   {% include "takeovers/_kafka-in-production_takeover.html" %}
   {% include "takeovers/_202006-ml-dell-webinar.html" %}
 

--- a/templates/takeovers/_ubuntu-masters-takeover-202006.html
+++ b/templates/takeovers/_ubuntu-masters-takeover-202006.html
@@ -1,0 +1,13 @@
+{% with title='Join the Ubuntu <br>Masters conference',
+subtitle="On June 30th, become part of the conversation with innovators from Scania, Domotz and Plus One Robotics",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg",
+image_style="width: 270px; height: 150px;",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/masters-conference?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_UbuntuMasters",
+primary_cta="Register now",
+primary_cta_class="p-button--positive"
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -142,4 +142,6 @@
 {% include "takeovers/_kafka-in-production_takeover.html" %}
 <p>2 June 2020</p>
 {% include "takeovers/_202006-ml-dell-webinar.html" %}
+<p>8 June 2020</p>
+{% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Added takeover for Ubuntu Masters
- Removed takeover for Roblox

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see the "Join the Ubuntu Masters conference" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1TVm1w1iyosZtUw8iFlaRCeFV1zbbca_rk1caV-0wssU/edit#gid=2113339190)
- Check that the "From bare metal to the edge" takeover has been removed
- Check that the new takeover is at the bottom of /takeovers


## Issue / Card

Fixes #7684 