### PR TITLE
Replace Wordpress class with BlogAPI class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 alembic==1.4.2
 canonicalwebteam.flask_base==0.6.3
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.0.0
+canonicalwebteam.blog==6.2.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.image-template==1.1.0
+canonicalwebteam.image-template==1.2.0
 canonicalwebteam.discourse-docs==1.0.0
 canonicalwebteam.launchpad==0.7.6
 python-dateutil==2.8.1

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -5,7 +5,7 @@
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">
       <a href="/blog/{{ article.slug }}" aria-hidden="true" tabindex="-1">
-        <img src="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }}" srcset="https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_460/{{ article.image.source_url }} 460w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_620/{{ article.image.source_url }} 620w, https://res.cloudinary.com/canonical/image/fetch/q_auto,f_auto,w_875/{{ article.image.source_url }} 875w" sizes="(min-width: 1031px) 460px, (max-width: 1030px) and (min-width: 876px) 460px, (max-width: 875px) and (min-width: 621px) 875px, (max-width: 620px) and (min-width: 461px) 620px, (max-width: 460px) 460px" alt="" loading="lazy" />
+        {{ article.image.rendered|safe }}
       </a>
     </div>
     {% endif %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -10,7 +10,7 @@ from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam.search import build_search_view
 from canonicalwebteam import image_template
-from canonicalwebteam.blog import build_blueprint, BlogViews, Wordpress
+from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
 from canonicalwebteam.discourse_docs import (
     DiscourseAPI,
     DiscourseDocs,
@@ -174,7 +174,7 @@ app.add_url_rule(
 # blog section
 
 blog_views = BlogViews(
-    api=Wordpress(session=session),
+    api=BlogAPI(session=session),
     excluded_tags=[3184, 3265, 3408],
     per_page=11,
 )


### PR DESCRIPTION
Replaces `admin.insights.ubuntu.com/wp-content/uploads` with `ubuntu.com/wp-content/uploads`. 
Additionally it enables the cloudinary service for our images again.

## QA

Check out the image url, it will be converted to a cloudinary url, and instead of `admin.insights.ubuntu.com/wp-content` the img url will show `ubuntu.com/wp-content`.

Browse to the blog to check the thumbnails:
https://ubuntu-com-7940.demos.haus/blog

Browse to an article:
https://ubuntu-com-7940.demos.haus/blog/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available

Browse to another article:
https://ubuntu-com-7940.demos.haus/blog/design-and-web-team-summary-20th-july-2020

Everything should look exactly like on prod.

## Issue / Card

Fixes #2995
