### PR TITLE
Update appliance homepage content

### DIFF
--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -10,7 +10,7 @@
 
 <section class="p-strip--suru is-dark">
   <div class="row">
-    <h1>Ubuntu Appliance portfolio</h1>
+    <h1>The Ubuntu Appliance Portfolio</h1>
     <p class="p-heading--four">Free appliance images for your PC or Raspberry Pi</p>
   </div>
 </section>
@@ -18,7 +18,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-2">
-      <h2 class="p-muted-heading">Featured today</h2>
+      <h2 class="p-muted-heading">Featured</h2>
     </div>
     <div class="col-2">
       <a href="/appliance/openhab" class="p-link--soft">
@@ -76,7 +76,8 @@
       <h2>Make something great today</h2>
       <p class="p-heading--four">We’ve got just the thing for you</p>
       <p>Transform a spare PC or Pi into a smart, secure, and ultra-simple box that does exactly what you want. Brilliantly.</p>
-      <p>Open or commercial. Enterprise or home. Entertainment. Automation. Gaming. Network. Storage. Fun. Come and play with something new today.</p>
+      <p>Open or commercial. Enterprise or home. Entertainment. Automation. Gaming. Network. Storage. Fun. Make something new today.</p>
+      <p><a href="/applicance/portfolio">Browse the portfolio&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
@@ -111,9 +112,10 @@
     </div>
     <div class="col-7">
       <h2>Try before you Pi</h2>
-      <p class="p-heading--four">Test drive them safely on your laptop</p>
-      <p>Just for fun, you can run a Virtual Ubuntu Appliance on any PC without affecting your existing system. Most of our appliances have a virtual version unless they really do depend on special hardware.</p>
-      <p>No need for a spare disk or board, just follow the steps  and you’ll be up and running quickly. Virtual Ubuntu Appliances work on Ubuntu, Windows and macOS.</p>
+      <p class="p-heading--four">Test drive safely on your laptop</p>
+      <p>Run a Virtual Ubuntu Appliance on any PC without affecting your existing system. Most appliances have a virtual version unless they depend on special hardware.</p>
+      <p>No need for a spare disk or board, just follow the steps  and you’ll be up and running in seconds. Virtual Ubuntu Appliances work on Ubuntu, Windows and macOS.</p>
+      <p><a href="/appliance/vm">Try an instant appliance now&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 
@@ -125,9 +127,9 @@
     <div class="col-7">
       <h2>App store easy</h2>
       <p class="p-heading--four">An app or two for extra foo</p>
-      <p>Upgrade your appliance with extra apps. Try out a new autopilot. Add an extra game. Each appliance starts with just the right stuff for everyone. Add the sauce you like.</p>
-      <p>Enjoy the same <a class="p-link--external" href="https://snapcraft.io/store">huge app selection as Ubuntu</a>, or get a dedicated store with unique apps for that specific thing. Publishers will shape the store you see.</p>
-      <p>Ubuntu Appliances get apps and updates from our global backbone, just like millions of Ubuntu workstations, laptops and servers every day.</p>
+      <p>Upgrade your appliance with extra apps. Try a new autopilot. Enjoy the latest game. Each appliance starts with just the right stuff for everyone. Add the sauce you like.</p>
+      <p>Enjoy the same <a class="p-link--external" href="https://snapcraft.io/store">huge app selection as Ubuntu</a>, or get a dedicated store with unique apps for your specific thing.</p>
+      <p>Ubuntu Appliances get apps and updates from our global backbone, just like millions of Ubuntu workstations, devices, laptops and servers every day.</p>
     </div>
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
@@ -164,8 +166,8 @@
       <h2>Secure by design</h2>
       <p class="p-heading--four">Crisp. Clean. Carrier-grade. Core.</p>
       <p>SecureBoot. Full disk encryption. Hardware crypto keys. An ironclad commitment to your peace of mind.</p>
-      <p>We toughened Ubuntu to harden these things. They bring their magic, we bring our mettle. Community or business-backed, they both enjoy <a href="/core">the same robust, secure Ubuntu Core</a>.</p>
-      <p>Strict confinement and read-only packages keep bad code locked down. Certs and signatures make for tamper proof provenance. Full containerisation for no loose ends. And we’ve got your back for critical jobs with ten year updates, guaranteed.</p>
+      <p>We toughened Ubuntu to harden these things. They bring their magic, we bring our mettle. Community or business-backed, both enjoy <a href="/core">the same robust, secure Ubuntu Core</a>.</p>
+      <p>Strict confinement and read-only packages keep bad code locked down. Certs and signatures for tamper-proof provenance. Full containerisation for no loose ends. And we’ve got your back on critical jobs with ten year updates guaranteed.</p>
     </div>
   </div>
 </section>
@@ -188,7 +190,7 @@
       <h2>Clear privacy policies</h2>
       <p>Every Ubuntu Appliance complies with EU data protection or California privacy law. Your personal data is precious. Your privacy even more so. Our mission is to defend them in this new world of ever-present sensor-driven software.</p>
       <p>Voice-activated software and computer vision are amazing tools. We ensure those microphones and cameras only work for you.</p>
-      <p><a href="/appliance/governance">Learn about your privacy protection&nbsp;&rsaquo;</a></p>
+      <p><a href="/appliance/community">Learn about your privacy protection&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6">
       {{
@@ -204,7 +206,7 @@
       <h2>Enterprise-grade control</h2>
       <p class="p-heading--four">Define the flow of fixes across your whole estate.</p>
       <p>Imagine a world where every firmware update was instantly available on any device. Imagine you could determine exactly when and where it rolled out. Imagine you knew the CVE status of everything you care about, everywhere, all the time.</p>
-      <p>That’s the precision of every Ubuntu Appliance. Made for mission-critical. One dashboard, one practice, one process for your entire multi-vendor estate. With a universal Ubuntu Core, your updates and security align from edge to cloud, no matter which hardware, no matter which appliance.</p>
+      <p>That’s the precision of every Ubuntu Appliance. Made for mission-critical. One dashboard, one practice, one process for your entire multi-vendor estate. With universal Ubuntu Core, your updates and security align from edge to cloud, no matter which hardware, no matter which brand.</p>
     </div>
   </div>
 
@@ -227,8 +229,8 @@
         ) | safe
       }}
       <h2>Future proven</h2>
-      <p class="p-heading--four">Stable. Beta. RC. Edge. Get future fixes faster here.</p>
-      <p>Every piece of software on your Ubuntu Appliance is offered in a set of streams. These channels offer all the current builds and if the publisher allows, early access versions too.</p>
+      <p class="p-heading--four">Stable. Beta. RC. Edge. Get future fixes faster.</p>
+      <p>Every piece of software on your Ubuntu Appliance is offered in a set of streams. These channels offer all the current builds and &mdash; if the publisher allows &mdash; early access versions too.</p>
       <p>Set your appliance to preview channels for a taste of future change before it’s fully done. Choose a safe canary box, and catch the issues there. Switch software streams at any time, for any system, anywhere.</p>
     </div>
     <div class="col-6">
@@ -243,9 +245,9 @@
         ) | safe
       }}
       <h2>Certified, Maintained or Experimental</h2>
-      <p>Some appliances are serious things, and you want to know that Canonical will keep them reliable, year after year, on a certified device. Those are marked ‘certified’, and they get constant testing and security coverage.</p>
-      <p>Other appliances have a company to keep the updates coming, for at least a certain time. Those ones are tagged ‘maintained’ and you can always see the minimum time assured of maintenance.</p>
-      <p>And then there are the crazy things, the community things, the experimental things. Enjoy those, but don’t get too attached to them. If enough people love them then they’ll get maintenance commitments too.</p>
+      <p>Some appliances are serious things, and you want to know that Canonical will keep them reliable, year after year. Those are marked ‘certified’, and they get constant testing and security coverage.</p>
+      <p>Other appliances have a company to keep the updates coming, for at least a certain time. Those are tagged ‘maintained’ and you can always see the minimum time assured of maintenance.</p>
+      <p>And then there are the crazy things, the community things, the experimental things. Enjoy those, but don’t get too attached. If enough people love them then they’ll get maintenance commitments soon enough.</p>
     </div>
   </div>
 
@@ -255,41 +257,41 @@
     </p>
   </div>
 
-    <div class="row u-equal-height">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+          alt="",
+          height="85",
+          width="85",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+      <h2>Community and Commercial</h2>
+      <p>Our open source community appliances get all the updates, benefits and care that goes into our mission-critical customers. That’s Ubuntu. That’s Canonical.</p>
+      <p>Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.</p>
+      <p><a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a></p>
+    </div>
       <div class="col-6">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+            url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
             alt="",
             height="85",
-            width="85",
+            width="149",
             hi_def=True,
             loading="auto"
           ) | safe
         }}
-        <h2>Community and Commercial</h2>
-        <p>Our open source community appliances get all the updates, benefits and care that goes into our mission-critical customers. That’s Ubuntu. That’s Canonical.</p>
-        <p>Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.</p>
-        <p><a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a></p>
+        <h2>Confidently compatible</h2>
+        <p class="p-heading--four">Choose your certified board or box</p>
+        <p>It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.</p>
+        <p>We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. You can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.</p>
+        <p><a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a></p>
       </div>
-        <div class="col-6">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
-              alt="",
-              height="85",
-              width="149",
-              hi_def=True,
-              loading="auto"
-            ) | safe
-          }}
-          <h2>Confidently compatible</h2>
-          <p class="p-heading--four">Choose your certified board or box</p>
-          <p>It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.</p>
-          <p>We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. That’s to be sure you can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.</p>
-          <p><a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a></p>
-        </div>
-      </div>
+    </div>
 </section>
 
 {% endblock content %}

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -173,7 +173,7 @@
 </section>
 
 {# 2 by 2 section #}
-<section class="p-strip--light is-deep">
+<section class="p-strip--light is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
       {{
@@ -274,24 +274,33 @@
       <p>Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.</p>
       <p><a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a></p>
     </div>
-      <div class="col-6">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
-            alt="",
-            height="85",
-            width="149",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
-        <h2>Confidently compatible</h2>
-        <p class="p-heading--four">Choose your certified board or box</p>
-        <p>It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.</p>
-        <p>We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. You can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.</p>
-        <p><a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a></p>
-      </div>
+    <div class="col-6">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
+          alt="",
+          height="85",
+          width="149",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+      <h2>Confidently compatible</h2>
+      <p class="p-heading--four">Choose your certified board or box</p>
+      <p>It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.</p>
+      <p>We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. You can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.</p>
+      <p><a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a></p>
     </div>
+  </div>
+</section>
+
+<section class="p-strip--suru-half-and-half">
+  <div class="row">
+    <div class="col-8">
+      <h2>Browse the Ubuntu Appliance Portfolio</h2>
+      <p><a href="/appliance/portfolio" class="p-button--positive u-no-margin--bottom">Browse the portfolio</a></p>
+    </div>
+  </div>
 </section>
 
 {% endblock content %}


### PR DESCRIPTION
## Done
- Update appliance homepage content
- Add CTA at the bottom of the page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance
- Check the content matches [the copy doc](https://docs.google.com/document/d/1Fcr5b5Rn06AB89D6DGPmoIgXLxLalijMhwnu_IyUxV4/edit)

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/84293033-262d1700-ab3f-11ea-8b03-716f326e086d.png)

