### PR TITLE
K8sdocs Remove stale conjure-up refs

### DIFF
--- a/templates/kubernetes/docs/operations.md
+++ b/templates/kubernetes/docs/operations.md
@@ -23,8 +23,7 @@ for more useful guides on operating Kubernetes.
 ## Install and configure kubectl
 
 You will need **kubectl** to be able to use your Kubernetes cluster. If it is not already
-installed (it is automatically installed if you used conjure-up to deploy **Charmed Kubernetes**), it is easy
-to add via a snap package:
+installed, it is easy to add via a snap package:
 
 ```bash
 sudo snap install kubectl --classic
@@ -86,7 +85,7 @@ The recommended way to do this is to use the built-in proxy service, run with th
 kubectl proxy
 ```
 
-The URL for the dashboard will then be [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/) 
+The URL for the dashboard will then be [http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/)
 
 For versions prior to 1.16, the dashboard URL will be [http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/).
 

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -154,7 +154,6 @@ Google. You can see which ones are ready to use by running this command:
 <!-- LINKS -->
 
 [jujucharms-com]: https://jujucharms.com
-[conjure-up-io]: https://conjure-up.io
 [install]: /kubernetes/docs/install-manual
 [overview]: /kubernetes/docs/overview
 [snapd-docs]: https://docs.snapcraft.io/core/install
@@ -165,14 +164,14 @@ Google. You can see which ones are ready to use by running this command:
 [cloud-rackspace]: https://www.rackspace.com/cloud/
 [cloud-azure]: https://azure.microsoft.com/
 [cloud-joyent]: https://www.joyent.com/
-[storage]: /kubernetes/docs/storage
+
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/quickstart.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/quickstart.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/templates/kubernetes/docs/troubleshooting.md
+++ b/templates/kubernetes/docs/troubleshooting.md
@@ -21,7 +21,7 @@ Using `juju status` can give you some insight as to what's happening in a cluste
 
 ```no-highlight
 Model                         Controller          Cloud/Region   Version  SLA          Timestamp
-conjure-canonical-kubern-ade  conjure-up-aws-91c  aws/eu-west-1  2.4.5    unsupported  08:38:09+01:00
+charmed-kubernetes            aws-91c             aws/eu-west-1  2.4.5    unsupported  08:38:09+01:00
 
 App                    Version  Status  Scale  Charm                  Store       Rev  OS      Notes
 aws-integrator         1.15.71  active      1  aws-integrator         jujucharms    5  ubuntu  
@@ -111,7 +111,7 @@ sudo snap install juju-crashdump --classic --channel edge
 juju-crashdump -a debug-layer -a config
 ```
 
-Running the `juju-crashdump` script will generate a tarball of debug information that includes systemd unit status and logs, Juju logs, charm unit data, and Kubernetes cluster information. It is recommended that you include this tarball when [filing a bug](https://bugs.launchpad.net/charmed-kubernetes). 
+Running the `juju-crashdump` script will generate a tarball of debug information that includes systemd unit status and logs, Juju logs, charm unit data, and Kubernetes cluster information. It is recommended that you include this tarball when [filing a bug](https://bugs.launchpad.net/charmed-kubernetes).
 
 ## Common Problems
 
@@ -161,7 +161,7 @@ This is caused by the API load balancer not forwarding ports in the context of t
 
     ```no-highlight
     Model                         Controller          Cloud/Region   Version  SLA          Timestamp
-    conjure-canonical-kubern-ade  conjure-up-aws-91c  aws/eu-west-1  2.4.5    unsupported  08:39:23+01:00
+    charmed-kubernetes            aws-91c  aws/eu-west-1  2.4.5    unsupported  08:39:23+01:00
 
     App                Version  Status  Scale  Charm              Store       Rev  OS      Notes
     flannel            0.10.0   active      2  flannel            jujucharms  146  ubuntu  
@@ -407,9 +407,9 @@ juju run --unit kubernetes-master/0 -- journalctl -u snap.kube-apiserver.daemon.
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/troubleshooting.md" class="p-notification__action">edit this page</a> 
-    or 
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/troubleshooting.md" class="p-notification__action">edit this page</a>
+    or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>


### PR DESCRIPTION
## Done

Removed an unused link and some stale text from examples relating to conjureup

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes #7886

