### PR TITLE
Fix "Public cloud" from wrapping in the secondary nav

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -209,10 +209,13 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
 
       &__logo {
         @extend %paragraph;
+
         align-items: center;
         color: $color-x-light;
         display: flex;
+        font-size: 0.875rem;
         margin-bottom: $sp-unit * 2 - map-get($nudges, nudge--p);
+        padding-top: 0.55rem;
         position: relative;
 
         @media (max-width: $breakpoint-navigation-threshold - 1) {

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -75,7 +75,7 @@
     <div class="col-12 u-equal-height">
       <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="{{ breadcrumbs.section.path }}">
         <h5 class="p-navigation--secondary__logo">
-          {{ breadcrumbs.section.title }}
+          {{ breadcrumbs.section.title | replace(" ", "&nbsp;") | safe }}
         </h5>
       </a>
       {% if breadcrumbs.children %}


### PR DESCRIPTION
## Done

- Fix "Public cloud" from wrapping in the secondary nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the word doesn't wrap like on live.

## Issue / Card

Fixes #7796
