### PR TITLE
Reduce the vertical space at the top of the appliance page

### DIFF
--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru-topped">
   <div class="row">
     <h1>
       The Ubuntu Appliance portfolio
@@ -19,7 +19,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip u-no-padding--top is-bordered">
   {% with heading="Featured" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
 </section>
 


### PR DESCRIPTION
## Done
- Reduce the vertical space at the top of the appliance page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance
- See that the space has been reduced in the hero strip

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7904

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/86910384-8a78d180-c111-11ea-8b17-b250d6d252a8.png)

