### PR TITLE
Update linkedin link in footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -169,7 +169,7 @@
               </svg></a>
             </li>
             <li class="p-inline-list__item">
-              <a class="p-inline-list__link--linkedin" title="Find Canonical on LinkedIn" href="https://www.linkedin.com/company/ubuntu/"><svg
+              <a class="p-inline-list__link--linkedin" title="Find Canonical on LinkedIn" href="https://www.linkedin.com/company/234280"><svg
                 xmlns="http://www.w3.org/2000/svg" viewbox="0 0 33 33">
                 <defs>
                   <style>


### PR DESCRIPTION
## Done

Changed the LinkedIn link in the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the LinkedIn icon in the footer goes to the Canonical company page


## Issue / Card

Fixes #7937