### PR TITLE
Fix broken /takeovers page

### DIFF
--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -137,7 +137,7 @@
 <p>15 May 2020</p>
 {% include "takeovers/_snapd-takeover.html" %}
 <p>22 May 2020</p>
-{% include "takeovers/_cio-guide-to-multipass-fr.html" %}
+{% include "takeovers/fr/_cio-guide-to-multipass.html" %}
 <p>28 May 2020</p>
 {% include "takeovers/_kafka-in-production_takeover.html" %}
 <p>2 June 2020</p>


### PR DESCRIPTION
## Done

Fix include to takeover which was causing the /templates page to 500

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page loads