### PR TITLE
Link /public-cloud main CTA to the right contact form

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -10,7 +10,7 @@
     <div class="col-8">
       <h1>Ubuntu on public clouds</h1>
       <p>Ubuntu is the world&rsquo;s most popular cloud operating system across public clouds. Thanks to its security, versatility and policy of regular updates, Ubuntu is the leading cloud guest OS and the only free cloud operating system with the option of enterprise-grade commercial support.</p>
-      <p><a class="p-button--positive" href="/openstack/managed#get-in-touch">Contact us</a></p>
+      <p><a class="p-button--positive" href="#get-in-touch">Contact us</a></p>
     </div>
   </div>
 </section>

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -10,7 +10,7 @@
     <div class="col-8">
       <h1>Ubuntu on public clouds</h1>
       <p>Ubuntu is the world&rsquo;s most popular cloud operating system across public clouds. Thanks to its security, versatility and policy of regular updates, Ubuntu is the leading cloud guest OS and the only free cloud operating system with the option of enterprise-grade commercial support.</p>
-      <p><a class="p-button--positive" href="#get-in-touch">Contact us</a></p>
+      <p><a class="p-button--positive js-invoke-modal" href="/openstack/managed">Contact us</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- On /public-cloud, the Get in touch CTA is currently linking to the wrong contact form. Since we don't have a public-cloud specific one, this fallbacks to the generic form.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the /public-cloud "Get in touch" CTA keeps you on the page and shows a generic modal contact form as opposed to an OpenStack one.
