### PR TITLE
Add webinar to /server

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -18,6 +18,11 @@
           Download Ubuntu Server
         </a>
       </p>
+      <p>
+        <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server">
+          Watch the webinar - “Ubuntu 20.04 LTS: What’s new in server?”
+        </a>
+      </p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
       {{
@@ -79,7 +84,7 @@
   </div>
   <div class="col-6">
     <p>
-      Our regular release cycle means access to the latest and most performant open source. A lean initial installation and integrated deployment and application modeling technologies make Ubuntu Server a great solution for simple deployment and management at scale.
+      Our regular release cycle means access to the latest and most performant open source. A lean initial installation and integrated deployment and application modelling technologies make Ubuntu Server a great solution for simple deployment and management at scale.
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Add webinar to /server
- Fixed spelling mistake

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#)


## Issue / Card

Fixes #7895

## Screenshots

![image](https://user-images.githubusercontent.com/441217/86769189-ad8a7f00-c046-11ea-8eb1-04e922f1787a.png)

