### PR TITLE
Add endpoint to post advantage subscriptions

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,6 +42,7 @@ from webapp.views import (
     download_thank_you,
     appliance_install,
     get_renewal,
+    post_advantage_subscriptions,
     post_customer_info,
     post_stripe_invoice_id,
     post_build,
@@ -140,6 +141,11 @@ def utility_processor():
 
 # Simple routes
 app.add_url_rule("/advantage", view_func=advantage_view)
+app.add_url_rule(
+    "/advantage/subscribe",
+    view_func=post_advantage_subscriptions,
+    methods=["POST"],
+)
 app.add_url_rule(
     "/advantage/customer-info", view_func=post_customer_info, methods=["POST"]
 )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -498,6 +498,24 @@ def advantage_view():
     )
 
 
+def post_advantage_subscriptions():
+    # 500 if 'error' arg is provided
+    if flask.request.args.get("error"):
+        return flask.jsonify({}), 500
+
+    payload = flask.request.json
+    if not payload:
+        return flask.jsonify({}), 400
+
+    customer_id = payload.get("customer_id")
+    products = payload.get("products")
+
+    if not customer_id or not products:
+        return flask.jsonify({}), 400
+
+    return flask.jsonify({}), 200
+
+
 def make_renewal(advantage, contract_info):
     """Return the renewal as present in the given info, or None."""
     renewals = contract_info.get("renewals")


### PR DESCRIPTION
## Done

Adds the endpoint to post advantage subscriptions.
For now it's just a dummy endpoint to speed up frontend work.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- curl -X POST --header "Content-Type: application/json"   --data '{"customer_id":"xyz","products":"xyz"}' `http://0.0.0.0:8001/advantage/subscribe`


## Issue / Card

Fixes #
