### PR TITLE
Update intel-nuc appliance instructions

### DIFF
--- a/templates/appliance/adguard/intel-nuc.html
+++ b/templates/appliance/adguard/intel-nuc.html
@@ -1,8 +1,8 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
 
-{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
 

--- a/templates/appliance/mosquitto/intel-nuc.html
+++ b/templates/appliance/mosquitto/intel-nuc.html
@@ -1,8 +1,8 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
 
-{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
 

--- a/templates/appliance/nextcloud/intel-nuc.html
+++ b/templates/appliance/nextcloud/intel-nuc.html
@@ -1,8 +1,8 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
 
-{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
 

--- a/templates/appliance/openhab/intel-nuc.html
+++ b/templates/appliance/openhab/intel-nuc.html
@@ -1,8 +1,8 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
 
-{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
 

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -6,13 +6,13 @@
   <div class="row u-vertically-center">
     <div class="col-8">
       {% if appliance.iso_url.pc %}
-      <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Intel NUC</h1>
+      <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for an Intel NUC</h1>
       <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
         <a href="{{ appliance.iso_url.pc }}">download now</a>.
         {% include "appliance/shared/_verify-checksums-pc.html" %}
       </p>
       {% else %}
-      <h1>Setup your Ubuntu {{ appliance.name }} appliance for Raspberry Pi</h1>
+      <h1>Setup your Ubuntu {{ appliance.name }} appliance for an Intel NUC</h1>
       {% endif %}
     </div>
     <div class="col-4 u-hide--small u-align--center">
@@ -56,7 +56,7 @@
       </nav>
 
       <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
-        {% with logo="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        {% include "appliance/shared/_install_instructions_intel-nuc.html" %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_ubuntu.html' %}
           {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
@@ -68,7 +68,7 @@
       </div>
 
       <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
-        {% with logo="https://assets.ubuntu.com/v1/30574235-windows-logo.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        {% include "appliance/shared/_install_instructions_intel-nuc.html" %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_windows.html' %}
           {% with command='type' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
@@ -80,7 +80,7 @@
       </div>
 
       <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
-        {% with logo="https://assets.ubuntu.com/v1/6042056d-MacOS_wordmark.svg" %}{% include "appliance/shared/_install_instructions_intel-nuc.html" %}{% endwith %}
+        {% include "appliance/shared/_install_instructions_intel-nuc.html" %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_macos.html' %}
           {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}

--- a/templates/appliance/shared/_steps_nuc_install_appliance.html
+++ b/templates/appliance/shared/_steps_nuc_install_appliance.html
@@ -9,7 +9,7 @@
       <li>Insert the first USB flash drive, containing Ubuntu Desktop 20.04 LTS</li>
       <li>Start the NUC and push <code>F10</code> to enter the boot menu</li>
       <li>Select the USB flash drive as a boot option</li>
-      <li>Select <code>"Try Ubuntu without installing"</code></li>
+      <li>Select <code>Try Ubuntu without installing</code></li>
       <li>Once the Ubuntu session has started, insert the second USB flash drive containing the appliance image file</li>
       <li>Open a terminal and use the following command to find out the target disk device to install the appliance to:
 <pre><code>sudo fdisk -l</code></pre>

--- a/templates/appliance/shared/_steps_nuc_thats-it.html
+++ b/templates/appliance/shared/_steps_nuc_thats-it.html
@@ -5,7 +5,7 @@
   </h4>
   <div class="p-stepped-list__content">
     <p>
-      Once setup is done, you can login with SSH into Ubuntu Core, from a machine on the same network, using the following command:
+      Once setup is done, you can login to a machine on the same network with SSH:
     </p>
     <pre><code>ssh &lt;Ubuntu SSO user name&gt;@&lt;device IP address&gt;</code></pre>
     <p>


### PR DESCRIPTION
## Done

- Update intel-nuc appliance instructions on /appliance/<appliance>/intel-nuc pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/adguard/intel-nuc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the text in the [sheet](https://docs.google.com/spreadsheets/d/1eZD3zISXBSNwAwkxlIRtV1UqP8GKPi0YAis8IRLZ9Po/edit#gid=1733381881)


## Issue / Card

Fixes #7707
