### PR TITLE
Adds "What is Kubernetes" blog card

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,7 +1,7 @@
 
 {% if article.tags and 1572 in article.tags %}
 <div class="p-card" id="rtp-bootstack">
-<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/00633f99-ubuntu-cloud-2.svg" alt="header image">
+<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/00633f99-ubuntu-cloud-2.svg" alt="openstack logo">
 <hr class="u-sv1">
   <h3>
     <a href="/openstack/managed">
@@ -12,6 +12,19 @@
     Designed with economics in mind, Canonical's Managed OpenStack is the most cost-efficient path to a fully managed private cloud.
   </p>
   <p><a href="/openstack/managed">Learn more about Managed OpenStack &rsaquo;</a></p>
+</div>
+{% elif article.tags and 1833 in article.tags %}
+<div class="p-card" id="rtp-k8s">
+<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="kubernetes logo">
+<hr class="u-sv1">
+  <h3>
+    <a href="/kubernetes/what-is-kubernetes">
+     What is Kubernetes?
+
+    </a>
+  </h3>
+  <p>Kubernetes, or K8s for short, is an open source platform pioneered by Google, which started as a simple container orchestration tool but has grown into a platform for deploying, monitoring and managing apps and services across clouds.</p>
+  <p><a href="/kubernetes/what-is-kubernetes">Learn more about Kubernetes &rsaquo;</a></p>
 </div>
 {% elif article.group and article.group.slug == "kubernetes" %}
 <div class="p-card" id="rtp-k8s">

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,7 +1,7 @@
 
 {% if article.tags and 1572 in article.tags %}
 <div class="p-card" id="rtp-bootstack">
-<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/00633f99-ubuntu-cloud-2.svg" alt="openstack logo">
+<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/00633f99-ubuntu-cloud-2.svg" alt="ubuntu for clouds logo">
 <hr class="u-sv1">
   <h3>
     <a href="/openstack/managed">


### PR DESCRIPTION
## Done

- Adds a "What is Kubernetes" info card to blog posts tagged with "kubernetes"
- Drive-by img alt param fixing

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure blog posts linked from [/blog/tag/kubernetes](https://ubuntu-com-canonical-web-and-design-pr-7918.run.demo.haus/blog/tag/kubernetes) show a "What is Kubernetes?" card on the right col.

## Screenshots

![Screenshot from 2020-07-09 23-09-55](https://user-images.githubusercontent.com/18480003/87091064-55679e80-c239-11ea-9b54-7e2ae72da3b9.png)

