### PR TITLE
Only accept 50 CVEs at once; validate codenames on package statuses Trying to upload CVEs to staging.ubuntu.com, I encountered 2 errors.

### DIFF
--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -75,8 +75,13 @@ class NoticeSchema(Schema):
 
 # CVEs
 # --
+def _validate_codename(codename):
+    if not db_session.query(Release).get(codename):
+        raise ValidationError(f"Unrecognised release codename: {codename}")
+
+
 class Status(Schema):
-    release_codename = Str(required=True)
+    release_codename = Str(required=True, validate=_validate_codename)
     status = Str(required=True)
     description = Str(allow_none=True)
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -464,12 +464,12 @@ def bulk_upsert_cve():
             400,
         )
 
-    if len(cves_data) > 300:
+    if len(cves_data) > 50:
         return (
             flask.jsonify(
                 {
                     "message": (
-                        "Please only submit up to 300 CVEs at a time. "
+                        "Please only submit up to 50 CVEs at a time. "
                         f"({len(cves_data)} submitted)"
                     )
                 }


### PR DESCRIPTION
First, I always got "request entity too large" until I reduced to only trying to submit 50 at once, presumably because of limits in the content-cache nginx config. So here I'm reducing the amount accepted to 50, so we provide a more meaningful error message. But I've also [asked IS](https://portal.admin.canonical.com/C126335/) to expand the max request entity size.

Second, once I reduced the size to 50, I got a 500 error, which was a bit hard to track down. It turned out it was because the CVEs were referencing the "upstream" release, which doesn't exist in the releases table at the moment. This should of course be fixed by adding it, but it should also have provided a friendlier error message. So here I'm also making this check part of the CVE schema for validating the input.