### PR TITLE
Add Managed OpenStack notice on BootStack blog posts

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -82,15 +82,6 @@
     <div class="row u-equal-height">
       <div class="col-8">
         <div class="p-post__content">
-          {% for tag in tags %}
-            {% if tag.name == 'BootStack' %}
-              <div class="p-card">
-                <h4 class="p-card__title">Looking for a fully managed private cloud?</h4>
-                <p class="p-card__content">Designed with economics in mind, Canonical's Managed OpenStack is the most cost-efficient path to a fully managed private cloud.<br/><br/></p>
-                <p><a class="" href="/openstack/managed">Learn more about Canonical's Managed OpenStack &rsaquo;</a></p>
-              </div>
-            {% endif %}
-          {% endfor %}
           {{ article.content.rendered|safe }}
         </div>
       </div>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -82,6 +82,15 @@
     <div class="row u-equal-height">
       <div class="col-8">
         <div class="p-post__content">
+          {% for tag in tags %}
+            {% if tag.name == 'BootStack' %}
+              <div class="p-card">
+                <h4 class="p-card__title">Looking for a fully managed private cloud?</h4>
+                <p class="p-card__content">Designed with economics in mind, Canonical's Managed OpenStack is the most cost-efficient path to a fully managed private cloud.<br/><br/></p>
+                <p><a class="" href="/openstack/managed">Learn more about Canonical's Managed OpenStack &rsaquo;</a></p>
+              </div>
+            {% endif %}
+          {% endfor %}
           {{ article.content.rendered|safe }}
         </div>
       </div>

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,4 +1,19 @@
-{% if article.group and article.group.slug == "kubernetes" %}
+
+{% if article.tags and 1572 in article.tags %}
+<div class="p-card" id="rtp-bootstack">
+<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/00633f99-ubuntu-cloud-2.svg" alt="header image">
+<hr class="u-sv1">
+  <h3>
+    <a href="/openstack/managed">
+      Looking for a fully managed private cloud?
+    </a>
+  </h3>
+  <p>
+    Designed with economics in mind, Canonical's Managed OpenStack is the most cost-efficient path to a fully managed private cloud.
+  </p>
+  <p><a href="/openstack/managed">Learn more about Managed OpenStack &rsaquo;</a></p>
+</div>
+{% elif article.group and article.group.slug == "kubernetes" %}
 <div class="p-card" id="rtp-k8s">
   <h3>
     <a href="/kubernetes">


### PR DESCRIPTION
## Done

- Added a custom Managed OpenStack notice on all blog posts tagged "BootStack"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the notice is present at the top of blog posts tagged with "BootStack", eg.
  - [/blog/the-enterprise-deployment-game-plan-why-multi-cloud-is-the-future](https://ubuntu-com-canonical-web-and-design-pr-7720.run.demo.haus/blog/the-enterprise-deployment-game-plan-why-multi-cloud-is-the-future)
  - [/blog/a-unified-openstack-for-a-scalable-open-infrastructure](https://ubuntu-com-canonical-web-and-design-pr-7720.run.demo.haus/blog/a-unified-openstack-for-a-scalable-open-infrastructure)
  - [/blog/unitas-global-and-canonical-provide-fully-managed-enterprise-openstack](https://ubuntu-com-canonical-web-and-design-pr-7720.run.demo.haus/blog/unitas-global-and-canonical-provide-fully-managed-enterprise-openstack)

## Screenshots

![Screenshot from 2020-06-11 12-20-30](https://user-images.githubusercontent.com/18480003/84374223-f97c0c80-abdd-11ea-8b04-3c8abb4a35d2.png)

