### PR TITLE
"Set up" not "Setup"

### DIFF
--- a/templates/download/iot/_setup-ubuntu-sso.html
+++ b/templates/download/iot/_setup-ubuntu-sso.html
@@ -1,6 +1,6 @@
 <li class="p-stepped-list__item ">
   <h3 class="p-stepped-list__title">
-    Setup an Ubuntu SSO account
+    Set up an Ubuntu SSO account
   </h3>
   <div class="p-stepped-list__content">
     <p>An Ubuntu SSO account is required to create the first user on an Ubuntu Core installation.</p>


### PR DESCRIPTION
"Setup" is a noun, "set up" is a verb

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)