### PR TITLE
Configure contracts API from optional configmap

### DIFF
--- a/deploy/site.yaml
+++ b/deploy/site.yaml
@@ -23,6 +23,12 @@ env:
       key: secret
       name: launchpad-imagebuild
 
+  - name: CONTRACTS_API_URL
+    configMapKeyRef:
+      key: url
+      name: contracts-api
+      optional: true
+
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 


### PR DESCRIPTION
## Done

Make it possible to connect to different environments of the contracts API

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]
