### PR TITLE
Make CVEs support components

### DIFF
--- a/webapp/security/alembic/versions/8e9386e7a94b_add_component_column_to_status_table.py
+++ b/webapp/security/alembic/versions/8e9386e7a94b_add_component_column_to_status_table.py
@@ -1,0 +1,38 @@
+"""add component column to status table
+
+Revision ID: 8e9386e7a94b
+Revises: fc282ca1dc4d
+Create Date: 2020-07-16 15:01:39.739465
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8e9386e7a94b"
+down_revision = "fc282ca1dc4d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    components_list = "'main', 'universe', 'esm-infra', 'esm-apps'"
+    op.execute(f"CREATE TYPE components AS ENUM ({components_list});")
+
+    op.add_column(
+        "status",
+        sa.Column(
+            "component",
+            sa.Enum(
+                "main", "universe", "esm-infra", "esm-apps", name="components"
+            ),
+            nullable=False,
+            server_default="main",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("status", "component")
+    op.execute("DROP TYPE components;")

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -166,6 +166,10 @@ class Status(Base):
         )
     )
     description = Column(String)
+    component = Column(
+        Enum("main", "universe", "esm-infra", "esm-apps", name="components"),
+        server_default="main",
+    )
 
     cve = relationship("CVE", back_populates="statuses")
     package = relationship("Package", back_populates="statuses")

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -40,6 +40,21 @@ class ReleaseCodename(String):
         return super()._deserialize(value, attr, data, **kwargs)
 
 
+class Component(String):
+    default_error_messages = {
+        "unrecognised_component": (
+            "Component must be one of "
+            "'main', 'universe', 'esm-infra' or 'esm-apps'"
+        )
+    }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value not in ["main", "universe", "esm-infra", "esm-apps"]:
+            raise self.make_error("unrecognised_component", input=value)
+
+        return super()._deserialize(value, attr, data, **kwargs)
+
+
 # Schemas
 # ===
 
@@ -76,6 +91,7 @@ class Status(Schema):
     release_codename = ReleaseCodename(required=True)
     status = String(required=True)
     description = String(allow_none=True)
+    component = Component(required=False)
 
 
 class CvePackage(Schema):

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -442,6 +442,9 @@ def update_statuses(cve, data, packages, releases):
             status.status = status_data["status"]
             status.description = status_data["description"]
 
+            if "component" in status_data:
+                status.component = status_data["component"]
+
             statuses[name][codename] = status
 
             updated_statuses.append(status)


### PR DESCRIPTION
Add `component` column to `status` table.

## QA

1. Check out this feature branch:
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu.com.git  # get my fork
git fetch albert-fork  # fetch the branches
git checkout add-component-to-cve  # checkout the branch
```

2. Reset database
```bash
docker-compose rm -fs
docker-compose up -d
```

3. Run migration and serve website
```bash
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec alembic upgrade head
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres exec python3 scripts/create-releases.py
dotrun --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres serve
```

4. In another terminal

If you do not have the project yet:
```bash
git clone -b test-status-component-field git@github.com:albertkol/ubuntu-cve-tracker.git # fetch testing branch
```
or if you already have the project just fetch the fork
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu-cve-tracker.git  # get my fork
git fetch albert-fork  # fetch the branches
git checkout test-status-component-field  # checkout the testing branch
```

5. Run import
```bash 
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

The script will import the CVEs and set a random a random component to their status (`main` or `universe`).

6. In a new terminal go to your local `ubuntu.com` repo run
```bash
docker exec -it db psql -h localhost -U postgres
SELECT cve_id,component FROM status
```
You will see that all the CVE's status have accepted a component

## Issue / Card

Fixes #7924
