### PR TITLE
Removed ubuntu masters takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,6 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
-  {% include "takeovers/_ubuntu-masters-takeover-202006.html" %}
   {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_ubuntu-pro-intro.html" %}
   {% include "takeovers/_us-kubernetes-event.html" %}


### PR DESCRIPTION
Removed ubuntu masters takeover

## Done

Removed ubuntu masters takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
