### PR TITLE
remove inline polyfill script

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "@canonical/cookie-policy": "2.1.0",
     "@canonical/global-nav": "2.4.1",
     "@canonical/latest-news": "1.0.3",
+    "url-polyfill": "1.1.9",
+    "url-search-params-polyfill": "8.1.0",
     "vanilla-framework": "2.14.0"
   },
   "resolutions": {

--- a/static/js/src/polyfills.js
+++ b/static/js/src/polyfills.js
@@ -1,3 +1,30 @@
 if (window.NodeList && !NodeList.prototype.forEach) {
   NodeList.prototype.forEach = Array.prototype.forEach;
 }
+
+if (!String.prototype.startsWith) {
+  Object.defineProperty(String.prototype, "startsWith", {
+    value: function (search, rawPos) {
+      var pos = rawPos > 0 ? rawPos | 0 : 0;
+      return this.substring(pos, pos + search.length) === search;
+    },
+  });
+}
+
+if (!Element.prototype.matches) {
+  Element.prototype.matches =
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.webkitMatchesSelector;
+}
+
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function (s) {
+    var el = this;
+
+    do {
+      if (Element.prototype.matches.call(el, s)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -12,8 +12,6 @@
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 
-  <!-- Temporary fix for IE11 (see: https://github.com/canonical-web-and-design/ubuntu.com/issues/6660) -->
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=URLSearchParams%2CArray.from%2CNodeList.prototype.forEach%2Cfetch%2CString.prototype.startsWith%2CElement.prototype.closest"></script>
   <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js"></script>
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
   <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -8,6 +8,8 @@ module.exports = {
   forms: "./static/js/src/forms.js",
   "image-download": "./static/js/src/image-download.js",
   main: [
+    "url-polyfill",
+    "url-search-params-polyfill",
     "./static/js/src/polyfills.js",
     "./static/js/src/contextual-menu.js",
     "./static/js/src/dynamic-contact-form.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8550,6 +8550,16 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.9.tgz#2c8d4224889a5c942800f708f5585368085603d9"
+  integrity sha512-q/R5sowGuRfKHm497swkV+s9cPYtZRkHxzpDjRhqLO58FwdWTIkt6Y/fJlznUD/exaKx/XnDzCYXz0V16ND7ow==
+
+url-search-params-polyfill@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.0.tgz#5c15b69687165bfd4f6c7d8a161d70d85385885b"
+  integrity sha512-MRG3vzXyG20BJ2fox50/9ZRoe+2h3RM7DIudVD2u/GY9MtayO1Dkrna76IUOak+uoUPVWbyR0pHCzxctP/eDYQ==
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
## Done

- replaced polyfills being pulled from polyfill.io (`URL`, `URLSearchParams`, `forEach` and `closest`) with our own where possible, and with build packages where it was less practical.

## QA

- Visit https://www.browserstack.com and launch IE11
- Visit https://ubuntu-com-canonical-web-and-design-pr-7915.run.demo.haus//tutorials/how-to-sdcard-ubuntu-server-raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View the console, see that are no JS errors, and click through the navigation links on the tutorial, see that the page behaves as expected.
