### PR TITLE
Add CVE component search field

### DIFF
--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -5,6 +5,7 @@ const searchInput = document.querySelector("#q");
 function handleCveIdInput(value) {
   const packageInput = document.querySelector("#package");
   const priorityInput = document.querySelector("#priority");
+  const componentInput = document.querySelector("#component");
   const searchButtonText = document.querySelector(".cve-search-text");
   const searchButtonValidCveText = document.querySelector(
     ".cve-search-valid-cve-text"
@@ -16,9 +17,11 @@ function handleCveIdInput(value) {
 
     disableField(packageInput);
     disableField(priorityInput);
+    disableField(componentInput);
   } else {
     enableField(packageInput);
     enableField(priorityInput);
+    enableField(componentInput);
 
     searchButtonText.classList.remove("u-hide");
     searchButtonValidCveText.classList.add("u-hide");

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -20,11 +20,19 @@
         <label for="q">CVE ID or description contains:</label>
         <input type="text" name="q" id="q" value="{{ query or '' }}">
       </div>
-      <div class="col-3">
+      <div class="col-2">
         <label for="package">Package:</label>
         <input type="text" name="package" id="package" value="{{ package or '' }}">
       </div>
-      <div class="col-3">
+      <div class="col-2">
+        <label for="component">Component:</label>
+        <select name="component" id="component">
+          <option value="">Any</option>
+          <option value="main" {% if component == 'main' %}selected{% endif %}>Main</option>
+          <option value="universe" {% if component == 'universe' %}selected{% endif %}>Universe</option>
+        </select>
+      </div>
+      <div class="col-2">
         <label for="priority">Priority:</label>
         <select name="priority" id="priority">
           <option value="">Any</option>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -322,6 +322,7 @@ def cve_index():
     package = flask.request.args.get("package")
     limit = flask.request.args.get("limit", default=20, type=int)
     offset = flask.request.args.get("offset", default=0, type=int)
+    component = flask.request.args.get("component")
 
     is_cve_id = re.match(r"^CVE-\d{4}-\d{4,7}$", query.upper())
 
@@ -378,6 +379,7 @@ def cve_index():
         priority=priority,
         query=query,
         package=package,
+        component=component,
     )
 
 


### PR DESCRIPTION
## Done

Add component search field

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the search form has a field for "Component" and that the options match [the UX spec](https://docs.google.com/document/d/1VuAElUpFay7MBFNmE3NhSyY9TkXiqHcA1ZHQ11AYO-Q/edit#heading=h.aoek8nxke7k9)
- Check that submitting the form puts a `component=` query parameter in the URL (this won't have any effect on the results until https://github.com/canonical-web-and-design/ubuntu.com/issues/7926 is done)


## Issue / Card

Fixes #7927 
