### PR TITLE
Check if notice as release packages before iterating

### DIFF
--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -27,6 +27,7 @@
     </div>
   </div>
 
+  {% if notice.packages %}
   <div class="row">
     <div class="col-12">
       <h2>Packages</h2>
@@ -36,7 +37,8 @@
         {% endfor %}
       </ul>
     </div>
-  
+  {% endif %}
+
   <div class="row">
     <div class="col-8">
       <h2>Details</h2>
@@ -47,6 +49,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Update instructions</h2>
+      {% if notice.release_packages %}
       <p>The problem can be corrected by updating your system to the following package versions:</p>
       {% for version in notice.release_packages.__reversed__() %}
         <h5>Ubuntu {{ version }}</h5>
@@ -68,6 +71,7 @@
           {% endfor %}
         </ul>
       {% endfor %}
+      {% endif %}
       <p>{{ notice.instructions|safe }}</p>
     </div>
   </div>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -36,23 +36,24 @@ def notice(notice_id):
     packages = []
     release_packages = SortedDict()
 
-    for codename, pkgs in notice.release_packages.items():
-        release_version = (
-            db_session.query(Release)
-            .filter(Release.codename == codename)
-            .one()
-            .version
-        )
+    if notice.release_packages:
+        for codename, pkgs in notice.release_packages.items():
+            release_version = (
+                db_session.query(Release)
+                .filter(Release.codename == codename)
+                .one()
+                .version
+            )
 
-        release_packages[release_version] = []
-        for package in pkgs:
-            if package["is_source"]:
-                packages.append(package)
-            else:
-                release_packages[release_version].append(package)
+            release_packages[release_version] = []
+            for package in pkgs:
+                if package["is_source"]:
+                    packages.append(package)
+                else:
+                    release_packages[release_version].append(package)
 
-        # Order packages for release by the name key
-        release_packages[release_version].sort(key=lambda pkg: pkg["name"])
+            # Order packages for release by the name key
+            release_packages[release_version].sort(key=lambda pkg: pkg["name"])
 
     # Order source packages by the name key
     packages.sort(key=lambda pkg: pkg["name"])


### PR DESCRIPTION
## Done

- Check if a notice has release_packages before trying to build the payload.
- Add checks on the templates so we don't display empty sections. 

## QA

- Check out this feature branch
- docker-compose up -d
- Update an existing notice(keep ID) and set release_packages to `None` **1***

- Run the site using the command `./run serve` or `dotrun`
- Browse the `localhost:8001/security/notices/<id_of_the_notice_you_kept>` and make sure it does not 500

**1*** - I ran `dotrun exec flask shell` and then inside it the following commands

```
from webapp.security.database import db_session
from webapp.security.models import Notice

notice = db_session.query(Notice).get("ID you kept")
notice.release_packages = None

db_session.add(notice)
db_session.commit()
```