### PR TITLE
Removed the AI Dell webinar form takeover rotation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,6 @@
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
   {% include "takeovers/_2004-migration-takeover.html" %}
-  {% include "takeovers/_202006-ml-dell-webinar.html" %}
   {% include "takeovers/_ubuntu-pro-intro.html" %}
 
   {# FRENCH #}


### PR DESCRIPTION
## Done

- Removed the AI Dell webinar form takeover rotation

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
