### PR TITLE
Add webinar to /kernel page

### DIFF
--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -12,6 +12,11 @@
     <div class="col-7">
       <h1>Ubuntu kernels from Canonical</h1>
       <p>At the core of the Ubuntu operating system is the Linux kernel, which manages and controls the hardware resources like I/O (networking, storage, graphics and various user interface devices, etc.), memory and CPU for your device or computer. It is one of the first software programs a booting device loads and runs on the central processing unit (CPU). The Linux kernel manages the system&rsquo;s hardware environment so other programs like the operating system&rsquo;s user space programs and application software programs can run well without modification on a variety of different platforms and without needing to know very much about that underlying system.</p>
+      <p>
+        <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server">
+          Watch the webinar - “Ubuntu 20.04 LTS: What’s new in server?”
+        </a>
+      </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Add webinar to /kernel page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kernel
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve the comments in the [copy doc](https://docs.google.com/document/d/1XLdk2Slh4vi4AjGnatcK1BmJGmMNKIjN27KwbTwG5iI/edit)


## Issue / Card

Fixes #7893

## Screenshots

![image](https://user-images.githubusercontent.com/441217/86768487-926b3f80-c045-11ea-83e6-6c3f8a7181c0.png)
