### PR TITLE
Fix the appliance link

### DIFF
--- a/templates/appliance/community.html
+++ b/templates/appliance/community.html
@@ -47,7 +47,7 @@
       <ol class="p-stepped-list">
         <li class="p-stepped-list__item" style="padding-bottom: 0;">
           <p class="p-stepped-list__title">
-            <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliance">Share your idea</a> with a <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances/proposed-new-appliances">Proposed New Appliance</a> topic to get community feedback
+            <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliance">Share your idea</a> with a <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliance/proposed-new-appliances">Proposed New Appliance</a> topic to get community feedback
           </p>
         </li>
         <li class="p-stepped-list__item" style="padding-bottom: 0;">

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -309,7 +309,7 @@
         Whatever your appliance interests, we hope you will join the Ubuntu Discourse and make yourself heard. Share your ideas with the community, discuss and design new appliances, join one of our teams or teach others how to make the most of something special.
       </p>
       <p>
-        <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliances">Join the discussion</a>
+        <a class="p-link--external" href="https://discourse.ubuntu.com/c/appliance">Join the discussion</a>
       </p>
     </div>
     <div class="col-6">

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -28,7 +28,7 @@
         Anyone can build their own Ubuntu Appliance, a software-defined IoT device that uses Ubuntu for security and to stay up to date. But it’s really all you. See our <a href="/appliance/community">community page</a> for more information or jump right to discourse to propose your new Ubuntu Appliance and start the conversation.
       </p>
       <p>
-        <a class="p-button p-link--external" href="https://discourse.ubuntu.com/c/appliances">Propose your new appliance</a>
+        <a class="p-button p-link--external" href="https://discourse.ubuntu.com/c/appliance">Propose your new appliance</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small u-vertically-center">


### PR DESCRIPTION
Find all occurrences of "https://discourse.ubuntu.com/c/appliances" and replace them with "https://discourse.ubuntu.com/c/appliance"

Fixes #7788