### PR TITLE
Handle VAT validation error

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,8 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.canonical.com/
+CONTRACTS_API_URL=https://contracts.staging.canonical.com/
+STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/static/js/src/renewals/error-handler.js
+++ b/static/js/src/renewals/error-handler.js
@@ -44,9 +44,15 @@ const INCORRECT_NUMBER_CODES = [
   "incomplete_number",
 ];
 
+const INCORRECT_VAT_CODES = ["tax_id_invalid"];
+
 const INCORRECT_ZIP_CODES = ["incorrect_zip", "incomplete_zip"];
 
-const PAYMENT_ERRORS = ["invoice payment failed", "payment method error"];
+const PAYMENT_ERRORS = [
+  "invoice payment failed",
+  "payment method error",
+  "invalid customer information",
+];
 
 function customErrorResponse(errorData) {
   const code = errorData.code;
@@ -77,6 +83,10 @@ function customErrorResponse(errorData) {
     error.message =
       "That expiry date is incorrect. Check the date and try again.";
     error.type = "card";
+  } else if (INCORRECT_VAT_CODES.includes(code)) {
+    error.message =
+      "That VAT number is invalid. Check the number and try again.";
+    error.type = "notification";
   } else if (code === "card_not_supported") {
     error.message =
       "That card doesn’t allow this kind of payment. Please contact your card issuer, or try a different card.";

--- a/static/js/src/renewals/tests/error-handler.test.js
+++ b/static/js/src/renewals/tests/error-handler.test.js
@@ -112,4 +112,13 @@ describe("parseForErrorObject", () => {
       );
     });
   });
+
+  describe("given an invalid VAT number error", () => {
+    it("should return an appropriate error object", () => {
+      expect(parseForErrorObject(contractsErrorObjects.invalidVat)).toEqual({
+        message: "That VAT number is invalid. Check the number and try again.",
+        type: "notification",
+      });
+    });
+  });
 });

--- a/static/js/src/renewals/tests/fixtures/error-responses.js
+++ b/static/js/src/renewals/tests/fixtures/error-responses.js
@@ -62,6 +62,12 @@ export const contractsErrorObjects = {
       'unexpected error updating customer information: {"code":"card_declined","doc_url":"https://stripe.com/docs/error-codes/card-declined","status":402,"message":"Your card has insufficient funds.","request_id":"req_SYTeIg5nO6lWt1","type":"card_error"}',
     traceId: "8ebe2d2d-35ad-434a-bd24-d5aa14a7b390",
   },
+  invalidVat: {
+    code: "invalid customer information",
+    message:
+      '{"code":"tax_id_invalid","doc_url":"https://stripe.com/docs/error-codes/tax-id-invalid","status":400,"message":"Invalid value for eu_vat.","request_id":"req_7pf3OCHAAwYnLj","type":"invalid_request_error"}',
+    traceId: "296e07f4-bc89-4e17-9915-4642c407ca69",
+  },
   priceMismatch: {
     code: "renewal is blocked",
     message:

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -114,6 +114,10 @@
             </div>
 
             <div class="col-9 col-start-large-4">
+              <small>e.g. GB101111, CY99999999L</small>
+            </div>
+            
+            <div class="col-9 col-start-large-4">
               <span class="p-form-validation__message u-hide"></span>
             </div>
           </div>

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -61,16 +61,19 @@ class AdvantageContracts:
     def put_customer_info(
         self, account_id, payment_method_id, address, name, tax_id
     ):
-        response = self._request(
-            method="put",
-            path=f"v1/accounts/{account_id}/customer-info/stripe",
-            json={
-                "paymentMethodID": payment_method_id,
-                "address": address,
-                "name": name,
-                "taxID": tax_id,
-            },
-        )
+        try:
+            response = self._request(
+                method="put",
+                path=f"v1/accounts/{account_id}/customer-info/stripe",
+                json={
+                    "paymentMethodID": payment_method_id,
+                    "address": address,
+                    "name": name,
+                    "taxID": tax_id,
+                },
+            )
+        except HTTPError as http_error:
+            return http_error.response.json()
 
         return response.json()
 


### PR DESCRIPTION
## Done

Display a useful error to the user if they've submitted an invalid VAT number during a renewal purchase.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login with SSO
- If you don't have any contracts with renewals, ask Scott to set you up with one
- Open the row of the expiring contract, and click "Renew"
- Fill out the payment method form, using the following card details:
  - card number: 4000008260000000
  - expiry: 4/24
  - CVC: 123
  - postcode: SE1 0HS
- Select United Kingdom from the country dropdown
- Fill out the revealed VAT with an invalid number e.g. 12345
- Click "Continue"
- See that an error message mentioning the invalid VAT number is displayed
- Change the value in the VAT to GB003232247 and click "Continue" again
- See that you progress to the next step in the modal


## Issue / Card

Fixes #7854 
