### PR TITLE
Focal migration webinar and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1040,6 +1040,13 @@
       type="whitepaper" %}
         {% include "engage/_article-card.html" %}
       {% endwith %}
+
+      {% with title="Migrating your infrastructure to Ubuntu 20.04 LTS",
+      description="How, when and why?",
+      slug="migrating-to-20.04",
+      type="webinar" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
     </div>
 
 </section>

--- a/templates/engage/migrating-to-20.04.md
+++ b/templates/engage/migrating-to-20.04.md
@@ -1,15 +1,15 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-  title: "Migrating your infrastructure to Ubuntu 20.04 LTS"
+  title: "Migrating yourinfrastructure to Ubuntu 20.04 LTS"
   meta_description: "Find out the right time to migrate to Ubuntu 20.04 and what factors you should take into account when planning a migration."
   meta_image: "https://assets.ubuntu.com/v1/451bf40c-focal_meta_image.png"
   meta_copydoc: "https://docs.google.com/document/d/1-K3MlEPYdA1ChVs81pjqnQ4UpU_al2fOHToXqhZLgys/edit"
-  header_title: "Migrating your infrastructure to Ubuntu 20.04 LTS:"
+  header_title: "Migrating your <br>infrastructure to Ubuntu&nbsp;20.04&nbsp;LTS:"
   header_subtitle: "How, when and why?"
   header_image: "https://assets.ubuntu.com/v1/6d623607-Focal+Fossa_orange_RGB.svg"
-  header_image_width: "250"
-  header_image_height: "194"
+  header_image_width: "380"
+  header_image_height: "290"
   header_url: "#register-section"
   header_cta: "Watch Webinar"
   header_cta_class: p-button--positive

--- a/templates/engage/migrating-to-20.04.md
+++ b/templates/engage/migrating-to-20.04.md
@@ -1,0 +1,22 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Migrating your infrastructure to Ubuntu 20.04 LTS"
+  meta_description: "Find out the right time to migrate to Ubuntu 20.04 and what factors you should take into account when planning a migration."
+  meta_image: "https://assets.ubuntu.com/v1/451bf40c-focal_meta_image.png"
+  meta_copydoc: "https://docs.google.com/document/d/1-K3MlEPYdA1ChVs81pjqnQ4UpU_al2fOHToXqhZLgys/edit"
+  header_title: "Migrating your infrastructure to Ubuntu 20.04 LTS:"
+  header_subtitle: "How, when and why?"
+  header_image: "https://assets.ubuntu.com/v1/6d623607-Focal+Fossa_orange_RGB.svg"
+  header_image_width: "250"
+  header_image_height: "194"
+  header_url: "#register-section"
+  header_cta: "Watch Webinar"
+  header_cta_class: p-button--positive
+  header_class: p-engage-banner--grad
+  webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 415632, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+It's 2020, and it's no longer just Linux, Apache, MySQL and PHP — open source ecosystems like Java, NodeJS, Python and Go are everywhere in the enterprise, as are modern workloads like Kafka, Elasticsearch and Cassandra. In opting for open source, development teams in every organisation are optimising for velocity, flexibility and ideal economics, and the result has been an incredible ramp up in software product delivery.
+
+Join us to discuss how this phenomenon has changed the way the IT and Security need to approach software provenance, patching and compliance, and how Ubuntu Pro for Azure can help address those challenges.

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
   {# ALL #}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
-  {% include "takeovers/_kafka-in-production_takeover.html" %}
+  {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_202006-ml-dell-webinar.html" %}
 
   {# FRENCH #}

--- a/templates/takeovers/_2004-migration-takeover.html
+++ b/templates/takeovers/_2004-migration-takeover.html
@@ -1,0 +1,16 @@
+{% with title="Migrating your infrastructure to Ubuntu&nbsp;20.04&nbsp;LTS:",
+subtitle="How, when and why?",
+class="",
+header_image="https://assets.ubuntu.com/v1/6d623607-Focal+Fossa_orange_RGB.svg",
+image_style="margin: 1.5rem 0;",
+image_height="290",
+image_width="380",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/migrating-to-20.04?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_20.04_WBN_Migratingto20.04",
+primary_cta="Learn more",
+primary_cta_class="",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -144,4 +144,6 @@
 {% include "takeovers/_202006-ml-dell-webinar.html" %}
 <p>8 June 2020</p>
 {% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
+<p>11th June 2020</p>
+{% include "takeovers/_2004-migration-takeover.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add 20.04 migration webinar takeover
- Add 20.04 migration engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Reload the page until you see the "Migrating your infrastructure to Ubuntu 20.04 LTS" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1Ko-fZ4njx6NRB6OIJS00-ujOULr-sg-CtN11xoUm2P0/edit#gid=2113339190)
- Click through to the engage page
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1Ko-fZ4njx6NRB6OIJS00-ujOULr-sg-CtN11xoUm2P0/edit#gid=1271849439) and [the copy doc](https://docs.google.com/document/d/1-K3MlEPYdA1ChVs81pjqnQ4UpU_al2fOHToXqhZLgys/edit)


## Issue / Card

Fixes #7704