### PR TITLE
Add bug links to CVE pages

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -228,6 +228,15 @@
           </li>
         </ul>
         {% endif %}
+
+        {% if cve.bugs %}
+        <h2>Bugs</h2>
+        <ul>
+          {% for bug in cve.bugs %}
+          <li><a href="{{ bug }}">{{ bug }}</a></li>
+          {% endfor %}
+        </ul>
+        {% endif %}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

Add bug links to CVE pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://localhost:8001/security/cve-2019-16935
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run DB:

```
docker-compose rm -fs
docker-compose up
```

In another terminal:

```
dotrun exec alembic upgrade head
dotrun exec python3 scripts/create-releases.py
dotrun
```

In yet another terminal:

```
git clone -b load-cve git@github.com:carkod/ubuntu-cve-tracker
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

You may have to uncomment line 60 in `upload-cve.py` so you are using localhost, and comment out the line under it

Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

- Check that there is a section called "Bugs" which has a list of links

## Issue/card
Fixes #7884
