### PR TITLE
Add Anbox whitepaper takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,7 @@
 
 {% block takeover_content %}
   {# ALL #}
+  {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
   {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_ubuntu-pro-intro.html" %}

--- a/templates/takeovers/_intro-to-anbox-cloud-whitepaper.html
+++ b/templates/takeovers/_intro-to-anbox-cloud-whitepaper.html
@@ -1,0 +1,16 @@
+{% with title="Scale Android apps in the cloud with Anbox Cloud",
+subtitle="Distribute apps to any device, securely and economically",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg",
+image_height="246",
+image_width="338",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/intro-to-anbox-cloud-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_AnboxCloud_Whitepaper_IntrotoAnboxCloud",
+primary_cta="Download the whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -152,4 +152,6 @@
 {% include "takeovers/_us-kubernetes-event.html" %}
 <p>22 July 2020 - Portuguese</p>
 {% include "takeovers/pt/_vmware-para-o-openstack.html" %}
+<p>22 July 2020 - Anbox whitepaper</p>
+{% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add Anbox whitepaper takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [brief](https://docs.google.com/spreadsheets/d/1DgSWaHKFsQRfdUiqWTCxvMIFlb3VozF3QPEOS-Zw_cE/edit#gid=2113339190)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2990

## Screenshots

![image](https://user-images.githubusercontent.com/441217/88200214-c3e72c00-cc3d-11ea-9530-d40bea8377bd.png)

