### PR TITLE
Fix post-release /appliance snags

### DIFF
--- a/templates/appliance/adguard/index.md
+++ b/templates/appliance/adguard/index.md
@@ -31,7 +31,7 @@ context:
     2: "California law"
   base: "core20"
   published_date: "2020-06-16"
-  maintenance_date: "2020-06-16"
+  maintenance_date: "2030-06-16"
   snaps:
     1:
       name: "AdGuard Home"

--- a/templates/appliance/adguard/index.md
+++ b/templates/appliance/adguard/index.md
@@ -29,7 +29,7 @@ context:
   compliance:
     1: "EU GDPR"
     2: "California law"
-  base: "core20"
+  base: "core18"
   published_date: "2020-06-16"
   maintenance_date: "2030-06-16"
   snaps:

--- a/templates/appliance/mosquitto/index.md
+++ b/templates/appliance/mosquitto/index.md
@@ -28,7 +28,7 @@ context:
   compliance:
     1: "EU GDPR"
     2: "California law"
-  base: "core20"
+  base: "core18"
   published_date: "2020-06-12"
   maintenance_date: "2030-06-16"
   snaps:

--- a/templates/appliance/nextcloud/index.md
+++ b/templates/appliance/nextcloud/index.md
@@ -28,7 +28,7 @@ context:
   compliance:
     1: "EU GDPR"
     2: "California law"
-  base: "core20"
+  base: "core18"
   published_date: "2020-06-16"
   maintenance_date: "2030-06-16"
   certification_note: "Not guaranteed to work on the Raspberry Pi 3A+"

--- a/templates/appliance/openhab/index.md
+++ b/templates/appliance/openhab/index.md
@@ -30,7 +30,7 @@ context:
   compliance:
     1: "EU GDPR"
     2: "California law"
-  base: "core20"
+  base: "core18"
   published_date: "2020-06-16"
   maintenance_date: "2030-06-16"
   certification_note: "Not guaranteed to work on the Raspberry Pi 3A+"

--- a/templates/appliance/openhab/index.md
+++ b/templates/appliance/openhab/index.md
@@ -32,7 +32,7 @@ context:
     2: "California law"
   base: "core20"
   published_date: "2020-06-16"
-  maintenance_date: "2020-06-16"
+  maintenance_date: "2030-06-16"
   certification_note: "Not guaranteed to work on the Raspberry Pi 3A+"
   snaps:
     1:

--- a/templates/appliance/plex/index.md
+++ b/templates/appliance/plex/index.md
@@ -33,7 +33,7 @@ context:
     2: "California law"
   base: "core20"
   published_date: "2020-06-16"
-  maintenance_date: "2020-06-16"
+  maintenance_date: "2030-06-16"
   certification_note: "Not guaranteed to work on the Raspberry Pi 3A+"
   snaps:
     1:

--- a/templates/appliance/plex/index.md
+++ b/templates/appliance/plex/index.md
@@ -31,7 +31,7 @@ context:
   compliance:
     1: "EU GDPR"
     2: "California law"
-  base: "core20"
+  base: "core18"
   published_date: "2020-06-16"
   maintenance_date: "2030-06-16"
   certification_note: "Not guaranteed to work on the Raspberry Pi 3A+"

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -28,16 +28,15 @@
       <div class="row">
         {% if downloads.raspberrypi %}
         <div class="col-2">
-          <a href="/appliance/{{ short_name }}/raspberry-pi2">
+          <a href="/appliance/{{ short_name }}/raspberry-pi">
             <h3 class="p-heading--five u-no-padding--top">
-              <a href="/appliance/{{ short_name }}/raspberry-pi">
-                Raspberry Pi 3 &amp; 4
-              </a>
+              Raspberry Pi 3 &amp; 4
             </h3>
             <hr>
             <div class="u-align--center">
               <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=100" alt="" style="width: 50%;">
             </div>
+          </a>
         </div>
         {% endif %}
         {% if downloads.intelnuc %}
@@ -61,7 +60,7 @@
             </h3>
             <hr>
             <div class="u-align--center">
-              <img src="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg" style="width: 45px;">
+              <img src="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg" style="width: 30%;">
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Done

- multipass logo is too small on small screens on /appliance/ pages
- hit area for raspberry pi is too small on /appliance/ pages
- all maintained until dates should be in 2030

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex (for example)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the multipass logo looks ok on small screens
- See that the image of the pi on that page is clickable
- See that the maintenance date is now in 2030


## Issue / Card

Fixes #7761
Fixes #7774
Fixes #7775


