### PR TITLE
fix appliance link typo

### DIFF
--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -25,7 +25,7 @@
         Turn your app into an Ubuntu Appliance
       </h3>
       <p>
-        Anyone can build their own Ubuntu Appliance, a software-defined IoT device that uses Ubuntu for security and to stay up to date. But it’s really all you. See our <a href="/appliances/community">community page</a> for more information or jump right to discourse to propose your new Ubuntu Appliance and start the conversation.
+        Anyone can build their own Ubuntu Appliance, a software-defined IoT device that uses Ubuntu for security and to stay up to date. But it’s really all you. See our <a href="/appliance/community">community page</a> for more information or jump right to discourse to propose your new Ubuntu Appliance and start the conversation.
       </p>
       <p>
         <a class="p-button p-link--external" href="https://discourse.ubuntu.com/c/appliances">Propose your new appliance</a>


### PR DESCRIPTION
## Done

Fixed typo in a link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/portfolio
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Find the "see our community page" link, make sure it doesn't lead to a 404


## Issue / Card

Fixes #7768
