### PR TITLE
Update to Vanilla framework v2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@canonical/cookie-policy": "2.1.0",
     "@canonical/global-nav": "2.4.1",
     "@canonical/latest-news": "1.0.3",
-    "vanilla-framework": "2.12.1"
+    "vanilla-framework": "2.14.0"
   },
   "resolutions": {
     "lodash": "4.17.15",

--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -1,7 +1,7 @@
-$breakpoint-medium:    875px;
-$viewport-threshold:      1281px;
-$color-brand:             #e95420;
-$sp-medium-small: 1rem * .85 !default;
+$breakpoint-medium: 875px;
+$viewport-threshold: 1281px;
+$color-brand: #e95420;
+$sp-medium-small: 1rem * 0.85 !default;
 $sp-medium-large: 1rem * 1.15 !default;
 $grid-max-width: 68rem;
 $nav-bg-color: #333;
@@ -10,3 +10,4 @@ $contrast-ratio: 5%;
 $color-whitepaper-accent: #772a54;
 $color-mid-x-light: #e5e5e5;
 $font-use-subset-latin: true;
+$font-display-option: fallback;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8624,10 +8624,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.12.1.tgz#45a5265acd5cac55089322aaa1d03bd2da2334dd"
-  integrity sha512-y6O3EODqpTDp5DZG2pGP3HjMbGOOeslu4jCDRhfWtzI9znxG3D8eSlIPjjxkgTsxALup5mMuScmS9RWlbdF7cA==
+vanilla-framework@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.14.0.tgz#acf62caa8d934e372bb4ab54682223871ebbb2d0"
+  integrity sha512-sTFlE83yuQZZUhn8hoX72nVqOAOMoihGVXeTX9MOCwXQCHt4YVz/+fD3ZbZA+tt9K/9Bim1kH0EfhpOJ3Bv7Ig==
 
 vanilla-framework@2.8.0:
   version "2.8.0"


### PR DESCRIPTION
## Done
- Update to Vanilla framework v2.14.0
- Change the font-display to fallback (issue raised to amend the default https://github.com/canonical-web-and-design/vanilla-framework/issues/3157) 

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Hard refresh and see the font load into place
- If you throttle your browser you should not see the font swap