### PR TITLE
WIP: Dyanmic engage thank-you page for pdfs

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -108,7 +108,7 @@
       {% if form_include %}
         {% set form = "engage/shared/_" + form_include + "_engage_form.html" %}
 
-        {% with id = form_id, returnURL = form_return_url %}
+        {% with id = form_id, returnURL = form_return_url, resouce_name = title %}
           {% include form %}
         {% endwith %}
       {% else %}

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -54,10 +54,10 @@
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" class="mktoField" value="{{ id }}" type="hidden" aria-label="formid">
         <input name="formVid" class="mktoField" value="{{ id }}" type="hidden" aria-label="formVid">
-        <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="returnURL">
-        <input type="hidden" name="retURL" value="{{ returnURL }}" aria-label="retURL">
-        <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="return_url">
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" name="returnURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" aria-label="returnURL">
+        <input type="hidden" name="retURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" aria-label="retURL">
+        <input type="hidden" name="returnURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" aria-label="return_url">
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -62,9 +62,9 @@
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
-        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
+        <input type="hidden" name="retURL" aria-label="retURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -61,9 +61,9 @@
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
-        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
+        <input type="hidden" name="retURL" aria-label="retURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -51,8 +51,8 @@
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ id }}" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{ returnURL }}" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{% if ".pdf" in returnURL %}http://ubuntu.com/engage/thank-you?resource_name={{ resouce_name | urlencode }}&resource_url={{ returnURL | urlencode }}{% else %}{{ returnURL }}{% endif %}" />
   </fieldset>
 </form>

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -39,12 +39,18 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
+      {% if 'pages.ubuntu.com' in resource_url %}
       <p>
         <strong>{{ resource_name }}</strong> is now ready to download.
       </p>
       <p>
         <a class="p-button--positive" href="{{ resource_url }}">Download</a>
       </p>
+      {% else %}
+        <p>
+          Sorry, we do not recognise this download request.  Please let us know by <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
+        </p>
+      {% endif %}
     </div>
   </div>
 </section>

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -1,0 +1,52 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Engage download "{{ resource_name }}"{% endblock %}
+
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            alt="Ubuntu",
+            width="143",
+            height="32",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </a>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <div>
+        <h1>
+          Thank you
+        </h1>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <p>
+        <strong>{{ resource_name }}</strong> is now ready to download.
+      </p>
+      <p>
+        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -41,7 +41,7 @@
     <div class="col-8">
       {% if 'pages.ubuntu.com' in resource_url %}
       <p>
-        <strong>{{ resource_name }}</strong> is now ready to download.
+        "{{ resource_name }}" is now ready to download.
       </p>
       <p>
         <a class="p-button--positive" href="{{ resource_url }}">Download</a>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -120,6 +120,8 @@ def context():
         "product": flask.request.args.get("product", ""),
         "request": flask.request,
         "releases": releases(),
+        "resource_name": flask.request.args.get("resource_name", ""),
+        "resource_url": flask.request.args.get("resource_url", ""),
         "user_info": user_info(flask.session),
         "utm_campaign": flask.request.args.get("utm_campaign", ""),
         "utm_medium": flask.request.args.get("utm_medium", ""),


### PR DESCRIPTION
## Done

- Created a thank-you page for engage pages that allows a user to download resources more easily.
- Currrenly it:
    - sees that the return url has a '.pdf' in it
    - creates a return url for marketo that adds the pdf url and the title of the engage page
    - displays dynamic page at /engage/thank-you
- Basically it currently doesn't require us to update the engage pages to work

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/thank-you?resource_name=Solving%20the%20software%20update%20challenge%20for%20IoT%20devices&resource_url=https%3A//pages.ubuntu.com/rs/066-EOV-335/images/Over-the-air%2520software_12.05.20.pdf or start from http://0.0.0.0:8001/engage/snapd-whitepaper (note: you will have to change the url from https://ubuntu.com to http://0.0.0.0:8001)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7852

