### PR TITLE
Revert /azure/pro to promote 18.04 first

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -12,7 +12,7 @@
         <h1>Ubuntu Pro for Azure</h1>
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for Azure is a premium image designed by Canonical to provide the most comprehensive feature set for production environments running on Azure public cloud. Offered as a virtual machine image through Azure Marketplace, it includes a subscription to Canonical's critical security and compliance services by default. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations — no contract necessary.</p>
-        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 20.04 LTS on Azure</span></a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on Azure</span></a></p>
         <p><a href="https://assets.ubuntu.com/v1/27a386bc-Ubuntu_Pro_Azure_03.04.20.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

- Revert /azure/pro to promote 18.04 first

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure/pro
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Updated per the [copy doc](https://docs.google.com/document/d/1WaQ5n3GxwZzbX0T6rLiRNejFvxIPIHd5V5XgdAwKmSw/edit#heading=h.lobrtzkut7aw)


## Issue / Card

Fixes #7912
