### PR TITLE
Update /appliance/<appliance>/vm instructions

### DIFF
--- a/templates/appliance/shared/_install_instructions_vm_macos.html
+++ b/templates/appliance/shared/_install_instructions_vm_macos.html
@@ -1,3 +1,4 @@
+<hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">

--- a/templates/appliance/shared/_install_instructions_vm_ubuntu.html
+++ b/templates/appliance/shared/_install_instructions_vm_ubuntu.html
@@ -1,4 +1,5 @@
+<hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
-  <li class="p-list__item is-ticked">A PC running <a href="/download/desktop">Ubuntu desktop</a></li>
+  <li class="p-list__item is-ticked"A PC running Ubuntu 18.04 LTS or later</li>
 </ul>

--- a/templates/appliance/shared/_install_instructions_vm_ubuntu.html
+++ b/templates/appliance/shared/_install_instructions_vm_ubuntu.html
@@ -1,5 +1,5 @@
 <hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
-  <li class="p-list__item is-ticked"A PC running Ubuntu 18.04 LTS or later</li>
+  <li class="p-list__item is-ticked">A PC running Ubuntu 18.04 LTS or later</li>
 </ul>

--- a/templates/appliance/shared/_install_instructions_vm_windows.html
+++ b/templates/appliance/shared/_install_instructions_vm_windows.html
@@ -1,6 +1,7 @@
+<hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">
-    A PC running Windows 10 Pro/Enterprise/Education Updatev 1803 or later with <a class="p-link--external" href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>.
+    A PC running Windows 10 Pro/Enterprise/Education Update 1803 or later, or any version of Windows with <a class="p-link--external" href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>.
   </li>
 </ul>

--- a/templates/appliance/shared/_steps-multipass-find-ip-macos.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-macos.html
@@ -1,0 +1,15 @@
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    Find your appliance
+  </h4>
+  <div class="p-stepped-list__content">
+    <p>
+      To use VirtualBox’s port forwarding run:
+    </p>
+    <pre><code>sudo VBoxManage modifyvm "&lt;instance name&gt;" --natpf2 "{{ appliance.alias }},tcp,,{{ appliance.port }},,{{ appliance.port }}"</code></pre>
+    <p>
+      You can find more information about what this command means in the <a class="p-link--external" href="https://multipass.run/docs/using-virtualbox-in-multipass-macos#port-forwarding">Multipass documentation</a>.
+    </p>
+  </div>
+</li>

--- a/templates/appliance/shared/_steps-multipass-find-ip-ubuntu.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-ubuntu.html
@@ -1,0 +1,12 @@
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    Find your appliance
+  </h4>
+    <div class="p-stepped-list__content">
+      <p>
+        Find your appliance VM’s IP address:
+      </p>
+      <pre><code>multipass list</code></pre>
+    </div>
+</li>

--- a/templates/appliance/shared/_steps-multipass-find-ip-windows.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-windows.html
@@ -1,0 +1,25 @@
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    Find and connect to your appliance
+  </h4>
+    <div class="p-stepped-list__content">
+      <h5>
+        Hyper-V instructions
+      </h5>
+      <p>
+        On Hyper-V, find your virtual appliance IP address:
+      </p>
+      <pre><code>multipass list</code></pre>
+      <h5>
+        VirtualBox instructions
+      </h5>
+      <p>
+        On VirtualBox, forward the appliance port to the outside world with this command in an Administrator PowerShell:
+      </p>
+      <pre><code>env:USERPROFILE\Downloads\PSTools\PsExec.exe -s $env:VBOX_MSI_INSTALL_PATH\VBoxManage.exe modifyvm "primary" --natpf1 "{{ appliance.alias }},tcp,,{{ appliance.port}},,{{ appliance.port}}"</code></pre>
+      <p>
+        For more information about this command see the <a class="p-link--external" href="https://multipass.run/docs/using-virtualbox-in-multipass-windows#port-forwarding">Multipass documentation</a>.
+      </p>
+    </div>
+</li>

--- a/templates/appliance/shared/_steps-multipass-launch.html
+++ b/templates/appliance/shared/_steps-multipass-launch.html
@@ -1,8 +1,12 @@
-<li>
-  <p>Now, launch your appliance image in a vm:</p>
-  <pre><code>multipass launch appliance:{{ appliance.alias }}</code></pre>
-</li>
-<li>
-  <p>Find your vm’s IP address:</p>
-  <pre><code>multipass list</code></pre>
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    Launch your Ubuntu Appliance
+  </h4>
+    <div class="p-stepped-list__content">
+      <p>
+        Launch your appliance image. Multipass gives your appliance an instance name like <code>happy-frog</code>. To name it yourself add <code>--name &lt;name&gt;</code>.
+      </p>
+      <pre><code>multipass launch appliance:{{ appliance.alias }}</code></pre>
+    </div>
 </li>

--- a/templates/appliance/shared/_steps_multipass_macos.html
+++ b/templates/appliance/shared/_steps_multipass_macos.html
@@ -1,7 +1,7 @@
 <hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
-    Set up and install a vm using Multipass
+    Install Multipass
   </h4>
   <div class="p-stepped-list__content">
     <ol>
@@ -12,7 +12,7 @@
       </li>
       <li>
         <p>
-          Activate the downloaded installer. You will need an account with Administrator privileges to complete the installation.
+          Activate the downloaded installer in an account with Administrator privileges.
         </p>
         {{
           image (
@@ -27,56 +27,10 @@
       </li>
       <li>
         <p>
-          There’s a script to uninstall Multipass if you need it:
+          To start Multipass with VirtualBox use this Terminal app command:
         </p>
-        <pre><code>sudo sh "/Library/Application Support/com.canonical.multipass/uninstall.sh"</code></pre>
+        <pre><code>multipass set local.driver=virtualbox</code></pre>
       </li>
-      {% include "appliance/shared/_steps-multipass-launch.html" %}
     </ol>
-  </div>
-</li>
-
-<hr>
-<li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    First run
-  </h4>
-  <div class="p-stepped-list__content">
-    <p>
-      To start using VirtualBox run:
-    </p>
-    <pre><code>multipass set local.driver=virtualbox</code></pre>
-    <div class="p-notification" id="notification">
-      <div class="p-notification__response">
-        <span class="p-notification__status">Note:</span>
-        <p>
-          After the next command Multipass gives your appliance an <code>instance name</code>. To name it yourself add <code>--name &lt;new name&gt;</code>  to the end of the next command.
-        </p>
-      </div>
-    </div>
-    <p>
-      Now, open the Terminal app and launch your appliance image in a vm:
-    </p>
-    <pre><code>multipass launch appliance:{{ appliance.alias }}</code></pre>
-  </div>
-</li>
-
-<li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    Find and connect to your appliance
-  </h4>
-  <div class="p-stepped-list__content">
-    <p>
-      To use VirtualBox’s port forwarding feature run:
-    </p>
-    <pre><code>sudo VBoxManage modifyvm "&lt;instance name&gt;" --natpf2 "{{ appliance.alias }},tcp,,{{ appliance.port }},,{{ appliance.port }}"</code></pre>
-    <div class="p-notification" id="notification">
-      <div class="p-notification__response">
-        <span class="p-notification__status">Note:</span>
-        <p>
-          You can find more information about what this command means in the <a class="p-link--external" href="https://multipass.run/docs/using-virtualbox-in-multipass-macos#port-forwarding">Multipass documentation</a>.
-        </p>
-      </div>
-    </div>
   </div>
 </li>

--- a/templates/appliance/shared/_steps_multipass_ubuntu.html
+++ b/templates/appliance/shared/_steps_multipass_ubuntu.html
@@ -1,23 +1,9 @@
 <hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
-    Set up and install a vm using Multipass
+    Install Multipass
   </h4>
   <div class="p-stepped-list__content">
-    <ol>
-      <li>
-        <p>
-          Install Multipass:
-        </p>
-        <pre><code>sudo snap install multipass</code></pre>
-        <div class="p-notification" id="notification">
-          <div class="p-notification__response">
-            <span class="p-notification__status">Note:</span>
-            <p>Multipass is about to name your appliance something like ‘cute-emperor’ or ‘prophetic-giraffe’. After this whatever you get will be your <code>{{ appliance.alias }}</code>. To use a different name simply add <code>--name &lt;your new name&gt;</code> to the end of the next line.</p>
-          </div>
-        </div>
-      </li>
-      {% include "appliance/shared/_steps-multipass-launch.html" %}
-    </ol>
+      <pre><code>sudo snap install multipass</code></pre>
   </div>
 </li>

--- a/templates/appliance/shared/_steps_multipass_windows.html
+++ b/templates/appliance/shared/_steps_multipass_windows.html
@@ -1,7 +1,7 @@
 <hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
-    Set up and install a vm using Multipass
+    Install Multipass
   </h4>
   <div class="p-stepped-list__content">
     <ol>
@@ -17,10 +17,9 @@
       </li>
       <li>
         <p>
-          Run the installer and it will guide you through the necessary steps. You will need to allow the installer to gain Administrator privileges.
+          Run the installer. You will need to allow the installer to gain Administrator privileges.
         </p>
       </li>
-      {% include "appliance/shared/_steps-multipass-launch.html" %}
     </ol>
   </div>
 </li>

--- a/templates/appliance/shared/_steps_vm_thats-it.html
+++ b/templates/appliance/shared/_steps_vm_thats-it.html
@@ -4,7 +4,9 @@
     That’s it
   </h4>
   <div class="p-stepped-list__content">
-    <p>Your appliance is now running in a Virtual Machine and you can start using it. If you want to access it through the command-line you can also shell into it:</p>
+    <p>
+      Your appliance is now running in a virtual machine. Start and stop it with <code>multipass start &lt;name&gt;</code> and <code>multipass stop &lt;name&gt;</code>. To access the command-line:
+      </p>
     <pre><code>multipass shell {{ appliance.alias }}</code></pre>
   </div>
 </li>

--- a/templates/appliance/shared/_vm.html
+++ b/templates/appliance/shared/_vm.html
@@ -6,7 +6,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       {% if appliance.iso_url.pc %}
-      <h1>Try the Ubuntu {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine</h1>
+      <h1>Try the {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine</h1>
       <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
         <a href="{{ appliance.iso_url.pc }}">download now</a>.
         {% include "appliance/shared/_verify-checksums-pc.html" %}
@@ -20,8 +20,8 @@
         image(
         url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
         alt="",
-        width="200",
-        height="200",
+        width="180",
+        height="180",
         hi_def=True,
         loading="auto",
         ) | safe
@@ -60,6 +60,8 @@
         {% include "appliance/shared/_install_instructions_vm_ubuntu.html" %}
         <ol class="p-stepped-list--detailed">
           {% include "appliance/shared/_steps_multipass_ubuntu.html" %}
+          {% include "appliance/shared/_steps-multipass-launch.html" %}
+          {% include "appliance/shared/_steps-multipass-find-ip-ubuntu.html" %}
           {% include 'appliance/shared/_steps_vm_thats-it.html' %}
         </ol>
       </div>
@@ -69,6 +71,8 @@
         {% include "appliance/shared/_install_instructions_vm_windows.html" %}
         <ol class="p-stepped-list--detailed">
           {% include "appliance/shared/_steps_multipass_windows.html" %}
+          {% include "appliance/shared/_steps-multipass-launch.html" %}
+          {% include "appliance/shared/_steps-multipass-find-ip-windows.html" %}
           {% include 'appliance/shared/_steps_vm_thats-it.html' %}
         </ol>
       </div>
@@ -78,6 +82,8 @@
         {% include "appliance/shared/_install_instructions_vm_macos.html" %}
         <ol class="p-stepped-list--detailed">
           {% include "appliance/shared/_steps_multipass_macos.html" %}
+          {% include "appliance/shared/_steps-multipass-launch.html" %}
+          {% include "appliance/shared/_steps-multipass-find-ip-macos.html" %}
           {% include 'appliance/shared/_steps_vm_thats-it.html' %}
         </ol>
       </div>


### PR DESCRIPTION
## Done

- Update vm appliance instructions on /appliance/<appliance>/vm pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/adguard/vm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the text in the [sheet](https://docs.google.com/spreadsheets/d/1eZD3zISXBSNwAwkxlIRtV1UqP8GKPi0YAis8IRLZ9Po/edit#gid=1733381881)


## Issue / Card

Fixes #7706
