### PR TITLE
Avoid displaying duplicate package descriptions

### DIFF
--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -27,13 +27,13 @@
     </div>
   </div>
 
-  {% if notice.packages %}
+  {% if notice.package_descriptions %}
   <div class="row">
     <div class="col-12">
       <h2>Packages</h2>
       <ul class="p-list">
-        {% for package in notice.packages %}
-          <li class="p-list__item">{{ package.name }} - {{ package.description }}</li>
+        {% for package_description in notice.package_descriptions %}
+          <li class="p-list__item">{{ package_description }}</li>
         {% endfor %}
       </ul>
     </div>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -33,7 +33,7 @@ def notice(notice_id):
     if not notice:
         flask.abort(404)
 
-    packages = []
+    package_descriptions = set()
     release_packages = SortedDict()
 
     if notice.release_packages:
@@ -48,15 +48,14 @@ def notice(notice_id):
             release_packages[release_version] = []
             for package in pkgs:
                 if package["is_source"]:
-                    packages.append(package)
+                    package_descriptions.add(
+                        f"{package['name']} - {package['description']}"
+                    )
                 else:
                     release_packages[release_version].append(package)
 
             # Order packages for release by the name key
             release_packages[release_version].sort(key=lambda pkg: pkg["name"])
-
-    # Order source packages by the name key
-    packages.sort(key=lambda pkg: pkg["name"])
 
     notice = {
         "id": notice.id,
@@ -65,7 +64,7 @@ def notice(notice_id):
         "summary": notice.summary,
         "details": markdown_parser(notice.details),
         "instructions": markdown_parser(notice.instructions),
-        "packages": packages,
+        "package_descriptions": sorted(package_descriptions),
         "release_packages": release_packages,
         "releases": notice.releases,
         "cves": notice.cves,


### PR DESCRIPTION
## Done
Remove duplicate package descriptions from the `Packages` section in notice detail page.

## QA

- Check out this feature branch
- `docker-compose up -d`
- `wget https://people.canonical.com/~ubuntu-security/usn/database.json`
- `jq '."4401-1" | { (.id): .}' database.json > /tmp/4401-1.json`
- `dotrun exec ./scripts/create-releases.py`
- `dotrun exec ./scripts/create-usns.py /tmp/4401-1.json`
- Run the site using the command `./run serve` or `dotrun`
- See the duplicates in https://ubuntu.com/security/notices/USN-4401-1
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices/USN-4401-1 and make sure it displays no duplicates.
