### PR TITLE
Copy and link updated to /kubeflow/install page

### DIFF
--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -9,7 +9,7 @@
 <section class="p-strip--suru-topped is-deep is-bordered">
   <div class="row u-equal-height">
     <div class="col-7 u-vertically-center">
-      <h1>Install Kubeflow on Ubuntu</h1>
+      <h1>Install Kubeflow anywhere</h1>
       <p>Create and train machine learning models on your laptop, in your data centre, or in the cloud.</p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
@@ -34,7 +34,7 @@
       If you already have Ubuntu or another Linux, the following instructions are all you need. However, if you are on Windows or Mac, consider using <a class="p-link--external" href="https://multipass.run">Multipass</a> to easily create an Ubuntu VM to work with.
     </p>
     <p>
-      For a more detailed guide, consider following the <a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Deploy Kubeflow on Ubuntu, Windows and MacOS</a> tutorial.
+      For a more detailed guide, consider following the <a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Deploy Kubeflow on Ubuntu, Windows and macOS</a> tutorial.
     </p>
     <p>
       The following step assumes you want to install <a class="p-link--external" href="https://microk8s.io/">MicroK8s</a> as your Kubernetes cluster.
@@ -92,7 +92,7 @@
         <h3 class="p-stepped-list__title">Access Kubeflow dashboard</h3>
         <div class="p-stepped-list__content">
           <p>
-            After installing kubeflow, an IP address and credentials will be prompted on your terminal. 
+            After installing kubeflow, an IP address and credentials will be prompted on your terminal.
           </p>
           <p>
             If you installed Microk8s on your local host, you simply need to access the IP address provided on your browser: <code>https://[kubeflow dashboard IP]</code>.
@@ -104,7 +104,7 @@
         <h3 class="p-stepped-list__title">Next Steps</h3>
         <div class="p-stepped-list__content">
           <p>
-            To get more information on this install process, including screenshots of the process, please visit the <a class="p-link--external" href="/tutorials/get-started-kubeflow">Getting Started with Kubeflow tutorial</a>.
+            To get more information on this install process, including screenshots of the process, please visit the <a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Deploy Kubeflow on Ubuntu, Windows and macOS</a>.
           </p>
           <p>
             More recommended reading:
@@ -126,7 +126,7 @@
               <a class="p-link--external" href="https://www.tensorflow.org/">TensorFlow</a> - open source library to help you develop and train ML models
             </li>
             <li class="p-list__item">
-              <a class="p-link--external" href="https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks">TensorFlow: CNN benchmarks</a> - high performance benchmarks
+              <a class="p-link--external" href="https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks">TensorFlow: CNN benchmarks</a> - high-performance benchmarks
             </li>
           </ul>
           <p>For tailored Enterprise training and assistance, please consider our <a href="/kubeflow/consulting">AI Consulting and Delivery</a> services.</p>

--- a/templates/kubeflow/shared/_learn-more.html
+++ b/templates/kubeflow/shared/_learn-more.html
@@ -33,7 +33,7 @@
         </li>
         <li class="p-list__item">
           <a href="/blog/ai-ml-model-ubuntu">
-            How to build and deploy your&nbsp;&rsaquo;
+            How to build and deploy your first AI/ML model on Ubuntu&nbsp;&rsaquo;
           </a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- Copy updates and link updated on the /kubeflow/install page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1KVyyvZsDyrfoi5tK2m5SLWs9YuHg9hgqVz0c8cWHsf8/edit#)


## Issue / Card

Fixes #7866