### PR TITLE
Update multipass links

### DIFF
--- a/templates/appliance/shared/_vm.html
+++ b/templates/appliance/shared/_vm.html
@@ -1,19 +1,7 @@
-{% if appliance.iso_url.pc %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
-{% endif %}
-
 <section class="p-strip--suru-topped" style="overflow: visible;">
   <div class="row u-equal-height">
     <div class="col-8">
-      {% if appliance.iso_url.pc %}
-      <h1>Try the {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine</h1>
-      <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
-        <a href="{{ appliance.iso_url.pc }}">download now</a>.
-        {% include "appliance/shared/_verify-checksums-pc.html" %}
-      </p>
-      {% else %}
       <h1>Setup the {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine</h1>
-      {% endif %}
     </div>
     <div class="col-4 u-hide-small u-vertically-center u-align--center">
       {{

--- a/templates/appliance/vm.html
+++ b/templates/appliance/vm.html
@@ -51,7 +51,7 @@
           </a>
         </div>
         <div class="col-4 p-divider__block u-align--center u-vertically-center">
-          <a href="https://github.com/canonical/multipass/releases/download/v1.2.1/multipass-1.2.1%2Bwin-win64.exe">
+          <a href="https://github.com/canonical/multipass/releases/download/v1.3.0/multipass-1.3.0%2Bwin-win64.exe">
             <img src="https://assets.ubuntu.com/v1/429929de-2020-logo-windows.svg" style="height: 55px;" alt="Windows">
             <p class="u-no-margin--bottom">
               Download Multipass for Windows
@@ -59,7 +59,7 @@
           </a>
         </div>
         <div class="col-4 p-divider__block u-align--center u-vertically-center">
-          <a href="https://github.com/canonical/multipass/releases/download/v1.2.1/multipass-1.2.1%2Bmac-Darwin.pkg">
+          <a href="https://github.com/canonical/multipass/releases/download/v1.3.0/multipass-1.3.0%2Bmac-Darwin.pkg">
             <img src="https://assets.ubuntu.com/v1/d2f8dca7-macOS.png" style="height: 55px;" alt="macOS">
             <p class="u-no-margin--bottom">
               Download Multipass for macOS


### PR DESCRIPTION
## Done
- Update the multipass version in the link
- Disable the download on vm

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/openhab/vm
- Check the download is not triggered and the title does not state it will be automaticly downloaded
- Go to /appliance/vm
- Check the multipass download links point to 1.3.0

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7777
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7778
