### PR TITLE
Update /about/release-cycle security status block

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -235,7 +235,13 @@
     <div class="row">
       <div class="col-8">
         <p>Ubuntu LTS releases transition into Extended Security Maintenance (ESM) phase as the standard, five-year public support window comes to a close. It is recommended for users and organisations to upgrade to the latest LTS release or <a href="/esm">subscribe to ESM</a> for continued security coverage.</p>
-        <p>This command will print the exact status of your system:</p>
+        <p>To check the support status of your system:</p>
+        <p><em>On Ubuntu 20.04 LTS, use this command:</em></p>
+        <div class="p-code-copyable" style="margin-top: .5rem;">
+          <input class="p-code-copyable__input" value="ubuntu-security-status" readonly="readonly">
+          <button class="p-code-copyable__action">Copy to clipboard</button>
+        </div>
+        <p><em>For earlier versions of Ubuntu, use this command:</em></p>
         <div class="p-code-copyable" style="margin-top: .5rem;">
           <input class="p-code-copyable__input" value="ubuntu-support-status" readonly="readonly">
           <button class="p-code-copyable__action">Copy to clipboard</button>


### PR DESCRIPTION
## Done

- Update /about/release-cycle security status block to offer different commands based on which version of Ubuntu you might be running.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit)

## Issue / Card

Fixes #7663

## Screenshots

![image](https://user-images.githubusercontent.com/441217/84628352-63e3c400-aee0-11ea-9108-ba5e16ab9722.png)

