### PR TITLE
Add new nginx proxy

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -135,6 +135,11 @@ production:
     }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
+  nginxServerSnippet: |
+    location /wp-content/uploads/ {
+      proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
+    }
+
 # Overrides for staging
 staging:
   replicas: 3
@@ -201,3 +206,8 @@ staging:
     }
     more_set_headers "X-Robots-Tag: noindex";
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
+
+  nginxServerSnippet: |
+    location /wp-content/uploads/ {
+      proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
+    }


### PR DESCRIPTION
Update ubuntu.com deploy settings to add Nginx rules to proxy requests for `ubuntu.com/wp-content/*` through to `admin.insights.ubuntu.com/wp-content/*`

## QA

Short story if you have `microk8s` configured to run `ubuntu.com`:
- git checkout this branch
- run `./qa-deploy production <path/to/ubuntu.com/repo>/deploy/site.ymal`
- `sudo vi /etc/hosts` and add `127.0.1.1	staging.ubuntu.com` and `127.0.1.1	ubuntu.com`
- run `curl -I --insecure https://ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` should return 200
- run `curl -I --insecure https://staging.ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` should return 200
- try the links in the browser too to confirm again that everything works: `https://ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` and `https://stating.ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` you should see an image

Long story if you did not even know about `microk8s` yesterday:
- git checkout this branch
- `docker-compose up -d` in ubuntu.com folder

- `snap install --channel=1.15/stable --classic microk8s`
- `git clone git@github.com:canonical-web-and-design/deployment-configs.git`
- `cd deployment-configs`

- create secrets:
`microk8s.kubectl create secret generic secret-keys --from-literal=ubuntu-com=local`
`microk8s.kubectl create secret generic launchpad-imagebuild --from-literal=token=local`
`microk8s.kubectl create secret generic google-api --from-literal=google-custom-search-key=local`
`microk8s.kubectl create secret generic usn-db-url --from-literal=database_url=postgres://postgres:pw@{local-IP}:5432/postgres`
`{local-IP}` => `ifconfig` and find your private IP
-edit secret:
`microk8s.kubectl edit secret launchpad-imagebuild`
Add new line under `secret: <code>` and write `token = <same-code-as-secret>`. Save.

- run `./qa-deploy production <path/to/ubuntu.com/repo>/deploy/site.ymal`
- you will be asked to login. Go to https://enigma.admin.canonical.com/ -> Docker-registry credentials -> Unzip file -> Line 1 in the file will be `{user}:{password}`
- `microk8s.kubectl get pods` you will see 3 items `ubuntu-com`, `ubuntu-com-blog` and `ubuntu-com-tutorials` look at the status, you will have to wait for a while until you see the `Status` show `RUNNING`

If you get an error some helpful commands for debugging:
`microk8s.kubectl describe pod <id>`
`microk8s.kubectl log pod <id>`

- `sudo vi /etc/hosts` and add `127.0.1.1	staging.ubuntu.com` and `127.0.1.1	ubuntu.com`
- run `curl -I --insecure https://ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` should return 200
- run `curl -I --insecure https://staging.ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` should return 200
- try the links in the browser too to confirm again that everything works: `https://ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` and `https://stating.ubuntu.com/wp-content/uploads/2e4c/dell-xps-2004.jpg` you should see an image

## Fixes #2130 step 1

