### PR TITLE
hide free subscription instructions in dropdown

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -493,6 +493,35 @@ summary {
   }
 }
 
+.p-contextual-menu--advantage {
+  .p-table--advantage {
+    margin: 0 auto;
+  }
+
+  .p-contextual-menu__toggle {
+    margin-bottom: -1px;
+
+    &[aria-expanded="true"] {
+      border-bottom-color: $color-x-light;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      border-left-color: $color-mid-light;
+      border-right-color: $color-mid-light;
+      border-top-color: $color-mid-light;
+      position: relative;
+      z-index: 11;
+
+      .p-icon--contextual-menu {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  .p-contextual-menu__dropdown {
+    box-shadow: none;
+  }
+}
+
 .u-arrow-up {
   overflow: visible;
   position: relative;

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -355,16 +355,23 @@
       <div class="col-12 u-hide--small">
         <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply). And if you’re a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it’s free on up to 50 machines.</p>      <p>Initially, this free subscription is available for Ubuntu 14.04 LTS only.</p>
 
-        <table style="width: auto;">
-          <tr style="border: 0;">
-            <td class="u-align--right">To attach a machine:</td>
-            <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua attach {{ personal_account.free_token }}</code></pre></td>
-          </tr>
-          <tr style="border: 0;">
-            <td class="u-align--right">To check status:</td>
-            <td><pre style="border: 0; padding: 0;" class="u-no-margin--bottom"><code>sudo ua status</code></pre></td>
-          </tr>
-        </table>
+        <span class="p-contextual-menu--left p-contextual-menu--advantage">
+          <a href="#" class="p-contextual-menu__toggle p-button--neutral" data-trigger="click" aria-controls="#free-sub" aria-expanded="false" aria-haspopup="true">Get your free token&nbsp;<i class="p-icon--contextual-menu">Open</i></a>
+          <span class="p-contextual-menu__dropdown p-table-expanding__panel" id="free-sub" aria-hidden="true" style="max-width: 70vw; padding: 1rem; width: 1170px; z-index: 10;">
+            <span class="p-contextual-menu__group">
+              <table class="p-table--advantage" style="width: auto;">
+                <tr style="border: 0;">
+                  <td class="u-align--right">To attach a machine:</td>
+                  <td class="u-no-padding--left"><code class="u-no-margin--left">sudo ua attach {{ personal_account.free_token }}</code></td>
+                </tr>
+                <tr style="border: 0;">
+                  <td class="u-align--right">To check status:</td>
+                  <td class="u-no-padding--left"><code class="u-no-margin--left">sudo ua status</code></td>
+                </tr>
+              </table>
+            </span>
+          </span>
+        </span>
       </div>
 
       <div class="col-12 u-hide--medium u-hide--large">


### PR DESCRIPTION
## Done

- added commands for attaching free subscription to a dropdown/tooltip

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Sign in with SSO
- See that "Your free subscription" has a CTA that opens a dropdown/tooltip with instructions on attaching machines.


## Issue / Card

Fixes #6086 

## Screenshots

![newdropdownFINALv3_FINAL](https://user-images.githubusercontent.com/2376968/85300913-13033b00-b49f-11ea-97c9-ccd1dc1fcb6b.gif)

