### PR TITLE
Fixup Windows appliance instructions

### DIFF
--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -70,8 +70,9 @@
       <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
         {% include "appliance/shared/_install_instructions_intel-nuc.html" %}
         <ol class="p-stepped-list--detailed">
+          {% include 'appliance/shared/_steps_install_openssh_windows.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_windows.html' %}
-          {% with command='type' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_sso_windows.html' %}
           {% with os='windows' %}{% include 'appliance/shared/_steps_nuc_flash_usb.html' %}{% endwith %}
           {% include 'appliance/shared/_steps_nuc_install_appliance.html' %}
           {% include 'appliance/shared/_steps_nuc_first_boot.html' %}
@@ -83,7 +84,7 @@
         {% include "appliance/shared/_install_instructions_intel-nuc.html" %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_ssh-keys_macos.html' %}
-          {% with command='cat' %}{% include 'appliance/shared/_steps_sso.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_sso.html' %}
           {% with os='macos' %}{% include 'appliance/shared/_steps_nuc_flash_usb.html' %}{% endwith %}
           {% include 'appliance/shared/_steps_nuc_install_appliance.html' %}
           {% include 'appliance/shared/_steps_nuc_first_boot.html' %}

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -63,7 +63,7 @@
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_ubuntu.html' %}
           {% include 'appliance/shared/_steps_sso.html' %}
-          {% with command='cat' %}{% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}
           {% include 'appliance/shared/_steps_pi_ssh-in.html' %}
           {% include 'appliance/shared/_steps_pi_thats-it.html' %}
         </ol>
@@ -75,9 +75,10 @@
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_windows.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
+          {% include 'appliance/shared/_steps_install_openssh_windows.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_windows.html' %}
-          {% include 'appliance/shared/_steps_sso.html' %}
-          {% with command='type' %}{% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_sso_windows.html' %}
+          {% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}
           {% include 'appliance/shared/_steps_pi_ssh-in.html' %}
           {% include 'appliance/shared/_steps_pi_thats-it.html' %}
         </ol>
@@ -91,7 +92,7 @@
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_macos.html' %}
           {% include 'appliance/shared/_steps_sso.html' %}
-          {% with command='cat' %}{% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}{% endwith %}
+          {% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}
           {% include 'appliance/shared/_steps_pi_ssh-in.html' %}
           {% include 'appliance/shared/_steps_pi_thats-it.html' %}
         </ol>

--- a/templates/appliance/shared/_steps_install_openssh_windows.html
+++ b/templates/appliance/shared/_steps_install_openssh_windows.html
@@ -1,0 +1,54 @@
+<hr>
+<li class="p-stepped-list__item">
+  <h4 class="p-stepped-list__title">
+    Install OpenSSH
+  </h4>
+  <div class="p-stepped-list__content">
+    <p>
+      The ‘Secure Shell’ protocol provides access to your Ubuntu Appliance and uses cryptographic keys to authenticate you to the device. You will need SSH software and keys.
+    </p>
+    <p>
+      Some versions of Windows 10 include an SSH client already, but if yours does not or you’re unsure, follow these steps to install one.
+    </p>
+    <ol>
+      <li>
+        <p>
+          OpenSSH client is an installable feature of Windows 10.
+        </p>
+        <p>
+          To install OpenSSH, start Settings then go to <code>Apps > Apps and Features > Manage Optional Features</code>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Scan this list to see if OpenSSH client is already installed. If not, at the top of the page select <code>Add a feature</code>, then, to install the OpenSSH client, locate <code>OpenSSH Client</code> and click <code>Install</code>
+        </p>
+        <p>
+          Once the installation completes, return to <code>Apps > Apps and Features > Manage Optional Features</code> and you should see the OpenSSH component(s) listed.
+        </p>
+      </li>
+    </ol>
+    <p>
+      To install OpenSSH using PowerShell, first launch PowerShell as an Administrator. To make sure that the OpenSSH features are available for install type the command:
+    </p>
+    <p>
+      <code>Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'</code>
+    </p>
+    <p>
+      This should return:
+    </p>
+    <pre><code>Name  : OpenSSH.Client~~~~0.0.1.0
+State : NotPresent</code></pre>
+    <p>
+      Then, install the client features:
+    </p>
+    <pre><code>Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0</code></pre>
+    <p>
+      Both commands should return:
+    </p>
+    <pre><code>Path          :
+Online        : True
+RestartNeeded : False
+</code></pre>
+    </div>
+  </li>

--- a/templates/appliance/shared/_steps_ssh-keys_windows.html
+++ b/templates/appliance/shared/_steps_ssh-keys_windows.html
@@ -5,50 +5,13 @@
   </h4>
   <div class="p-stepped-list__content">
     <p>
-      The ‘Secure Shell’ protocol provides access to your Ubuntu Appliance and uses cryptographic keys to authenticate you to the device. You will need SSH software and keys.
+      After you have installed OpenSSH client you will need to generate user SSH keys to secure the connection to your Raspberry Pi.
     </p>
     <p>
-      Some versions of Windows 10 include an SSH client already, but if yours does not or you’re unsure, follow these steps to install one.
-    </p>
-    <ol>
-      <li>
-        <p>
-          OpenSSH client is an installable feature of Windows 10.
-        </p>
-        <p>
-          To install OpenSSH, start Settings then go to <code>Apps > Apps and Features > Manage Optional Features</code>.
-        </p>
-      </li>
-      <li>
-        <p>
-          Scan this list to see if OpenSSH client is already installed. If not, at the top of the page select <code>Add a feature</code>, then, to install the OpenSSH client, locate <code>OpenSSH Client</code> and click <code>Install</code>
-        </p>
-        <p>
-          Once the installation completes, return to <code>Apps > Apps and Features > Manage Optional Features</code> and you should see the OpenSSH component(s) listed.
-        </p>
-      </li>
-    </ol>
-    <p>
-      To install OpenSSH using PowerShell, first launch PowerShell as an Administrator. To make sure that the OpenSSH features are available for install type the command:
+      Launch ‘Windows PowerShell’ as an Administrator, and type:
     </p>
     <p>
-      <code>Get-WindowsCapability -Online | ? Name -like 'OpenSSH*'</code>
+      <code>ssh-keygen</code>
     </p>
-    <p>
-      This should return:
-    </p>
-    <pre><code>Name  : OpenSSH.Client~~~~0.0.1.0
-State : NotPresent</code></pre>
-    <p>
-      Then, install the client features:
-    </p>
-    <pre><code>Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0</code></pre>
-    <p>
-      Both commands should return:
-    </p>
-    <pre><code>Path          :
-Online        : True
-RestartNeeded : False
-</code></pre>
-    </div>
-  </li>
+  </div>
+</li>

--- a/templates/appliance/shared/_steps_sso_windows.html
+++ b/templates/appliance/shared/_steps_sso_windows.html
@@ -8,13 +8,13 @@
       Your Ubuntu Appliance will be added to your Ubuntu cloud account and use your SSH keys to identify you. Add your keys to your account at <a class="p-link--external" href="https://login.ubuntu.com/ssh-keys">https://login.ubuntu.com/ssh-keys</a>.
     </p>
     <p>
-      To do so, run the following command in your terminal.
+      To do so, run the following command in your terminal, which will copy your public key to your keyboard.
     </p>
     <p>
-      <code>cat ~/.ssh/id_rsa.pub</code>
+      <code>type ~\.ssh\id_rsa.pub | clip.exe</code>
     </p>
     <p>
-      Copy the result into the text field on the website. Click <code>import</code> and will have the key set up.
+      You can then paste your key result into the text field on your Ubuntu One account. Click <code>import</code> and will have the key set up.
     </p>
   </div>
 </li>


### PR DESCRIPTION
## Done

- Added step 'Install OpenSSH' and fixed up the Windows ssh steps
- Added fixed the ssh windows command

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex/raspberry-pi2 and http://0.0.0.0:8001/appliance/plex/intel-nuc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it matches the windows sections of Pi and PC on the [google sheet](https://docs.google.com/spreadsheets/d/1eZD3zISXBSNwAwkxlIRtV1UqP8GKPi0YAis8IRLZ9Po/edit?ts=5ee0fad1#gid=1141575055)


## Issue / Card

Fixes #7864
