### PR TITLE
Add recaptcha to /legal/terms-and-policies/contact-us page

### DIFF
--- a/templates/legal/terms-and-policies/contact-us.html
+++ b/templates/legal/terms-and-policies/contact-us.html
@@ -5,6 +5,134 @@
 
 {% block head_extra %}
 <script type="text/javascript">
+  // initialize our variables
+  var captchaReady = 0;
+  var wFORMSReady = 0;
+
+  // when wForms is loaded call this
+  var wformsReadyCallback = function () {
+    // using this var to denote if wForms is loaded
+    wFORMSReady = 1;
+    // call our recaptcha function which is dependent on both
+    // wForms and an async call to google
+    // note the meat of this function wont fire until both
+    // wFORMSReady = 1 and captchaReady = 1
+    onloadCallback();
+  }
+  var gCaptchaReadyCallback = function() {
+    // using this var to denote if captcha is loaded
+    captchaReady = 1;
+    // call our recaptcha function which is dependent on both
+    // wForms and an async call to google
+    // note the meat of this function wont fire until both
+    // wFORMSReady = 1 and captchaReady = 1
+    onloadCallback();
+  };
+
+  // add event listener to fire when wForms is fully loaded
+  document.addEventListener("wFORMSLoaded", wformsReadyCallback);
+
+  var enableSubmitButton = function() {
+    var submitButton = document.getElementById('submit_button');
+    var explanation = document.getElementById('disabled-explanation');
+    if (submitButton != null) {
+      submitButton.removeAttribute('disabled');
+      if (explanation != null) {
+        explanation.style.display = 'none';
+      }
+    }
+  };
+  var disableSubmitButton = function() {
+    var submitButton = document.getElementById('submit_button');
+    var explanation = document.getElementById('disabled-explanation');
+    if (submitButton != null) {
+      submitButton.disabled = true;
+      if (explanation != null) {
+        explanation.style.display = 'block';
+      }
+    }
+  };
+
+  // call this on both captcha async complete and wforms fully
+  // initialized since we can't be sure which will complete first
+  // and we need both done for this to function just check that they are
+  // done to fire the functionality
+  var onloadCallback = function () {
+    // if our captcha is ready (async call completed)
+    // and wFORMS is completely loaded then we are ready to add
+    // the captcha to the page
+    if (captchaReady && wFORMSReady) {
+      grecaptcha.render('g-recaptcha-render-div', {
+        'sitekey': '6LeISQ8UAAAAAL-Qe-lDcy4OIElnii__H_cEGV0C',
+        'theme': 'light',
+        'size': 'normal',
+        'callback': 'enableSubmitButton',
+        'expired-callback': 'disableSubmitButton'
+      });
+      var oldRecaptchaCheck = parseInt('1');
+      if (oldRecaptchaCheck === -1) {
+        var standardCaptcha = document.getElementById("tfa_captcha_text");
+        standardCaptcha = standardCaptcha.parentNode.parentNode.parentNode;
+        standardCaptcha.parentNode.removeChild(standardCaptcha);
+      }
+
+      if (!wFORMS.instances['paging']) {
+        document.getElementById("g-recaptcha-render-div").parentNode.parentNode.parentNode.style.display = "block";
+        //document.getElementById("g-recaptcha-render-div").parentNode.parentNode.parentNode.removeAttribute("hidden");
+      }
+      document.getElementById("g-recaptcha-render-div").getAttributeNode('id').value = 'tfa_captcha_text';
+
+      var captchaError = '';
+      if (captchaError == '1') {
+        var errMsgText = 'The CAPTCHA was not completed successfully.';
+        var errMsgDiv = document.createElement('div');
+        errMsgDiv.id = "tfa_captcha_text-E";
+        errMsgDiv.className = "err errMsg";
+        errMsgDiv.innerText = errMsgText;
+        var loc = document.querySelector('.g-captcha-error');
+        loc.insertBefore(errMsgDiv, loc.childNodes[0]);
+
+        /* See wFORMS.behaviors.paging.applyTo for origin of this code */
+        if (wFORMS.instances['paging']) {
+          var b = wFORMS.instances['paging'][0];
+          var pp = base2.DOM.Element.querySelector(document, wFORMS.behaviors.paging.CAPTCHA_ERROR);
+          if (pp) {
+            var lastPage = 1;
+            for (var i = 1; i < 100; i++) {
+              if (b.behavior.isLastPageIndex(i)) {
+                lastPage = i;
+                break;
+              }
+            }
+            b.jumpTo(lastPage);
+          }
+        }
+      }
+    }
+  };
+</script>
+<script src='https://www.google.com/recaptcha/api.js?onload=gCaptchaReadyCallback&render=explicit&hl=en_GB' async
+defer></script>
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function() {
+    var warning = document.getElementById("javascript-warning");
+    if (warning != null) {
+      warning.parentNode.removeChild(warning);
+    }
+    var oldRecaptchaCheck = parseInt('1');
+    if (oldRecaptchaCheck !== -1) {
+      var explanation = document.getElementById('disabled-explanation');
+      var submitButton = document.getElementById('submit_button');
+      if (submitButton != null) {
+        submitButton.disabled = true;
+        if (explanation != null) {
+          explanation.style.display = 'block';
+        }
+      }
+    }
+  });
+</script>
+<script type="text/javascript">
   document.addEventListener("DOMContentLoaded", function(){
     const FORM_TIME_START = Math.floor((new Date).getTime()/1000);
     let formElement = document.getElementById("tfa_0");
@@ -40,16 +168,16 @@
   });
 </script>
 
-<link href="https://www.tfaforms.com/dist/form-builder/5.0.0/wforms-layout.css?v=300ce69b53390defc4b94b3a88f6268017c48dd5" rel="stylesheet" type="text/css" />
+<link href="https://www.tfaforms.com/dist/form-builder/5.0.0/wforms-layout.css?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2" rel="stylesheet" type="text/css" />
 
 <link href="https://www.tfaforms.com/wForms/3.4/css/blank/wforms.css" rel="stylesheet" type="text/css" />
-<link href="https://www.tfaforms.com/dist/form-builder/5.0.0/wforms-jsonly.css?v=300ce69b53390defc4b94b3a88f6268017c48dd5" rel="alternate stylesheet" title="This stylesheet activated by javascript" type="text/css" />
-<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/wforms.js?v=300ce69b53390defc4b94b3a88f6268017c48dd5"></script>
+<link href="https://www.tfaforms.com/dist/form-builder/5.0.0/wforms-jsonly.css?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2" rel="alternate stylesheet" title="This stylesheet activated by javascript" type="text/css" />
+<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/wforms.js?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2"></script>
 <script type="text/javascript">
   wFORMS.behaviors.prefill.skip = false;
 </script>
-<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/localization-en_GB.js?v=300ce69b53390defc4b94b3a88f6268017c48dd5"></script>
-{% endblock %}
+<script type="text/javascript" src="https://www.tfaforms.com/wForms/3.11/js/localization-en_GB.js?v=9cab24f50ea39e2cd0e4eb3def0940a2b3cb2ad2"></script>
+{% endblock head_extra %}
 
 {% block content %}
 <section class="p-strip is-deep">
@@ -61,6 +189,7 @@
   </div>
   <div class="row">
     <div class="col-8">
+
       <div class="wFormContainer" >
         <div class="wFormHeader"></div>
         <style type="text/css">
@@ -218,10 +347,7 @@
               display: none;
             }
           </style></div>
-
           <form method="post" action="https://www.tfaforms.com/responses/processor" class=" labelsLeftAligned" id="36087" role="form" enctype="multipart/form-data">
-
-
             <div class="htmlSection" id="tfa_9631608629065"><div class="htmlContent" id="tfa_9631608629065-HTML">
               <p class="western" style="margin-bottom: 0cm"><font color="#ff0000">* signifies a required field</font></p>
             </div></div>
@@ -539,7 +665,21 @@
                     <div class="oneField field-container-D    " id="tfa_9631608629067-D">
                       <label id="tfa_9631608629067-L" class="label preField " for="tfa_9631608629067">If you would like to include an attachment with your request please add it here</label><div class="inputWrapper"><input type="file" id="tfa_9631608629067" name="tfa_9631608629067" size="" title="If you would like to include an attachment with your request please add it here" class=""></div>
                     </div>
-                    <div class="actions" id="36087-A"><input type="submit" data-label="Submit" class="primaryAction" id="submit_button" value="Submit"></div>
+                    <div class="actions" id="36087-A">
+                      <div id="google-captcha" style="display: none">
+                        <br><div class="captcha">
+                          <div class="oneField">
+                            <div class="g-recaptcha" id="g-recaptcha-render-div"></div>
+                            <div class="g-captcha-error"></div>
+                            <br>
+                          </div>
+                          <div class="captchaHelp">reCAPTCHA helps prevent automated form spam.<br>
+                          </div>
+                          <div id="disabled-explanation" class="captchaHelp" style="display: none">The submit button will be disabled until you complete the CAPTCHA.</div>
+                        </div>
+                      </div>
+                      <input type="submit" data-label="Submit" class="primaryAction" id="submit_button" value="Submit">
+                    </div>
                     <div style="clear:both"></div>
                     <input type="hidden" value="36087" name="tfa_dbFormId" id="tfa_dbFormId"><input type="hidden" value="" name="tfa_dbResponseId" id="tfa_dbResponseId"><input type="hidden" value="c004ae4348a8919232a477fa58f8a3bf" name="tfa_dbControl" id="tfa_dbControl"><input type="hidden" value="29" name="tfa_dbVersionId" id="tfa_dbVersionId"><input type="hidden" value="" name="tfa_switchedoff" id="tfa_switchedoff">
                   </form>


### PR DESCRIPTION
## Done

- Add recaptcha to /legal/terms-and-policies/contact-us page
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/terms-and-policies/contact-us
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that google recaptcha has been added per legal team request


## Issue / Card

Fixes #7762

