### PR TITLE
move /advantage signout button to its own row

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -21,15 +21,16 @@
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})
-          <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral is-inline u-no-margin--bottom" onclick="dataLayer.push({
-            'event' : 'GAEvent',
-            'eventCategory' : 'Advantage',
-            'eventAction' : 'Authentication',
-            'eventLabel' : 'Sign out',
-            'eventValue' : undefined
-          });">Sign out</a>
-        </p>
+
+        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})</p>
+         
+        <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
+          'event' : 'GAEvent',
+          'eventCategory' : 'Advantage',
+          'eventAction' : 'Authentication',
+          'eventLabel' : 'Sign out',
+          'eventValue' : undefined
+        });">Sign out</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- moved sign out button on /advantage to its own row

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Sign in with SSO
- See the "Sign out" button is no longer in line with the "you are signed in as XYZ" text
- Resize the window, see that there is space between the button and the line above

## Issue / Card

Fixes #7831

## Screenshots

Old:
![Screenshot from 2020-07-01 15-02-39](https://user-images.githubusercontent.com/2376968/86258606-e643d780-bbb2-11ea-9059-2682bc69ae54.png)

![Screenshot from 2020-07-01 15-01-49](https://user-images.githubusercontent.com/2376968/86258521-d1674400-bbb2-11ea-8439-62bdf95c9e9f.png)

New:

![Screenshot from 2020-07-01 15-04-00](https://user-images.githubusercontent.com/2376968/86258581-dfb56000-bbb2-11ea-9dbe-88963a0b4606.png)



