### PR TITLE
Remove Ubuntu string and release name from CVE table

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -81,7 +81,7 @@
                 <i class="p-icon--placeholder"></i>
               </div>
               <div class="icon-container__text">
-                Ubuntu {{ release.name }} {{ release.version }} {{ release.support_tag }}
+                {{ release.version }} {{ release.support_tag }}
               </div>
             </th>
           {% endfor %}


### PR DESCRIPTION
## Done

Removed the release name and the Ubuntu string from CVE table header

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the table headers only have the Ubuntu versions and support tag, e.g. 18.04 LTS, 18.10 etc.


## Issue / Card

Fixes #7749 