### PR TITLE
Anbox whitepaper engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1081,5 +1081,14 @@
       {% endwith %}
     </div>
 
+    <div class="row u-equal-height u-clearfix">
+      {% with title="Scale Android applications economically in the cloud with Anbox Cloud",
+      description="Discover Canonical&rsquo;s scalable, hardware-agnostic mobile cloud computing platform",
+      slug="intro-to-anbox-cloud-whitepaper",
+      type="whitepaper" %}
+        {% include "engage/_article-card.html" %}
+      {% endwith %}
+    </div>
+
 </section>
 {% endblock content %}

--- a/templates/engage/intro-to-anbox-cloud-whitepaper.md
+++ b/templates/engage/intro-to-anbox-cloud-whitepaper.md
@@ -1,0 +1,34 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Scale Android applications economically in the cloud with Anbox Cloud"
+  meta_description: "Discover Canonical&rsquo;s scalable, hardware-agnostic mobile cloud computing platform"
+  meta_image: https://assets.ubuntu.com/v1/984acab7-85391216-cae92480-b541-11ea-8e9e-9f408efc8c9f.png
+  meta_copydoc: https://docs.google.com/document/d/1mX36YIHLL2ctJaFNVFlDhabhBdZPpRiOnMaUvsxZhIQ/edit
+  header_title: "Scale Android applications economically in the cloud with Anbox Cloud"
+  header_subtitle: "Discover Canonical&rsquo;s scalable, hardware-agnostic mobile cloud computing platform"
+  header_image: "https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg"
+  header_image_width: "338"
+  header_image_height: "246"
+  header_url: "#register-section"
+  header_cta: Download whitepaper
+  header_cta_class: p-button--positive
+  header_class: p-engage-banner--grad
+  form_include: en
+  form_id: 3539
+  form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/Over-the-air%20software_12.05.20.pdf"
+---
+
+Hardware limitations have long been a roadblock for developers of Android applications. Given the immense variety of Android device specifications, it is often impossible to deliver the most modern application experiences without alienating a large number of potential users who do not own high-end devices.
+
+Mobile cloud computing platforms provide an answer to this by allowing apps to run from the cloud, rather than locally on the device. Traditionally, the only solution to this challenge has been to set up a virtual machine-based Android cloud instance. But this approach requires extensive manual configuration and management – making it prohibitively expensive for most businesses.
+
+Now, enterprises have a new alternative. Anbox Cloud leverages Canonical&rsquo;s automation and virtualisation tools to deliver a scalable Android in the cloud platform that combines the capabilities of virtual machines with the low overheads and manageability of containers. By enabling companies to centrally and cost-effectively manage the user experience for millions of global customers, Anbox Cloud eliminates the barriers to entry for developing hardware-agnostic, cloud-based Android apps.
+
+Read this whitepaper to learn more, including:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">The advantages that Anbox Cloud offers in economics, security, scalability, and performance</li>
+  <li class="p-list__item is-ticked">Four common use cases for Anbox Cloud &mdash; game streaming, virtual devices, enterprise mobile applications, and application testing at scale</li>
+  <li class="p-list__item is-ticked">The technology behind Anbox Cloud</li>
+</ul>

--- a/templates/engage/intro-to-anbox-cloud-whitepaper.md
+++ b/templates/engage/intro-to-anbox-cloud-whitepaper.md
@@ -16,7 +16,7 @@ context:
   header_class: p-engage-banner--grad
   form_include: en
   form_id: 3585
-  form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/Over-the-air%20software_12.05.20.pdf"
+  form_return_url: "https://pages.ubuntu.com/IntrotoAnboxCloud_TY.html"
 ---
 
 Hardware limitations have long been a roadblock for developers of Android applications. Given the immense variety of Android device specifications, it is often impossible to deliver the most modern application experiences without alienating a large number of potential users who do not own high-end devices.

--- a/templates/engage/intro-to-anbox-cloud-whitepaper.md
+++ b/templates/engage/intro-to-anbox-cloud-whitepaper.md
@@ -15,7 +15,7 @@ context:
   header_cta_class: p-button--positive
   header_class: p-engage-banner--grad
   form_include: en
-  form_id: 3539
+  form_id: 3585
   form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/Over-the-air%20software_12.05.20.pdf"
 ---
 


### PR DESCRIPTION
## Done
Anbox whitepaper engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/intro-to-anbox-cloud-whitepaper
- Check the page matched [the design](https://github.com/canonical-web-and-design/ubuntu.com/issues/2921)
- Check it matches [the copy doc](https://docs.google.com/spreadsheets/d/1DgSWaHKFsQRfdUiqWTCxvMIFlb3VozF3QPEOS-Zw_cE/edit#gid=738287198)
- Check the form submits and goes to the anbox thank you page which you can download the whitepaper from.

**No takeover or addition to the engage list required**

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7813

## Screenshots

![image](https://user-images.githubusercontent.com/1413534/86938307-346b5480-c138-11ea-83af-a69527191d7e.png)

