### PR TITLE
Add kubernetes event takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1063,6 +1063,13 @@
       type="webinar" %}
         {% include "engage/_article-card.html" %}
       {% endwith %}
+
+      {% with title="Kubernetes from Cloud to Edge",
+      description="On 31 July, learn how to streamline your Kubernetes deployment and operations from Canonical's experts.",
+      slug="kubernetes-event-us",
+      type="webinar" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
     </div>
 
 </section>

--- a/templates/engage/kubernetes-event-us.md
+++ b/templates/engage/kubernetes-event-us.md
@@ -31,7 +31,7 @@ context:
 wanting to learn more about how to overcome common Kubernetes challenges in a variety of contexts, and the most efficient solutions for executing their Kubernetes strategy.
 
 **What you will learn**: Best tools and strategies for streamlining your Kubernetes deployment and operations from public cloud, to containers, and even lightweight devices. We will also discuss the Kubernetes portfolio of Canonical and Ubuntu, and how its main components - MicroK8s and Charmed Kubernetes - can contribute to the flexibility you need deployment at every stage of your container DevOps cycle.
-
+## Speakers:
 <div class="p-media-object--large">
   {{
     image(

--- a/templates/engage/kubernetes-event-us.md
+++ b/templates/engage/kubernetes-event-us.md
@@ -1,0 +1,87 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Kubernetes from Cloud to Edge: A Virtual Event"
+  meta_description: "From public cloud, to containers, and even lightweight devices, discover strategies for optimising your Kubernetes deployment and operations. Join us live on 31 July 2020."
+  meta_image: https://assets.ubuntu.com/v1/5098807a-85410502-1a8a1900-b55f-11ea-9e1a-e5edf86735e7.jpg
+  meta_copydoc: https://docs.google.com/document/d/1LClShZkNAZYCHhXah452SEFYdwetyPstodwRL0Y9ZV8/edit
+  header_title: "Kubernetes from Cloud to Edge"
+  header_subtitle: "On 31 July, learn how to streamline your Kubernetes deployment and operations from Canonical's experts."
+  header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
+  header_image_width: "419"
+  header_image_height: "172"
+  header_url: "https://www.brighttalk.com/webcast/6793/421884?utm_source=Canonical&utm_medium=brighttalk&utm_campaign=421884"
+  header_cta: Register now
+  header_cta_class: p-button--positive
+  header_cta_all_sizes: true
+  header_class: p-engage-banner--dark
+  header_lang: en-us
+  webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 421884, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+## About the event
+
+**Date and time**
+31 July, 2020
+[2:30-4:30pm CT]
+
+**What it is**: A live, interactive virtual workshop with Canonical’s Kubernetes experts. This will include a presentation from our speakers, panel discussion incorporating live comments and questions from the audience, and free Kubernetes resources and demos to help you achieve your technology goals.
+
+**Who should attend**: Developers and enterprise IT teams
+wanting to learn more about how to overcome common Kubernetes challenges in a variety of contexts, and the most efficient solutions for executing their Kubernetes strategy.
+
+**What you will learn**: Best tools and strategies for streamlining your Kubernetes deployment and operations from public cloud, to containers, and even lightweight devices. We will also discuss the Kubernetes portfolio of Canonical and Ubuntu, and how its main components - MicroK8s and Charmed Kubernetes - can contribute to the flexibility you need deployment at every stage of your container DevOps cycle.
+
+<div class="p-media-object--large">
+  {{
+    image(
+      url="https://assets.ubuntu.com/v1/f1e6db5b-iatrou.jpeg",
+      alt="",
+      height="150",
+      width="150",
+      hi_def=True,
+      attrs={"class": "p-media-object__image"},
+      loading="lazy",
+    ) | safe
+  }}
+  <div class="p-media-object__details">
+    <h3 class="u-no-margin--bottom">Michael Iatrou</h3>
+    <p>Director Field Engineering (Americas)</p>
+  </div>
+</div>
+
+<div class="p-media-object--large">
+  {{
+    image(
+      url="https://assets.ubuntu.com/v1/bc82288c-tim.jpeg",
+      alt="",
+      height="150",
+      width="150",
+      hi_def=True,
+      attrs={"class": "p-media-object__image"},
+      loading="lazy",
+    ) | safe
+  }}
+  <div class="p-media-object__details">
+    <h3 class="u-no-margin--bottom">Tim van Steenberg</h3>
+    <p>Engineering Manager (Kubernetes)</p>
+  </div>
+</div>
+
+<div class="p-media-object--large">
+  {{
+    image(
+      url="https://assets.ubuntu.com/v1/71ebf5e1-sohini.jpg",
+      alt="",
+      height="150",
+      width="150",
+      hi_def=True,
+      attrs={"class": "p-media-object__image"},
+      loading="lazy",
+    ) | safe
+  }}
+  <div class="p-media-object__details">
+    <h3 class="u-no-margin--bottom">Sohini Roy</h3>
+    <p>Product Manager</p>
+  </div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
   {% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
   {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_ubuntu-pro-intro.html" %}
+  {% include "takeovers/_us-kubernetes-event.html" %}
 
   {# FRENCH #}
   {% include "takeovers/_cio-guide-to-multipass-fr.html" %}

--- a/templates/takeovers/_us-kubernetes-event.html
+++ b/templates/takeovers/_us-kubernetes-event.html
@@ -1,0 +1,14 @@
+{% with title="Kubernetes From<br> Cloud to Edge",
+subtitle="A virtual workshop for US enterprises and developers. Join live on July 31st.",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg",
+image_style="width: 419px;",
+image_hide_small="true",
+primary_url="/engage/kubernetes-event-us?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020",
+primary_cta="Register now",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="en" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -148,4 +148,6 @@
 {% include "takeovers/_2004-migration-takeover.html" %}
 <p>16th June 2020</p>
 {% include "takeovers/_ubuntu-pro-intro.html" %}
+<p>24th June 2020</p>
+{% include "takeovers/_us-kubernetes-event.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Add takeover and engage page for US k8s event

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Reload the page until you see the "Kubernetes From Cloud to Edge" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/18vsAl7oYtIJSSPuuMJUXipgUn9ZjveWt7F9B5rGS87o/edit#gid=2113339190)
- Click through to the engage page and check that it matches [the brief](https://docs.google.com/spreadsheets/d/18vsAl7oYtIJSSPuuMJUXipgUn9ZjveWt7F9B5rGS87o/edit#gid=1271849439) and [the copy doc](https://docs.google.com/document/d/1LClShZkNAZYCHhXah452SEFYdwetyPstodwRL0Y9ZV8/edit)

## Issue / Card

Fixes #7818 

## Screenshots
![screencapture-localhost-8001-engage-kubernetes-event-us-1592990056616](https://user-images.githubusercontent.com/501889/85528298-9ccc1900-b603-11ea-9ef2-b7bcf535dfee.png)
