### PR TITLE
Add the smart start whitepaper engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1072,5 +1072,14 @@
       {% endwith %}
     </div>
 
+    <div class="row u-equal-height u-clearfix">
+      {% with title="Accelerating IoT device time to market",
+      description="Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process",
+      slug="smart-start-whitepaper",
+      type="webinar" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
+    </div>
+
 </section>
 {% endblock content %}

--- a/templates/engage/smart-start-whitepaper.md
+++ b/templates/engage/smart-start-whitepaper.md
@@ -1,0 +1,31 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Accelerating IoT device time to market"
+     meta_description: "Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process"
+     meta_image: https://assets.ubuntu.com/v1/e8e5fa6d-85998029-33347c00-ba02-11ea-8bd5-085d16b88553.png
+     meta_copydoc: https://docs.google.com/document/d/1XSGcMXhCT7FbGtLhlOLTDZBFTqz_dhW8ber72pmbpUM/edit
+     header_title: "Accelerating IoT device time to market"
+     header_subtitle: "Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process"
+     header_image: https://assets.ubuntu.com/v1/bc976d87-IoT-smart-start-time-to-market-white.svg
+     header_image_width: "393"
+     header_image_height: "384"
+     header_url: '#register-section'
+     header_cta: "Download the whitepaper"
+     header_class: "p-engage-banner--dark"
+     header_lang: en
+     form_include: en
+     form_id: 3574
+     form_return_url: https://pages.ubuntu.com/Timetomarket_TY.html
+---
+
+The IoT market has immense potential: industry analysts 451 Research report that the IoT market opportunity will reach $648bn by 2024, and it is set to reach $1tn within the decade. But succeeding in the IoT arena is not without its challenges. Slow or rushed decision making, alongside mismanagement of resources and talent, frequently cause IoT projects to stall.
+
+This is why Canonical has introduced SMART START &mdash; a packaged IoT solution that reduces business and technical decision-making into a 2-week, fixed-cost process. SMART START fast tracks an enterprise’s IoT strategy by guiding it through hardware selection and delivering the infrastructure needed to develop and deploy software to fleets of devices, with consulting services to minimise risk and fill skill gaps.
+
+This whitepaper draws findings from more than 30 case studies, project summaries, and business cases to identify the central IoT pitfalls and their solutions. Read the whitepaper to learn about:
+<ul>
+  <li>The three most significant challenges in bringing IoT devices to market: hardware decision making, infrastructure complexity, and risk management.</li>
+  <li>Practical steps enterprises can take to overcome these challenges.</li>
+  <li>How SMART START drastically simplifies the process, driving down costs and accelerating time to market.</li>
+</ul>


### PR DESCRIPTION
## Done
Add the smart start whitepaper engage page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/smart-start-whitepaper
- Check the content matches [the copy doc](https://docs.google.com/document/d/1XSGcMXhCT7FbGtLhlOLTDZBFTqz_dhW8ber72pmbpUM/edit)
- Check it matches [design](https://github.com/canonical-web-and-design/web-squad/issues/2918)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7812

