### PR TITLE
Fix the endpoint to update notices

### DIFF
--- a/scripts/create-usns.py
+++ b/scripts/create-usns.py
@@ -123,7 +123,7 @@ with open(args.file_path) as usn_json:
         # Build endpoint
         endpoint = notice_endpoint
         if http_method == "PUT":
-            endpoint = f"{notice_endpoint}/{notice['id']}"
+            endpoint = f"{notice_endpoint}/USN-{notice['id']}"
 
         response = client.request(
             http_method,

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -253,25 +253,27 @@ def update_notice(notice_id):
     """
     PUT method to update a single notice
     """
+    notice = db_session.query(Notice).get(notice_id)
+
+    if not notice:
+        return (
+            flask.jsonify({"message": f"Notice {notice_id} doesn't exist"}),
+            404,
+        )
+
+    notice_schema = NoticeSchema()
+    notice_schema.context["release_codenames"] = [
+        rel.codename for rel in db_session.query(Release).all()
+    ]
 
     try:
-        notice_data = NoticeSchema().load(flask.request.json, unknown=EXCLUDE)
+        notice_data = notice_schema.load(flask.request.json, unknown=EXCLUDE)
     except ValidationError as error:
         return (
             flask.jsonify(
                 {"message": "Invalid payload", "errors": error.messages}
             ),
             400,
-        )
-
-    notice = db_session.query(Notice).get(notice_id)
-
-    if not notice:
-        return (
-            flask.jsonify(
-                {"message": f"Notice {notice_data['notice_id']} doesn't exist"}
-            ),
-            404,
         )
 
     notice = _update_notice_object(notice, notice_data)


### PR DESCRIPTION
## Done
Adds `release_codenames` to `NoticeSchema` context on the update endpoint.

## QA
- Check out this feature branch
- `docker-compose up -d`
- `jq '."4147-1" | { (.id): .}' database.json > 4147-1.json`
- Run the site using the command `./run serve` or `dotrun`
- `dotrun exec ./scripts/create-usns.py 4147-1.json` should return a `200`
- Browse http://localhost:8001/securtity/notices/USN-4147-1
- Change the `title` value in `4147-1.json`
- `dotrun exec ./scripts/create-usns.py --update 4147-1.json` should return a `200`
- Browse http://localhost:8001/security/notices/USN-4147-1 and see the updated title.
