### PR TITLE
Appliance fix instrctions

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -29,7 +29,7 @@ appliance:
       path: /appliance/community
     - title: Hardware
       path: /appliance/hardware
-    - title: Vitual machines
+    - title: Virtual machines
       path: /appliance/vm
     - title: Contact us
       path: /appliance/contact-us

--- a/static/js/src/tabotronic.js
+++ b/static/js/src/tabotronic.js
@@ -4,7 +4,7 @@
 
   tabContent.forEach((tab) => {
     const link = document.querySelector(
-      `#${tab.getAttribute("aria-labledby")}`
+      `#${tab.getAttribute("aria-labelledby")}`
     );
     if (link && link.getAttribute("aria-selected") !== "true") {
       tab.classList.add("u-hide");

--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -5,5 +5,5 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_appliance" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/appliance/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
-    <script src="{{ versioned_static('js/build/appliance.min.js') }}" defer></script>
+    <script src="{{ versioned_static('js/dist/appliance.js') }}" defer></script>
 {% endblock %}

--- a/templates/appliance/about.html
+++ b/templates/appliance/about.html
@@ -36,34 +36,15 @@
       <h2>Why are we hosting Ubuntu Appliances?</h2>
       <p class="u-no-max-width">Software is everywhere in the modern home and office &mdash; in your fridge, in your vacuum cleaner, in your heating and lighting system. Software-based appliances enhance our modern lives. But they also represent a risk &mdash; of bad data practices, or bad software. Ubuntu Appliances set the standard for smart connected devices that meet consistent criteria for security, privacy, maintenance and operations.</p>
       <p class="u-no-max-width">The Ubuntu Appliance mission is to enable secure, self-healing, smart things, everywhere. Open source is the backbone of the platform, and both open and commercial appliances co-exist in the ecosystem.</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--suru is-dark" style="padding-bottom: 8rem !important; padding-top: 2rem;">
-  <div class="row">
-    <div class="col-2 u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/665fb5d0-free-download-install.svg",
-        alt="",
-        width="105",
-        height="140",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}
-      <img src="" alt="" />
-    </div>
-    <div class="col-8">
       <h3>Free to download and use</h3>
       <p>All Ubuntu Appliances are free to download and install.</p>
-      <p><a href="/appliance/portfolio" class="p-button--neutral">Download for free</a></p>
     </div>
   </div>
-</section>
 
-<section class="p-strip">
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
   <div class="row">
     <div class="col-8">
       <h2 class="u-sv3">We’ve taken care of everything for you</h2>

--- a/templates/appliance/hardware.html
+++ b/templates/appliance/hardware.html
@@ -598,6 +598,6 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>
 
 {% endblock content %}

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.pc %}
-<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.pc }}">
+<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -1,5 +1,5 @@
 {% if appliance.iso_url.pc %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
+<meta http-equiv="re fresh" content="3;url={{ appliance.iso_url.pc }}">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">
@@ -94,4 +94,4 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -100,4 +100,4 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>

--- a/templates/appliance/shared/_raspberry-pi2.html
+++ b/templates/appliance/shared/_raspberry-pi2.html
@@ -100,4 +100,4 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>

--- a/templates/appliance/shared/_vm.html
+++ b/templates/appliance/shared/_vm.html
@@ -91,4 +91,4 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/build/tabotronic.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -176,7 +176,7 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/dist/cve.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>
 
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
 {% include "shared/contextual_footers/_contextual_footer.html" %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -176,7 +176,7 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/build/cve.min.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/cve.min.js') }}" defer></script>
 
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
 {% include "shared/contextual_footers/_contextual_footer.html" %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -18,6 +18,7 @@ module.exports = {
   ],
   "release-chart": "./static/js/src/release-chart.js",
   tabotronic: "./static/js/src/tabotronic.js",
+  appliance: "./static/js/src/appliance.js",
   "tco-calculator": "./static/js/src/tco-calculator.js",
   "renewal-modal": "./static/js/src/renewal-modal.js",
   "sticky-nav": "./static/js/src/sticky-nav.js",


### PR DESCRIPTION
## Done
- Fixed the virtual machines menu item
- Muted the free strip on the about page
- Fixed a typo in the `tabotronic.js`
- Added the appliance JS file to build with webpack
- Updated the paths to the JS dist folder 

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliances/about
- Check the Free section is much more subtle with no button
- Go to /appliance/openhab/intel-nuc
- Check the instruction tabs work