### PR TITLE
Add apps link to OpenStack and k8s pages

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -64,6 +64,8 @@ openstack:
       path: /tco-calculator
     - title: Install
       path: /openstack/install
+    - title: Apps
+      path: /managed
     - title: Thank you
       path: /openstack/newsletter-thank-you
       hidden: True
@@ -160,6 +162,8 @@ kubernetes:
       path: /kubernetes/install
     - title: Docs
       path: /kubernetes/docs
+    - title: Apps
+      path: /managed
 
       children:
         - title: Home


### PR DESCRIPTION
## Done

Add apps link to secondary navigation on /openstack and /kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /openstack and check that there is an `apps` link in the secondary navigation that takes you to /managed
- Go to /kubernetes and check that there is an `apps` link in the secondary navigation that takes you to /managed


## Issue / Card

Fixes #7745 