### PR TITLE
Fix path to image download script

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -279,7 +279,7 @@
   <script src="{{ versioned_static('js/src/contributions.js') }}"></script>
 
   {% if start_download %}
-    <script src="{{ versioned_static('js/dist/image-download.min.js') }}"></script>
+    <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
     <script defer>
       var architecture = '{{ architecture }}';
       var mirrors = {{ mirror_list | safe }};

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -96,7 +96,7 @@
 
   {% endblock content %}
   {% block footer_extra %}
-  <script src="{{ versioned_static('js/dist/image-download.min.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
   <script defer>
     var architecture = '{{ architecture }}';


### PR DESCRIPTION
## Done

Fix path to image downloader script

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- Click download and see that it works as expected
## Issue / Card

Fixes #7726