### PR TITLE
Only get UTMs from localstorage when they are present

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -165,7 +165,7 @@ function addUTMToForms() {
   for (let i = 0; i < utm_names.length; i++) {
     var utm_fields = document.getElementsByName("utm_" + utm_names[i]);
     for (let j = 0; j < utm_fields.length; j++) {
-      if (utm_fields[j]) {
+      if (utm_fields[j] && localStorage.getItem("utm_" + utm_names[i])) {
         utm_fields[j].value = localStorage.getItem("utm_" + utm_names[i]);
       }
     }


### PR DESCRIPTION
## Done

- Only get UTMs from localstorage when they are present
- This allows a fallback on URL params as opposed to an empty value when localstorage is not available (eg. some mobile webviews don't enable it, causing a lack of form/campaign attribution)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /engage/vmware-to-charmed-openstack?utm_source=foobar
- Ensure your local storage contains that value
- Empty and disable localstorage for that domain in your browser
- Go back to the page, ensure the form source contains the `utm_source` field with the expected value
