### PR TITLE
Add links to Debian, NVD and Launchpad to CVE page

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -213,18 +213,30 @@
         {% endif %}
 
         <h2>References</h2>
-        {% if cve.references %}
         <ul>
-          {% for reference in cve.references %}
-          <li><a href="{{ reference }}">{{ reference }}</a></li>
-          {% endfor %}
-        </ul>
-        {% else %}
-        <ul>
+          {% if cve.references %}
+            {% for reference in cve.references %}
+            <li><a href="{{ reference }}">{{ reference }}</a></li>
+            {% endfor %}
+          {% else %}
+            <li>
+              <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
+                MITRE
+              </a>
+            </li>
+          {% endif %}
           <li>
-            <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
-              MITRE
+            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
+              NVD
             </a>
+          </li>
+          <li>
+            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
+              Launchpad
+            </a>
+          </li>
+          <li>
+            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
           </li>
         </ul>
         {% endif %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -239,7 +239,6 @@
             <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
           </li>
         </ul>
-        {% endif %}
 
         {% if cve.bugs %}
         <h2>Bugs</h2>


### PR DESCRIPTION
## Done

Add Debian, NVD and Launchpad links to CVE pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://localhost:8001/security/cve-2019-16935
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Run DB:

```
docker-compose rm -fs
docker-compose up
```

In another terminal:

```
dotrun exec alembic upgrade head
dotrun exec python3 scripts/create-releases.py
dotrun
```

In yet another terminal:

```
git clone -b load-cve git@github.com:carkod/ubuntu-cve-tracker
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

You may have to uncomment line 60 in `upload-cve.py` so you are using localhost, and comment out the line under it

Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

- Check that there are links to the NVD, Debian and Launchpad bugtrackers in the references section

## Issue/card
Fixes #7884
