### PR TITLE
Add CVE search Ubuntu version and status fields

### DIFF
--- a/static/js/src/cve/cve-search.js
+++ b/static/js/src/cve/cve-search.js
@@ -67,4 +67,60 @@ function enableField(field) {
   field.removeAttribute("disabled");
 }
 
-export { isValidCveId, isDomNode, disableField, enableField };
+/**
+ * attachRowEvents
+ *
+ * Adds event listeners to search row buttons
+ *
+ * @returns {undefined}
+ */
+function attachRowEvents() {
+  const addRowButtons = document.querySelectorAll(".js-add-row");
+  const removeRowButtons = document.querySelectorAll(".js-remove-row");
+
+  addRowButtons.forEach((addRowButton) => {
+    addRowButton.addEventListener("click", addRow);
+  });
+
+  removeRowButtons.forEach((removeRowButton) => {
+    removeRowButton.addEventListener("click", removeRow);
+  });
+}
+
+/**
+ * addRow
+ *
+ * Adds Ubuntu version/status row to CVE search form
+ *
+ * @param {Event} e
+ * @returns {undefined}
+ */
+function addRow(e) {
+  e.preventDefault();
+
+  const rowTemplate = document.getElementById("version-field-row-template");
+  const newRowContainer = document.getElementById("new-row-container");
+  const newRow = rowTemplate.content.cloneNode(true);
+
+  newRowContainer.appendChild(newRow);
+
+  attachRowEvents();
+}
+
+/**
+ * removeRow
+ *
+ * Removes Ubuntu version/status row from CVE search form
+ *
+ * @param {Event} e
+ * @returns {undefined}
+ */
+function removeRow(e) {
+  e.preventDefault();
+
+  const row = e.currentTarget.closest(".js-version-field-row");
+
+  row.parentNode.removeChild(row);
+}
+
+export { isValidCveId, isDomNode, disableField, enableField, attachRowEvents };

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -1,4 +1,9 @@
-import { isValidCveId, disableField, enableField } from "./cve-search.js";
+import {
+  isValidCveId,
+  disableField,
+  enableField,
+  attachRowEvents,
+} from "./cve-search.js";
 
 const searchInput = document.querySelector("#q");
 
@@ -6,6 +11,12 @@ function handleCveIdInput(value) {
   const packageInput = document.querySelector("#package");
   const priorityInput = document.querySelector("#priority");
   const componentInput = document.querySelector("#component");
+  const statusInputs = document.querySelectorAll(".js-status-input");
+  const ubuntuVersionInputs = document.querySelectorAll(
+    ".js-ubuntu-version-input"
+  );
+  const addRowButtons = document.querySelectorAll(".js-add-row");
+  const removeRowButtons = document.querySelectorAll(".js-remove-row");
   const searchButtonText = document.querySelector(".cve-search-text");
   const searchButtonValidCveText = document.querySelector(
     ".cve-search-valid-cve-text"
@@ -18,10 +29,30 @@ function handleCveIdInput(value) {
     disableField(packageInput);
     disableField(priorityInput);
     disableField(componentInput);
+
+    statusInputs.forEach((statusInput) => disableField(statusInput));
+    ubuntuVersionInputs.forEach((ubuntuVersionInput) =>
+      disableField(ubuntuVersionInput)
+    );
+    addRowButtons.forEach((addRowButton) => disableField(addRowButton));
+    removeRowButtons.forEach((removeRowButton) =>
+      disableField(removeRowButton)
+    );
   } else {
     enableField(packageInput);
     enableField(priorityInput);
     enableField(componentInput);
+
+    statusInputs.forEach((statusInput) => enableField(statusInput));
+    ubuntuVersionInputs.forEach((ubuntuVersionInput) =>
+      enableField(ubuntuVersionInput)
+    );
+    addRowButtons.forEach((addRowButton) => enableField(addRowButton));
+    removeRowButtons.forEach((removeRowButton, index) => {
+      if (index > 0) {
+        enableField(removeRowButton);
+      }
+    });
 
     searchButtonText.classList.remove("u-hide");
     searchButtonValidCveText.classList.add("u-hide");
@@ -35,3 +66,5 @@ function handleSearchInput(event) {
 }
 
 searchInput.addEventListener("keyup", handleSearchInput);
+
+attachRowEvents();

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -1,0 +1,105 @@
+<table class="cve-table">
+  <thead>
+    <tr>
+      <th style="width: 12em">CVE</th>
+      <th>Package</th>
+      {% for release in releases %}
+        <th>
+          <div class="icon-container__icon">
+            <i class="p-icon--placeholder"></i>
+          </div>
+          <div class="icon-container__text">
+            {{ release.version }} {{ release.support_tag }}
+          </div>
+        </th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for cve in cves %}
+      {% for package_name, statuses in cve.status_tree.items() %}
+        <tr>
+          {% if loop.index == 1 %}
+            <td rowspan="{{ cve.status_tree | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
+          {% endif %}
+          <td>{{ package_name }}</td>
+          {% for release in releases %}
+            {% if release.codename in statuses %}
+              {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
+                <td class="cve-table-cell--muted">
+              {% else %}
+                <td class="cve-table-cell">
+              {% endif %}
+            {% endif %}
+            {% if release.codename in statuses %}
+              {% if statuses[release.codename].status == "DNE" %}
+                <div class="cve-color-strip--dne"></div>
+              {% elif statuses[release.codename].status == "needs-triage" %}
+                <div class="cve-color-strip--needs-triage"></div>
+              {% elif statuses[release.codename].status == "not-affected" %}
+                <div class="cve-color-strip--not-affected"></div>
+              {% elif statuses[release.codename].status == "needed" %}
+                <div class="cve-color-strip--needed"></div>
+              {% elif statuses[release.codename].status == "deferred" %}
+                <div class="cve-color-strip--deferred"></div>
+              {% elif statuses[release.codename].status == "ignored" %}
+                <div class="cve-color-strip--ignored"></div>
+              {% elif statuses[release.codename].status == "pending" %}
+                <div class="cve-color-strip--pending"></div>
+              {% elif statuses[release.codename].status == "released" %}
+                <div class="cve-color-strip--released"></div>
+              {% endif %}
+            {% endif %}
+              <div class="icon-container__icon">
+                {% if statuses[release.codename].status == 'DNE' or statuses[release.codename].status == 'not-affected' %}
+                  <i class="p-icon--placeholder"></i>
+                {% else %}
+                  {% if cve.priority == 'unknown' %}
+                    <i class="p-icon--placeholder"></i>
+                  {% elif cve.priority == 'negligible' %}
+                    <i class="p-icon--negligible-priority"></i>
+                  {% elif cve.priority == 'low' %}
+                    <i class="p-icon--low-priority"></i>
+                  {% elif cve.priority == 'medium' %}
+                    <i class="p-icon--medium-priority"></i>
+                  {% elif cve.priority == 'high' %}
+                    <i class="p-icon--high-priority"></i>
+                  {% elif cve.priority == 'critical' %}
+                    <i class="p-icon--critical-priority"></i>
+                  {% else %}
+                    <i class="p-icon--placeholder"></i>
+                  {% endif %}
+                {% endif %}
+              </div>
+              <div class="icon-container__text">
+                {% if release.codename in statuses %}
+                  {% if statuses[release.codename].status == "DNE" %}
+                    Does not exist
+                  {% elif statuses[release.codename].status == "needs-triage" %}
+                    Needs triage
+                  {% elif statuses[release.codename].status == "not-affected" %}
+                    Not vulnerable
+                  {% elif statuses[release.codename].status == "needed" %}
+                    Needed
+                  {% elif statuses[release.codename].status == "deferred" %}
+                    Deferred
+                  {% elif statuses[release.codename].status == "ignored" %}
+                    Ignored
+                  {% elif statuses[release.codename].status == "pending" %}
+                    Pending
+                  {% elif statuses[release.codename].status == "released" %}
+                    Released
+                  {% else %}
+                    &mdash;
+                  {% endif %}
+                {% else %}
+                  &mdash;
+                {% endif %}
+              </div>
+            </td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/security/cve/_status-fields.html
+++ b/templates/security/cve/_status-fields.html
@@ -1,0 +1,25 @@
+<option value="">Any</option>
+<option value="DNE" {% if statuses[index] == "DNE" %}selected{% endif %}>
+  Does not exist
+</option>
+<option value="needs-triage" {% if statuses[index] == "needs-triage" %}selected{% endif %}>
+  Needs triage
+</option>
+<option value="not-vulnerable" {% if statuses[index] == "not-vulnerable" %}selected{% endif %}>
+  Not vulnerable
+</option>
+<option value="needed" {% if statuses[index] == "needed" %}selected{% endif %}>
+  Needed
+</option>
+<option value="deferred" {% if statuses[index] == "deferred" %}selected{% endif %}>
+  Deferred
+</option>
+<option value="ignored" {% if statuses[index] == "ignored" %}selected{% endif %}>
+  Ignored
+</option>
+<option value="pending" {% if statuses[index] == "pending" %}selected{% endif %}>
+  Pending
+</option>
+<option value="released" {% if statuses[index] == "released" %}selected{% endif %}>
+  Released
+</option>

--- a/templates/security/cve/_version-fields.html
+++ b/templates/security/cve/_version-fields.html
@@ -1,0 +1,6 @@
+<option value="current" {% if versions[index] == "current" %}selected{% endif %}>Any current release</option>
+{% for release in releases %}
+  <option value="{{ release.version }}" {% if versions[index] == release.version %}selected{% endif %}>
+    {{ release.name }} {{ release.version }} {{ release.support_tag }}
+  </option>
+{% endfor %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -53,12 +53,62 @@
           </option>
         </select>
       </div>
-      <div class="col-12">
-        <button type="submit" class="p-button--positive" id="cve-search-button">
-          <span class="cve-search-text">Search</span>
-          <span class="cve-search-valid-cve-text u-hide">Go to CVE</span>
-        </button>
+    </div>
+    <div class="row">
+      <div class="col-3">
+        <label for="version">Ubuntu version</label>
+        <select name="version" id="version" class="js-ubuntu-version-input">
+          <option value="">Any</option>
+          {% with versions=versions, releases=releases, index=0 %}
+          {% include "security/cve/_version-fields.html" %}
+          {% endwith %}
+        </select>
       </div>
+      <div class="col-3">
+        <label for="status">Status</label>
+        <select name="status" id="status" class="js-status-input">
+          {% with statuses=statuses, index=0 %}
+          {% include "security/cve/_status-fields.html" %}
+          {% endwith %}
+        </select>
+      </div>
+      <div class="col-3">
+        <label>&nbsp;</label> <!-- for layout purposes -->
+        <button class="js-remove-row" disabled>&minus;</button>
+        <button class="js-add-row">&plus;</button>
+      </div>
+    </div>
+    {% for status in statuses %}
+      {% if loop.index > 1 %}
+        <div class="row js-version-field-row">
+          <div class="col-3">
+            <select name="version" class="js-ubuntu-version-input">
+              <option value="">Any</option>
+              {% with versions=versions, releases=releases, index=loop.index - 1 %}
+              {% include "security/cve/_version-fields.html" %}
+              {% endwith %}
+            </select>
+          </div>
+          <div class="col-3">
+            <select name="status" class="js-status-input">
+              {% with statuses=statuses, index=loop.index - 1 %}
+              {% include "security/cve/_status-fields.html" %}
+              {% endwith %}
+            </select>
+          </div>
+          <div class="col-3">
+            <button class="js-remove-row" disabled>&minus;</button>
+            <button class="js-add-row">&plus;</button>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+    <div id="new-row-container"></div>
+    <div class="u-fixed-width">
+      <button type="submit" class="p-button--positive" id="cve-search-button">
+        <span class="cve-search-text">Search</span>
+        <span class="cve-search-valid-cve-text u-hide">Go to CVE</span>
+      </button>
     </div>
   </form>
 </section>
@@ -86,111 +136,9 @@
 
   {% if total_results > 0 %}
   <div class="u-fixed-width">
-    <table class="cve-table">
-      <thead>
-        <tr>
-          <th style="width: 12em">CVE</th>
-          <th>Package</th>
-          {% for release in releases %}
-            <th>
-              <div class="icon-container__icon">
-                <i class="p-icon--placeholder"></i>
-              </div>
-              <div class="icon-container__text">
-                {{ release.version }} {{ release.support_tag }}
-              </div>
-            </th>
-          {% endfor %}
-        </tr>
-      </thead>
-      <tbody>
-        {% for cve in cves %}
-          {% for package_name, statuses in cve.status_tree.items() %}
-            <tr>
-              {% if loop.index == 1 %}
-                <td rowspan="{{ cve.status_tree | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
-              {% endif %}
-              <td>{{ package_name }}</td>
-              {% for release in releases %}
-                {% if release.codename in statuses %}
-                  {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
-                    <td class="cve-table-cell--muted">
-                  {% else %}
-                    <td class="cve-table-cell">
-                  {% endif %}
-                {% endif %}
-                {% if release.codename in statuses %}
-                  {% if statuses[release.codename].status == "DNE" %}
-                    <div class="cve-color-strip--dne"></div>
-                  {% elif statuses[release.codename].status == "needs-triage" %}
-                    <div class="cve-color-strip--needs-triage"></div>
-                  {% elif statuses[release.codename].status == "not-affected" %}
-                    <div class="cve-color-strip--not-affected"></div>
-                  {% elif statuses[release.codename].status == "needed" %}
-                    <div class="cve-color-strip--needed"></div>
-                  {% elif statuses[release.codename].status == "deferred" %}
-                    <div class="cve-color-strip--deferred"></div>
-                  {% elif statuses[release.codename].status == "ignored" %}
-                    <div class="cve-color-strip--ignored"></div>
-                  {% elif statuses[release.codename].status == "pending" %}
-                    <div class="cve-color-strip--pending"></div>
-                  {% elif statuses[release.codename].status == "released" %}
-                    <div class="cve-color-strip--released"></div>
-                  {% endif %}
-                {% endif %}
-                  <div class="icon-container__icon">
-                    {% if statuses[release.codename].status == 'DNE' or statuses[release.codename].status == 'not-affected' %}
-                      <i class="p-icon--placeholder"></i>
-                    {% else %}
-                      {% if cve.priority == 'unknown' %}
-                        <i class="p-icon--placeholder"></i>
-                      {% elif cve.priority == 'negligible' %}
-                        <i class="p-icon--negligible-priority"></i>
-                      {% elif cve.priority == 'low' %}
-                        <i class="p-icon--low-priority"></i>
-                      {% elif cve.priority == 'medium' %}
-                        <i class="p-icon--medium-priority"></i>
-                      {% elif cve.priority == 'high' %}
-                        <i class="p-icon--high-priority"></i>
-                      {% elif cve.priority == 'critical' %}
-                        <i class="p-icon--critical-priority"></i>
-                      {% else %}
-                        <i class="p-icon--placeholder"></i>
-                      {% endif %}
-                    {% endif %}
-                  </div>
-                  <div class="icon-container__text">
-                    {% if release.codename in statuses %}
-                      {% if statuses[release.codename].status == "DNE" %}
-                        Does not exist
-                      {% elif statuses[release.codename].status == "needs-triage" %}
-                        Needs triage
-                      {% elif statuses[release.codename].status == "not-affected" %}
-                        Not vulnerable
-                      {% elif statuses[release.codename].status == "needed" %}
-                        Needed
-                      {% elif statuses[release.codename].status == "deferred" %}
-                        Deferred
-                      {% elif statuses[release.codename].status == "ignored" %}
-                        Ignored
-                      {% elif statuses[release.codename].status == "pending" %}
-                        Pending
-                      {% elif statuses[release.codename].status == "released" %}
-                        Released
-                      {% else %}
-                        &mdash;
-                      {% endif %}
-                    {% else %}
-                      &mdash;
-                    {% endif %}
-                  </div>
-                </td>
-              {% endfor %}
-            </tr>
-          {% endfor %}
-        {% endfor %}
-      </tbody>
-    </table>
+    {% with cves=cves, releases=releases %}
+    {% include "security/cve/_cve-table.html" %}
+    {% endwith %}
 
     {% with %}
     {% include "security/cve/_pagination.html" %}
@@ -198,6 +146,37 @@
   </div>
   {% endif %}
 </section>
+
+<template id="version-field-row-template">
+  <div class="row js-version-field-row">
+    <div class="col-3">
+      <select name="version" class="js-ubuntu-version-input">
+        <option value="">Any</option>
+        <option value="current">Any current release</option>
+        {% for release in releases %}
+          <option value="{{ release.version }}">{{ release.name }} {{ release.version }} {{ release.support_tag }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-3">
+      <select name="status" class="js-status-input">
+        <option value="">Any</option>
+        <option value="DNE">Does not exist</option>
+        <option value="needs-triage">Needs triage</option>
+        <option value="not-vulnerable">Not vulnerable</option>
+        <option value="needed">Needed</option>
+        <option value="deferred">Deferred</option>
+        <option value="ignored">Ignored</option>
+        <option value="pending">Pending</option>
+        <option value="released">Released</option>
+      </select>
+    </div>
+    <div class="col-3">
+      <button class="js-remove-row">&minus;</button>
+      <button class="js-add-row">&plus;</button>
+    </div>
+  </div>
+</template>
 
 <script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -380,6 +380,8 @@ def cve_index():
         query=query,
         package=package,
         component=component,
+        versions=flask.request.args.getlist("version"),
+        statuses=flask.request.args.getlist("status"),
     )
 
 


### PR DESCRIPTION
## Done

- Move CVE table to partial to make template more legible
- Add CVE search fields for Ubuntu version and status

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Check that there are search fields for Ubuntu version and status
- Check that you are able to add and remove rows
- Submit the form and check that the appropriate fields are still selected
- **Note:** The results won't be affected until the backend is completed in https://github.com/canonical-web-and-design/ubuntu.com/issues/7928

## Issue / Card

Fixes #7929 

## Screenshots

![cve_search](https://user-images.githubusercontent.com/501889/87947497-51d6e180-ca9b-11ea-8006-e5dc4a0acb9e.png)

