### PR TITLE
Add a phone field to /download/server/thank-you page

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -54,6 +54,10 @@
               <label for="email" class="mktoLabel ">Work email:</label>
               <input required  id="email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
             </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+            </li>
             <li class="mktField p-list__item u-sv2">
               <input class="mktoField" value="yes" id="CanonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
               <label class="mktoLabel mktoHasWidth" for="CanonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -118,6 +118,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -124,6 +124,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -161,9 +161,9 @@
                 <label for="Email" class="mktoLabel">Email address:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
-              <li class="mktoField p-list__item">
-                <label for="Tel" class="mktoLabel">Phone</label>
-                <input id="Tel" name="Tel" maxlength="255" type="tel" class="mktoField" />
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -193,6 +193,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -143,6 +143,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -224,6 +224,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -153,6 +153,10 @@
               <label for="Email" class="mktoLabel">Work email:</label>
               <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
             </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+            </li>
             <li class="mktField p-list__item">
               <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
               <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -116,6 +116,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -15,6 +15,10 @@
                 <label for="Email" class="mktoLabel">Email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
                 <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -209,6 +209,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -165,6 +165,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -177,6 +177,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -152,6 +152,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -544,6 +544,10 @@
                   required="required"
                 />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input
                   class="mktoField"

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -163,6 +163,10 @@
                 <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                 <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>


### PR DESCRIPTION
## Done

- Add a phone field to /download/server/thank-you page
- And all other modal forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/thank-you and the other sections #get-in-touch forms 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that they all have a required telephone field
