### PR TITLE
Open cors to all sites for mega menu

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -258,7 +258,7 @@ app.add_url_rule(
     "templates",
     lambda filename: (
         flask.render_template(f"templates/{filename}.html"),
-        {"Access-Control-Allow-Origin": "https://discourse.ubuntu.com"},
+        {"Access-Control-Allow-Origin": "*"},
     ),
 )
 


### PR DESCRIPTION
## Done

- Allow mega menu pages to be pulled from all sites via javascript

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Update this pastebin file locally to pull from wherever you run the demo - https://pastebin.canonical.com/p/8jP7XjKSXH/
- See that the mega menu works
