### PR TITLE
Update /appliance homepage text and design and add /appliances/portfolio page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -21,19 +21,14 @@ appliance:
   children:
     - title: Overview
       path: /appliance
-    - title: Tutorials
-      path: /appliance/tutorials
-    - title: Community
-      path: /appliance/community
     - title: About
       path: /appliance/about
-    - title: Docs
-      path: /appliance/docs
-      persist: True
-      hidden: True
+    - title: Portfolio
+      path: /appliance/portfolio
+    - title: Community
+      path: /appliance/community
     - title: Vitual machines
       path: /appliance/vm
-      hidden: True
     - title: Contact us
       path: /appliance/contact-us
       hidden: True
@@ -47,65 +42,50 @@ appliance:
       children:
         - title: Raspberry Pi
           path: /appliance/plex/raspberry-pi
-          hidden: False
         - title: Intel NUC
           path: /appliance/plex/intel-nuc
-          hidden: False
         - title: VM
           path: /appliance/plex/vm
-          hidden: False
     - title: AdGuard
       path: /appliance/adguard
       hidden: True
       children:
         - title: Raspberry Pi
           path: /appliance/adguard/raspberry-pi
-          hidden: False
         - title: Intel NUC
           path: /appliance/adguard/intel-nuc
-          hidden: False
         - title: VM
           path: /appliance/adguard/vm
-          hidden: False
     - title: OpenHAB
       path: /appliance/openhab
       hidden: True
       children:
         - title: Raspberry Pi
           path: /appliance/openhab/raspberry-pi
-          hidden: False
         - title: Intel NUC
           path: /appliance/openhab/intel-nuc
-          hidden: False
         - title: VM
           path: /appliance/openhab/vm
-          hidden: False
     - title: NexCloud
       path: /appliance/nextcloud
       hidden: True
       children:
         - title: Raspberry Pi
           path: /appliance/nextcloud/raspberry-pi
-          hidden: False
         - title: Intel NUC
           path: /appliance/nextcloud/intel-nuc
-          hidden: False
         - title: VM
           path: /appliance/nextcloud/vm
-          hidden: False
     - title: Mosquitto
       path: /appliance/mosquitto
       hidden: True
       children:
         - title: Raspberry Pi
           path: /appliance/mosquitto/raspberry-pi
-          hidden: False
         - title: Intel NUC
           path: /appliance/mosquitto/intel-nuc
-          hidden: False
         - title: VM
           path: /appliance/mosquitto/vm
-          hidden: False
 aws:
   title: AWS
   path: /aws

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -11,109 +11,80 @@
 <section class="p-strip--suru is-dark">
   <div class="row">
     <h1>Ubuntu Appliance portfolio</h1>
-    <p class="p-heading--four">Free appliance images for your PC or Raspberry Pi</p>
+    <p class="p-heading--four">
+      Free appliance images for your PC or Raspberry Pi
+    </p>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  {% with heading="Featured today" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>
+        Make something great today
+      </h2>
+      <p class="p-heading--four">
+        We’ve got just the thing for you
+      </p>
+      <p>
+        Transform a spare PC or Pi into a smart, secure, and ultra-simple box that does exactly what you want. Brilliantly.
+      </p>
+      <p>
+        Open or commercial. Enterprise or home. Entertainment. Automation. Gaming. Network. Storage. Fun. Play with something new today.
+      </p>
+      <p>
+        <a class="p-button--positive" href="/appliance/portfolio">Browse the portfolio</a>
+      </p>
+    </div>
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+        alt="",
+        height="114",
+        width="200",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-2">
-      <h2 class="p-muted-heading">Featured today</h2>
-    </div>
-    <div class="col-2">
-      <a href="/appliance/openhab" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">OpenHab</h3>
-        <hr />
-        <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png" style="height:32px; margin-top:2rem;">
-        </div>
-      </a>
-    </div>
-    <div class="col-2">
-      <a href="/appliance/plex" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">Plex</h3>
-        <hr />
-        <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" alt="" style="height:32px; margin-top:2rem;">
-        </div>
-      </a>
-    </div>
-    <div class="col-2">
-      <a href="/appliance/nextcloud" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">NextCloud</h3>
-        <hr />
-        <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png" alt="" style="height:62px; margin-top:1.25rem;">
-        </div>
-      </a>
-    </div>
-    <div class="col-2">
-      <a href="/appliance/adguard" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">Adguard</h3>
-        <hr />
-        <div class="u-align--center">
-          <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png" alt="" style="height:62px; margin-top:1.25rem;">
-        </div>
-      </a>
-    </div>
-    <div class="col-2">
-      <a href="/appliance/mosquitto" class="p-link--soft">
-        <h3 class="p-heading--five u-no-padding--top">Mosquitto</h3>
-        <hr />
-        <div class="u-align--center">
-          <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/08/mosquitto-logo-only.svg.png" alt="" style="height:72px; margin-top:1rem;">
-        </div>
-      </a>
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h2>Make something great today</h2>
-      <p class="p-heading--four">We’ve got just the thing for you</p>
-      <p>Transform a spare PC or Pi into a smart, secure, and ultra-simple box that does exactly what you want. Brilliantly.</p>
-      <p>Open or commercial. Enterprise or home. Entertainment. Automation. Gaming. Network. Storage. Fun. Come and play with something new today.</p>
-    </div>
-    <div class="col-5 u-align--center u-hide--small u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
-          alt="",
-          height="114",
-          width="200",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
   <div class="row u-equal-height">
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
-          alt="",
-          height="180",
-          width="180",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
+        alt="",
+        height="180",
+        width="180",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>
     <div class="col-7">
-      <h2>Try before you Pi</h2>
-      <p class="p-heading--four">Test drive them safely on your laptop</p>
-      <p>Just for fun, you can run a Virtual Ubuntu Appliance on any PC without affecting your existing system. Most of our appliances have a virtual version unless they really do depend on special hardware.</p>
-      <p>No need for a spare disk or board, just follow the steps  and you’ll be up and running quickly. Virtual Ubuntu Appliances work on Ubuntu, Windows and macOS.</p>
+      <h2>
+        Try before you Pi
+      </h2>
+      <p class="p-heading--four">
+        Test drive them safely on your laptop
+      </p>
+      <p>
+        Run a Virtual Ubuntu Appliance on any PC without affecting your existing system. Most appliances have a virtual version unless they depend on special hardware.
+      </p>
+      <p>
+        No need for a spare disk or board, just follow the steps and you’ll be up and running in seconds. Virtual Ubuntu Appliances work on Ubuntu, Windows and macOS.
+      </p>
+      <p>
+        <a class="p-button" href="/appliance/vm">Try an instant appliance now</a>
+      </p>
     </div>
   </div>
 
@@ -123,21 +94,34 @@
 
   <div class="row">
     <div class="col-7">
-      <h2>App store easy</h2>
-      <p class="p-heading--four">An app or two for extra foo</p>
-      <p>Upgrade your appliance with extra apps. Try out a new autopilot. Add an extra game. Each appliance starts with just the right stuff for everyone. Add the sauce you like.</p>
-      <p>Enjoy the same <a class="p-link--external" href="https://snapcraft.io/store">huge app selection as Ubuntu</a>, or get a dedicated store with unique apps for that specific thing. Publishers will shape the store you see.</p>
-      <p>Ubuntu Appliances get apps and updates from our global backbone, just like millions of Ubuntu workstations, laptops and servers every day.</p>
+      <h2>
+        App store easy
+      </h2>
+      <p class="p-heading--four">
+        An app or two for extra foo
+      </p>
+      <p>
+        Upgrade your appliance with extra apps. Try a new autopilot. Enjoy the latest game. Each appliance starts with the essential stuff. Add the sauce you like.
+      </p>
+      <p>
+        Enjoy the same huge app selection as Ubuntu, or get a dedicated store with unique apps for your specific thing. Publishers curate the store you see.
+      </p>
+      <p>
+        Ubuntu Appliances get apps and updates from our global backbone, just like millions of Ubuntu workstations, devices, laptops and servers every day.
+      </p>
+      <p>
+        <a class="p-button p-link--external" href="https://snapcraft.io/store">Visit the Snapstore</a>
+      </p>
     </div>
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/22f88d02-apps.svg",
-          alt="",
-          height="114",
-          width="200",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/22f88d02-apps.svg",
+        alt="",
+        height="114",
+        width="200",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>
@@ -151,60 +135,89 @@
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
-          alt="",
-          height="180",
-          width="180",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
+        alt="",
+        height="180",
+        width="180",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>
     <div class="col-7">
-      <h2>Secure by design</h2>
-      <p class="p-heading--four">Crisp. Clean. Carrier-grade. Core.</p>
-      <p>SecureBoot. Full disk encryption. Hardware crypto keys. An ironclad commitment to your peace of mind.</p>
-      <p>We toughened Ubuntu to harden these things. They bring their magic, we bring our mettle. Community or business-backed, they both enjoy <a href="/core">the same robust, secure Ubuntu Core</a>.</p>
-      <p>Strict confinement and read-only packages keep bad code locked down. Certs and signatures make for tamper proof provenance. Full containerisation for no loose ends. And we’ve got your back for critical jobs with ten year updates, guaranteed.</p>
+      <h2>
+        Secure by design
+      </h2>
+      <p class="p-heading--four">
+        Crisp. Clean. Carrier-grade. Core.
+      </p>
+      <p>
+        SecureBoot. Full disk encryption. Hardware crypto keys. An ironclad commitment to your peace of mind.
+      </p>
+      <p>
+        We toughened Ubuntu to harden these things. They bring their magic, we bring our mettle. Community or business-backed, both enjoy the same robust, secure Ubuntu Core.
+      </p>
+      <p>
+        Strict confinement and read-only packages keep bad code locked down. Certs and signatures for tamper-proof provenance. Full containerisation for no loose ends. And we’ve got your back on critical jobs with ten year updates guaranteed.
+      </p>
+      <p>
+        <a class="p-button " href="/core">Learn about Ubuntu Core</a>
+      </p>
     </div>
   </div>
 </section>
 
 {# 2 by 2 section #}
-<section class="p-strip--light is-deep">
+<section class="p-strip--square-lightsuru is-deep">
   <div class="row u-equal-height">
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
-          alt="",
-          height="85",
-          width="149",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "u-hide--small"}
+        url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
+        alt="",
+        height="85",
+        width="149",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-hide--small"}
         ) | safe
       }}
-      <h2>Clear privacy policies</h2>
-      <p>Every Ubuntu Appliance complies with EU data protection or California privacy law. Your personal data is precious. Your privacy even more so. Our mission is to defend them in this new world of ever-present sensor-driven software.</p>
-      <p>Voice-activated software and computer vision are amazing tools. We ensure those microphones and cameras only work for you.</p>
-      <p><a href="/appliance/governance">Learn about your privacy protection&nbsp;&rsaquo;</a></p>
+      <h2>
+        Clear privacy policies
+      </h2>
+      <p>
+        Every Ubuntu Appliance complies with EU data protection or California privacy law. Your personal data is precious. Your privacy even more so. Our mission is to defend them in this new world of ever-present sensor-driven software.
+      </p>
+      <p>
+        Voice-activated software and computer vision are amazing tools. We ensure those microphones and cameras only work for you.
+      </p>
+      <p>
+        <a href="/appliance/governance">Learn about your privacy protection&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
-          alt="",
-          height="85",
-          width="85",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
+        alt="",
+        height="85",
+        width="85",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
-      <h2>Enterprise-grade control</h2>
-      <p class="p-heading--four">Define the flow of fixes across your whole estate.</p>
-      <p>Imagine a world where every firmware update was instantly available on any device. Imagine you could determine exactly when and where it rolled out. Imagine you knew the CVE status of everything you care about, everywhere, all the time.</p>
-      <p>That’s the precision of every Ubuntu Appliance. Made for mission-critical. One dashboard, one practice, one process for your entire multi-vendor estate. With a universal Ubuntu Core, your updates and security align from edge to cloud, no matter which hardware, no matter which appliance.</p>
+      <h2>
+        Enterprise-grade control
+      </h2>
+      <p class="p-heading--four">
+        Define the flow of fixes across your whole estate.
+      </p>
+      <p>
+        Imagine a world where every firmware update was instantly available on any device. Imagine you could determine exactly when and where it rolled out. Imagine you knew the CVE status of everything you care about, everywhere, all the time.
+      </p>
+      <p>
+        That’s the precision of every Ubuntu Appliance. Made for mission-critical. One dashboard, one practice, one process for your entire multi-vendor estate. With universal Ubuntu Core, your updates and security align from edge to cloud, no matter which hardware, no matter which brand.
+      </p>
     </div>
   </div>
 
@@ -218,78 +231,119 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
-          alt="",
-          height="85",
-          width="85",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
+        alt="",
+        height="85",
+        width="85",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
-      <h2>Future proven</h2>
-      <p class="p-heading--four">Stable. Beta. RC. Edge. Get future fixes faster here.</p>
-      <p>Every piece of software on your Ubuntu Appliance is offered in a set of streams. These channels offer all the current builds and if the publisher allows, early access versions too.</p>
-      <p>Set your appliance to preview channels for a taste of future change before it’s fully done. Choose a safe canary box, and catch the issues there. Switch software streams at any time, for any system, anywhere.</p>
+      <h2>
+        Future proven
+      </h2>
+      <p class="p-heading--four">
+        Stable. Beta. RC. Edge. Get future fixes faster.
+      </p>
+      <p>
+        Every piece of software on your Ubuntu Appliance is offered in a set of streams. These channels offer all the current builds and - if the publisher allows - early access versions too.
+      </p>
+      <p>
+        Set your appliance to preview channels for a taste of future change before it’s fully done. Choose a safe canary box, and catch the issues there. Switch software streams at any time, for any system, anywhere.
+      </p>
     </div>
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
-          alt="",
-          height="85",
-          width="63",
-          hi_def=True,
-          loading="auto"
+        url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
+        alt="",
+        height="85",
+        width="63",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
-      <h2>Certified, Maintained or Experimental</h2>
-      <p>Some appliances are serious things, and you want to know that Canonical will keep them reliable, year after year, on a certified device. Those are marked ‘certified’, and they get constant testing and security coverage.</p>
-      <p>Other appliances have a company to keep the updates coming, for at least a certain time. Those ones are tagged ‘maintained’ and you can always see the minimum time assured of maintenance.</p>
-      <p>And then there are the crazy things, the community things, the experimental things. Enjoy those, but don’t get too attached to them. If enough people love them then they’ll get maintenance commitments too.</p>
+      <h2>
+        Certified, Maintained or Experimental
+      </h2>
+      <p>
+        Some appliances are serious things, and you want to know that Canonical will keep them reliable, year after year. Those are marked ‘certified’, and they get constant testing and security coverage.
+      </p>
+      <p>
+        Other appliances have a company to keep the updates coming, for at least a certain time. Those are tagged ‘maintained’ and you can always see the minimum time assured of maintenance.
+      </p>
+      <p>
+        And then there are the crazy things, the community things, the experimental things. Enjoy those, but don’t get too attached. If enough people love them then they’ll get maintenance commitments soon enough.
+      </p>
     </div>
   </div>
 
   <div class="u-fixed-width">
     <p class="u-sv3">
       &nbsp;
+
     </p>
   </div>
 
-    <div class="row u-equal-height">
-      <div class="col-6">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
-            alt="",
-            height="85",
-            width="85",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
-        <h2>Community and Commercial</h2>
-        <p>Our open source community appliances get all the updates, benefits and care that goes into our mission-critical customers. That’s Ubuntu. That’s Canonical.</p>
-        <p>Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.</p>
-        <p><a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a></p>
-      </div>
-        <div class="col-6">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
-              alt="",
-              height="85",
-              width="149",
-              hi_def=True,
-              loading="auto"
-            ) | safe
-          }}
-          <h2>Confidently compatible</h2>
-          <p class="p-heading--four">Choose your certified board or box</p>
-          <p>It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.</p>
-          <p>We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. That’s to be sure you can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.</p>
-          <p><a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a></p>
-        </div>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+        alt="",
+        height="85",
+        width="85",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      <h2>
+        Community and Commercial
+      </h2>
+      <p>
+        Our open source community appliances get all the updates, benefits and care that goes into our mission-critical customers. That’s Ubuntu. That’s Canonical.
+      </p>
+      <p>
+        Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.
+      </p>
+      <p>
+        <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a>
+      </p>
+    </div>
+    <div class="col-6">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/ebac33ef-hardware_easy.svg",
+        alt="",
+        height="85",
+        width="149",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      <h2>
+        Confidently compatible
+      </h2>
+      <p class="p-heading--four">
+        Choose your certified board or box
+      </p>
+      <p>
+        It takes a team to make this work. Canonical and appliance publishers, hardware vendors and open source communities work together to ensure your appliance is updated, safely, for years to come.
+      </p>
+      <p>
+        We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. You can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.
+      </p>
+      <p>
+        <a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a>
+      </p>
+    </div>
+  </div>
+  <div class="u-no-fixed-width u-align--center">
+    <h3 style="padding-top: 3rem;">
+      <a href="/appliance/portfolio">Browse the Ubuntu Appliance Portfolio&nbsp;&rsaquo;</a>
+    </h3>
+
+  </div>
 </section>
 
 {% endblock content %}

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -339,7 +339,7 @@
     </div>
   </div>
   <div class="u-no-fixed-width u-align--center">
-    <h3 style="padding-top: 3rem;">
+    <h3 class="u-no-max-width" style="padding-top: 3rem;">
       <a href="/appliance/portfolio">Browse the Ubuntu Appliance Portfolio&nbsp;&rsaquo;</a>
     </h3>
 

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -10,7 +10,9 @@
 
 <section class="p-strip--suru is-dark">
   <div class="row">
-    <h1>Ubuntu Appliance portfolio</h1>
+    <h1>
+      The Ubuntu Appliance portfolio
+    </h1>
     <p class="p-heading--four">
       Free appliance images for your PC or Raspberry Pi
     </p>
@@ -18,7 +20,7 @@
 </section>
 
 <section class="p-strip is-bordered">
-  {% with heading="Featured today" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
+  {% with heading="Featured" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
 </section>
 
 <section class="p-strip--light is-bordered">
@@ -74,7 +76,7 @@
         Try before you Pi
       </h2>
       <p class="p-heading--four">
-        Test drive them safely on your laptop
+        Test drive safely on your laptop
       </p>
       <p>
         Run a Virtual Ubuntu Appliance on any PC without affecting your existing system. Most appliances have a virtual version unless they depend on special hardware.

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru-bottomed">
   <div class="row">
     <h1>Find your favourite Ubuntu Appliance</h1>
   </div>
@@ -17,8 +17,6 @@
 <section class="p-strip--light is-bordered">
   {% with heading="Featured today" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
 </section>
-
-{% include "/appliance/shared/_join_the_community.html" %}
 
 <section class="p-strip is-deep">
   <div class="row u-equal-height">

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -20,4 +20,32 @@
 
 {% include "/appliance/shared/_join_the_community.html" %}
 
+<section class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h3>
+        Turn your app into an Ubuntu Appliance
+      </h3>
+      <p>
+        Anyone can build their own Ubuntu Appliance, a software-defined IoT device that uses Ubuntu for security and to stay up to date. But it’s all about your work. See our <a href="/appliances/community">community page</a> for more information or jump right to discourse to propose your new Ubuntu Appliance and start the conversation.
+      </p>
+      <p>
+        <a class="p-button p-link--external" href="https://discourse.ubuntu.com/c/appliances">Propose your new appliance</a>
+      </p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small u-vertically-center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/7de21966-snapshot.svg",
+          alt="",
+          height="140",
+          width="140",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+        }}
+    </div>
+  </div>
+</section>
+
 {% endblock %}

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -25,7 +25,7 @@
         Turn your app into an Ubuntu Appliance
       </h3>
       <p>
-        Anyone can build their own Ubuntu Appliance, a software-defined IoT device that uses Ubuntu for security and to stay up to date. But it’s all about your work. See our <a href="/appliances/community">community page</a> for more information or jump right to discourse to propose your new Ubuntu Appliance and start the conversation.
+        Anyone can build their own Ubuntu Appliance, a software-defined IoT device that uses Ubuntu for security and to stay up to date. But it’s really all you. See our <a href="/appliances/community">community page</a> for more information or jump right to discourse to propose your new Ubuntu Appliance and start the conversation.
       </p>
       <p>
         <a class="p-button p-link--external" href="https://discourse.ubuntu.com/c/appliances">Propose your new appliance</a>

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -1,0 +1,23 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Ubuntu Appliance{% endblock %}
+
+{% block meta_description %}Ubuntu Appliances are certified to run flawlessly on Raspberry Pi and PC boards. They are free, privacy-friendly and come with maintenance guarantees.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1DABafCPzl9WwOmHX8ejkkiUEKXI2fTlF7UXNB0Xhlo0/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru is-dark">
+  <div class="row">
+    <h1>Find your favourite Ubuntu Appliance</h1>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  {% with heading="Featured today" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
+</section>
+
+{% include "/appliance/shared/_join_the_community.html" %}
+
+{% endblock %}

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -200,29 +200,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2>
-        Join the community
-      </h2>
-      <p>
-        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place for news and views.
-      </p>
-    </div>
-    <div class="col-4 u-align--center u-hide--small">
-      {{  image(
-        url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
-        alt="",
-        width="150",
-        height="150",
-        hi_def=True,
-        loading="lazy",
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+{% include "/appliance/shared/_join_the_community.html" %}
 
 <script>
   (function () {

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -1,4 +1,9 @@
 <div class="row">
+  {% if heading %}
+  <div class="col-2">
+    <h2 class="p-muted-heading">{{ heading }}</h2>
+  </div>
+  {% endif %}
   <div class="col-2">
     <a href="/appliance/openhab" class="p-link--soft">
       <h3 class="p-heading--five u-no-padding--top">OpenHab</h3>
@@ -28,7 +33,7 @@
   </div>
   <div class="col-2">
     <a href="/appliance/adguard" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Adguard</h3>
+      <h3 class="p-heading--five u-no-padding--top">AdGuard</h3>
       <hr />
       <div class="u-align--center">
         <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png" alt="" style="height:62px; margin-top:1.25rem;">

--- a/templates/appliance/shared/_join_the_community.html
+++ b/templates/appliance/shared/_join_the_community.html
@@ -1,11 +1,15 @@
-<section class="p-strip--light">
+<section class="p-strip--light is-deep">
   <div class="row">
     <div class="col-8">
       <h2>
         Join the community
       </h2>
       <p>
-        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place for news and views.
+        {% if appliance_name %}
+        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place news views.
+        {% else %}
+        Our <a href="https://discourse.ubuntu.com/c/appliance">discussion forum for Ubuntu Appliances</a> is the best place for news and views.
+        {% endif %}
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">

--- a/templates/appliance/shared/_join_the_community.html
+++ b/templates/appliance/shared/_join_the_community.html
@@ -1,0 +1,23 @@
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>
+        Join the community
+      </h2>
+      <p>
+        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place for news and views.
+      </p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Update /appliance homepage text and design
- Add /appliances/portfolio page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance and http://0.0.0.0:8001/appliance/portfolio
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Copy docs for [overview](https://docs.google.com/document/d/1Fcr5b5Rn06AB89D6DGPmoIgXLxLalijMhwnu_IyUxV4/edit#heading=h.oq1bqfd7kna3) and [portfolio](https://docs.google.com/document/d/1DABafCPzl9WwOmHX8ejkkiUEKXI2fTlF7UXNB0Xhlo0/edit#heading=h.tf6nbxjryj9q) pages

## Issue / Card

Fixes #7709