### PR TITLE
Update nuc bios update link

### DIFF
--- a/templates/appliance/shared/_install_instructions_intel-nuc.html
+++ b/templates/appliance/shared/_install_instructions_intel-nuc.html
@@ -5,7 +5,7 @@
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">Two USB 2.0 or 3.0 flash drives (2GB minimum)</li>
-  <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="http://www.intel.com/content/www/us/en/support/boards-and-kits/000005850.html">update instructions</a>)</li>
+  <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="https://www.intel.com/content/www/us/en/support/articles/000033300/intel-nuc.html">update instructions</a>)</li>
   <li class="p-list__item is-ticked">A Mini HDMI to HDMI cable</li>
   <li class="p-list__item is-ticked">A monitor with VGA or HDMI interface</li>
   <li class="p-list__item is-ticked">A VGA or HDMI cable</li>

--- a/templates/download/intel-nuc-desktop.html
+++ b/templates/download/intel-nuc-desktop.html
@@ -21,7 +21,7 @@
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="http://www.intel.com/content/www/us/en/support/boards-and-kits/000005850.html">update instructions</a>)</li>
+            <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="https://www.intel.com/content/www/us/en/support/articles/000033300/intel-nuc.html">update instructions</a>)</li>
             <li class="p-list__item is-ticked">1 USB 2.0 or 3.0 flash drive (4GB minimum for Dawson Canyon NUCs, 2GB for older generations)</li>
             <li class="p-list__item is-ticked">A USB keyboard and a mouse</li>
             <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>

--- a/templates/download/intel-nuc.html
+++ b/templates/download/intel-nuc.html
@@ -22,7 +22,7 @@
           <h3>Minimum requirements</h3>
           <ul class="p-list">
             <li class="p-list__item is-ticked">An Ubuntu SSO account with an SSH key</li>
-            <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="http://www.intel.com/content/www/us/en/support/boards-and-kits/000005850.html">update instructions</a>)</li>
+            <li class="p-list__item is-ticked">An Intel NUC with BIOS updated to the latest version (<a class="p-link--external" href="https://www.intel.com/content/www/us/en/support/articles/000033300/intel-nuc.html">update instructions</a>)</li>
             <li class="p-list__item is-ticked">2 USB 2.0 or 3.0 flash drives (2GB minimum)</li>
             <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
             <li class="p-list__item is-ticked">A Mini HDMI to HDMI cable</li>


### PR DESCRIPTION
## Done

- Updated link to update Intel NUC bios

`s/http://www.intel.com/content/www/us/en/support/boards-and-kits/000005850.html/https://www.intel.com/content/www/us/en/support/articles/000033300/intel-nuc.html/`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/intel-nuc-desktop. http://0.0.0.0:8001/download/intel-nuc.html and all the appliance nuc pages 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link works and is on the above pages


## Issue / Card

Fixes #7876

