### PR TITLE
Remove 'CVE-' prefix from CVE links in notice page

### DIFF
--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -83,7 +83,7 @@
       <ul class="p-list">
         {% if notice.cves %}
           {% for cve in notice.cves %}
-            <li class="p-list__item"><a href="https://people.canonical.com/~ubuntu-security/cve/CVE-{{ cve.id }}">CVE-{{ cve.id }}</a></li>
+            <li class="p-list__item"><a href="https://people.canonical.com/~ubuntu-security/cve/{{ cve.id }}">{{ cve.id }}</a></li>
           {% endfor %}
         {% endif %}
 


### PR DESCRIPTION
## Done
Remove the `CVE-` prefix from links to CVE pages.

## QA

- Check out this feature branch
- docker-compose up -d
- Run the site using the command `./run serve` or `dotrun`
- Go to http://0.0.0.0:8001/security/notices and then select one of the notices and make sure cve links look good