### PR TITLE
Fix rendering for k8s docs container image list

### DIFF
--- a/templates/kubernetes/docs/1.18/components.md
+++ b/templates/kubernetes/docs/1.18/components.md
@@ -332,6 +332,7 @@ The [addons][] installed alongside Kubernetes make use of additional container
 images. These are the ones used by this release:
 
 <!-- GENERATED CONTAINER IMAGES -->
+
 -   addon-resizer-amd64:1.8.5
 -   addon-resizer-arm64:1.8.5
 -   addon-resizer-ppc64le:1.8.5
@@ -382,6 +383,7 @@ images. These are the ones used by this release:
 -   registry-amd64:2.6
 -   registry-arm64:2.6
 -   sonatype/nexus3:latest
+
 <!-- CONTAINER IMAGES END -->
 
 ## Snaps


### PR DESCRIPTION
the markdown parser on u.c expects a blank line before the list

## Done

Added two blank lines to components doc page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that the images list renders as a <ul> 


