### PR TITLE
Remove conjure-up.io from nav and update list of /legal/websites

### DIFF
--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -14,7 +14,7 @@
           <a href="https://canonical.com">canonical.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
+          <a href="http://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://certification.ubuntu.com">certification.ubuntu.com</a>
@@ -110,7 +110,7 @@
           <a href="https://netplan.io">netplan.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
+          <a href="http://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://packaging.ubuntu.com">packaging.ubuntu.com</a>
@@ -141,9 +141,6 @@
         </li>
         <li class="p-list__item">
           <a href="https://vanillaframework.io">vanillaframework.io</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://voices.canonical.com">voices.canonical.com</a>
         </li>
       </ul>
     </div>

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Canonical websites{% endblock %}
-{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1UPhx8ARReA6-vDYNHbsGmJN-rY1LHGacq6g4PV6eCoA/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -11,22 +11,19 @@
       <h1>Canonical websites</h1>
       <ul class="p-list">
         <li class="p-list__item">
-          <a href="https://blog.ubuntu.com">blog.ubuntu.com</a>
+          <a href="https://canonical.com">canonical.com</a>
         </li>
         <li class="p-list__item">
-          <a href="http://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
+          <a href="https://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://certification.ubuntu.com ">certification.ubuntu.com </a>
+          <a href="https://certification.ubuntu.com">certification.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://cloud-images.ubuntu.com">cloud-images.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://cloud-init.io">cloud-init.io</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://conjure-up.io">conjure-up.io</a>
         </li>
         <li class="p-list__item">
           <a href="https://cn.ubuntu.com">cn.ubuntu.com</a>
@@ -38,22 +35,22 @@
           <a href="https://design.ubuntu.com">design.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://developer.ubuntu.com">developer.ubuntu.com</a>
+          <a href="https://discourse.juju.is">discourse.juju.is</a>
         </li>
         <li class="p-list__item">
-          <a href="https://docs.conjure-up.io">docs.conjure-up.io</a>
+          <a href="https://discourse.maas.io">discourse.maas.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://docs.maas.io">docs.maas.io</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://docs.ubuntu.com">docs.ubuntu.com</a>
+          <a href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://docs.snapcraft.io">docs.snapcraft.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://docs.vanillaframework.io">docs.vanillaframework.io</a>
+          <a href="https://docs.ubuntu.com">docs.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://dqlite.io">dqlite.io</a>
         </li>
         <li class="p-list__item">
           <a href="https://errors.ubuntu.com">errors.ubuntu.com</a>
@@ -62,13 +59,16 @@
           <a href="https://fridge.ubuntu.com">fridge.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://help.ubuntu.com  ">help.ubuntu.com  </a>
+          <a href="https://help.ubuntu.com">help.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://jaas.ai">jaas.ai</a>
         </li>
         <li class="p-list__item">
           <a href="https://jp.ubuntu.com">jp.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://jujucharms.com">jujucharms.com</a>
+          <a href="https://juju.is">juju.is</a>
         </li>
         <li class="p-list__item">
           <a href="https://landscape.canonical.com">landscape.canonical.com</a>
@@ -77,13 +77,16 @@
           <a href="https://launchpad.net">launchpad.net</a>
         </li>
         <li class="p-list__item">
+          <a href="https://linuxcontainers.org">linuxcontainers.org</a>
+        </li>
+        <li class="p-list__item">
           <a href="https://lists.ubuntu.com">lists.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://login.ubuntu.com">login.ubuntu.com</a>
+          <a href="https://loco.ubuntu.com">loco.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="http://loco.ubuntu.com">loco.ubuntu.com</a>
+          <a href="https://login.ubuntu.com">login.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://maas.io">maas.io</a>
@@ -92,16 +95,28 @@
           <a href="https://merges.ubuntu.com">merges.ubuntu.com</a>
         </li>
         <li class="p-list__item">
+          <a href="https://microk8s.io">microk8s.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://microstack.run">microstack.run</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://mir-server.io">mir-server.io</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://multipass.io">multipass.io</a>
+        </li>
+        <li class="p-list__item">
           <a href="https://netplan.io">netplan.io</a>
         </li>
         <li class="p-list__item">
-          <a href="http://packaging.ubuntu.com">packaging.ubuntu.com</a>
+          <a href="https://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://partners.ubuntu.com">partners.ubuntu.com</a>
+          <a href="https://packaging.ubuntu.com">packaging.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="http://planet.ubuntu.com">planet.ubuntu.com</a>
+          <a href="https://planet.ubuntu.com">planet.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://popcon.ubuntu.com">popcon.ubuntu.com</a>
@@ -110,13 +125,10 @@
           <a href="https://releases.ubuntu.com">releases.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://shop.canonical.com ">shop.canonical.com </a>
-        </li>
-        <li class="p-list__item">
           <a href="https://snapcraft.io">snapcraft.io</a>
         </li>
         <li class="p-list__item">
-          <a href="/tutorials">/tutorials</a>
+          <a href="https://ubuntu.com">ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://ubuntuforums.org">ubuntuforums.org</a>
@@ -132,15 +144,6 @@
         </li>
         <li class="p-list__item">
           <a href="https://voices.canonical.com">voices.canonical.com</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://www.canonical.com">www.canonical.com</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://www.ubuntu.com">www.ubuntu.com</a>
-        </li>
-        <li class="p-list__item">
-          <a href="http://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
         </li>
       </ul>
     </div>

--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -329,9 +329,6 @@
               <a href="https://cloud-init.io/">cloud-init</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="https://conjure-up.io/">conjure-up</a>
-            </li>
-            <li class="p-inline-list__item">
               <a href="https://jujucharms.com/">Juju</a>
             </li>
             <li class="p-inline-list__item">


### PR DESCRIPTION
## Done

- We are retiring conjure-up.io, this is part of that work
- Also updated /legal/websites to be more current

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/websites
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the list to the [sheet](https://docs.google.com/spreadsheets/d/19V5BOEkR_OkKu0P8UFNk-e9DaYSrC18TaznlXheSFjY/edit#gid=0)

Fixes #7885

