### PR TITLE
Add motd legal page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -992,6 +992,9 @@ legal:
         - title: Partner Portal
           path: /legal/partner-portal-terms
           hidden: True
+        - title: MOTD
+          path: /legal/motd
+          hidden: True
         - title: Ubuntu font
           path: /legal/font-licence
           hidden: True

--- a/templates/legal/motd.html
+++ b/templates/legal/motd.html
@@ -52,7 +52,7 @@
             <td>&ldquo;aws&rdquo; or &ldquo;openstack&rdquo; or &ldquo;unknown&rdquo;</td>
           </tr>
           <tr>
-            <td>&ldquo;Curl&rdquo; version &mdash; the command used to get the message from the URL has it&rsquo;s version appended. This is standard practice in a &lsquo;user-agent&rsquo; string for HTTP requests.</td>
+            <td>&ldquo;Curl&rdquo; version &mdash; the command used to get the message from the URL has its version appended. This is standard practice in a &lsquo;user-agent&rsquo; string for HTTP requests.</td>
             <td>&ldquo;7.58.0-2ubuntu3.8&rdquo;</td>
           </tr>
         </tbody>

--- a/templates/legal/motd.html
+++ b/templates/legal/motd.html
@@ -1,0 +1,127 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}MOTD Information{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1pe_72kC7bClPqlgHU6maSMHYhAAuQdfCcNvAo-lDYVg/{% endblock meta_copydoc %}
+
+{% block content %}
+
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h1 id="title">Legal Notice &mdash; MOTD Information</h1>
+      <p><strong>Version &mdash; June 2020</strong></p>
+      <p>This legal notice tells you about the information we collect using MOTD &mdash; Message of the Day. &ldquo;motd-news&rdquo; is a package that makes a call periodically to Canonical servers to get updated news for support and informational purposes. An example of an MOTD is shown at the end of this notice. As part of sending the message information is also collected by Canonical as set out below.</p>
+      <h2 id="who-are-we">Who are we?</h2>
+      <p>We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> for the attention of &ldquo;Legal&rdquo;.</p>
+      <h2 id="what-information-do-we-collect">What information do we collect?</h2>
+      <p>The following data is being collected by Canonical</p>
+      <table>
+        <thead>
+          <tr>
+            <th>What is being sent?</th>
+            <th>Example</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Version of Ubuntu (/etc/lsb-release)</td>
+            <td>&ldquo;Ubuntu/18.04.3/LTS&rdquo;</td>
+          </tr>
+          <tr>
+            <td>Operating System Name (uname -o)</td>
+            <td>&ldquo;GNU/Linux&rdquo;</td>
+          </tr>
+          <tr>
+            <td>Kernel Version (uname -r)</td>
+            <td>&ldquo;4.15.0-72-generic&rdquo;</td>
+          </tr>
+          <tr>
+            <td>Machine Hardware Name (uname -m)</td>
+            <td>&ldquo;x86_64&rdquo;</td>
+          </tr>
+          <tr>
+            <td>CPU Brand & Model (/proc/cpuinfo)</td>
+            <td>&ldquo;Intel(R)/Core(TM)/i5-8500B/CPU/@/3.00GHZ&rdquo;</td>
+          </tr>
+          <tr>
+            <td>System Uptime (time since last boot) & Idle time (/proc/uptime)</td>
+            <td>&ldquo;uptime/108266.13/212047.71&rdquo;</td>
+          </tr>
+          <tr>
+            <td>cloud_id (/usr/bin/cloud-id) &mdash; Way to know what cloud (if any) this machine is running on.</td>
+            <td>&ldquo;aws&rdquo; or &ldquo;openstack&rdquo; or &ldquo;unknown&rdquo;</td>
+          </tr>
+          <tr>
+            <td>&ldquo;Curl&rdquo; version &mdash; the command used to get the message from the URL has it&rsquo;s version appended. This is standard practice in a &lsquo;user-agent&rsquo; string for HTTP requests.</td>
+            <td>&ldquo;7.58.0-2ubuntu3.8&rdquo;</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>None of this data can be used to identify a machine or user.</p>
+      <p>Along with this data, the IP address and other network information is transmitted to facilitate communication on the internet from the Ubuntu machine to Canonical. This information is not stored by Canonical.</p>
+      <h2 id="how-do-you-disable-the-collection">How do you disable the collection?</h2>
+      <p>Note that all of the system information may be shared with Canonical. If you would prefer that Canonical does not receive any item of system information, please do not consent to it being sent. You can disable this service as follows:</p>
+      <p>/etc/default/motd-news has an <code>ENABLED=1</code> setting that if set to <code>0</code> will turn off this functionality.</p>
+      <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
+      <p>The purpose of sending the system information is so that Canonical can tailor the message returned by https://motd.canonical.com. This allows Canonical to make users aware of new features of Ubuntu or services from Canonical that would be interesting to the Ubuntu user on the command line.  For instance, something specific to only users with Intel CPUs, or specific to only users of older versions of Ubuntu.</p>
+      <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
+      <p>Your information is stored in our systems and may be processed by Canonical globally.</p>
+      <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>
+      <p>We keep the system information for so long as reasonably required in accordance with our record retention policy.</p>
+      <h2 id="your-rights-over-your-system-information">Your rights over your system information</h2>
+      <p>You can decide whether to share the system information with Canonical or not.</p>
+      <p>If you do share the system information with Canonical we are unable to identify you against your system information, so we are unable to provide you with a copy of the system information or to delete the system information on request.</p>
+      <h2 id="contact">Contact</h2>
+      <p>Questions, comments and requests regarding this legal notice are welcomed and should be addressed to <a href="mailto:legal@canonical.com">legal@canonical.com</a> or to the address below:</p>
+      <p>
+        Legal, Canonical<br>
+        5th Floor, Blue Fin Building<br>
+        110 Southwark Street<br>
+        London, SE1 0SU
+      </p>
+      <h2 id="example-motd-news-message">Example motd-news Message</h2>
+      <p>This is an example of a motd-news message:</p>
+      <pre>* MicroK8s gets a native Windows installer and command-line integration.
+https://ubuntu.com/blog/microk8s-installers-windows-and-macos</pre>
+      <h2 id="example-full-motd-message">Example Full MOTD Message</h2>
+      <p>The message below is the full MOTD, displayed when you login via the console to an Ubuntu system. The motd-news portion is highlighted in green, the other pieces of the MOTD are informational only and do not reach out to the internet for any information:</p>
+      <pre>Welcome to Ubuntu 18.04.4 LTS (GNU/Linux 4.15.0-101-generic x86_64)
+
+* Documentation:  https://help.ubuntu.com
+* Management:     https://landscape.canonical.com
+* Support:        https://ubuntu.com/advantage
+
+System information as of Wed Jun 17 11:56:43 MDT 2020
+
+System load:               4.33
+Usage of /home:            81.0% of 393.60GB
+Memory usage:              63%
+Swap usage:                17%
+Processes:                 1270
+Users logged in:           1
+IP address for br0:        10.10.0.13
+
+=> / is using 85.0% of 53.79GB
+
+* MicroK8s gets a native Windows installer and command-line integration.
+
+https://ubuntu.com/blog/microk8s-installers-windows-and-macos
+
+36 packages can be updated.
+9 updates are security updates.
+
+
+You have packages from the Hardware Enablement Stack (HWE) installed that
+are going out of support on 2023-04-30.
+
+There is a graphics stack installed on this system. An upgrade to a
+configuration supported for the full lifetime of the LTS will become
+available on 2020-07-21 and can be installed by running 'update-manager'
+in the Dash.
+
+*** System restart required ***</pre>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -127,6 +127,11 @@
       <p>This privacy notice tells you about the information collected from you when you access the Anbox Cloud Demo Service.</p>
       <p><a href="/legal/anbox-cloud-privacy-notice">View Anbox Cloud Demo privacy notice&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-6 p-card">
+      <h3>MOTD Information</h3>
+      <p>Find out about the information we may collect for Message of the Day (MOTD).</p>
+      <p><a href="/legal/motd">View MOTD information notice&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Added /legal/motd page
- Added card linking to /legal/motd to /legal/terms-and-policies

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/terms-and-policies
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that there is a card towards the bottom for "MOTD information"
- Click through to the MOTD page and check that it matches [the copy doc](https://docs.google.com/document/d/1pe_72kC7bClPqlgHU6maSMHYhAAuQdfCcNvAo-lDYVg/edit#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2943 and https://github.com/canonical-web-and-design/web-squad/issues/2942