### PR TITLE
Fix cve search

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -60,7 +60,14 @@
     {% if query or package or priority %}
     <h2>
       {% if total_results > 1 %}
-      {{ offset + 1 }} &ndash; {{ offset + limit  }} of
+        {{ offset + 1 }}
+        &ndash;
+        {% if offset + limit > total_results %}
+          {{ total_results }}
+        {% else %}
+          {{ offset + limit }}
+        {% endif %}
+        of
       {% endif %}
       {{ total_results }} result{% if total_results != 1 %}s{% endif %}
     </h2>

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -76,6 +76,7 @@
     {% endif %}
   </div>
 
+  {% if total_results > 0 %}
   <div class="u-fixed-width">
     <table class="cve-table">
       <thead>
@@ -96,10 +97,10 @@
       </thead>
       <tbody>
         {% for cve in cves %}
-          {% for package_name, statuses in cve.active_status_tree.items() %}
+          {% for package_name, statuses in cve.status_tree.items() %}
             <tr>
               {% if loop.index == 1 %}
-                <td rowspan="{{ cve.active_status_tree | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
+                <td rowspan="{{ cve.status_tree | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
               {% endif %}
               <td>{{ package_name }}</td>
               {% for release in releases %}
@@ -181,6 +182,7 @@
     {% include "security/cve/_pagination.html" %}
     {% endwith %}
   </div>
+  {% endif %}
 </section>
 
 <script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>


### PR DESCRIPTION
## Done

- Hide CVE table if no search results
- Fix total results count on last page of results

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Search with part of a CVE ID e.g. `CVE-2020`
- Check that the results count matches the displayed results e.g 1 - 3 or 3 results rather than 1 - 20 or 3 results

## Issue / Card

Fixes #7785