### PR TITLE
Reduces whitespace around USN title + summary

### DIFF
--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -3,19 +3,12 @@
 {% block title %}{{ notice.id }}: {{ notice.title }} | Ubuntu security notices{% endblock %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
+<section class="p-strip--suru-topped">
   <div class="row">
-    <div class="col-8">
+    <div class="col-12">
 	    <h1>{{ notice.id }}: {{ notice.title }}</h1>
       <p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
       <p>{{ notice.summary | safe }}</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-12">
       <h2>Releases</h2>
       <ul class="p-inline-list u-no-margin--bottom">
         {% for release in notice.releases %}


### PR DESCRIPTION
## Done

Reduced scrolling required on USN pages by:
- Making the spacing between the summary and the Releases section consistent with the other sections.
- Increasing the title + summary section width from `col-8` to `col-12`, consistent with (most) other sections.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- Visit any individual notice page

## Issue / Card

none

## Screenshots

Before | After
-|-
![image](https://user-images.githubusercontent.com/19801137/87786914-b2171a80-c832-11ea-8315-c43066651ed5.png) | ![image](https://user-images.githubusercontent.com/19801137/87787023-dffc5f00-c832-11ea-9b23-d1afd130b138.png)

