### PR TITLE
Fix url for jaas.ai on enterprise mega menu

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -141,7 +141,7 @@
         <h4 class="p-muted-heading"><a href="/server">Data centre&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS - fast server provisioning</a></li>
-          <li class="p-list__item"><a href="https://jaas.ai.com" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
+          <li class="p-list__item"><a href="https://jass.ai" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
           <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
           <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -141,7 +141,7 @@
         <h4 class="p-muted-heading"><a href="/server">Data centre&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS - fast server provisioning</a></li>
-          <li class="p-list__item"><a href="https://jass.ai" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
+          <li class="p-list__item"><a href="https://jaas.ai" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
           <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
           <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>


### PR DESCRIPTION
## Done

- Fix url for jaas.ai on enterprise mega menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/#enterprise
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link to 'Multi cloud operations with Juju' now goes to https://jaas.ai not https://jaas.ai.com

