### PR TITLE
Add the AT&T Ubuntu Pro webinar

### DIFF
--- a/templates/engage/at&t-azure-webinar.html
+++ b/templates/engage/at&t-azure-webinar.html
@@ -1,0 +1,45 @@
+{% extends "engage/base_engage.html" %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://assets.ubuntu.com/v1/9ff56c03-86017215-adbdc580-ba1b-11ea-9759-1056b19b68a7.png">
+<meta property="og:image" content="https://assets.ubuntu.com/v1/9ff56c03-86017215-adbdc580-ba1b-11ea-9759-1056b19b68a7.png">
+{% endblock %}
+
+{% block title %}AT&T Private Offer on Azure - Ubuntu Pro + Support{% endblock %}
+{% block meta_description %}Learn about the numerous improvements and new features that enhance OpenStack with the Ussuri release{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1-JgNxLM2BU2EK64NYqtocC6qdERD1QtDvB73dUh8HaA/edit#{% endblock meta_copydoc %}
+
+
+{% block content %}
+{% with title="AT&T Private Offer on Azure - Ubuntu Pro + Support",
+  subtitle="Secure, Updated Ubuntu with 24x7 Support Special pricing and SLAs for AT&T",
+  url="#register-section",
+  cta="Register for the webinar",
+  class="p-strip p-engage-banner--grad",
+  header_image="https://assets.ubuntu.com/v1/18b8f2d6-ubuntu-at-t-azure.svg" %}
+  {% include "engage/shared/_header.html" %}
+{% endwith %}
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <p>
+        Every day, various groups at AT&T use open source innovation as part of their development and operations. Many have embraced Linux and are now adopting open source beyond the core platform, as evidenced by the widespread adoption of ecosystems like Python, Node.js and Go, and workloads like Kafka, Redis and Elasticsearch. Ubuntu is a preferred platform running on Azure to harness that innovation, and Canonical &mdash; the company behind Ubuntu &mdash; has created a private Ubuntu Pro offer for AT&T to get updated, supported Ubuntu with special pricing and custom SLAs for AT&T.
+      </p>
+      <p>
+        In this webinar, you’ll learn how AT&T and Canonical are partnering to ensure you can achieve more through open source software in a trusted way &mdash; with no compromises on security and support and with pricing that makes it easy and cost-effective to purchase Ubuntu Pro using your Azure subscriptions.  In addition to covering features of Ubuntu Pro such as Livepatch, Extended Security Maintenance and FIPS/Common Criteria, we’ll share our roadmap and joint vision for open source security and compliance in public clouds.  You will also learn the details of Canonical’s special offer to AT&T and instructions on how to purchase Ubuntu Pro with your Azure subscriptions.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow" id="register-section">
+  <div class="row" id="register-section">
+    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 417193, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1072,14 +1072,5 @@
       {% endwith %}
     </div>
 
-    <div class="row u-equal-height u-clearfix">
-      {% with title="AT&T Private Offer on Azure - Ubuntu Pro + Support",
-      description="Secure, Updated Ubuntu with 24x7 Support Special pricing and SLAs for AT&T",
-      slug="at&t-azure-webinar",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
-    </div>
-
 </section>
 {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1072,5 +1072,14 @@
       {% endwith %}
     </div>
 
+    <div class="row u-equal-height u-clearfix">
+      {% with title="AT&T Private Offer on Azure - Ubuntu Pro + Support",
+      description="Secure, Updated Ubuntu with 24x7 Support Special pricing and SLAs for AT&T",
+      slug="at&t-azure-webinar",
+      type="webinar" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
+    </div>
+
 </section>
 {% endblock content %}


### PR DESCRIPTION
## Done
Add the private AT&T Ubuntu Pro webinar

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/at&t-azure-webinar
- Check the content matches the [copy doc](https://docs.google.com/document/d/1-JgNxLM2BU2EK64NYqtocC6qdERD1QtDvB73dUh8HaA/edit)
- Check that the meta data is correct [from the doc](https://docs.google.com/spreadsheets/d/1vbSP1Lw2OX4BEzLHYS88TMT4XMZe9O5EiBYt00JEwhw/edit#gid=1271849439)
- Check it matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/2924)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7817

