### PR TITLE
Change colours on OpenStack chart to match others

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1303,8 +1303,8 @@ export var openStackStatus = {
   TECH_PREVIEW: "chart__bar--orange-light",
   LTS: "chart__bar--orange",
   MATCHING_OPENSTACK_RELEASE_SUPPORT: "chart__bar--grey",
-  EXTENDED_SUPPORT_FOR_CUSTOMERS: "chart__bar--aubergine",
-  EXTENDED_SUPPORT_MAINTENANCE: "chart__bar--green",
+  EXTENDED_SUPPORT_MAINTENANCE: "chart__bar--aubergine",
+  EXTENDED_SUPPORT_FOR_CUSTOMERS: "chart__bar--green",
 };
 
 export var kubernetesStatus = {


### PR DESCRIPTION
## Done

- Made ESM be autbergine and Extended support for customers green to match what other charts do

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-openstack-release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that ESM is aubergine on the page and that Extended support for customers is green


## Issue / Card

Fixes #7877

## Screenshots

![image](https://user-images.githubusercontent.com/441217/87533134-121f8c80-c68c-11ea-99f7-0d7113e666fa.png)

