### PR TITLE
Add missing links to security notices index page

### DIFF
--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -15,8 +15,8 @@
   <div class="row">
     <div class="col-8">
       {% if not search %}
-      <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="#">official Ubuntu package</a>.</p>
-      <p>To report a security vulnerability in an Ubuntu package, please <a href="#">contact the Security Team</a>.</p>
+      <p>Developers issue an Ubuntu Security Notice when a security issue is fixed in an <a href="https://packages.ubuntu.com">official Ubuntu package</a>.</p>
+      <p>To report a security vulnerability in an Ubuntu package, please <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Contact">contact the Security Team</a>.</p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7808

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check the links now point to the URL's specified on the issue.
