### PR TITLE
7654 update openstack release table

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -3,62 +3,62 @@ export var smallReleases = [
     startDate: new Date("2019-10-01T00:00:00"),
     endDate: new Date("2020-07-06T00:00:00"),
     taskName: "Ubuntu 19.10",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2022-10-01T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2022-10-01T00:00:00"),
     endDate: new Date("2025-04-02T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2025-04-02T00:00:00"),
     endDate: new Date("2030-04-02T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-10-01T00:00:00"),
     endDate: new Date("2021-07-07T00:00:00"),
     taskName: "Ubuntu 20.10",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2021-10-01T00:00:00"),
     endDate: new Date("2022-07-07T00:00:00"),
     taskName: "Ubuntu 21.10",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2022-01-05T00:00:00"),
     taskName: "Ubuntu 21.04",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2022-04-01T00:00:00"),
     endDate: new Date("2024-09-30T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2024-09-30T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2027-04-01T00:00:00"),
     endDate: new Date("2032-04-09T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var serverAndDesktopReleases = [
@@ -66,117 +66,117 @@ export var serverAndDesktopReleases = [
     startDate: new Date("2014-04-01T00:00:00"),
     endDate: new Date("2016-09-30T00:00:00"),
     taskName: "Ubuntu 14.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2016-09-30T00:00:00"),
     endDate: new Date("2019-04-02T00:00:00"),
     taskName: "Ubuntu 14.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
 
   {
     startDate: new Date("2019-04-02T00:00:00"),
     endDate: new Date("2022-04-02T00:00:00"),
     taskName: "Ubuntu 14.04 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-04-01T00:00:00"),
     endDate: new Date("2018-10-01T00:00:00"),
     taskName: "Ubuntu 16.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2018-10-01T00:00:00"),
     endDate: new Date("2021-04-02T00:00:00"),
     taskName: "Ubuntu 16.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2021-04-02T00:00:00"),
     endDate: new Date("2024-04-02T00:00:00"),
     taskName: "Ubuntu 16.04 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2020-09-30T00:00:00"),
     taskName: "Ubuntu 18.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2020-09-30T00:00:00"),
     endDate: new Date("2023-04-02T00:00:00"),
     taskName: "Ubuntu 18.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2023-04-02T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "Ubuntu 18.04 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2019-10-01T00:00:00"),
     endDate: new Date("2020-07-06T00:00:00"),
     taskName: "Ubuntu 19.10",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2022-10-01T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2022-10-01T00:00:00"),
     endDate: new Date("2025-04-02T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2025-04-02T00:00:00"),
     endDate: new Date("2030-04-02T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-10-01T00:00:00"),
     endDate: new Date("2021-07-07T00:00:00"),
     taskName: "Ubuntu 20.10",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2021-10-01T00:00:00"),
     endDate: new Date("2022-07-07T00:00:00"),
     taskName: "Ubuntu 21.10",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2022-01-05T00:00:00"),
     taskName: "Ubuntu 21.04",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2022-04-01T00:00:00"),
     endDate: new Date("2024-09-30T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES"
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2024-09-30T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "MAINTENANCE_UPDATES"
+    status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2027-04-01T00:00:00"),
     endDate: new Date("2032-04-09T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var kernelReleases = [
@@ -184,152 +184,152 @@ export var kernelReleases = [
     startDate: new Date("2014-04-01T00:00:00"),
     endDate: new Date("2019-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-01T00:00:00"),
     endDate: new Date("2022-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2014-08-01T00:00:00"),
     endDate: new Date("2019-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-01T00:00:00"),
     endDate: new Date("2022-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-04-01T00:00:00"),
     endDate: new Date("2021-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2024-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-08-01T00:00:00"),
     endDate: new Date("2019-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-01T00:00:00"),
     endDate: new Date("2022-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-08-01T00:00:00"),
     endDate: new Date("2021-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2024-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2023-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-01T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-08-01T00:00:00"),
     endDate: new Date("2021-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2024-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-07-01T00:00:00"),
     endDate: new Date("2023-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-01T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2019-02-01T00:00:00"),
     endDate: new Date("2019-08-01T00:00:00"),
     taskName: "Ubuntu 18.04.2 LTS (v4.18)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-01T00:00:00"),
     endDate: new Date("2020-01-01T00:00:00"),
     taskName: "Ubuntu 19.04 (v5.0)",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2019-08-01T00:00:00"),
     endDate: new Date("2020-02-01T00:00:00"),
     taskName: "Ubuntu 18.04.3 LTS (v5.0)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-10-01T00:00:00"),
     endDate: new Date("2020-07-01T00:00:00"),
     taskName: "Ubuntu 19.10 (v5.3)",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-02-01T00:00:00"),
     endDate: new Date("2020-08-01T00:00:00"),
     taskName: "Ubuntu 18.04.4 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2025-04-01T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2030-04-01T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2023-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-01T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var kernelReleases2004 = [
@@ -337,56 +337,56 @@ export var kernelReleases2004 = [
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-22T00:00:00"),
     endDate: new Date("2030-04-21T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2022-02-12T00:00:00"),
     endDate: new Date("2022-08-17T00:00:00"),
     taskName: "Ubuntu 20.04.4 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-08-16T00:00:00"),
     endDate: new Date("2022-02-18T00:00:00"),
     taskName: "Ubuntu 20.04.3 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-02-17T00:00:00"),
     endDate: new Date("2021-08-22T00:00:00"),
     taskName: "Ubuntu 20.04.2 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-07-22T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-22T00:00:00"),
     endDate: new Date("2030-04-21T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-22T00:00:00"),
     endDate: new Date("2030-04-21T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var kernelReleases1804 = [
@@ -394,56 +394,56 @@ export var kernelReleases1804 = [
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-20T00:00:00"),
     endDate: new Date("2028-04-18T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-02-06T00:00:00"),
     endDate: new Date("2020-08-10T00:00:00"),
     taskName: "Ubuntu 18.04.4 LTS (v5.3)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-08-08T00:00:00"),
     endDate: new Date("2020-02-10T00:00:00"),
     taskName: "Ubuntu 18.04.3 LTS  (v5.0)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-02-14T00:00:00"),
     endDate: new Date("2019-08-19T00:00:00"),
     taskName: "Ubuntu 18.04.2 LTS (v4.18)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-07-26T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-20T00:00:00"),
     endDate: new Date("2028-04-18T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-04-26T00:00:00"),
     endDate: new Date("2023-04-25T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-25T00:00:00"),
     endDate: new Date("2028-04-23T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var kernelReleases1604 = [
@@ -451,56 +451,56 @@ export var kernelReleases1604 = [
     startDate: new Date("2018-08-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-20T00:00:00"),
     endDate: new Date("2024-04-19T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-02-01T00:00:00"),
     endDate: new Date("2018-07-31T00:00:00"),
     taskName: "Ubuntu 16.04.4 LTS (v4.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2017-08-01T00:00:00"),
     endDate: new Date("2018-01-31T00:00:00"),
     taskName: "Ubuntu 16.04.3 LTS (v4.10)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2017-02-01T00:00:00"),
     endDate: new Date("2017-07-31T00:00:00"),
     taskName: "Ubuntu 16.04.2 LTS (v4.8)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-20T00:00:00"),
     endDate: new Date("2024-04-19T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-04-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-20T00:00:00"),
     endDate: new Date("2024-04-19T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var kernelReleases1404 = [
@@ -508,56 +508,56 @@ export var kernelReleases1404 = [
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
     endDate: new Date("2022-04-19T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-02-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.4 LTS (v4.2)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2015-08-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.3 LTS (v3.19)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2015-02-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.2 LTS (v3.16)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2014-08-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
     endDate: new Date("2022-04-19T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2014-04-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
     endDate: new Date("2022-04-19T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "ESM"
-  }
+    status: "ESM",
+  },
 ];
 
 export var kernelReleasesALL = [
@@ -565,230 +565,230 @@ export var kernelReleasesALL = [
     startDate: new Date("2014-01-01T00:00:00"),
     endDate: new Date("2014-04-21T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2014-04-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2014-05-01T00:00:00"),
     endDate: new Date("2014-08-21T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2014-08-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2015-02-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.2 LTS (v3.16)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2015-08-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.3 LTS (v3.19)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-02-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.4 LTS (v4.2)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-01-01T00:00:00"),
     endDate: new Date("2016-04-21T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2016-04-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-05-01T00:00:00"),
     endDate: new Date("2016-08-21T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-05-01T00:00:00"),
     endDate: new Date("2016-08-21T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2017-02-01T00:00:00"),
     endDate: new Date("2017-07-31T00:00:00"),
     taskName: "Ubuntu 16.04.2 LTS (v4.8)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2017-08-01T00:00:00"),
     endDate: new Date("2018-01-31T00:00:00"),
     taskName: "Ubuntu 16.04.3 LTS (v4.10)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-02-01T00:00:00"),
     endDate: new Date("2018-07-31T00:00:00"),
     taskName: "Ubuntu 16.04.4 LTS (v4.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-01-03T00:00:00"),
     endDate: new Date("2018-04-21T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2018-04-21T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-04-04T00:00:00"),
     endDate: new Date("2018-07-01T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2018-07-01T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-05-04T00:00:00"),
     endDate: new Date("2018-08-21T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2018-08-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-02-01T00:00:00"),
     endDate: new Date("2019-08-06T00:00:00"),
     taskName: "Ubuntu 18.04.2 LTS (v4.18)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-16T00:00:00"),
     endDate: new Date("2020-01-20T00:00:00"),
     taskName: "Ubuntu 19.04 (v5.0)",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2019-08-01T00:00:00"),
     endDate: new Date("2020-02-03T00:00:00"),
     taskName: "Ubuntu 18.04.3 LTS (v5.0)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-10-15T00:00:00"),
     endDate: new Date("2020-07-20T00:00:00"),
     taskName: "Ubuntu 19.10 (v5.3)",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-02-01T00:00:00"),
     endDate: new Date("2020-07-31T00:00:00"),
     taskName: "Ubuntu 18.04.4 LTS (v5.3)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-01-24T00:00:00"),
     endDate: new Date("2020-04-23T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2020-07-22T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2020-07-22T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-05-01T00:00:00"),
     endDate: new Date("2020-08-01T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-02-17T00:00:00"),
     endDate: new Date("2021-08-22T00:00:00"),
     taskName: "Ubuntu 20.04.2 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-08-16T00:00:00"),
     endDate: new Date("2022-02-18T00:00:00"),
     taskName: "Ubuntu 20.04.3 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-02-12T00:00:00"),
     endDate: new Date("2022-08-17T00:00:00"),
     taskName: "Ubuntu 20.04.4 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-05-13T00:00:00"),
     endDate: new Date("2022-08-11T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
-    status: "EARLY"
+    status: "EARLY",
   },
   {
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
-    status: "LTS"
-  }
+    status: "LTS",
+  },
 ];
 
 export var kernelReleasesLTS = [
@@ -796,224 +796,224 @@ export var kernelReleasesLTS = [
     startDate: new Date("2014-04-21T00:00:00"),
     endDate: new Date("2016-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-04-01T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2014-08-21T00:00:00"),
     endDate: new Date("2016-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-04-01T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2015-02-01T00:00:00"),
     endDate: new Date("2015-05-01T00:00:00"),
     taskName: "Ubuntu 14.04.2 LTS (v3.16)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2015-05-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.2 LTS (v3.16)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2015-08-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.3 LTS (v3.19)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-02-01T00:00:00"),
     endDate: new Date("2016-07-31T00:00:00"),
     taskName: "Ubuntu 14.04.4 LTS (v4.2)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-04-21T00:00:00"),
     endDate: new Date("2018-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2023-03-31T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2018-04-01T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2018-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2017-02-01T00:00:00"),
     endDate: new Date("2017-07-31T00:00:00"),
     taskName: "Ubuntu 16.04.2 LTS (v4.8)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2017-08-01T00:00:00"),
     endDate: new Date("2018-01-31T00:00:00"),
     taskName: "Ubuntu 16.04.3 LTS (v4.10)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-02-01T00:00:00"),
     endDate: new Date("2018-07-31T00:00:00"),
     taskName: "Ubuntu 16.04.4 LTS (v4.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-04-26T00:00:00"),
     endDate: new Date("2020-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2025-03-31T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2018-07-26T00:00:00"),
     endDate: new Date("2020-04-01T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2018-08-21T00:00:00"),
     endDate: new Date("2020-04-01T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2019-02-14T00:00:00"),
     endDate: new Date("2019-07-31T00:00:00"),
     taskName: "Ubuntu 18.04.2 LTS (v4.18)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-08-08T00:00:00"),
     endDate: new Date("2020-01-31T00:00:00"),
     taskName: "Ubuntu 18.04.3 LTS (v5.0)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-02-06T00:00:00"),
     endDate: new Date("2020-07-31T00:00:00"),
     taskName: "Ubuntu 18.04.4 LTS (v5.3)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2022-04-23T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2020-07-22T00:00:00"),
     endDate: new Date("2022-04-13T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-04-13T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2022-04-23T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-04-23T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
-    status: "CVE"
+    status: "CVE",
   },
   {
     startDate: new Date("2021-02-17T00:00:00"),
     endDate: new Date("2021-08-22T00:00:00"),
     taskName: "Ubuntu 20.04.2 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-08-16T00:00:00"),
     endDate: new Date("2022-02-18T00:00:00"),
     taskName: "Ubuntu 20.04.3 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-02-12T00:00:00"),
     endDate: new Date("2022-07-17T00:00:00"),
     taskName: "Ubuntu 20.04.4 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2024-08-10T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2024-08-10T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
-    status: "CVE"
-  }
+    status: "CVE",
+  },
 ];
 
 export var kernelReleaseSchedule = [
@@ -1021,149 +1021,215 @@ export var kernelReleaseSchedule = [
     startDate: new Date("2014-04-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
     taskName: "Ubuntu 14.04 LTS (v3.13)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2016-04-21T00:00:00"),
     endDate: new Date("2021-04-20T00:00:00"),
     taskName: "Ubuntu 16.04 LTS (v4.4)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2018-04-21T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
     taskName: "Ubuntu 18.04 LTS (v4.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-16T00:00:00"),
     endDate: new Date("2020-01-20T00:00:00"),
     taskName: "Ubuntu 19.04 (v5.0)",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2019-10-15T00:00:00"),
     endDate: new Date("2020-07-20T00:00:00"),
     taskName: "Ubuntu 19.10 (v5.3)",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "LTS"
-  }
+    status: "LTS",
+  },
 ];
 
 export var openStackReleases = [
   {
-    startDate: new Date("2016-04-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04 LTS",
-    status: "LTS"
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "OpenStack Y LTS",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date("2016-04-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "OpenStack Mitaka LTS",
-    status: "LTS"
+    startDate: new Date("2027-04-01T00:00:00"),
+    endDate: new Date("2032-04-01T00:00:00"),
+    taskName: "OpenStack Y LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
   },
   {
-    startDate: new Date("2016-10-01T00:00:00"),
-    endDate: new Date("2018-04-01T00:00:00"),
-    taskName: "OpenStack Newton",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04 LTS",
+    status: "LTS",
   },
   {
-    startDate: new Date("2017-02-01T00:00:00"),
-    endDate: new Date("2018-08-01T00:00:00"),
-    taskName: "OpenStack Ocata",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
+    startDate: new Date("2027-04-01T00:00:00"),
+    endDate: new Date("2032-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04 LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
   },
   {
-    startDate: new Date("2018-08-01T00:00:00"),
-    endDate: new Date("2020-02-01T00:00:00"),
-    taskName: "OpenStack Ocata",
-    status: "EXTENDED_SUPPORT_FOR_CUSTOMERS"
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2025-04-01T00:00:00"),
+    taskName: "OpenStack Y",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date("2017-08-01T00:00:00"),
-    endDate: new Date("2019-02-01T00:00:00"),
-    taskName: "OpenStack Pike",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
-  },
-  {
-    startDate: new Date("2018-03-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "OpenStack Queens",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
-  },
-  {
-    startDate: new Date("2018-04-01T00:00:00"),
+    startDate: new Date("2021-10-01T00:00:00"),
     endDate: new Date("2023-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04 LTS",
-    status: "LTS"
+    taskName: "OpenStack X",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date("2018-04-01T00:00:00"),
-    endDate: new Date("2023-04-01T00:00:00"),
-    taskName: "OpenStack Queens LTS",
-    status: "LTS"
+    startDate: new Date("2021-04-01T00:00:00"),
+    endDate: new Date("2022-10-01T00:00:00"),
+    taskName: "OpenStack W",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date("2018-08-01T00:00:00"),
-    endDate: new Date("2020-02-01T00:00:00"),
-    taskName: "OpenStack Rocky",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
-  },
-  {
-    startDate: new Date("2019-04-01T00:00:00"),
-    endDate: new Date("2020-10-01T00:00:00"),
-    taskName: "OpenStack Stein",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
+    startDate: new Date("2022-10-01T00:00:00"),
+    endDate: new Date("2024-04-01T00:00:00"),
+    taskName: "OpenStack W",
+    status: "EXTENDED_SUPPORT_FOR_CUSTOMERS",
   },
   {
     startDate: new Date("2020-10-01T00:00:00"),
     endDate: new Date("2022-04-01T00:00:00"),
-    taskName: "OpenStack Stein",
-    status: "EXTENDED_SUPPORT_FOR_CUSTOMERS"
+    taskName: "OpenStack Victoria",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
+    startDate: new Date("2020-04-01T00:00:00"),
+    endDate: new Date("2020-05-15T00:00:00"),
+    taskName: "OpenStack Ussuri LTS",
+    status: "TECH_PREVIEW",
+  },
+  {
+    startDate: new Date("2020-05-15T00:00:00"),
+    endDate: new Date("2025-04-01T00:00:00"),
+    taskName: "OpenStack Ussuri LTS",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2030-04-01T00:00:00"),
+    taskName: "OpenStack Ussuri LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2020-04-01T00:00:00"),
+    endDate: new Date("2025-04-01T00:00:00"),
+    taskName: "Ubuntu 20.04 LTS",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2030-04-01T00:00:00"),
+    taskName: "Ubuntu 20.04 LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2020-04-01T00:00:00"),
+    endDate: new Date("2020-05-15T00:00:00"),
+    taskName: "OpenStack Ussuri",
+    status: "TECH_PREVIEW",
+  },
+  {
+    startDate: new Date("2020-05-15T00:00:00"),
+    endDate: new Date("2023-04-01T00:00:00"),
+    taskName: "OpenStack Ussuri",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
     startDate: new Date("2019-08-01T00:00:00"),
     endDate: new Date("2021-02-01T00:00:00"),
     taskName: "OpenStack Train",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date('2020-04-01T00:00:00'),
-    endDate: new Date('2020-05-15T00:00:00'),
-    taskName: 'OpenStack Ussuri LTS',
-    status: 'TECH_PREVIEW'
+    startDate: new Date("2019-04-01T00:00:00"),
+    endDate: new Date("2020-10-01T00:00:00"),
+    taskName: "OpenStack Stein",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date('2020-05-15T00:00:00'),
-    endDate: new Date('2025-04-01T00:00:00'),
-    taskName: 'OpenStack Ussuri LTS',
-    status: 'LTS'
+    startDate: new Date("2020-10-01T00:00:00"),
+    endDate: new Date("2022-04-01T00:00:00"),
+    taskName: "OpenStack Stein",
+    status: "EXTENDED_SUPPORT_FOR_CUSTOMERS",
   },
   {
-    startDate: new Date('2020-04-01T00:00:00'),
-    endDate: new Date('2025-04-01T00:00:00'),
-    taskName: 'Ubuntu 20.04 LTS',
-    status: 'LTS'
+    startDate: new Date("2018-08-30T00:00:00"),
+    endDate: new Date("2020-02-21T00:00:00"),
+    taskName: "OpenStack Rocky",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date('2020-04-01T00:00:00'),
-    endDate: new Date('2020-05-15T00:00:00'),
-    taskName: 'OpenStack Ussuri',
-    status: 'TECH_PREVIEW'
+    startDate: new Date("2018-04-20T00:00:00"),
+    endDate: new Date("2023-04-20T00:00:00"),
+    taskName: "OpenStack Queens LTS",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date('2020-05-15T00:00:00'),
-    endDate: new Date('2023-04-01T00:00:00'),
-    taskName: 'OpenStack Ussuri',
-    status: 'MATCHING_OPENSTACK_RELEASE_SUPPORT'
-  }
+    startDate: new Date("2023-04-20T00:00:00"),
+    endDate: new Date("2028-04-01T00:00:00"),
+    taskName: "OpenStack Queens LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2018-04-20T00:00:00"),
+    endDate: new Date("2023-04-20T00:00:00"),
+    taskName: "Ubuntu 18.04 LTS",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2023-04-20T00:00:00"),
+    endDate: new Date("2028-04-01T00:00:00"),
+    taskName: "Ubuntu 18.04 LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2018-02-01T00:00:00"),
+    endDate: new Date("2021-04-01T00:00:00"),
+    taskName: "OpenStack Queens",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
+    startDate: new Date("2016-04-01T00:00:00"),
+    endDate: new Date("2021-04-01T00:00:00"),
+    taskName: "OpenStack Mitaka LTS",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
+    startDate: new Date("2021-04-01T00:00:00"),
+    endDate: new Date("2024-04-01T00:00:00"),
+    taskName: "OpenStack Mitaka LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2016-04-01T00:00:00"),
+    endDate: new Date("2021-04-01T00:00:00"),
+    taskName: "Ubuntu 16.04 LTS",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2021-04-01T00:00:00"),
+    endDate: new Date("2024-04-01T00:00:00"),
+    taskName: "Ubuntu 16.04 LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE",
+  },
 ];
 
 export var kubernetesReleases = [
@@ -1171,78 +1237,79 @@ export var kubernetesReleases = [
     startDate: new Date("2019-03-01T00:00:00"),
     endDate: new Date("2019-12-01T00:00:00"),
     taskName: "Kubernetes 1.14",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT"
+    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2019-06-14T00:00:00"),
     endDate: new Date("2020-03-02T00:00:00"),
     taskName: "Kubernetes 1.15",
-    status: "CHARMED_KUBERNETES_SUPPORT"
+    status: "CHARMED_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2019-10-22T00:00:00"),
     endDate: new Date("2020-07-22T00:00:00"),
     taskName: "Kubernetes 1.16",
-    status: "CHARMED_KUBERNETES_SUPPORT"
+    status: "CHARMED_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2020-01-07T00:00:00"),
     endDate: new Date("2020-10-07T00:00:00"),
     taskName: "Kubernetes 1.17",
-    status: "CHARMED_KUBERNETES_SUPPORT"
+    status: "CHARMED_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2020-03-24T00:00:00"),
     endDate: new Date("2020-12-23T00:00:00"),
     taskName: "Kubernetes 1.18",
-    status: "CHARMED_KUBERNETES_SUPPORT"
+    status: "CHARMED_KUBERNETES_SUPPORT",
   },
   {
-    startDate: new Date('2020-06-16T00:00:00'),
-    endDate: new Date('2021-04-16T00:00:00'),
-    taskName: 'Kubernetes 1.19',
-    status: 'CHARMED_KUBERNETES_SUPPORT'
-  }
+    startDate: new Date("2020-06-16T00:00:00"),
+    endDate: new Date("2021-04-16T00:00:00"),
+    taskName: "Kubernetes 1.19",
+    status: "CHARMED_KUBERNETES_SUPPORT",
+  },
 ];
 
 export var desktopServerStatus = {
   HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--orange",
   MAINTENANCE_UPDATES: "chart__bar--orange-light",
   INTERIM_RELEASE: "chart__bar--grey",
-  ESM: "chart__bar--aubergine"
+  ESM: "chart__bar--aubergine",
 };
 
 export var kernelStatus = {
   LTS: "chart__bar--orange",
   INTERIM_RELEASE: "chart__bar--grey",
-  ESM: "chart__bar--aubergine"
+  ESM: "chart__bar--aubergine",
 };
 
 export var kernelReleaseScheduleStatus = {
   LTS: "chart__bar--orange",
-  INTERIM_RELEASE: "chart__bar--grey"
+  INTERIM_RELEASE: "chart__bar--grey",
 };
 
 export var kernelStatusLTS = {
   LTS: "chart__bar--orange",
-  CVE: "chart__bar--grey"
+  CVE: "chart__bar--grey",
 };
 export var kernelStatusALL = {
   LTS: "chart__bar--orange",
   INTERIM_RELEASE: "chart__bar--grey",
-  EARLY: "chart__bar--aubergine"
+  EARLY: "chart__bar--aubergine",
 };
 
 export var openStackStatus = {
   TECH_PREVIEW: "chart__bar--orange-light",
   LTS: "chart__bar--orange",
   MATCHING_OPENSTACK_RELEASE_SUPPORT: "chart__bar--grey",
-  EXTENDED_SUPPORT_FOR_CUSTOMERS: "chart__bar--aubergine"
+  EXTENDED_SUPPORT_FOR_CUSTOMERS: "chart__bar--aubergine",
+  EXTENDED_SUPPORT_MAINTENANCE: "chart__bar--green",
 };
 
 export var kubernetesStatus = {
   CHARMED_KUBERNETES_SUPPORT: "chart__bar--orange",
-  CHARMED_KUBERNETES_EXPIRED_SUPPORT: "chart__bar--grey"
+  CHARMED_KUBERNETES_EXPIRED_SUPPORT: "chart__bar--grey",
 };
 
 export var smallReleaseNames = [
@@ -1251,7 +1318,7 @@ export var smallReleaseNames = [
   "Ubuntu 21.04",
   "Ubuntu 20.10",
   "Ubuntu 20.04 LTS",
-  "Ubuntu 19.10"
+  "Ubuntu 19.10",
 ];
 
 export var desktopServerReleaseNames = [
@@ -1263,7 +1330,7 @@ export var desktopServerReleaseNames = [
   "Ubuntu 19.10",
   "Ubuntu 18.04 LTS",
   "Ubuntu 16.04 LTS",
-  "Ubuntu 14.04 LTS"
+  "Ubuntu 14.04 LTS",
 ];
 
 export var kernelReleaseNames = [
@@ -1281,7 +1348,7 @@ export var kernelReleaseNames = [
   "Ubuntu 14.04.5 LTS (v3.13)",
   "Ubuntu 16.04.0 LTS (v4.4)",
   "Ubuntu 14.04.1 LTS (v3.13)",
-  "Ubuntu 14.04.0 LTS (v3.13)"
+  "Ubuntu 14.04.0 LTS (v3.13)",
 ];
 
 export var kernelReleaseNames2004 = [
@@ -1290,7 +1357,7 @@ export var kernelReleaseNames2004 = [
   "Ubuntu 20.04.2 LTS",
   "Ubuntu 20.04.3 LTS",
   "Ubuntu 20.04.4 LTS",
-  "Ubuntu 20.04.5 LTS"
+  "Ubuntu 20.04.5 LTS",
 ];
 
 export var kernelReleaseNames1804 = [
@@ -1299,7 +1366,7 @@ export var kernelReleaseNames1804 = [
   "Ubuntu 18.04.2 LTS (v4.18)",
   "Ubuntu 18.04.3 LTS  (v5.0)",
   "Ubuntu 18.04.4 LTS (v5.3)",
-  "Ubuntu 18.04.5 LTS"
+  "Ubuntu 18.04.5 LTS",
 ];
 
 export var kernelReleaseNames1604 = [
@@ -1308,7 +1375,7 @@ export var kernelReleaseNames1604 = [
   "Ubuntu 16.04.2 LTS (v4.8)",
   "Ubuntu 16.04.3 LTS (v4.10)",
   "Ubuntu 16.04.4 LTS (v4.13)",
-  "Ubuntu 16.04.5 LTS (v4.15)"
+  "Ubuntu 16.04.5 LTS (v4.15)",
 ];
 
 export var kernelReleaseNames1404 = [
@@ -1317,7 +1384,7 @@ export var kernelReleaseNames1404 = [
   "Ubuntu 14.04.2 LTS (v3.16)",
   "Ubuntu 14.04.3 LTS (v3.19)",
   "Ubuntu 14.04.4 LTS (v4.2)",
-  "Ubuntu 14.04.5 LTS (v3.13)"
+  "Ubuntu 14.04.5 LTS (v3.13)",
 ];
 
 export var kernelReleaseNamesALL = [
@@ -1346,7 +1413,7 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 20.04.2 LTS",
   "Ubuntu 20.04.3 LTS",
   "Ubuntu 20.04.4 LTS",
-  "Ubuntu 20.04.5 LTS"
+  "Ubuntu 20.04.5 LTS",
 ];
 
 export var kernelReleaseNamesLTS = [
@@ -1373,10 +1440,16 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 20.04.2 LTS",
   "Ubuntu 20.04.3 LTS",
   "Ubuntu 20.04.4 LTS",
-  "Ubuntu 20.04.5 LTS"
+  "Ubuntu 20.04.5 LTS",
 ];
 
 export var openStackReleaseNames = [
+  "OpenStack Y LTS",
+  "Ubuntu 22.04 LTS",
+  "OpenStack Y",
+  "OpenStack X",
+  "OpenStack W",
+  "OpenStack Victoria",
   "OpenStack Ussuri LTS",
   "Ubuntu 20.04 LTS",
   "OpenStack Ussuri",
@@ -1386,11 +1459,8 @@ export var openStackReleaseNames = [
   "OpenStack Queens LTS",
   "Ubuntu 18.04 LTS",
   "OpenStack Queens",
-  "OpenStack Pike",
-  "OpenStack Ocata",
-  "OpenStack Newton",
   "OpenStack Mitaka LTS",
-  "Ubuntu 16.04 LTS"
+  "Ubuntu 16.04 LTS",
 ];
 
 export var kubernetesReleaseNames = [
@@ -1399,7 +1469,7 @@ export var kubernetesReleaseNames = [
   "Kubernetes 1.17",
   "Kubernetes 1.16",
   "Kubernetes 1.15",
-  "Kubernetes 1.14"
+  "Kubernetes 1.14",
 ];
 
 export var kernelReleaseScheduleNames = [
@@ -1408,5 +1478,5 @@ export var kernelReleaseScheduleNames = [
   "Ubuntu 18.04 LTS (v4.15)",
   "Ubuntu 19.04 (v5.0)",
   "Ubuntu 19.10 (v5.3)",
-  "Ubuntu 20.04 LTS"
+  "Ubuntu 20.04 LTS",
 ];

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -4,7 +4,6 @@
 
 .chart__bar--orange {
   fill: #e95420; // sass-lint:disable-line no-color-literals
-
   stroke: #e95420; // sass-lint:disable-line no-color-literals
   stroke-width: 1px;
 }
@@ -27,6 +26,12 @@
   stroke-width: 1px;
 }
 
+.chart__bar--green {
+  fill: green; // sass-lint:disable-line no-color-literals
+  stroke: green; // sass-lint:disable-line no-color-literals
+  stroke-width: 1px;
+}
+
 .chart__label--bold {
   font-weight: bold;
 }
@@ -41,6 +46,10 @@
   font-size: 14px;
 }
 
+.chart-key text {
+  font-size: 14px;
+}
+
 .x.axis text {
   font-size: 12px;
   text-anchor: start !important;
@@ -52,8 +61,4 @@
 
 .chart-key__row {
   display: block;
-}
-
-.chart-key text {
-  font-size: 14px;
 }

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -413,6 +413,7 @@
               <th>Released</th>
               <th>End of life</th>
               <th>Extended customer support</th>
+              <th>Extended security maintenance</th>
             </tr>
           </thead>
           <tbody>
@@ -422,6 +423,7 @@
               <td>Apr 2022</td>
               <td>Apr 2027</td>
               <td>&nbsp;</td>
+              <td>Apr 2032</td>
             </tr>
             <tr>
               <td>Ubuntu 22.04 LTS</td>
@@ -429,12 +431,14 @@
               <td>Apr 2022</td>
               <td>Apr 2027</td>
               <td>&nbsp;</td>
+              <td>Apr 2032</td>
             </tr>
             <tr>
               <td>OpenStack Y</td>
               <td>&nbsp;</td>
               <td>Apr 2022</td>
               <td>Apr 2025</td>
+              <td>&nbsp;</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -443,6 +447,7 @@
               <td>Oct 2021</td>
               <td>Apr 2023</td>
               <td>&nbsp;</td>
+              <td>&nbsp;</td>
             </tr>
             <tr>
               <td>OpenStack W</td>
@@ -450,12 +455,14 @@
               <td>Apr 2021</td>
               <td>Oct 2022</td>
               <td>Apr 2024</td>
+              <td>&nbsp;</td>
             </tr>
             <tr>
               <td>OpenStack Victoria</td>
               <td>&nbsp;</td>
               <td>Oct 2020</td>
               <td>Apr 2022</td>
+              <td>&nbsp;</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -464,6 +471,7 @@
               <td>May 2020</td>
               <td>Apr 2025</td>
               <td>&nbsp;</td>
+              <td>Apr 2030</td>
             </tr>
             <tr>
               <td>Ubuntu 20.04 LTS</td>
@@ -471,12 +479,14 @@
               <td>Apr 2020</td>
               <td>Apr 2025</td>
               <td>&nbsp;</td>
+              <td>Apr 2030</td>
             </tr>
             <tr>
               <td>OpenStack Ussuri</td>
               <td>Apr 2020</td>
               <td>May 2020</td>
               <td>Apr 2023</td>
+              <td>&nbsp;</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -485,6 +495,7 @@
               <td>Aug 2019</td>
               <td>Feb 2021</td>
               <td>&nbsp;</td>
+              <td>&nbsp;</td>
             </tr>
             <tr>
               <td>OpenStack Stein</td>
@@ -492,12 +503,14 @@
               <td>Apr 2019</td>
               <td>Oct 2020</td>
               <td>Apr 2022</td>
+              <td>&nbsp;</td>
             </tr>
             <tr>
               <td>OpenStack Rocky</td>
               <td>&nbsp;</td>
               <td>Aug 2018</td>
               <td>Feb 2020</td>
+              <td>&nbsp;</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -506,6 +519,7 @@
               <td>Apr 2018</td>
               <td>Apr 2023</td>
               <td>&nbsp;</td>
+              <td>Apr 2028</td>
             </tr>
             <tr>
               <td>Ubuntu 18.04 LTS</td>
@@ -513,12 +527,14 @@
               <td>Apr 2018</td>
               <td>Apr 2023</td>
               <td>&nbsp;</td>
+              <td>Apr 2028</td>
             </tr>
             <tr>
               <td>OpenStack Queens</td>
               <td>&nbsp;</td>
               <td>Feb 2018</td>
               <td>Apr 2021</td>
+              <td>&nbsp;</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -527,6 +543,7 @@
               <td>Apr 2016</td>
               <td>Apr 2021</td>
               <td>&nbsp;</td>
+              <td>Apr 2024</td>
             </tr>
             <tr>
               <td>Ubuntu 16.04 LTS</td>
@@ -534,6 +551,7 @@
               <td>Apr 2016</td>
               <td>Apr 2021</td>
               <td>&nbsp;</td>
+              <td>Apr 2024</td>
             </tr>
           </tbody>
         </table>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -417,6 +417,48 @@
           </thead>
           <tbody>
             <tr>
+              <td>OpenStack Y LTS</td>
+              <td>&nbsp;</td>
+              <td>Apr 2022</td>
+              <td>Apr 2027</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>Ubuntu 22.04 LTS</td>
+              <td>&nbsp;</td>
+              <td>Apr 2022</td>
+              <td>Apr 2027</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack Y</td>
+              <td>&nbsp;</td>
+              <td>Apr 2022</td>
+              <td>Apr 2025</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack X</td>
+              <td>&nbsp;</td>
+              <td>Oct 2021</td>
+              <td>Apr 2023</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td>OpenStack W</td>
+              <td>&nbsp;</td>
+              <td>Apr 2021</td>
+              <td>Oct 2022</td>
+              <td>Apr 2024</td>
+            </tr>
+            <tr>
+              <td>OpenStack Victoria</td>
+              <td>&nbsp;</td>
+              <td>Oct 2020</td>
+              <td>Apr 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
               <td>OpenStack Ussuri LTS</td>
               <td>Apr 2020</td>
               <td>May 2020</td>
@@ -459,7 +501,7 @@
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>OpenStack Queens</td>
+              <td>OpenStack Queens LTS</td>
               <td>&nbsp;</td>
               <td>Apr 2018</td>
               <td>Apr 2023</td>
@@ -480,28 +522,7 @@
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>OpenStack Pike</td>
-              <td>&nbsp;</td>
-              <td>Aug 2017</td>
-              <td>Feb 2019</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Ocata</td>
-              <td>&nbsp;</td>
-              <td>Feb 2017</td>
-              <td>Aug 2018</td>
-              <td>Feb 2020</td>
-            </tr>
-            <tr>
-              <td>OpenStack Newton</td>
-              <td>&nbsp;</td>
-              <td>Oct 2016</td>
-              <td>Apr 2018</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Mitaka</td>
+              <td>OpenStack Mitaka LTS</td>
               <td>&nbsp;</td>
               <td>Apr 2016</td>
               <td>Apr 2021</td>
@@ -512,90 +533,6 @@
               <td>&nbsp;</td>
               <td>Apr 2016</td>
               <td>Apr 2021</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Mitaka</td>
-              <td>&nbsp;</td>
-              <td>Apr 2016</td>
-              <td>Apr 2019</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Liberty</td>
-              <td>&nbsp;</td>
-              <td>Oct 2015</td>
-              <td>Apr 2017</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Kilo</td>
-              <td>&nbsp;</td>
-              <td>Apr 2015</td>
-              <td>Oct 2016</td>
-              <td>Apr 2018</td>
-            </tr>
-            <tr>
-              <td>OpenStack Juno</td>
-              <td>&nbsp;</td>
-              <td>Oct 2014</td>
-              <td>Apr 2016</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Icehouse</td>
-              <td>&nbsp;</td>
-              <td>Apr 2014</td>
-              <td>Apr 2019</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>Ubuntu 14.10 LTS</td>
-              <td>&nbsp;</td>
-              <td>Apr 2014</td>
-              <td>Apr 2019</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Icehouse</td>
-              <td>&nbsp;</td>
-              <td>Apr 2014</td>
-              <td>Apr 2017</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Havana</td>
-              <td>&nbsp;</td>
-              <td>Oct 2013</td>
-              <td>Jul 2014</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Grizzly</td>
-              <td>&nbsp;</td>
-              <td>May 2013</td>
-              <td>Aug 2014</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Folsom</td>
-              <td>&nbsp;</td>
-              <td>Sep 2012</td>
-              <td>Jun 2014</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>OpenStack Essex</td>
-              <td>&nbsp;</td>
-              <td>Apr 2012</td>
-              <td>Apr 2017</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>Ubuntu 12.04 LTS</td>
-              <td>&nbsp;</td>
-              <td>Apr 2012</td>
-              <td>Apr 2017</td>
               <td>&nbsp;</td>
             </tr>
           </tbody>


### PR DESCRIPTION
## Done

Updated the OpenStack release cycle chart to match the spreadsheet

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-openstack-release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the OpenStack release cycle chart data matches [the google sheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1483484944)
- Check that the table in small screen view is also up to date


## Issue / Card

Fixes #7654 