### PR TITLE
Add a space to /masters-conference

### DIFF
--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -92,7 +92,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h2>
-        The open (source)road to smarter robots
+        The open (source) road to smarter robots
       </h2>
       <p>
         <strong>


### PR DESCRIPTION
## Done

- Add a space to /masters-conference

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001//masters-conference
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a space s/The open (source)road to smarter robots/The open (source) road to smarter robots/
