### PR TITLE
Restore discourse docs "edit" link and update date

### DIFF
--- a/templates/ceph/document.html
+++ b/templates/ceph/document.html
@@ -1,7 +1,7 @@
 
 {% extends "ceph/base_docs.html" %}
 
-{% block title %} {{ document.title }} | Server documentation{% endblock %}
+{% block title %} {{ document.title }} | Ceph documentation{% endblock %}
 
 {% block content_docs %}
 <div class="p-strip is-shallow">
@@ -10,5 +10,14 @@
     </div>
 </div>
 
-{% endblock %}
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        <div class="p-notification--information">
+            <p class="p-notification__response">
+                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
+            </p>
+        </div>
+    </div>
+</div>
 
+{% endblock %}


### PR DESCRIPTION
## Done

- Restore discourse docs "edit" link and update date

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph/docs
- Check that above mentioned things appear

