### PR TITLE
“setup” > “set up”; fixes alt= text

### DIFF
--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -43,7 +43,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/4044372b-ClearpathRobotics-logo.png",
-          alt="clearpath",
+          alt="Clearpath",
           width="144",
           height="52",
           hi_def=True,
@@ -56,7 +56,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/255f733c-robotis_logo.png",
-          alt="robotis",
+          alt="Robotis",
           width="144",
           height="29",
           hi_def=True,
@@ -69,7 +69,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/e8609fb4-KUKA-logo.svg",
-          alt="kuka robotics",
+          alt="Kuka Robotics",
           width="144",
           height="25",
           hi_def=True,
@@ -82,7 +82,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/fb984e2b-ApexAI_logo.png",
-          alt="apex ai",
+          alt="Apex.AI",
           width="144",
           height="37",
           hi_def=True,
@@ -95,7 +95,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/723b9e31-pal-logo.png",
-          alt="pal robotics",
+          alt="PAL Robotics",
           width="144",
           height="60",
           hi_def=True,
@@ -108,7 +108,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/a78c754a-locus_logo_horizon-removebg-preview.png",
-          alt="lhttps://assets.ubuntu.com/v1/0a342b26-robotics-overview-banner.pngocus robotics",
+          alt="Locus Robotics",
           width="144",
           height="44",
           hi_def=True,
@@ -122,7 +122,7 @@
         {{
           image(
           url="https://assets.ubuntu.com/v1/9f8bc8e5-Fetch-2019-Horizontal-331x120.png",
-          alt="fetch robotics",
+          alt="Fetch Robotics",
           width="144",
           height="52",
           hi_def=True,
@@ -473,10 +473,10 @@
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          Setup your service infrastructure
+          Set up your service infrastructure
         </h3>
         <div class="p-stepped-list__content">
-          <p>Before going to production, get in touch with us to setup the infrastructure for the successful launch, maintenance and long term support of your product.</p>
+          <p>Before going to production, get in touch with us to set up the infrastructure for the successful launch, maintenance and long term support of your product.</p>
         </div>
       </li>
     </ol>


### PR DESCRIPTION
## Done

- Corrects “setup” (noun) to “set up” (verb)
- Capitalises company names in alt= text, and corrects a copy-paste error

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics

## Issue / Card

None

[Misspelling noticed in screenshot on [vanilla-framework#1917](https://github.com/canonical-web-and-design/vanilla-framework/issues/1917).]