### PR TITLE
Ceph docs

### DIFF
--- a/templates/ceph/base_docs.html
+++ b/templates/ceph/base_docs.html
@@ -1,0 +1,40 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+<div class="l-documentation">
+  <div class="l-documentation__sidebar">
+    <aside class="p-sidebar" id="navigation">
+      <div class="p-sidebar__banner u-hide--medium u-hide--large">
+        <i class="p-sidebar__toggle p-icon--menu"></i>
+      </div>
+      <div class="p-sidebar__content u-hide--small">
+        <nav class="p-sidebar-nav">
+          {{ navigation | safe }}
+        </nav>
+      </div>
+    </aside>
+  </div>
+
+  <div class="l-documentation__content p-content">
+    {% block content_docs %}{% endblock %}
+  </div>
+</div>
+
+<script>
+  const path = window.location.pathname;
+  const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
+  if (active) {
+    active.classList.add("is-active");
+  }
+
+  const toggleSidebar = document.querySelector(".p-sidebar__toggle");
+  const sidebar = document.querySelector(".p-sidebar__content");
+  if (toggleSidebar) {
+    toggleSidebar.addEventListener("click", function(e) {
+      sidebar.classList.toggle("u-hide--small");
+      toggleSidebar.classList.toggle("p-icon--close");
+      toggleSidebar.classList.toggle("p-icon--menu");
+    });
+  }
+</script>
+{% endblock %}

--- a/templates/ceph/document.html
+++ b/templates/ceph/document.html
@@ -10,14 +10,5 @@
     </div>
 </div>
 
-<div class="p-strip is-shallow">
-    <div class="p-content__row">
-        <div class="p-notification--information">
-            <p class="p-notification__response">
-                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
-            </p>
-        </div>
-    </div>
-</div>
 {% endblock %}
 

--- a/templates/ceph/document.html
+++ b/templates/ceph/document.html
@@ -1,0 +1,23 @@
+
+{% extends "ceph/base_docs.html" %}
+
+{% block title %} {{ document.title }} | Server documentation{% endblock %}
+
+{% block content_docs %}
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        {{ document.body_html | safe }}
+    </div>
+</div>
+
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        <div class="p-notification--information">
+            <p class="p-notification__response">
+                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -115,6 +115,22 @@ class TestRoutes(VCRTestCase):
 
         self.assertEqual(self.client.get("/advantage").status_code, 200)
 
+    def test_ceph(self):
+        """
+        When given the ceph docs URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/ceph").status_code, 200)
+
+    def test_ceph_docs(self):
+        """
+        When given the ceph docs URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/ceph/docs").status_code, 200)
+
     def test_not_found(self):
         """
         When given a non-existent URL,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -279,6 +279,17 @@ app.add_url_rule(
 )
 tutorials_docs.init_app(app)
 
+# Ceph docs
+ceph_docs = DiscourseDocs(
+    parser=DocParser(
+        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
+    ),
+    document_template="/ceph/document.html",
+    url_prefix="/ceph/docs",
+    blueprint_name="ceph",
+)
+ceph_docs.init_app(app)
+
 
 @app.after_request
 def cache_headers(response):


### PR DESCRIPTION
## Done

- Add discourse module, setup category and topic
- Add tests

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph/docs
- Check that docs appear, navigation links work
