### PR TITLE
Update colors on CVE tables

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -39,8 +39,7 @@
   .cve-color-strip {
     border-bottom-style: solid;
     border-bottom-width: 3px;
-    margin-left: 0.25rem;
-    margin-right: 0.25rem;
+    left: 0.25rem;
     position: absolute;
     top: -1px;
     width: calc(100% - 0.5rem);

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -12,22 +12,44 @@
     color: $color-x-light;
   }
 
+  .cve-table thead tr {
+    border-bottom: 0;
+  }
+
+  .cve-table tbody tr {
+    border-top: 0;
+  }
+
   .cve-table td {
+    border-top: 1px solid $color-mid-light;
     position: relative;
+  }
+
+  .cve-table .cve-table-cell {
+    border-top: 0;
+    overflow: visible;
+  }
+
+  .cve-table-cell--muted {
+    @extend .cve-table-cell;
+
+    color: $color-mid-dark;
   }
 
   .cve-color-strip {
     border-bottom-style: solid;
     border-bottom-width: 3px;
-    top: 0;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
     position: absolute;
-    width: 100%;
+    top: -1px;
+    width: calc(100% - 0.5rem);
   }
 
   .cve-color-strip--dne {
     @extend .cve-color-strip;
 
-    border-bottom-color: #666;
+    border-bottom-color: $color-mid-light;
   }
 
   .cve-color-strip--needs-triage {
@@ -39,7 +61,7 @@
   .cve-color-strip--not-affected {
     @extend .cve-color-strip;
 
-    border-bottom-color: #e6ab02;
+    border-bottom-color: $color-mid-light;
   }
 
   .cve-color-strip--needed {

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -28,6 +28,7 @@
   .cve-table .cve-table-cell {
     border-top: 0;
     overflow: visible;
+    padding-left: 0.75rem;
   }
 
   .cve-table-cell--muted {
@@ -39,7 +40,7 @@
   .cve-color-strip {
     border-bottom-style: solid;
     border-bottom-width: 3px;
-    left: 0.25rem;
+    left: 0.5rem;
     position: absolute;
     top: -1px;
     width: calc(100% - 0.5rem);

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -147,7 +147,13 @@
                         Ubuntu {{ release.version }} {{ release.support_tag }} ({{ release.name }})
                       {% endif %}
                     </td>
-                    <td>
+                    {% if release.codename in statuses %}
+                        {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
+                          <td class="cve-table-cell--muted">
+                        {% else %}
+                          <td class="cve-table-cell">
+                        {% endif %}
+                      {% endif %}
                       {% if release.codename in statuses %}
                         {% if statuses[release.codename].status == "DNE" %}
                           Does not exist

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -104,7 +104,13 @@
               {% endif %}
               <td>{{ package_name }}</td>
               {% for release in releases %}
-                <td>
+                {% if release.codename in statuses %}
+                  {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
+                    <td class="cve-table-cell--muted">
+                  {% else %}
+                    <td class="cve-table-cell">
+                  {% endif %}
+                {% endif %}
                 {% if release.codename in statuses %}
                   {% if statuses[release.codename].status == "DNE" %}
                     <div class="cve-color-strip--dne"></div>


### PR DESCRIPTION
## Done

Updated the visual design of the CVE tables to make them easier to understand

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Check that the table matches the screenshots
- Click through to a CVE and check that the table matches the screenshots

More context on the design: https://github.com/canonical-web-and-design/web-squad/issues/2913#issuecomment-648907977

## Issue / Card

Fixes #7825

## Screenshots

### CVE page
![cve_page](https://user-images.githubusercontent.com/501889/85690622-a91ba900-b6cb-11ea-82e7-a29fa1f16d91.png)

### CVE list
![cve_list](https://user-images.githubusercontent.com/501889/85690627-aae56c80-b6cb-11ea-94e6-7fdc96fa9817.png)

