### PR TITLE
Update links to multipass downloads to the new links

### DIFF
--- a/templates/appliance/shared/_steps_multipass_macos.html
+++ b/templates/appliance/shared/_steps_multipass_macos.html
@@ -7,7 +7,7 @@
     <ol>
       <li>
         <p>
-          <a class="p-link--external" href="https://multipass.run/#install">Download Multipass for macOS</a>
+          <a class="p-link--external" href="https://multipass.run/download/macos">Download Multipass for macOS</a>
         </p>
       </li>
       <li>

--- a/templates/appliance/shared/_steps_multipass_windows.html
+++ b/templates/appliance/shared/_steps_multipass_windows.html
@@ -12,7 +12,7 @@
       </li>
       <li>
         <p>
-          <a class="p-link--external" href="https://multipass.run/#install">Download Multipass for Windows</a>
+          <a class="p-link--external" href="https://multipass.run/download/windows">Download Multipass for Windows</a>
         </p>
       </li>
       <li>

--- a/templates/appliance/vm.html
+++ b/templates/appliance/vm.html
@@ -51,7 +51,7 @@
           </a>
         </div>
         <div class="col-4 p-divider__block u-align--center u-vertically-center">
-          <a href="https://github.com/canonical/multipass/releases/download/v1.3.0/multipass-1.3.0%2Bwin-win64.exe">
+          <a href="https://multipass.run/download/windows">
             <img src="https://assets.ubuntu.com/v1/429929de-2020-logo-windows.svg" style="height: 55px;" alt="Windows">
             <p class="u-no-margin--bottom">
               Download Multipass for Windows
@@ -59,7 +59,7 @@
           </a>
         </div>
         <div class="col-4 p-divider__block u-align--center u-vertically-center">
-          <a href="https://github.com/canonical/multipass/releases/download/v1.3.0/multipass-1.3.0%2Bmac-Darwin.pkg">
+          <a href="https://multipass.run/download/macos">
             <img src="https://assets.ubuntu.com/v1/d2f8dca7-macOS.png" style="height: 55px;" alt="macOS">
             <p class="u-no-margin--bottom">
               Download Multipass for macOS


### PR DESCRIPTION
## Done

- Update links to multipass downloads to the new links so we don't have to update the site when multipass releases new versions

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/appliance/adguard/vm#macos
    - http://0.0.0.0:8001/appliance/adguard/vm#windows
    - http://0.0.0.0:8001/appliance/vm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it goes to a new multpass.run link that redirects to the latest release
