### PR TITLE
Update CVE release labels on CVE page

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -140,7 +140,13 @@
                     {% if loop.index == 1 %}
                       <td rowspan="{{ releases | length }}">{{ package_name }}</td>
                     {% endif %}
-                    <td>{{ release.name }}</td>
+                    <td>
+                      {% if release.name == "Upstream" %}
+                        {{ release.name }}
+                      {% else %}
+                        Ubuntu {{ release.version }} {{ release.support_tag }} ({{ release.name }})
+                      {% endif %}
+                    </td>
                     <td>
                       {% if release.codename in statuses %}
                         {% if statuses[release.codename].status == "DNE" %}


### PR DESCRIPTION
## Done

Update the release labels on the CVE page status table

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run DB:

```
docker-compose rm -fs
docker-compose up
```

In another terminal:

```
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec alembic upgrade head
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec python3 scripts/create-releases.py
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres serve
```

In yet another terminal:

```
git clone -b load-cve git@github.com:carkod/ubuntu-cve-tracker
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
uncomment line 60 and comment out line 61 of upload-cve.py
time python3 upload-cve.py ../active
```

Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

- Click through to a CVE page
- Check that all Ubuntu releases have the format of "Ubuntu 18.04 LTS (Bionic Beaver)"

## Issue / Card

Fixes #7786

## Screenshots
![Screenshot from 2020-06-18 12-12-03](https://user-images.githubusercontent.com/501889/85013793-17f18300-b15d-11ea-8000-64e1fa9eb1e3.png)
