### PR TITLE
Add webinar to /openstack/features

### DIFF
--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -14,6 +14,11 @@
       <p class="p-heading--three" style="max-width: none;">Architectural freedom. Fully automated operations. Telco-grade OpenStack for all.</p>
       <p>Canonical&rsquo;s OpenStack on Ubuntu gives you the flexibility to place your OpenStack services exactly where you want them, while sharing all the operational code with a large community.</p>
       <p><a href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact Us for OpenStack insights', 'eventLabel' : 'Contact Us for OpenStack insights - Top CTA', 'eventValue' : undefined });" class="p-button--positive js-invoke-modal">Contact us for OpenStack insights</a></p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/408805">
+          Watch the webinar - “OpenStack Ussuri: What’s new?”
+        </a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Add webinar to /openstack/features

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/features
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in [copy doc](https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit#)

## Issue / Card

Fixes #7897

## Screenshots

![image](https://user-images.githubusercontent.com/441217/86770563-be3bf480-c048-11ea-8998-cc8c59e54118.png)

