### PR TITLE
Validate notice ID matches expected pattern

### DIFF
--- a/scripts/create-usns.py
+++ b/scripts/create-usns.py
@@ -72,7 +72,6 @@ if os.path.exists(client.cookies.filename):
     client.cookies.load(ignore_discard=True)
 
 notice_endpoint = f"{args.host}/security/notices"
-
 http_method = "PUT" if args.update else "POST"
 
 # Make a first call to make sure we are logged in
@@ -121,11 +120,16 @@ with open(args.file_path) as usn_json:
             else:
                 references.append(reference)
 
+        # Build endpoint
+        endpoint = notice_endpoint
+        if http_method == "PUT"
+            endpoint = f"{notice_endpoint}/{notice['id']}"
+
         response = client.request(
             http_method,
-            url=notice_endpoint,
+            url=endpoint,
             json={
-                "id": notice["id"],
+                "id": f"USN-{notice['id']}",
                 "description": notice["description"],
                 "references": references,
                 "cves": cves,

--- a/scripts/create-usns.py
+++ b/scripts/create-usns.py
@@ -122,7 +122,7 @@ with open(args.file_path) as usn_json:
 
         # Build endpoint
         endpoint = notice_endpoint
-        if http_method == "PUT"
+        if http_method == "PUT":
             endpoint = f"{notice_endpoint}/{notice['id']}"
 
         response = client.request(

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -56,7 +56,7 @@ class NoticePackage(Schema):
 
 
 class NoticeSchema(Schema):
-    id = String(required=True)
+    id = String(required=True, validate=Regexp(r"USN-\d{4}-\d{1,2}"))
     title = String(required=True)
     summary = String(required=True)
     instructions = String(required=True)


### PR DESCRIPTION
## Done

Validate that notice ID's match `r"USN-\d{4}-\d{1,2}"`.
Also update the `create-usns.py` script to post `USN-` prefixed ID's.

## QA

- Check out this feature branch
- docker-compose up -d
- `dotrun` or `./run`
- `dotrun exec ./scripts/create-usns.py database.json` let it create a couple notices and `CTRL-C`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices and see notices are prefixed.
