### PR TITLE
raise 401 statuses when getting accounts from ua-contracts service

### DIFF
--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -1,3 +1,6 @@
+from requests.exceptions import HTTPError
+
+
 class AdvantageContracts:
     def __init__(
         self,
@@ -15,17 +18,18 @@ class AdvantageContracts:
         self.api_url = api_url.rstrip("/")
 
     def _request(self, method, path, json=None):
-        return self.session.request(
+        response = self.session.request(
             method=method,
             url=f"{self.api_url}/{path}",
             json=json,
             headers={"Authorization": f"Macaroon {self.authentication_token}"},
         )
+        response.raise_for_status()
+
+        return response
 
     def get_accounts(self):
         response = self._request(method="get", path="v1/accounts")
-
-        response.raise_for_status()
 
         return response.json().get("accounts", [])
 
@@ -86,11 +90,14 @@ class AdvantageContracts:
         return response.json()
 
     def accept_renewal(self, renewal_id):
-        response = self._request(
-            method="post", path=f"v1/renewals/{renewal_id}/acceptance"
-        )
+        try:
+            response = self._request(
+                method="post", path=f"v1/renewals/{renewal_id}/acceptance"
+            )
+        except HTTPError as http_error:
+            if http_error.code == 500:
+                return response.json()
+            else:
+                raise http_error
 
-        if response.ok:
-            return {}
-        else:
-            return response.json()
+        return {}

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -25,6 +25,8 @@ class AdvantageContracts:
     def get_accounts(self):
         response = self._request(method="get", path="v1/accounts")
 
+        response.raise_for_status()
+
         return response.json().get("accounts", [])
 
     def get_account_contracts(self, account):


### PR DESCRIPTION
## Done

Spotted in a call with Francesco & Will - currently if a macroon needs to be refreshed and is causing an authentication issue, the 401 response we get from ua-contracts is being swallowed, and the user will see the logged in view, but only the "Your free subscription" section, without a machine ID. Any enterprise subscriptions they have won't be visible.

This PR raises adds `raise_for_status` on the accounts API call, so we can prompt the user to login again.

## QA

- Check out `master` branch
- Run the site using the command `./run serve` or `dotrun`
- Edit line 355 of webapp/views.py, from `flask.session["authentication_token"]` to an empty string (`""`), to simulate an invalid auth
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- See that the logged in view is visible, and you can see the `Your free subscription` section without a machine ID after the `sudo ua attach` command.

- Checkout this branch
- Run the site using the command `./run serve` or `dotrun`
- Edit line 355 of webapp/views.py, from `flask.session["authentication_token"]` to an empty string (`""`), to simulate an invalid auth
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- See that you're now prompted to sign in again
