### PR TITLE
Move FIPS and CC-EAL2 and CIS under under a Certifications column

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -297,27 +297,26 @@
                         </div>
                       </td>
                       <td id="expanded-row-certifications-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-                        <div class="row">
-                          <div class="col-8 col-start-small-1 col-start-medium-2 col-start-large-4">
-                            <p class="u-no-margin--bottom"><strong>FIPS 140-2</strong> Level 1 certified packages use older software versions.</p>
-                            <p>Use them only if your organisation requires it.</p>
-                            <ul class="p-list" style="padding-left: 2rem;">
-                              <li>Available on: Ubuntu 16.04 LTS, 18.04 LTS</li>
-                              <li>To activate FIPS: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/fips">FIPS setup instructions</a></li>
-                            </ul>
-
-                            <p class="u-no-margin--bottom"><strong>CC-EAL2</strong> certified packages use older software versions.</p>
-                            <p>Use them only if your organisation requires it.</p>
-                            <ul class="p-list" style="padding-left: 2rem;">
-                              <li>Available on: Ubuntu 16.04 LTS</li>
-                              <li>To activate CC-EAL2: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cc-16/">CC-EAL2 setup instructions</a></li>
-                            </ul>
+                        <div class="row" >
+                          <div class="col-12" style="text-align: center;">
+                            <div  style="display: inline-block; text-align: left;">
+                            <strong>FIPS 140-2</strong> Level 1 certified packages use older software versions.<br />
+                            Use them only if your organisation requires it.<br /><br />
                             
-                            <p><strong>CIS tools</strong> test compliance with the CIS security benchmark.</p>
-                            <ul class="p-list" style="padding-left: 2rem;">
-                              <li>Available on: Ubuntu 16.04 LTS, 18.04 LTS</li>
-                              <li>To use the tools: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cis-18-16.html">CIS setup instructions</a></li>
-                            </ul>
+                            Available on: Ubuntu 16.04 LTS, 18.04 LTS<br />
+                            To activate FIPS: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/fips">FIPS setup instructions</a><br /><br />
+                            
+                            <strong>CC-EAL2</strong> certified packages use older software versions<br />
+                            Use them only if your organisation requires it.<br /><br />
+                            
+                            Available on: Ubuntu 16.04 LTS<br />
+                            To activate CC-EAL2: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cc-16/">CC-EAL2 setup instructions</a><br /><br />
+                            
+                            <strong>CIS tools</strong> test compliance with the CIS security benchmark.<br /><br />
+
+                            Available on: Ubuntu 16.04 LTS, 18.04 LTS<br />
+                            To use the tools: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cis-18-16.html">CIS setup instructions</a>
+                          </div>
                           </div>
                         </div>
                       </td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -69,8 +69,7 @@
                   <th class="u-align--center">Attached</th>
                   <th class="u-align--center">ESM</th>
                   <th class="u-align--center">Livepatch</th>
-                  <th class="u-align--center">FIPS</th>
-                  <th class="u-align--center">CC-EAL</th>
+                  <th class="u-align--center">Certifications</th>
                   <th class="u-hide">&nbsp;</th>
                   <th class="u-hide">&nbsp;</th>
                   <th class="u-hide">&nbsp;</th>
@@ -131,24 +130,14 @@
                         {% endif %}
                       </td>
                       <td class="u-align--center">
-                        {% if contract['entitlements']['fips']  == True %}
-                        <button class="u-toggle" aria-controls="#expanded-row-fips-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+                        {% if contract['entitlements']['fips']  == True or contract['entitlements']['cc-eal']  == True %}
+                        <button class="u-toggle" aria-controls="#expanded-row-certifications-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
                           <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
                         <span style="padding-top: 0.35rem;">N/A</span>
                         {% endif %}
                       </td>
-                      <td class="u-align--center">
-                        {% if contract['entitlements']['cc-eal']  == True %}
-                        <button class="u-toggle" aria-controls="#expanded-row-cc-eal-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                          <span class="u-truncate"><i class="p-icon--success"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
-                        </button>
-                        {% else %}
-                        <span style="padding-top: 0.35rem;">N/A</span>
-                        {% endif %}
-                      </td>
-
                       <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
                         <div class="row">
                           <div class="col-12 u-align--center">
@@ -307,31 +296,28 @@
                           </div>
                         </div>
                       </td>
-                      <td id="expanded-row-fips-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
+                      <td id="expanded-row-certifications-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
                         <div class="row">
-                          <div class="col-12">
-                            <div class="p-notification--caution">
-                              <p class="p-notification__response">
-                                Older versions of software are used for FIPS-certified packages. Use them only if your organisation requires it.
-                              </p>
-                            </div>
-                          </div>
-                          <div class="col-12 u-align--center">
-                            To activate FIPS: <code>sudo ua enable fips</code>
-                          </div>
-                        </div>
-                      </td>
-                      <td id="expanded-row-cc-eal-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
-                        <div class="row">
-                          <div class="col-12">
-                            <div class="p-notification--caution">
-                              <p class="p-notification__response">
-                                Older versions of software are used for CC-EAL-certified packages. Use them only if your organisation requires it.
-                              </p>
-                            </div>
-                          </div>
-                          <div class="col-12 u-align--center">
-                            To activate CC-EAL: <code>sudo ua enable cc-eal</code>
+                          <div class="col-8 col-start-small-1 col-start-medium-2 col-start-large-4">
+                            <p class="u-no-margin--bottom"><strong>FIPS 140-2</strong> Level 1 certified packages use older software versions.</p>
+                            <p>Use them only if your organisation requires it.</p>
+                            <ul class="p-list" style="padding-left: 2rem;">
+                              <li>Available on: Ubuntu 16.04 LTS, 18.04 LTS</li>
+                              <li>To activate FIPS: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/fips">FIPS setup instructions</a></li>
+                            </ul>
+
+                            <p class="u-no-margin--bottom"><strong>CC-EAL2</strong> certified packages use older software versions.</p>
+                            <p>Use them only if your organisation requires it.</p>
+                            <ul class="p-list" style="padding-left: 2rem;">
+                              <li>Available on: Ubuntu 16.04 LTS</li>
+                              <li>To activate CC-EAL2: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cc-16/">CC-EAL2 setup instructions</a></li>
+                            </ul>
+                            
+                            <p><strong>CIS tools</strong> test compliance with the CIS security benchmark.</p>
+                            <ul class="p-list" style="padding-left: 2rem;">
+                              <li>Available on: Ubuntu 16.04 LTS, 18.04 LTS</li>
+                              <li>To use the tools: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cis-18-16.html">CIS setup instructions</a></li>
+                            </ul>
                           </div>
                         </div>
                       </td>


### PR DESCRIPTION
## Done
Move FIPS and CC-EAL2 and CIS under under a Certifications column

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Make sure there is a `Certifications` column on the contracts table and that when you expand it the content matches the [specification document](https://docs.google.com/document/d/1K65n3NpZCh7EWDXKLhG31seGJ2jKbW6lqw3BwV2mlnU/), including that we are linking to the right place



## Issue / Card
Fixes #6154
Fixes #6710