### PR TITLE
Add an endpoint to delete security notices

### DIFF
--- a/scripts/delete-usns.py
+++ b/scripts/delete-usns.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python3
+
+# Standard library
+import argparse
+import os
+from http.cookiejar import MozillaCookieJar
+
+# Packages
+from macaroonbakery import httpbakery
+
+
+parser = argparse.ArgumentParser(description="Helper script to delete USNs")
+parser.add_argument("usn_ids", action="store", nargs="+", type=str)
+parser.add_argument(
+    "--host", action="store", type=str, default="http://localhost:8001"
+)
+args = parser.parse_args()
+
+
+client = httpbakery.Client(cookies=MozillaCookieJar(".login"))
+
+if os.path.exists(client.cookies.filename):
+    client.cookies.load(ignore_discard=True)
+
+base_endpoint = f"{args.host}/security/notices"
+
+# Make a first call to make sure we are logged in
+response = client.request("POST", url=base_endpoint)
+client.cookies.save(ignore_discard=True)
+
+# Delete each of the USN's
+for usn_id in args.usn_ids:
+    response = client.request(
+        method="DELETE",
+        url=f"{base_endpoint}/{usn_id}",
+    )
+
+    print(response, response.text)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -53,6 +53,7 @@ from webapp.login import login_handler, logout, user_info
 from webapp.security.database import db_session
 from webapp.security.views import (
     create_notice,
+    delete_notice,
     notice,
     notices,
     notices_feed,
@@ -193,6 +194,11 @@ app.add_url_rule(
 app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
 app.add_url_rule(
     "/security/notices/<notice_id>", view_func=update_notice, methods=["PUT"]
+)
+app.add_url_rule(
+    "/security/notices/<notice_id>",
+    view_func=delete_notice,
+    methods=["DELETE"],
 )
 
 app.add_url_rule("/security/notices/<feed_type>.xml", view_func=notices_feed)

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -283,6 +283,25 @@ def update_notice(notice_id):
     return flask.jsonify({"message": "Notice updated"}), 200
 
 
+@authorization_required
+def delete_notice(notice_id):
+    """
+    DELETE method to delete a single notice
+    """
+    notice = db_session.query(Notice).get(notice_id)
+
+    if not notice:
+        return (
+            flask.jsonify({"message": f"Notice {notice_id} doesn't exist"}),
+            404,
+        )
+
+    db_session.delete(notice)
+    db_session.commit()
+
+    return flask.jsonify({"message": f"Notice {notice_id} deleted"}), 200
+
+
 # CVE views
 # ===
 def cve_index():


### PR DESCRIPTION
## Done
Adds an endpoint to delete security notices.

## QA

- Check out this feature branch
- `docker-compose up -d`
-  Run the site using the command `./run serve` or `dotrun`
- Browse http://0.0.0.0:8001/security/notices and pick a notice.
- `dotrun exec ./scripts/delete-usns.py <ID>`
- Go back to `/security/notices` and make sure the notice was deleted.


## Issue / Card

https://github.com/canonical-web-and-design/web-squad/issues/2910