### PR TITLE
Make "what is openstack" page title less redundant

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 
-{% block title %}What is Openstack | OpenStack{% endblock %}
+{% block title %}What is Openstack{% endblock %}
 {% block meta_description %}OpenStack is an open source cloud computing platform that allows businesses to control large pools of compute, storage and networking in a data centre.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit{% endblock meta_copydoc %}
 

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 
-{% block title %}What is Openstack{% endblock %}
+{% block title %}What is OpenStack{% endblock %}
 {% block meta_description %}OpenStack is an open source cloud computing platform that allows businesses to control large pools of compute, storage and networking in a data centre.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

- Make what is openstack page title less redundant:
  - "What is Openstack | OpenStack | Ubuntu" -> "What is OpenStack | Ubuntu"


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


