### PR TITLE
Updated the benefits of Ceph diagram on /ceph

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -95,7 +95,7 @@
       <figure>
         {{
           image(
-            url="https://assets.ubuntu.com/v1/5d868fd5-Benefits-of-ceph-on-ubuntu.svg",
+            url="https://assets.ubuntu.com/v1/e76a9b6d-Benefits-of-ceph-on-ubuntu-2020-opt1.svg",
             alt="Ubuntu, Openstack and Ceph support cadence",
             height="246",
             width="772",

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -91,14 +91,14 @@
   </div>
 
   <div class="row">
-    <div class="col-9 u-sv3">
+    <div class="col-12 u-sv3">
       <figure>
         {{
           image(
             url="https://assets.ubuntu.com/v1/e76a9b6d-Benefits-of-ceph-on-ubuntu-2020-opt1.svg",
             alt="Ubuntu, Openstack and Ceph support cadence",
-            height="246",
-            width="772",
+            height="208",
+            width="798",
             hi_def=True,
             loading="lazy",
           ) | safe


### PR DESCRIPTION
## Done

- Updated the benefits of Ceph diagram on /ceph

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a new image shows OpenStack Stein as being associated with Ceph Mimic.

## Issue / Card

Fixes #7979

## Screenshots

![](https://assets.ubuntu.com/v1/e76a9b6d-Benefits-of-ceph-on-ubuntu-2020-opt1.svg)
