### PR TITLE
Update next steps and multipass instructions

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -9,8 +9,8 @@ appliances:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
       pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *plexmediaserver-core18-pi.img.xz"
-      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *plexmediaserver-core18-amd64.img.xz"
+      raspberrypi: "a05439e8ff97f9542bb611d16be6469943b5285934a5dff4d3b98164fea8d3f9 *plexmediaserver-core18-pi.img.xz"
+      pc: "fec85292571d68a08b12991e9e044840d7379c35333b3a2d44176daa25507f49 *plexmediaserver-core18-amd64.img.xz"
   adguard:
     name: "AdGuard"
     appliance_name: "AdGuard"
@@ -21,8 +21,8 @@ appliances:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi.img.xz"
       pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *adguard-home-core18-pi.img.xz"
-      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *adguard-home-core18-amd64.img.xz"
+      raspberrypi: "5c72286dee4c683dd24128455340285a6a7a0b82efaf004ccc7b2afe5ae2a1d8 *adguard-home-core18-pi.img.xz"
+      pc: "6fc90a0695ec2b1e731be4cdd8583021aa284b4b829d99aba75e54d2da23fd14 *adguard-home-core18-amd64.img.xz"
   openhab:
     name: "OpenHAB"
     appliance_name: "OpenHAB"
@@ -33,8 +33,8 @@ appliances:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi.img.xz"
       pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *openhab-core18-pi.img.xz"
-      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *openhab-core18-amd64.img.xz"
+      raspberrypi: "757b834c103313637d6930ddf3ab1701a969e2af4f28373622dd21c6de6f6eef *openhab-core18-pi.img.xz"
+      pc: "d56b97b4df707f5299b45f075fd9f29734ebd6cf22b2950276a98e795f805a36 *openhab-core18-amd64.img.xz"
   mosquitto:
     name: "mosquitto"
     appliance_name: "Mosquitto"
@@ -45,8 +45,8 @@ appliances:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi.img.xz"
       pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *openhab-core18-pi.img.xz"
-      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *openhab-core18-amd64.img.xz"
+      raspberrypi: "0fe7c069190e0e9bd8a1727ecfec540367a0890b6030831d5216090649848bb4 *mosquitto-core18-pi.img.xz"
+      pc: "5a67a1de6f68cc55f5b27fb0210a83246e47f535ec7fd714ba207a5f4a10ed65 *mosquitto-core18-amd64.img.xz"
   nextcloud:
     name: "NextCloud"
     appliance_name: "NextCloud"
@@ -57,5 +57,5 @@ appliances:
       raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi.img.xz"
       pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-amd64.img.xz"
     checksum:
-      raspberrypi: "c6e6e8ea221e2573f61ec41a5e1694eec8cb4269761a46a726a167ce2abbad5e *openhab-core18-pi.img.xz"
-      pc: "3af71d34ed1a0b8be012d1aee7cdae1a1dd8d65a2248988ef08a74d85a5c7c8e *openhab-core18-amd64.img.xz"
+      raspberrypi: "b123b94f9ccec67dd207c90c48ea96c68c3cf45d896bcc31a5b466f55fcfb05a *nextcloud-core18-pi.img.xz"
+      pc: "090560765f61b5ab509a303a2778c3782f13fa2d7cadae3e95b84a33c9bc558c *nextcloud-core18-amd64.img.xz"

--- a/templates/appliance/adguard/_next-steps.html
+++ b/templates/appliance/adguard/_next-steps.html
@@ -1,22 +1,23 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center">
+    <div class="col-6">
       <div>
         <h2>
           Start using your {{ appliance.name }} Ubuntu Appliance
         </h2>
         <p>
-          When you run AdGuard Home for the first time, it will start listening to <code>http://0.0.0.0:3000</code> or <code>http://127.0.0.1:3000</code> and prompt you to open it in your browser.
+          Now you can go ahead and set everything up. Go to:
         </p>
+        <pre><code>http://0.0.0.0:3000</code></pre>
         <p>
           There you will go through the initial configuration wizard.
         </p>
         <p>
-          Now you can follow the instructions on the screen to get started using your new {{ appliance.name }} Ubuntu Appliance. For more information or more documentation on what to do next, the <a class="p-link--external" href="https://adguard.com/">AdGuard website</a> is the best place to go next.
+          Where you will find the initial configuration wizard. Follow the instructions to start using your new Adguard Home Ubuntu Appliance. For more information or more documentation on what to do now, the <a class="p-link--external" href="https://adguard.com/">AdGuard website</a> is the best place to go next.
         </p>
       </div>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{  image(
         url="https://assets.ubuntu.com/v1/636bd444-adguard-first-screen.png",
         alt="AdGuard wizard screen",

--- a/templates/appliance/mosquitto/_next-steps.html
+++ b/templates/appliance/mosquitto/_next-steps.html
@@ -1,0 +1,59 @@
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h2>
+        Start using your Mosquitto Ubuntu Appliance
+      </h2>
+      <p>
+        After installing the Mosquitto image, the Mosquitto broker will be running with the default configuration, listening for connections on port 1883. To test the broker, you can use the <code>mosquitto-pub</code> and <code>mosquitto-sub</code> command-line utilities. This is a basic test example to start using your appliance. If you want more information about Mosquitto and what to do next the best place to go is the <a class="p-link--external" href="https://mosquitto.org/">Mosquitto website</a>.
+      </p>
+      <p>
+        <code>mosquitto_pub</code> allows you to publish messages to an MQTT broker, and <code>mosquitto_sub</code> allows you to subscribe to messages from an MQTT broker. Both tools have options to control how they are used so they are useful for a wide variety of tasks. In this case, we will use them for some simple testing.
+      </p>
+      <p>
+        To subscribe to all messages being published to the MQTT broker on the <code>snap/example</code> topic, run this command in your appliance:
+      </p>
+
+      <pre><code>mosquitto_sub -h localhost -t 'snap/example' -v</code></pre>
+
+      <p>
+        If your MQTT broker is not running on the same machine as <code>mosquitto_sub</code>, you will need to change the <code>localhost</code> argument to match your MQTT broker host or IP address.
+      </p>
+      <p>
+        The <code>-t snap/example</code> option sets the topic to subscribe and can be provided multiple times. The <code>-v</code> option means to print both the topic of the message as well as its payload. Now to publish a message to the same topic you use mosquitto_pub:
+      </p>
+      <pre><code>mosquitto_pub -h localhost -t 'snap/example' -m 'Hello from mosquitto_pub'</code></pre>
+      <p>
+        In this case, the <code>-m</code> option provides the message payload to be published. If everything works as planned, you should see <code>mosquitto_sub</code> print
+      </p>
+
+      <pre><code>snap/example Hello from mosquitto_pub</code></pre>
+      <p>
+        This is a very simple example but allows testing of the broker operation. Other things you may wish to try are subscribing to wildcard topics that include <code>#</code> or <code></code>, or subscribing to the <code>$SYS/#</code> topic to see the information the broker is publishing about itself.
+      </p>
+      <div class="p-notification" id="notification">
+        <div class="p-notification__response">
+          <span class="p-notification__status">Note:</span>
+          <p>The command line treats <code>#</code> as a special character, and <code>SSYS</code> will be expanded as an environment variable if you do not surround them with single quotes.
+          </p>
+        </div>
+      </div>
+      <p>
+        Once you have finished your testing, you will want to configure your broker to have encrypted connections and use authentication, or possibly configuring bridges, which allow different brokers to share topics. or many other options. To do this, you need to provide a new configuration file. The snap provides an example configuration file at <code>/var/snap/mosquitto/common/mosquitto_example.conf</code>.
+      </p>
+      <p>
+        This file contains all of the broker configurations, in a similar manner to the <a href="https://mosquitto.org/man/">man page</a>. To create your own configuration, copy the example file to <code>/var/snap/mosquitto/common/mosquitto.conf</code> and edit according to your needs. Any additional files required by the configuration, such as TLS certificates and keys, must also be placed in <code>/var/snap/mosquitto/common/</code> and have their full path provided in the configuration file.
+      </p>
+    </div>
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/0fbfab25-mosquitto-text-side.png",
+        alt="",
+        width="400",
+        height="81",
+        hi_def=True,
+        loading="lazy",
+        ) | safe}}
+      </div>
+    </div>
+  </section>

--- a/templates/appliance/nextcloud/_next-steps.html
+++ b/templates/appliance/nextcloud/_next-steps.html
@@ -21,7 +21,7 @@
           <code>http://&lt;IP-of-your-appliance&gt;</code>
         </p>
         <p>
-          On a Virtual machine go to your vm’s IP address in your browser. After that, you can start using your new Nextcloud server. For more information and <a class="p-link--external" href="https://docs.nextcloud.com/server/18/admin_manual/installation/index.html">documentation</a> visit the <a class="p-link--external" href="https://docs.nextcloud.com/">Nextcloud website</a>.
+          After that, you can start using your new Nextcloud server. For more information and <a class="p-link--external" href="https://docs.nextcloud.com/server/18/admin_manual/installation/index.html">documentation</a> visit the <a class="p-link--external" href="https://docs.nextcloud.com/">Nextcloud website</a>.
        </p>
       </div>
     </div>

--- a/templates/appliance/nextcloud/_next-steps.html
+++ b/templates/appliance/nextcloud/_next-steps.html
@@ -1,6 +1,6 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center">
+    <div class="col-6">
       <div>
         <h2>
           Start using your {{ appliance.name }} Ubuntu Appliance
@@ -9,14 +9,23 @@
           When you start NextCloud for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
         </p>
         <p>
+          <em>On Raspberry Pis and PCs:</em>
+        </p>
+        <p>
           <a href="http://nextcloud.local">http://nextcloud.local</a>
         </p>
         <p>
-          After that, you can start using your new Nextcloud server. For more information and documentation visit the Nextcloud website.
+          <em>On a Virtual machine:</em>
+        </p>
+        <p>
+          <code>http://&lt;IP-of-your-appliance&gt;</code>
+        </p>
+        <p>
+          On a Virtual machine go to your vm’s IP address in your browser. After that, you can start using your new Nextcloud server. For more information and <a class="p-link--external" href="https://docs.nextcloud.com/server/18/admin_manual/installation/index.html">documentation</a> visit the <a class="p-link--external" href="https://docs.nextcloud.com/">Nextcloud website</a>.
        </p>
       </div>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{  image(
         url="https://assets.ubuntu.com/v1/4945963f-nextcloud-screenshot.png ",
         width="600",

--- a/templates/appliance/openhab/_next-steps.html
+++ b/templates/appliance/openhab/_next-steps.html
@@ -1,6 +1,6 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center">
+    <div class="col-6">
       <div>
         <h2>
           Start using your {{ appliance.name }} Ubuntu Appliance
@@ -12,11 +12,11 @@
           <code>http://&lt;IP-of-your-machine&gt;:8080</code>
         </p>
         <p>
-          Now you can follow the instructions on the screen to get started using your new openHAB Ubuntu Appliance. For more information or more documentation on what to do next, the <a href="https://www.openhab.org/">openHAB website</a> is the best place to go next.
+          Now just follow the instructions on the screen to use your new openHAB Ubuntu Appliance. For more information or more <a class="p-link--external" href="https://www.openhab.org/docs/">documentation</a>, the <a class="p-link--external" href="https://www.openhab.org/">openHAB website</a> is the best place to go next.
         </p>
       </div>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{  image(
         url="https://assets.ubuntu.com/v1/5727f492-openhab-first-screen.jpg",
         alt="Openhab wizard screen",

--- a/templates/appliance/plex/_next-steps.html
+++ b/templates/appliance/plex/_next-steps.html
@@ -5,13 +5,14 @@
         Start using your {{ appliance.name }} Ubuntu Appliance
       </h2>
       <p>
-        On a computer or mobile device, visit your Appliance’s IP address in a browser at port 32400. (e.g. http://192.168.1.107:32400)
+        When you start Plex Media Server for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
       </p>
+      <pre><code>http://&lt;IP-of-your-appliance&gt;:32400/web</code></pre>
       <p>
-        Now you can follow the instructions on the screen to get started using your new Plex Media Server Ubuntu Appliance. For more information or more documentation on what to do next, the <a class="p-link--external" href="https://www.plex.tv/">Plex Media Server website</a> is the best place to go next.
+        Then just follow the instructions on the screen. For more information or more <a class="p-link--external" href="https://support.plex.tv/articles/">documentation</a>, the <a class="p-link--external" href="https://www.plex.tv/">Plex Media Server website</a> is the best place to go next.
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{  image(
         url="https://assets.ubuntu.com/v1/5765e231-plex-first-screen.png",
         alt="Plex welcome screen",

--- a/templates/appliance/shared/_install_instructions_vm_macos.html
+++ b/templates/appliance/shared/_install_instructions_vm_macos.html
@@ -2,6 +2,6 @@
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">
-    A Mac running macOS and <a class="p-link--external" href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>.
+    A Mac running macOS and <a class="p-link--external" href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>. To use Multipass on macOS <a class="p-link--external" href="https://multipass.run/docs/using-virtualbox-in-multipass-macos">this is required</a>.
   </li>
 </ul>

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.pc %}
-<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.pc }}">
+<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.raspberrypi %}
-<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
+<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">

--- a/templates/appliance/shared/_steps_multipass_macos.html
+++ b/templates/appliance/shared/_steps_multipass_macos.html
@@ -29,7 +29,7 @@
         <p>
           To start Multipass with VirtualBox use this Terminal app command:
         </p>
-        <pre><code>multipass set local.driver=virtualbox</code></pre>
+        <pre><code>sudo multipass set local.driver=virtualbox</code></pre>
       </li>
     </ol>
   </div>

--- a/templates/appliance/shared/_vm.html
+++ b/templates/appliance/shared/_vm.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.pc %}
-<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.pc }}">
+<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">


### PR DESCRIPTION
## Done

- Update ALL of the next steps and multipass instructions

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/<appliance>/vm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the copy docs:
    - [adguard](https://docs.google.com/document/d/1ZqSQdPuQ3EYhNuzoaeln6tCivLq27Zwaj5sdPNpHOno/edit?ts=5ee76bbd)
    - [plex]()
    - [openhab](https://docs.google.com/document/d/19BL4l1m7F_jE-GkMGxg19KG1SsZtqzjLAFuyLngSy9Y/edit?ts=5ee76bcd)
    - [nextcloud](https://docs.google.com/document/d/12m4WT3ZvlfAuBQ6tT-0ARAQeYGFMaSWhBEzs-9l3ww8/edit?ts=5ee76bd8)
    - [mosquitto](https://docs.google.com/document/d/1nkWQ7c9uV7MAic8jbb5Ao0v8Ymw0HiO0vZnjFSqe-Gg/edit?ts=5ee76bfc)
    - [plex](https://docs.google.com/document/d/1gtGGn1aiF7Ijz6xL1mL4EzxSSGWlENN_L-Ln-mqfHB0/edit?ts=5ee76c13)

