### PR TITLE
Fix copy on discourse appliance cta

### DIFF
--- a/templates/appliance/shared/_join_the_community.html
+++ b/templates/appliance/shared/_join_the_community.html
@@ -6,7 +6,7 @@
       </h2>
       <p>
         {% if appliance_name %}
-        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place news views.
+        Our <a href="https://discourse.ubuntu.com/c/appliance">Discourse forum for {{ appliance_name }}</a> is the best place for news and views.
         {% else %}
         Our <a href="https://discourse.ubuntu.com/c/appliance">discussion forum for Ubuntu Appliances</a> is the best place for news and views.
         {% endif %}


### PR DESCRIPTION
## Done

- Fixed text on the appliance pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/nextcloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that s/Our Discourse forum for NextCloud is the best place news views/Our Discourse forum for NextCloud is the best place **for** news **and** views/


## Issue / Card

Fixes #7952
