### PR TITLE
Remove icons from DNE and not-affected CVE status

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -117,11 +117,11 @@
                   {% endif %}
                 {% endif %}
                   <div class="icon-container__icon">
-                    {% if release.status == 'DNE' or release.status == 'not-affected' %}
+                    {% if statuses[release.codename].status == 'DNE' or statuses[release.codename].status == 'not-affected' %}
                       <i class="p-icon--placeholder"></i>
                     {% else %}
                       {% if cve.priority == 'unknown' %}
-                        <i class="p-icon--unknown-priority"></i>
+                        <i class="p-icon--placeholder"></i>
                       {% elif cve.priority == 'negligible' %}
                         <i class="p-icon--negligible-priority"></i>
                       {% elif cve.priority == 'low' %}


### PR DESCRIPTION
## Done

Removed icons for DNE and not-affected statuses in the CVE table

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run DB:

```
docker-compose rm -fs
docker-compose up
```

In another terminal:

```
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec alembic upgrade head
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec python3 scripts/create-releases.py
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres serve
```

In yet another terminal:

```
git clone -b load-cve git@github.com:carkod/ubuntu-cve-tracker
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

- Check that any table cells that say "Does not exist" or "Not vulnerable" do not have icons


## Issue / Card

Fixes #7748 