### PR TITLE
Update link on /lega/motd

### DIFF
--- a/templates/legal/motd.html
+++ b/templates/legal/motd.html
@@ -63,7 +63,7 @@
       <p>Note that all of the system information may be shared with Canonical. If you would prefer that Canonical does not receive any item of system information, please do not consent to it being sent. You can disable this service as follows:</p>
       <p>/etc/default/motd-news has an <code>ENABLED=1</code> setting that if set to <code>0</code> will turn off this functionality.</p>
       <h2 id="why-do-we-collect-this-information">Why do we collect this information?</h2>
-      <p>The purpose of sending the system information is so that Canonical can tailor the message returned by https://motd.canonical.com. This allows Canonical to make users aware of new features of Ubuntu or services from Canonical that would be interesting to the Ubuntu user on the command line.  For instance, something specific to only users with Intel CPUs, or specific to only users of older versions of Ubuntu.</p>
+      <p>The purpose of sending the system information is so that Canonical can tailor the message returned by https://motd.ubuntu.com. This allows Canonical to make users aware of new features of Ubuntu or services from Canonical that would be interesting to the Ubuntu user on the command line.  For instance, something specific to only users with Intel CPUs, or specific to only users of older versions of Ubuntu.</p>
       <h2 id="what-do-we-do-with-your-information">What do we do with your information?</h2>
       <p>Your information is stored in our systems and may be processed by Canonical globally.</p>
       <h2 id="how-long-do-we-keep-your-information-for">How long do we keep your information for?</h2>


### PR DESCRIPTION
## Done

- Update motd.canonical.com to motd.ubuntu.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/motd
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link now works


