### PR TITLE
Prevent tabbing to images in the blog list

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -1,15 +1,15 @@
 <div class="col-4 blog-p-card--post">
   {% include 'blog/blog-card-header.html' %}
-  
+
   <div class="blog-p-card__content">
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">
-      <a href="/blog/{{ article.slug }}">
+      <a href="/blog/{{ article.slug }}" aria-hidden="true" tabindex="-1">
         <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}" srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w" sizes="(min-width: 1031px) 460px, (max-width: 1030px) and (min-width: 876px) 460px, (max-width: 875px) and (min-width: 621px) 875px, (max-width: 620px) and (min-width: 461px) 620px, (max-width: 460px) 460px" alt="" loading="lazy" />
       </a>
     </div>
     {% endif %}
-    
+
     <h3 class="p-heading--four">
       <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
     </h3>


### PR DESCRIPTION
## Done
After [reading this post](https://www.sarasoueidan.com/blog/keyboard-friendlier-article-listings/) I decided to implement the fix on our blog too.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- Tab to the main content
- Tab through the articles and see they do not focus on the duplicated link on the image

