### PR TITLE
Add webinar to /openstack/what-is-openstack

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -16,6 +16,11 @@
       <p class="u-no-margin--bottom">
         <a class="p-button--positive" href="/openstack/managed">Get fully managed OpenStack</a>
       </p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/404267/open-source-infrastructure-from-bare-metal-to-microservices">
+          Watch the webinar - “Open source infrastructure: from bare metal to microservices”
+        </a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Add webinar to /openstack/what-is-openstack

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/what-is-openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve the comment in the [copy doc](https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit#)


## Issue / Card

Fixes #7899

## Screenshots

![image](https://user-images.githubusercontent.com/441217/86774508-8637b000-c04e-11ea-83fe-76edfeb4b168.png)

