### PR TITLE
Add section path matching to 2nd nav generation (fixes /managed nav)

### DIFF
--- a/webapp/context.py
+++ b/webapp/context.py
@@ -73,7 +73,7 @@ def get_navigation(path):
                 # always show "Topics" as active on child topic pages
                 child["active"] = True
                 break
-            elif child["path"] == path or (
+            elif (child["path"] == path and path.startswith(nav_section["path"])) or (
                 child.get("persist") and path.startswith(child["path"])
             ):
                 # If child path matches current path or has persist set to true

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -73,10 +73,9 @@ def get_navigation(path):
                 # always show "Topics" as active on child topic pages
                 child["active"] = True
                 break
-            elif (child["path"] == path and path.startswith(
-                nav_section["path"])) or (
-                child.get("persist") and path.startswith(child["path"])
-            ):
+            elif (
+                child["path"] == path and path.startswith(nav_section["path"])
+            ) or (child.get("persist") and path.startswith(child["path"])):
                 # If child path matches current path or has persist set to true
                 child["active"] = True
                 nav_section["active"] = True

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -73,7 +73,8 @@ def get_navigation(path):
                 # always show "Topics" as active on child topic pages
                 child["active"] = True
                 break
-            elif (child["path"] == path and path.startswith(nav_section["path"])) or (
+            elif (child["path"] == path and path.startswith(
+                nav_section["path"])) or (
                 child.get("persist") and path.startswith(child["path"])
             ):
                 # If child path matches current path or has persist set to true


### PR DESCRIPTION
## Done

- This is an attempt at fixing the currently broken [/managed](https://ubuntu.com/managed) nav. When adding /managed to the /kubernetes and /openstack nav, the current nav building logic considers that /managed is part of /kubernetes, therefore shows the /kubernetes nav in the /managed section.
- The logic now looks for a section path match with the current path before building the navigation.
- **This change needs testing for corner cases I'm not necessarily aware of :)**

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7784

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure /managed shows the correct navigation.
- Ensure it doesn't break nav corner cases.
