### PR TITLE
 Add strips to promote /appliances around site

### DIFF
--- a/templates/appliance/shared/_appliance-advert-strip.html
+++ b/templates/appliance/shared/_appliance-advert-strip.html
@@ -1,0 +1,15 @@
+<div class="row" style="padding-bottom: 2rem;">
+  <div class="col-8">
+    {% if head %}
+    <h2>
+      {{ head }}
+    </h2>
+    {% endif %}
+    {% if subhead %}
+    <p>
+      {{ subhead }}
+    </p>
+    {% endif %}
+  </div>
+</div>
+{% include "/appliance/shared/_featured_appliances.html" %}

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -15,7 +15,7 @@
   </div>
   <div class="col-2">
     <a href="/appliance/plex" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Plex Media Server</h3>
+      <h3 class="p-heading--five u-no-padding--top">Plex<span class="u-hide--medium"> Media Server</span></h3>
       <hr />
       <div class="u-align--center">
         <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" alt="" style="height:32px; margin-top:2rem;">

--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip--suru-topped is-bordered">
+<section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Ubuntu flavours</h1>
@@ -16,9 +16,9 @@
       </p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip is-shallow">
+<section class="p-strip is-shallow">
   <div class="row">
     <div class="col-12">
       <ul class="p-matrix is-trisected">
@@ -149,7 +149,11 @@
       <p>A complete list of known flavours, editions and customisations is maintained on the <a class="p-link--external" href="https://wiki.ubuntu.com/UbuntuFlavors">Ubuntu Wiki's UbuntuFlavors page</a>.</p>
     </div>
   </div>
-</div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  {% with head="Download an Ubuntu Appliance", subhead="Try a new class of Ubuntu derivative using Ubuntu Core" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
+</section>
 
 {% with first_item="_download_more_info_enterprise", second_item="_download_all_installation", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -146,6 +146,13 @@
       </div>
     </section>
 
+    <section class="p-strip--light is-deep">
+      {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual machinei" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
+    </section>
+
+
+    {% with heading="Not finding the board you want? " %}{% include "/pricing/shared/_enablement-strip.html" %}{% endwith %}
+
     {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
     {% endblock content %}

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -244,6 +244,9 @@
   </div>
 </section>
 
+<section class="p-strip--light is-deep">
+  {% with head="Make something great today", subhead="Create an Ubuntu Appliance with a Raspberry Pi" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
+</section>
 
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -64,7 +64,11 @@
 
 {% include 'download/shared/_multipass-install.html' %}
 
-<section class="p-strip--light is-shallow">
+<section class="p-strip--light is-bordered">
+  {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual machine" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
+</section>
+
+<section class="p-strip">
   <div class="row">
     <div class="col-10">
       <h2>Alternative architectures</h2>

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -316,58 +316,7 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-7">
-      <h2>SoC, board and device enablement</h2>
-      <p class="p-heading--four">Give your SoC, board or device a custom kernel that’s proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</p>
-    </div>
-  </div>
-
-  <div class="row p-divider" style="padding-top: 1.9rem;">
-    <div class="col-6 p-divider__block">
-      <h3 class="p-heading--five">Beyond BSPs</h3>
-      <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>
-    </div>
-
-    <div class="col-6 p-divider__block">
-      <h3 class="p-heading--five">Ongoing testing and security updates</h3>
-
-      <p>For an annual charge of $25k, Canonical will perform continuous security maintenance and testing on your board. When a security issue is fixed in Ubuntu, the fix will be tested on your board. These security updates will be published to the snap store for use on your device. Update Control can be used to require additional testing and validation by your team before these updates are automatically applied to your devices. Testing will cover kernel and base system debs and snaps, along with any board-specific and app-specific tests you specify.</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-vertically-center">
-    <div class="col-8">
-      <h2>Certification of boards and devices</h2>
-      <p class="p-heading--four">Guarantee long-term security, application compatibility, support and operational consistency with the Ubuntu Certified logo for enterprise-grade devices.</p>
-      <p>Long-term automated Canonical testing of every update and security patch ensures devices perform reliably over the full lifetime of the certified Ubuntu LTS release. Certified devices must run a Canonical kernel. We require four units of every certified board or device for continuous testing. In the case of devices built with existing certified boards, running their standard certified kernel, we reduce this requirement to two devices.</p>
-
-      <p>Certification for devices that include pre-installed snaps can include validation of the integrity of those snaps.</p>
-    </div>
-
-
-    <div class="col-2 col-start-large-10 u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg",
-        alt="Ubuntu Certified",
-        width="127",
-        height="159",
-        hi_def=True,
-        loading="lazy",
-        attrs={"class": "col-2 col-start-large-10 u-hide--small"},
-        ) | safe
-      }}
-    </div>
-
-  </div>
-  <div class="u-fixed-width">
-    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get your board of device certified</a>
-  </div>
-</section>
+{% include "/pricing/shared/_enablement-strip.html" %}
 
 <section class="p-strip">
   <div class="row">

--- a/templates/pricing/shared/_enablement-strip.html
+++ b/templates/pricing/shared/_enablement-strip.html
@@ -1,0 +1,52 @@
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h2>{% if heading %}{{ heading }}{% else %}SoC, board and device enablement{% endif %}</h2>
+      <p class="p-heading--four">Give your SoC, board or device a custom kernel that’s proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</p>
+    </div>
+  </div>
+
+  <div class="row p-divider" style="padding-top: 1.9rem;">
+    <div class="col-6 p-divider__block">
+      <h3 class="p-heading--five">Beyond BSPs</h3>
+      <p>Ubuntu applications depend on a wide range of kernel features such as security modules, filesystems and container primitives. Ensure that your device kernel meets Ubuntu application expectations with a Canonical built custom kernel. Enablement fees vary from $25k to $200k as a one-time charge, depending on the particular board or chipset. Canonical delivers a custom kernel matching a standard Ubuntu LTS release, or interim release with a path to the next LTS.</p>
+    </div>
+
+    <div class="col-6 p-divider__block">
+      <h3 class="p-heading--five">Ongoing testing and security updates</h3>
+
+      <p>For an annual charge of $25k, Canonical will perform continuous security maintenance and testing on your board. When a security issue is fixed in Ubuntu, the fix will be tested on your board. These security updates will be published to the snap store for use on your device. Update Control can be used to require additional testing and validation by your team before these updates are automatically applied to your devices. Testing will cover kernel and base system debs and snaps, along with any board-specific and app-specific tests you specify.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h2>Certification of boards and devices</h2>
+      <p class="p-heading--four">Guarantee long-term security, application compatibility, support and operational consistency with the Ubuntu Certified logo for enterprise-grade devices.</p>
+      <p>Long-term automated Canonical testing of every update and security patch ensures devices perform reliably over the full lifetime of the certified Ubuntu LTS release. Certified devices must run a Canonical kernel. We require four units of every certified board or device for continuous testing. In the case of devices built with existing certified boards, running their standard certified kernel, we reduce this requirement to two devices.</p>
+
+      <p>Certification for devices that include pre-installed snaps can include validation of the integrity of those snaps.</p>
+    </div>
+
+
+    <div class="col-2 col-start-large-10 u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg",
+        alt="Ubuntu Certified",
+        width="127",
+        height="159",
+        hi_def=True,
+        loading="lazy",
+        attrs={"class": "col-2 col-start-large-10 u-hide--small"},
+        ) | safe
+      }}
+    </div>
+
+  </div>
+  <div class="u-fixed-width">
+    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get your board of device certified</a>
+  </div>
+</section>

--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -80,6 +80,8 @@
       <div class="col-3">
         <h4 class="p-muted-heading--small">Read the docs</h4>
         <p class="p-p--small">Read the official docs for <a href='https://help.ubuntu.com/'>Ubuntu Desktop</a>, <a href='https://help.ubuntu.com/'>Ubuntu Server</a>, and <a href='http://docs.ubuntu.com/core'>Ubuntu Core</a></p>
+        <h4 class="p-muted-heading--small">Ubuntu Appliances</h4>
+        <p class="p-p--small">An <a href="/appliance">Ubuntu Appliance</a> is an official system image which blends a single application with Ubuntu Core. Certified to run on Raspberry Pi and PC boards.</p>
       </div>
       <div class="col-3">
         <h4 class="p-muted-heading--small">Other ways to download</h4>


### PR DESCRIPTION
## Done

- Add strips to promote /appliances around site
- Added to the download mega menu
- Added some text from /pricing/devices to /download/iot

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/download/server
    - http://0.0.0.0:8001/download/flavours
    - http://0.0.0.0:8001/download/iot
    - http://0.0.0.0:8001/download/raspberry-pi
    - https://0.0.0.0:8001/#download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the copy docs:
    - [/download/server](https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit?ts=5ee7d8c0#)
    - [/download/flavours](https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit?ts=5ee7d8c7#heading=h.mh0k2ttcr9t3)
    - [/download/iot](https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit?ts=5ee7d8c8#heading=h.mq97q398z6vr)
    - [/download/raspberry-pi](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?ts=5ee7d8bd#heading=h.mh0k2ttcr9t3)
    - [download menu](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit)

Fixes #7430 