### PR TITLE
Add gsi webinar takeover and engage page

### DIFF
--- a/templates/engage/_article-card.html
+++ b/templates/engage/_article-card.html
@@ -1,5 +1,5 @@
 <article class="col-4 blog-p-card--post">
-  <header class="blog-p-card__header--{{group}}">
+  <header class="blog-p-card__header{% if 'whitepaper' in type %}--internet-of-things{% elif 'webinar' in type %}--desktop{% elif 'case study' in type %}--cloud-and-server{% endif %}">
     <h5 class="p-muted-heading u-no-margin--bottom">
       {{type}}
     </h5>

--- a/templates/engage/gsi-webinar-series.html
+++ b/templates/engage/gsi-webinar-series.html
@@ -1,0 +1,237 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Building powerful customer solutions{% endblock %}
+
+{% block meta_description %}A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments{% endblock %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/533d8f4a-social-gsi-webinar-series.png{% endblock meta_image %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1ZweTXyHO9kIU9aE8pw2_Ni_NoBShM_KseY5H2XtGueg/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
+<section class="p-strip p-engage-banner--dark">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+        alt="Ubuntu",
+        width="143",
+        height="32",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </a>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-7  u-vertically-center">
+      <div>
+        <h1>
+          Building powerful customer solutions
+        </h1>
+        <h4>
+          A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments
+        </h4>
+      </div>
+    </div>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/1224031f-1-Discovery.svg",
+        alt="",
+        width="325",
+        height="198",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <p>
+        Join us for a webinar series for GSI professionals who are:
+      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Overcoming difficult technological challenges to build solutions and platforms for their customers</li>
+        <li class="p-list__item is-ticked">Want scaleable, automated and repeatable deployments that lead to better customer opex, economics and revenue opportunities, while helping customers meet their digital transformation goals</li>
+        <li class="p-list__item is-ticked">Seizing new models for delivery</li>
+      </ul>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>
+        How to create a private cloud with your data centre: provisioning servers in minutes
+      </h2>
+      <h4>
+        20 August at 12 pm ET and later on demand
+      </h4>
+      <p>
+        <em>
+          What you will learn:
+        </em>
+      </p>
+      <ul class="p-link">
+        <li class="p-link__item">
+          Hear how T-Mobile implemented their MAAS solution.
+        </li>
+        <li class="p-link__item">
+          Engage directly with Canonical experts about accelerating data centre operations by automating hardware provisioning and configuration.
+        </li>
+        <li class="p-link__item">
+          Learn how to implement a self-service UX for large scale operations with MAAS, taking deployment times from months down to minutes.
+        </li>
+        <li class="p-link__item">
+          Discuss the application for both for you as an SI, and your clients.
+        </li>
+      </ul>
+      <p>
+        <em>
+          Who should attend:
+        </em>
+      </p>
+      <p>
+        Teams that want to learn how to future-proof their data centre or multi-cloud architecture. A demo will be available for technical team members who want to see how the platform works.
+      </p>
+      <p>
+        <a class="p-button--positive p-link--external" href="https://www.brighttalk.com/webcast/6793/427943?utm_source=Canonical&utm_medium=brighttalk&utm_campaign=427943">
+          Watch the webinar
+        </a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/40d4f11a-servers.svg",
+        alt="",
+        width="290",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr style="margin: 2rem 0;" />
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>
+        Streamlined Kubernetes from cloud to edge: open source, cloud-native container orchestration for innovation and scaling
+      </h2>
+      <h4>
+        10 September at 12 pm ET and later on demand
+      </h4>
+      <p>
+        Kubernetes has spawned much interest from developers and businesses with many use case scenarios for adoption.
+      </p>
+      <p>
+        <em>
+          During this talk we will address:
+        </em>
+      </p>
+      <ul class="p-link">
+        <li class="p-link__item">
+          Full flexibility of Kubernetes from cloud to edge for efficient innovation and scaling.
+        </li>
+        <li class="p-link__item">
+          Challenges users face when adopting Kubernetes.
+        </li>
+        <li class="p-link__item">
+          Reusability of processes and functionality across substrates.
+        </li>
+        <li class="p-link__item">
+          MicroK8s for local devices, restricted environment and edge enterprise distribution of Kubernetes.
+        </li>
+      </ul>
+      <p>
+        <em>
+          Who should attend:
+        </em>
+      </p>
+      <p>
+        Business decision-makers who want to Interact directly with experts from Canonical about implementing a reliable strategy for Kubernetes deployment across varying needs.
+      </p>
+      <p>
+        <a class="p-button--positive p-link--external" href="https://www.brighttalk.com/webcast/6793/427958?utm_source=Canonical&utm_medium=brighttalk&utm_campaign=427958">
+          Watch the webinar
+        </a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/91154a9f-Managed+Kubernetes.svg",
+        alt="Kubernetes Managed Service Provider",
+        width="290",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        attrs={"style": "height: 200px;"},
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row">
+    <h2>
+      Learn more about partnering for success
+    </h2>
+  </div>
+  <div class="row p-divided">
+    <div class="col-4 p-divider__block">
+      <h4>
+        Resources
+      </h4>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="/engage/private-cloud-build-webinar">
+            Lessons learned from 100+ private cloud builds&nbsp;&rsaquo;
+          </a>
+        </li>
+        <li class="p-list__item">
+          <a href="/engage/moving-to-opensource-whitepaper">
+            Embracing the open source mandate&nbsp;&rsaquo;
+          </a>
+        </li>
+        <li class="p-list__item">
+          <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/385799">
+            Accelerating IoT device time to market
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>
+        Grow with Canonical
+      </h4>
+      <p>
+        <a class="p-link--external" href="https://canonical.com/partners/gsi">Learn more about our GSI Partner Programme.</a>
+      </p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>
+        Access the Partner Portal
+      </h4>
+      <p>
+        <a class="p-link--external" href="https://partner-portal.canonical.com">Tools for learning, sales support and deal registration.</a>
+      </p>
+    </div>
+
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -18,1077 +18,972 @@
 <section class="p-strip is-shallow" id="posts-list">
   <div class="row u-equal-height u-clearfix">
     {% with title="ESM for Ubuntu 14.04 LTS Trusty Tahr",
-      description="Extended Security Maintenance (ESM) will be available for Ubuntu 14.04 LTS Trusty Tahr for continued security and compliance of the most popular linux operating system.",
-      slug="14-04-esm",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Extended Security Maintenance (ESM) will be available for Ubuntu 14.04 LTS Trusty Tahr for continued security and compliance of the most popular linux operating system.",
+    slug="14-04-esm",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="With the release of Ubuntu 19.04",
-      description="Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.",
-      slug="19-04-webinar",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Our most advanced release to date offers developers and innovators the first chance to experience the latest open source software available including the Linux 5.0 Kernel, OpenStack Stein, Kubernetes version 1.14 and Ceph Mimic.",
+    slug="19-04-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Connected cars and autonomous driving",
-      description="The automotive industry is expanding its frontiers with the arrival of connected cars and autonomous driving. Find out the challenges brought by this revolution and what is being done to overcome them.",
-      slug="451-automotive",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="The automotive industry is expanding its frontiers with the arrival of connected cars and autonomous driving. Find out the challenges brought by this revolution and what is being done to overcome them.",
+    slug="451-automotive",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Busting the myth of private cloud economics",
-      description="Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.",
-      slug="451-cloud-economics",
-      group="cloud-and-server",
-      type="case-study" %}
-      {% include "engage/_article-card.html" %}
+    description="Canonical took part in 451 Research Cloud Price Index (CPI) in Sept 2017, and compared its pricing and services against the industry using the CPI’s benchmark averages and market distributions.",
+    slug="451-cloud-economics",
+    type="case-study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How to get started and progress with an AI program",
-      description="Whether you are just exploring the opportunities that AI can hold for your business or are preparing to deploy in production at scale join us to learn what you need to achieve your goals.",
-      slug="ai-gettingstarted",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Whether you are just exploring the opportunities that AI can hold for your business or are preparing to deploy in production at scale join us to learn what you need to achieve your goals.",
+    slug="ai-gettingstarted",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Artificial intelligence, machine learning and Ubuntu",
-      description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.",
-      slug="ai-ml-ubuntu",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.",
+    slug="ai-ml-ubuntu",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="An introduction to AppArmor",
-      description="An explanation of AppArmor, its key features and why the principle of least privilege is recommended.",
-      slug="apparmor-intro",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="An explanation of AppArmor, its key features and why the principle of least privilege is recommended.",
+    slug="apparmor-intro",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Azeti uses Ubuntu Core to improve deployment and security",
-      description="Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.",
-      slug="casestudy-azeti",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.",
+    slug="casestudy-azeti",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="AZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions",
-      description="Learn how Azlogica, a Latin American IoT company, turned to Ubuntu to help their client, Oceanos, to maximise shrimp production and revenues utilising Ubuntu Core and Dell Edge Gateways.",
-      slug="casestudy-azlogica",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn how Azlogica, a Latin American IoT company, turned to Ubuntu to help their client, Oceanos, to maximise shrimp production and revenues utilising Ubuntu Core and Dell Edge Gateways.",
+    slug="casestudy-azlogica",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="BotsAndUs builds a social robot on Ubuntu",
-      description="To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects.",
-      slug="casestudy-botsandus",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="To bring its robot, Bo, to market, BotsAndUs needed an OS that could support the wide variety of hardware and software involved in the product; and the robotics company quickly discovered that Ubuntu offered the ideal combination of versatility and suitability for embedded projects.",
+    slug="casestudy-botsandus",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Cinergy makes significant digital signage saving with Screenly Pro and Ubuntu Core",
-      description="Find out why Cinergy turned to Screenly Pro and Ubuntu Core to help with their content management needs in such a marketing driven business.",
-      slug="casestudy-cinergy",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Find out why Cinergy turned to Screenly Pro and Ubuntu Core to help with their content management needs in such a marketing driven business.",
+    slug="casestudy-cinergy",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="City Network brings OpenStack cloud hosting to the financial services sector with Canonical",
-      description="In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance.",
-      slug="casestudy-city-network",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="In the global cloud hosting arena, City Network stands out from the pack thanks to superb service quality and a unique focus on industry-specific regulatory compliance.",
+    slug="casestudy-city-network",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Commercetools uses Ubuntu Server to power its next-generation ecommerce platform",
-      description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels.",
-      slug="casestudy-commercetools",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Commercetools helps enterprises to digitally transform their entire sales operations across all channels.",
+    slug="casestudy-commercetools",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="IMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in the supply chain",
-      description="Find out how IMS Evolve adopted Ubuntu Core running on Dell Edge Gateways to run the cold-chain solutions of some of the recognisable food retailers.",
-      slug="casestudy-imsevolve",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Find out how IMS Evolve adopted Ubuntu Core running on Dell Edge Gateways to run the cold-chain solutions of some of the recognisable food retailers.",
+    slug="casestudy-imsevolve",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How Ubuntu helped InnovaPOS revolutionise the vending machine industry",
-      description="The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period.",
-      slug="casestudy-innovapos",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="The smart vending machines market is on the rise with estimates of 2.7 million to be sold by 2020 with Asia Pacific predicted to be the fastest growing region with a CAGR of 15% over the same period.",
+    slug="casestudy-innovapos",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance",
-      description="Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.",
-      slug="ITstrategen-case-study",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Extended Security Maintenance extends official support for the operating system, guaranteeing the continued security of ITstrategen’s servers and saving its clients from costly application updates.",
+    slug="ITstrategen-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="NEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE",
-      description="IoT is delivering real value for many smart businesses and is capturing people’s imagination because of its immense openness and flexibility.",
-      slug="casestudy-nexiona",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="IoT is delivering real value for many smart businesses and is capturing people’s imagination because of its immense openness and flexibility.",
+    slug="casestudy-nexiona",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Rocket.Chat communication platform enables simplicity through snaps",
-      description="As Rocket.Chat has evolved, it has been keen to get its platform into the hands of as many users as possible without the difficulties of installation often associated with bespoke Linux deployments.",
-      slug="casestudy-rocketchat",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="As Rocket.Chat has evolved, it has been keen to get its platform into the hands of as many users as possible without the difficulties of installation often associated with bespoke Linux deployments.",
+    slug="casestudy-rocketchat",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Sensape uses Landscape to remotely support revolutionary interactive retail displays",
-      description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.",
-      slug="casestudy-sensape",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Sensape is teaching computers to see, understand and interact with people at trade events and in retail locations. Instead of using unchanging, predefined content, the Sensape systems senses its environment and reacts accordingly.",
+    slug="casestudy-sensape",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Busting the myth of private cloud economics",
-      description="Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.",
-      slug="cloud-economics",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Private cloud costs: the new report from 451 Research found Canonical’s managed private cloud to be cheaper than 25 of the public cloud providers included in the Cloud Price benchmark.",
+    slug="cloud-economics",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How to face the challenges of becoming a cloud operator",
-      description="In a shifting market, the traditional revenues of telcos and service providers are under threat. Voice revenues are at an all-time low, and high wireless data costs are negatively impacting margins.",
-      slug="cloud-fray",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="In a shifting market, the traditional revenues of telcos and service providers are under threat. Voice revenues are at an all-time low, and high wireless data costs are negatively impacting margins.",
+    slug="cloud-fray",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Cloud init",
-      description="Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast.",
-      slug="cloud-init-whitepaper",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Private cloud, public cloud, hybrid cloud, multi-cloud… the variety of locations, platforms and physical substrate you can start a cloud instance on is vast.",
+    slug="cloud-init-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Why Ubuntu Core is the most secure choice for IoT",
-      description="Join this webinar hosted by Alex Murray, Technical Lead of the Ubuntu Security Team to find out about the latest security features of Ubuntu Core, the tiny, transactional version of Ubuntu designed specifically for IoT.",
-      slug="core18-security",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Join this webinar hosted by Alex Murray, Technical Lead of the Ubuntu Security Team to find out about the latest security features of Ubuntu Core, the tiny, transactional version of Ubuntu designed specifically for IoT.",
+    slug="core18-security",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="CTO’s guide to SDN, NFV &amp; VNF",
-      description="Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital: from function-specific, proprietary devices to software-enabled commodity hardware.",
-      slug="cto-guide-sdn-nfv-vnf",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="Networking and communications standards and methodologies are undergoing the greatest transition since the migration from analogue to digital: from function-specific, proprietary devices to software-enabled commodity hardware.",
+    slug="cto-guide-sdn-nfv-vnf",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="How to build and deploy your first AI/ML model on Ubuntu",
-      description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.",
-      slug="deploy-ai-ml-model",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="An introduction to AI and ML workloads on Ubuntu workstations, servers and in the cloud on a Kubernetes stack.",
+    slug="deploy-ai-ml-model",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Six reasons why developers choose Ubuntu Desktop",
-      description="What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu.",
-      slug="developer-desktop",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="What's the most popular Linux OS? This whitepaper examines six key reasons why the developer community turn to Ubuntu.",
+    slug="developer-desktop",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Get started with DevOps best practices: CI/CD",
-      description="A webinar to learn how to automate Continuous Integration, Continuous Delivery, and Continuous Deployment with Kubernetes",
-      slug="devops-cicd-webinar",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="A webinar to learn how to automate Continuous Integration, Continuous Delivery, and Continuous Deployment with Kubernetes",
+    slug="devops-cicd-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="The transformation of the DevOps journey in IoT",
-      description="Traditional development methods do not scale into the IoT sphere",
-      slug="devops-iot-webinar",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Traditional development methods do not scale into the IoT sphere",
+    slug="devops-iot-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Server Provisioning: What Network Admins &amp; IT Pros Need to Know",
-      description="Server provisioning tools help organisations to take full advantage of existing investments by maximising hardware efficiency.",
-      slug="ebook-maas",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="Server provisioning tools help organisations to take full advantage of existing investments by maximising hardware efficiency.",
+    slug="ebook-maas",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="A guide to edge computing and the tools you need",
-      description="Join Canonical Product Managers for a series of webinars on edge computing to learn what is driving businesses to process their data at the edge and how you can add an edge computing layer to your business infrastructure.",
-      slug="edge-month",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Join Canonical Product Managers for a series of webinars on edge computing to learn what is driving businesses to process their data at the edge and how you can add an edge computing layer to your business infrastructure.",
+    slug="edge-month",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="The essential guide for Telecoms and Service Providers adopting big data solutions",
-      description="This eBook provides telecom and service provider executives with a basic introduction to big data and analytics processing in the telecom industry.",
-      slug="essential-guide-big-data-solutions",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="This eBook provides telecom and service provider executives with a basic introduction to big data and analytics processing in the telecom industry.",
+    slug="essential-guide-big-data-solutions",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Keep up with evolving software",
-      description="Software keeps evolving and management complexity tends to increase with successive stack updates. Learn how using Juju can solve software management complexity and how it provides a familiar approach to managing any type of stack.",
-      slug="evolving-software",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Software keeps evolving and management complexity tends to increase with successive stack updates. Learn how using Juju can solve software management complexity and how it provides a familiar approach to managing any type of stack.",
+    slug="evolving-software",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Canonical presents Financial Services Month",
-      description="The fintech infrastructure is moving on. A series of webinars to have an understanding of the emerging technologies: multi-cloud, AI/ML, Blockchain and Containers, and their impact on the financial services industry.",
-      slug="financial-services-month",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="The fintech infrastructure is moving on. A series of webinars to have an understanding of the emerging technologies: multi-cloud, AI/ML, Blockchain and Containers, and their impact on the financial services industry.",
+    slug="financial-services-month",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Fing serves 30,000 customers with a secure, future-proof IoT device",
-      description="Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades.",
-      slug="fingbox-case-study",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Case study: using Ubuntu Core and an IoT appstore enabled Fing to bring a secure IoT device to market very quickly, saving development time and allowing for automated upgrades.",
+    slug="fingbox-case-study",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Multi-cloud fundamental to financial services transformation",
-      description="This whitepaper highlights the need for the finserv industry to evolve its infrastructure and the means to achieve it without friction.",
-      slug="finserv-multi-cloud",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="This whitepaper highlights the need for the finserv industry to evolve its infrastructure and the means to achieve it without friction.",
+    slug="finserv-multi-cloud",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Future-proofing Fingbox, the IoT home network monitoring device",
-      description="In this webinar, you’ll learn how Fingbox was built with Ubuntu Core and how Fingbox’s key features are updated and improved ongoing using Snaps.",
-      slug="future-proof-iot",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="In this webinar, you’ll learn how Fingbox was built with Ubuntu Core and how Fingbox’s key features are updated and improved ongoing using Snaps.",
+    slug="future-proof-iot",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Hiri successfully monetises their snap",
-      description="Business focused email client demonstrates that proprietary apps can be monetised on the Linux desktop.",
-      slug="hiri-case-study",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Business focused email client demonstrates that proprietary apps can be monetised on the Linux desktop.",
+    slug="hiri-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Apellix engineers safer work environments with Ubuntu powered aerial robotics",
-      description="This case study presents how Apellix, an industrial drone company, engineers safer work environments with Ubuntu.",
-      slug="industrial-drones-case-study",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="This case study presents how Apellix, an industrial drone company, engineers safer work environments with Ubuntu.",
+    slug="industrial-drones-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Precision drones on Ubuntu: flying at the edge of innovation",
-      description="This webinar discusses how Apellix uses Ubuntu to solve industrial IoT challenges with precision drones.",
-      slug="industrial-drones",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="This webinar discusses how Apellix uses Ubuntu to solve industrial IoT challenges with precision drones.",
+    slug="industrial-drones",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Establishing a software defined IoT business model",
-      description="Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs.",
-      slug="iot-business-model",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Whitepaper: How device manufacturers can go from building single function devices with little to no software strategy to building devices defined by software and software business models, powered by app stores and ecosystems of 3rd party ISVs.",
+    slug="iot-business-model",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="The transformation of the DevOps journey in IoT",
-      description="Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms",
-      slug="iot-devops",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Traditional development methods do not scale into the IoT sphere. Strong inter-dependencies and blurred boundaries among components in the edge device stack result in fragmentation, slow updates, security issues, increased cost, and reduced reliability of platforms",
+    slug="iot-devops",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Securing IoT device data against physical access",
-      description="A technical overview of how Ubuntu Core with full disk encryption and secure boot can be implemented in IoT devices to provide protection in data sensitive scenarios.",
-      slug="iot-disk-encryption",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="A technical overview of how Ubuntu Core with full disk encryption and secure boot can be implemented in IoT devices to provide protection in data sensitive scenarios.",
+    slug="iot-disk-encryption",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="ITstrategen keeps legacy applications secure with Extended Security Maintenance",
-      description="ITstrategen keeps legacy applications secure with Extended Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical.",
-      slug="ITstrategen-case-study",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="ITstrategen keeps legacy applications secure with Extended Security Maintenance (ESM), a feature of the Ubuntu Advantage support subscriptions from Canonical.",
+    slug="ITstrategen-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Allan Gray unlocks unprecedented availability and productivity with Charmed Kubernetes",
-      description="Canonical's Charmed Kubernetes cut financial servies company, Allan Gray's, Kubernetes cluster deployment time from two months to two weeks, with enterprise Kubernetes support provided to ensure maximum availability.",
-      slug="k8s-allan-gray",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Canonical's Charmed Kubernetes cut financial servies company, Allan Gray's, Kubernetes cluster deployment time from two months to two weeks, with enterprise Kubernetes support provided to ensure maximum availability.",
+    slug="k8s-allan-gray",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Low latency and real-time kernels for telco and NFV",
-      description="Which kernel provides the most balanced operational efficiency? A detailed analysis comparing real-time kernel assumptions against test results designed to reflect telco and NFV workloads.",
-      slug="kernel-telco-nfv",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Which kernel provides the most balanced operational efficiency? A detailed analysis comparing real-time kernel assumptions against test results designed to reflect telco and NFV workloads.",
+    slug="kernel-telco-nfv",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Low latency and real time kernels for telco and NFV",
-      description="This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes.",
-      slug="low-latency-report",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="This special report provides data on dozens of kernel-specific benchmark scenarios, and a complete analysis of their outcomes.",
+    slug="low-latency-report",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How to build a lightweight system container cluster",
-      description="LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them.",
-      slug="lxd-whitepaper",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="LXD, the system container manager, developed by Canonical and shipped by default with Ubuntu, makes it possible to create many containers of various Linux distributions and manage them in a way similar to virtual machines (VMs) but with lower overhead costs associated with them.",
+    slug="lxd-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How to integrate Ubuntu Desktop with Active Directory",
-      description="Ubiquitous use of Microsoft tools coupled with increasing popularity of open source Linux software for enterprise presents new challenges for non-Microsoft operating systems that require seamless integration with Active Directory for authentication and identity management.",
-      slug="microsoft-active-directory",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Ubiquitous use of Microsoft tools coupled with increasing popularity of open source Linux software for enterprise presents new challenges for non-Microsoft operating systems that require seamless integration with Active Directory for authentication and identity management.",
+    slug="microsoft-active-directory",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Modernise your cloud",
-      description="This webinar discusses how Trilio and Canonical help organisations transition to new, maintainable cloud architecture in just weeks.",
-      slug="modern-cloud",
-      group="desktop",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="This webinar discusses how Trilio and Canonical help organisations transition to new, maintainable cloud architecture in just weeks.",
+    slug="modern-cloud",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="CIO guide to multi-cloud operations",
-      description="What is the right cloud strategy for your business? A whitepaper with objective discussion of the various approaches to cloud computing and a clear definition for each of them: public cloud, private cloud, managed cloud, hybrid cloud and multi-cloud.",
-      slug="multi-cloud-guide",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="What is the right cloud strategy for your business? A whitepaper with objective discussion of the various approaches to cloud computing and a clear definition for each of them: public cloud, private cloud, managed cloud, hybrid cloud and multi-cloud.",
+    slug="multi-cloud-guide",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="NFV and SDN on OpenStack",
-      description="Network Functions Virtualisation (NFV) and Software-Defined Networking (SDN) are two of the hottest infrastructure technologies around",
-      slug="nfv-sdn-openstack",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="Network Functions Virtualisation (NFV) and Software-Defined Networking (SDN) are two of the hottest infrastructure technologies around",
+    slug="nfv-sdn-openstack",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="North America‘s first autonomous runway snowplough",
-      description="Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.",
-      slug="northstar",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Northstar Robotics, a Canadian tech start-up founded in 2016, wants to address these challenges by developing autonomous vehicles and wanted to find out if an entire network of vehicles can be powered by a single intelligent control system.",
+    slug="northstar",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="OpenStack made easy",
-      description="The change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge from a different perspective.",
-      slug="openstack-made-easy",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="The change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge from a different perspective.",
+    slug="openstack-made-easy",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Private cloud security",
-      description="In regulated sectors, private cloud security needs to meet the highest requirements. This webinar explains how to deliver on these with an Openstack cloud.",
-      slug="openstack-security-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="In regulated sectors, private cloud security needs to meet the highest requirements. This webinar explains how to deliver on these with an Openstack cloud.",
+    slug="openstack-security-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Private cloud security",
-      description="In regulated sectors, private cloud security needs to meet the highest requirements. This Whitepaper explains how to deliver on these with an Openstack cloud.",
-      slug="openstack-security-whitepaper",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="In regulated sectors, private cloud security needs to meet the highest requirements. This Whitepaper explains how to deliver on these with an Openstack cloud.",
+    slug="openstack-security-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Telcos and Service Providers expect near 100% uptime",
-      description="Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.",
-      slug="openstack-telco-clouds",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="Discover why Ubuntu OpenStack enables Telcos to maximise margins, reduce the costs and risks of introducing new value-added services and speed up time-to-revenue.",
+    slug="openstack-telco-clouds",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Building a private cloud? Take the leap!",
-      description="With Ubuntu OpenStack, you can deploy a cloud infrastructure on your laptop or on a small group of test machines to get your cloud strategy underway.",
-      slug="private-cloud",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="With Ubuntu OpenStack, you can deploy a cloud infrastructure on your laptop or on a small group of test machines to get your cloud strategy underway.",
+    slug="private-cloud",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Make IT rain: public cloud on Ubuntu OpenStack",
-      description="Read this eBook to understand the basics about running Ubuntu OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu OpenStack deployment.",
-      slug="public-cloud",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="Read this eBook to understand the basics about running Ubuntu OpenStack for public clouds. We’ll also give you some tips and tricks to make the most of your new Ubuntu OpenStack deployment.",
+    slug="public-cloud",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Key considerations when choosing a robot’s operating system",
-      description="Robots have been the subject of science fiction films for decades, but with technological advances, including the rise of internet connected devices, a real robotic revolution is beginning to emerge.",
-      slug="robot-operating-system-choice",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Robots have been the subject of science fiction films for decades, but with technological advances, including the rise of internet connected devices, a real robotic revolution is beginning to emerge.",
+    slug="robot-operating-system-choice",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Small Robot Company sows the seeds for autonomous and more profitable farming",
-      description="In Europe, the cost of running a cereal farm – cultivating wheat, rice, and other grains – has risen by 85% in the last 25 years, yet crop yields and revenues have stagnated. And while farms struggle to remain profitable, it won’t be long before those static yields become insufficient to support growing populations.",
-      slug="small-robot-company",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="In Europe, the cost of running a cereal farm – cultivating wheat, rice, and other grains – has risen by 85% in the last 25 years, yet crop yields and revenues have stagnated. And while farms struggle to remain profitable, it won’t be long before those static yields become insufficient to support growing populations.",
+    slug="small-robot-company",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Optimising IoT bandwidth with delta updates",
-      description="Learn how snap deltas' over-the-air updates are efficient and effective.",
-      slug="snap-deltas",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn how snap deltas' over-the-air updates are efficient and effective.",
+    slug="snap-deltas",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Getting started with AI",
-      description="From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges.",
-      slug="starting-with-ai",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="From the smallest startups to the largest enterprises alike, organizations are using Artificial Intelligence and Machine Learning to make the best, fastest, most informed decisions to overcome their biggest business challenges.",
+    slug="starting-with-ai",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How to escape StuckStack and profit from your OpenStack investment",
-      description="This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.",
-      slug="stuckstack-ebook",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="This eBook offers a four-point plan to remobilising the StuckStack infrastructure and regaining organisational agility.",
+    slug="stuckstack-ebook",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Carrier Cloudification: What every telecom executive needs to know",
-      description="This eBook is designed to help telecom executives understand industry best practices as they move towards ‘cloudification’ of their network infrastructure.",
-      slug="telco-cloudification-ebook",
-      group="",
-      type="eBook" %}
-      {% include "engage/_article-card.html" %}
+    description="This eBook is designed to help telecom executives understand industry best practices as they move towards ‘cloudification’ of their network infrastructure.",
+    slug="telco-cloudification-ebook",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="What's New in Ubuntu 18.10",
-      description="An overview of the Ubuntu 18.10 release updates from the Canonical product team. Features of the 18.10 software release focus on multi-cloud deployments, AI software development, a new community desktop theme and richer snap desktop integration.",
-      slug="ubuntu-18-10",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="An overview of the Ubuntu 18.10 release updates from the Canonical product team. Features of the 18.10 software release focus on multi-cloud deployments, AI software development, a new community desktop theme and richer snap desktop integration.",
+    slug="ubuntu-18-10",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Securing the enterprise: how Ubuntu is at the forefront of security and compliance",
-      description="This webinar discusses how Ubuntu’s trusted security and
-      compliance solutions solve regulatory issues across a range of industries, including government, financial services and healthcare.",
-      slug="ubuntu-compliance",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="This webinar discusses how Ubuntu’s trusted security and
+    compliance solutions solve regulatory issues across a range of industries, including government, financial services and healthcare.",
+    slug="ubuntu-compliance",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Ubuntu Core and Kura: A framework for IoT gateways",
-      description="A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices.",
-      slug="ubuntu-core-and-kura",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="A combination of Ubuntu Core, snaps and Kura can solve the limitations that come with Linux distributions for IoT edge gateway devices.",
+    slug="ubuntu-core-and-kura",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="The future of mobile connectivity",
-      description="Unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025.",
-      slug="ubuntu-lime-telco",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Unlike the introduction of 4G which was dominated by consumer benefits, 5G is expected to be driven by enterprise use. According to IDC, enterprises will generate 60 percent of the world’s data by 2025.",
+    slug="ubuntu-lime-telco",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="From VMWare To Charmed OpenStack",
-      description="Ready to make the migration from proprietary virtualisation to OpenStack?",
-      slug="vmware-to-charmed-openstack",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Ready to make the migration from proprietary virtualisation to OpenStack?",
+    slug="vmware-to-charmed-openstack",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Learn What's New In Ubuntu Server 14.04 LTS",
-      description="Released in April 2014, Ubuntu Server 14.04 is the latest LTS release of Ubuntu server. It includes OpenStack Icehouse and many new features and tools for cloud and hyperscale computing.",
-      slug="whats-new-ubuntu-14-04-lts",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Released in April 2014, Ubuntu Server 14.04 is the latest LTS release of Ubuntu server. It includes OpenStack Icehouse and many new features and tools for cloud and hyperscale computing.",
+    slug="whats-new-ubuntu-14-04-lts",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="For CTOs: the no-nonsense way to accelerate your business with containers",
-      description="This eBook is designed to help telecom executives understand industry best practices as they move towards ‘cloudification’ of their network infrastructure.",
-      slug="whitepaper-containers",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="This eBook is designed to help telecom executives understand industry best practices as they move towards ‘cloudification’ of their network infrastructure.",
+    slug="whitepaper-containers",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Taking charge of the IoT's security vulnerabilities",
-      description="Canonical&#39;s report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed.",
-      slug="whitepaper-iot-security",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Canonical&#39;s report examines closely the behaviours and attitudes of UK consumers to IoT security, looks at some of the leading IoT security issues in the industry, and asks how they might be addressed.",
+    slug="whitepaper-iot-security",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="A shift to the Linux app store experience",
-      description="Linux app stores are successfully alleviating historical challenges faced by software developers whilst improving visibility to enterprises and end users.",
-      slug="shift-to-app-store-experience",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Linux app stores are successfully alleviating historical challenges faced by software developers whilst improving visibility to enterprises and end users.",
+    slug="shift-to-app-store-experience",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Creating a cloud-like bare metal experience in the data centre",
-      description="For organisations looking to turn the management of bare-metal server resources into a cloud-like environment, hardware testing is a must-do.",
-      slug="maas-hardware-testing",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="For organisations looking to turn the management of bare-metal server resources into a cloud-like environment, hardware testing is a must-do.",
+    slug="maas-hardware-testing",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Creating accurate AI models with data",
-      description="Learn how Kubeflow and machine learning help you maximise your data",
-      slug="data-pipelines-kubeflow",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn how Kubeflow and machine learning help you maximise your data",
+    slug="data-pipelines-kubeflow",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="A guide to developing Android apps on Ubuntu",
-      description="Android is the most popular mobile operating system and is continuing to grow its market share. IDC expects that Android will have 85.5% of the market by 2022, demonstrating that app development on Android will continue to be an in-demand skill.",
-      slug="developing-android-on-ubuntu",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Android is the most popular mobile operating system and is continuing to grow its market share. IDC expects that Android will have 85.5% of the market by 2022, demonstrating that app development on Android will continue to be an in-demand skill.",
+    slug="developing-android-on-ubuntu",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="How to manage snaps in an enterprise environment",
-      description="How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies.",
-      slug="enterprise-snap-management",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="How the Snap Store Proxy overcomes challenges presented by restricted networks and management policies.",
+    slug="enterprise-snap-management",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Machine Learning Operations (MLOps)",
-      description="This webinar will dive into what success looks like when deploying machine learning models, including training, at scale.",
-      slug="get-started-with-ai-part-2",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="This webinar will dive into what success looks like when deploying machine learning models, including training, at scale.",
+    slug="get-started-with-ai-part-2",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Accelerating deep tech with Ubuntu",
-      description="How innovators are leveraging open source to create life-changing tech.",
-      slug="deeptech",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="How innovators are leveraging open source to create life-changing tech.",
+    slug="deeptech",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Canonical presents edge month",
-      description="Join us for a month of webinars on edge computing. Learn how edge computing provides enterprises with real-time data processing, cost-effective security and scalability.",
-      slug="edge-month",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Join us for a month of webinars on edge computing. Learn how edge computing provides enterprises with real-time data processing, cost-effective security and scalability.",
+    slug="edge-month",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Yahoo! Japan builds their IaaS environment with Canonical",
-      description="Using Ubuntu and a wide range of Canonical’s management tools, Yahoo! Japan has been able to reduce both CAPEX and OPEX costs while successfully building and operating a large scale IaaS environment.",
-      slug="yahoo-japan-case-study",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Using Ubuntu and a wide range of Canonical’s management tools, Yahoo! Japan has been able to reduce both CAPEX and OPEX costs while successfully building and operating a large scale IaaS environment.",
+    slug="yahoo-japan-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="How Domotz streamlined provisioning of IoT devices",
-      description="Domotz eases provisioning and maintenance with snap-based, enterprise remote network monitoring and management device.",
-      slug="domotz-case-study",
-      group="cloud-and-server",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Domotz eases provisioning and maintenance with snap-based, enterprise remote network monitoring and management device.",
+    slug="domotz-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="What’s new in Ubuntu 19.10",
-      description="Ubuntu 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train live-migration extensions for easier infrastructure deployments and more.",
-      slug="19-10-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Ubuntu 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train live-migration extensions for easier infrastructure deployments and more.",
+    slug="19-10-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="TIM ensures system security and client confidence with ESM",
-      description="TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits.",
-      slug="case-study-acuris",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="TIM turned to Canonical’s Extended Security Maintenance - part of Ubuntu Advantage for Infrastructure - to benefit from ongoing support against critical vulnerabilities and exploits.",
+    slug="case-study-acuris",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Ensuring security and isolation in Kubernetes with Kata Containers",
-      description="Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation.",
-      slug="kata-containers-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn the benefits of using Kata Containers in a Charmed Kubernetes environment to provide better security and isolation.",
+    slug="kata-containers-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="The Wellcome Sanger Institute turns to Canonical for high level Ceph support",
-      description="The Wellcome Sanger Institute, a global centre of excellence for genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular genetics.",
-      slug="wellcome-sanger-case-study",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="The Wellcome Sanger Institute, a global centre of excellence for genomic research, leads the scientific advancement of areas such as cancer, infectious diseases and cellular genetics.",
+    slug="wellcome-sanger-case-study",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Lessons learned from 100+ Private cloud builds",
-      description="Reducing the complexities of building a private cloud on OpenStack",
-      slug="private-cloud-build-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Reducing the complexities of building a private cloud on OpenStack",
+    slug="private-cloud-build-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Linux security with Ubuntu",
-      description="Ubuntu is built with security in mind from the outset, which is one of the reasons it’s such a popular Linux distribution used by developers.",
-      slug="linux_security_webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Ubuntu is built with security in mind from the outset.",
+    slug="linux_security_webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Build smart display devices with Mir: fast to production, secure, open-source",
-      description="Industrial robots, home appliances, advertising screens, office information boards&hellip; devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display.",
-      slug="build-smart-devices-with-mir-whitepaper",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Industrial robots, home appliances, advertising screens, office information boards&hellip; devices of every type around us are getting connected. As they do, their screens turn from single purpose displays to reconfigurable, multi-purpose smart display.",
+    slug="build-smart-devices-with-mir-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="SBI Group unlocks infrastructure automation with secure, on-premises OpenStack cloud",
-      description="SBI BITS provides IT services and infrastructure to the SBI Group &mdash; Japan&rsquo;s market leading financial services company group &mdash; which is made up of over 250 companies, and 6,000 employees.",
-      slug="sbi-casestudy",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="SBI BITS provides IT services and infrastructure to the SBI Group &mdash; Japan&rsquo;s market leading financial services company group &mdash; which is made up of over 250 companies, and 6,000 employees.",
+    slug="sbi-casestudy",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Register for WSLConf",
-      description="WSLConf is a community-organized event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.",
-      slug="wslconf",
-      group="webinar",
-      type="event" %}
-      {% include "engage/_article-card.html" %}
+    description="WSLConf is a community-organized event on all things Windows Subsystem for Linux and WSL-related. The event will include two days of workshops, presentations, and networking events for developers, sysadmins, and power users on WSL.",
+    slug="wslconf",
+    type="event" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Cyberdyne keeps cleaning robots up-to-date in the field with snaps",
-      description="As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo’s two main airports.",
-      slug="cyberdyne",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="As Japan&rsquo;s workforce ages, certain roles are being fulfilled by advanced robots to help bridge the gap. Cyberdyne, a Japanese robotics company, are building such robots and have rolled them out into shopping centres and Tokyo’s two main airports.",
+    slug="cyberdyne",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="An intro to MicroK8s",
-      description="Learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started.",
-      slug="intro-to-microk8s-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn why developers choose to work with MicroK8s as a reliable, fast, small and upstream version of Kubernetes and how you can get started.",
+    slug="intro-to-microk8s-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Ubuntu Desktop for the enterprise",
-      description="Linux is increasingly emerging in enterprises as a desktop operating system (OS) alternative to Windows and Mac.",
-      slug="linux-enterprise-whitepaper",
-      group="desktop",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Linux is increasingly emerging in enterprises as a desktop operating system (OS) alternative to Windows and Mac.",
+    slug="linux-enterprise-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Kubernetes: a secure, flexible and automated edge for IoT developers",
-      description="The factors for implementing Kubernetes successfully at the edge.",
-      slug="microk8s-451research",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="The factors for implementing Kubernetes successfully at the edge.",
+    slug="microk8s-451research",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Migration von VMware zu OpenStack",
-      description="Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann.",
-      slug="de/migration-von-vmware-zu-openstack",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Wie ein Umstieg auf Charmed OpenStack die Gesamtkosten spürbar senken kann.",
+    slug="de/migration-von-vmware-zu-openstack",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="De VMware a Charmed OpenStack",
-      description="Migra de VMware a Charmed OpenStack para reducir costes e incrementar la eficiencia de la infraestructura.",
-      slug="es/vmware-a-charmed-openstack",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Migra de VMware a Charmed OpenStack para reducir costes e incrementar la eficiencia de la infraestructura.",
+    slug="es/vmware-a-charmed-openstack",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Artificial Intelligence at the edge in a 5G world",
-      description="Deploying AI/ML solutions in latency-sensitive environments requires a new solution architecture approach",
-      slug="ai-edge-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Deploying AI/ML solutions in latency-sensitive environments requires a new solution architecture approach",
+    slug="ai-edge-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Deploy Kubernetes in your data centre",
-      description="Learn what sets Kubernetes apart from other options and how you can get started.",
-      slug="dell-kubernetes-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn what sets Kubernetes apart from other options and how you can get started.",
+    slug="dell-kubernetes-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="An introduction to Anbox Cloud",
-      description="Enpowering innovators to create righ digital experiences on various mobile form factors",
-      slug="anbox-cloud-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Enpowering innovators to create righ digital experiences on various mobile form factors",
+    slug="anbox-cloud-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Accelerating IoT device time to market",
-      description="Launching IoT devices and managing them at scale can be a time intensive and complex process. ",
-      slug="smart-start-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Launching IoT devices and managing them at scale can be a time intensive and complex process. ",
+    slug="smart-start-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Hosted private cloud infrastructure: a cost analysis",
-      description="Accelerate initial deployment and reduce operational costs by outsourcing private cloud infrastructure management",
-      slug="private-cloud-cost-analysis-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Accelerate initial deployment and reduce operational costs by outsourcing private cloud infrastructure management",
+    slug="private-cloud-cost-analysis-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="ESM maintains Interana's system security while upgrading",
-      description="How Ubuntu helps Interana provide their customers with some of the fastest analytics capabilities on the market and why they turned to ESM to maintain system security while upgrading",
-      slug="interana-casestudy",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="How Ubuntu helps Interana provide their customers with some of the fastest analytics capabilities on the market and why they turned to ESM to maintain system security while upgrading",
+    slug="interana-casestudy",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Smart card login on Ubuntu",
-      description="How to configure Ubuntu 18.04 LTS to operate with a smart card",
-      slug="smart-card-whitepaper",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="How to configure Ubuntu 18.04 LTS to operate with a smart card",
+    slug="smart-card-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Securing ROS robotics platforms",
-      description="The steps you need to take to maximise robotics security with Ubuntu",
-      slug="securing-ros-on-robotics-platforms-whitepaper",
-      group="internet-of-things",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="The steps you need to take to maximise robotics security with Ubuntu",
+    slug="securing-ros-on-robotics-platforms-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
 
   <div class="row u-equal-height u-clearfix">
     {% with title="Rigado cuts customers' time-to-market",
-      description="Rigado utilises Ubuntu Core and AWS to help their customers get their IoT devices to market quicker.",
-      slug="case-study-rigado",
-      group="case-study",
-      type="case study" %}
-      {% include "engage/_article-card.html" %}
+    description="Rigado utilises Ubuntu Core and AWS to help their customers get their IoT devices to market quicker.",
+    slug="case-study-rigado",
+    type="case study" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Virtual event: MicroK8s & Kubernetes",
-      description="Join our virtual event to learn more about MicroK8s, what it is and why you should use it. This event will also include discussions on Kubernetes, an introduction to Canonical and much more!",
-      slug="pre-kubecon-event",
-      group="event",
-      type="event" %}
-      {% include "engage/_article-card.html" %}
+    description="Join our virtual event to learn more about MicroK8s, what it is and why you should use it. This event will also include discussions on Kubernetes, an introduction to Canonical and much more!",
+    slug="pre-kubecon-event",
+    type="event" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Ubuntu Core: a cybersecurity analysis",
-      description="An independent evaluation of Ubuntu Core’s security capabilities",
-      slug="ubuntu-core-security-audit",
-      group="whitepaper",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="An independent evaluation of Ubuntu Core’s security capabilities",
+    slug="ubuntu-core-security-audit",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>
   <div class="row u-equal-height u-clearfix">
     {% with title="A guide to a successful OpenStack adoption and deployment",
-      description="Discover Canonical’s proven OpenStack implementation process",
-      slug="charmed-openstack-adoption-whitepaper",
-      group="whitepaper",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Discover Canonical’s proven OpenStack implementation process",
+    slug="charmed-openstack-adoption-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Managed apps webinar",
-      description="Maintaining business focus in a cloud-native world with Managed Apps",
-      slug="managed-apps-webinar",
-      group="webinar",
-      type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Maintaining business focus in a cloud-native world with Managed Apps",
+    slug="managed-apps-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="What&rsquo;s new in Ubuntu 20.04 LTS?",
-      description="Learn all about the major features introduced as part of the Ubuntu 20.04 LTS release",
-      slug="20.04-webinars",
-          type="webinar" %}
-      {% include "engage/_article-card.html" %}
+    description="Learn all about the major features introduced as part of the Ubuntu 20.04 LTS release",
+    slug="20.04-webinars",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
   </div>
   <div class="row u-equal-height u-clearfix">
 
     {% with title="Embracing the open source mandate",
-      description="85% of enterprises have an open source mandate, preference or are exploring",
-      slug="moving-to-opensource-whitepaper",
-          type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="85% of enterprises have an open source mandate, preference or are exploring",
+    slug="moving-to-opensource-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Streamlined Kubernetes, from Cloud to Edge",
-      description="Innovating and scaling efficiently, with Charmed Kuberenetes and MicroK8s",
-      slug="eu-kubernetes-event",
-      type="event" %}
-      {% include "engage/_article-card.html" %}
+    description="Innovating and scaling efficiently, with Charmed Kuberenetes and MicroK8s",
+    slug="eu-kubernetes-event",
+    type="event" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Leveraging open source with Ubuntu Pro on Azure",
-        description="How Microsoft and Canonical are partnering to ensure every organisation can achive more through open source software in a trusted way",
-        slug="azure-webinar",
-        type="webinar" %}
-        {% include "engage/_article-card.html" %}
+    description="How Microsoft and Canonical are partnering to ensure every organisation can achive more through open source software in a trusted way",
+    slug="azure-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
-    </div>
+  </div>
 
-    <div class="row u-equal-height u-clearfix">
+  <div class="row u-equal-height u-clearfix">
 
     {% with title="Secure IoT device management",
-      description="Build and deploy a central IoT management solution",
-      slug="iot-device-management-whitepaper",
-          type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="Build and deploy a central IoT management solution",
+    slug="iot-device-management-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
     {% with title="Solving the software update challenge for IoT devices",
-      description="How Ubuntu Core transforms over-the-air software updates",
-      slug="snapd-whitepaper",
-      type="whitepaper" %}
-      {% include "engage/_article-card.html" %}
+    description="How Ubuntu Core transforms over-the-air software updates",
+    slug="snapd-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
     {% endwith %}
 
-      {% with title="Kafka in production", description="Learn how to plan and operate a fast, reliable and secure Kafka deployment",
-      slug="kafka-in-production",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
+    {% with title="Kafka in production", description="Learn how to plan and operate a fast, reliable and secure Kafka deployment",
+    slug="kafka-in-production",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    </div>
+  </div>
 
-    <div class="row u-equal-height u-clearfix">
+  <div class="row u-equal-height u-clearfix">
 
-      {% with title="Standardising machine learning &mdash; from workstation to production", description="Leverage the best tools for AI/ML from workstation to data center",
-      slug="ml-dell-webinar",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
+    {% with title="Standardising machine learning &mdash; from workstation to production", description="Leverage the best tools for AI/ML from workstation to data center",
+    slug="ml-dell-webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-      {% with title="Utilising cloud-init on Microsoft Azure",
-      description="Simplify cloud instance deployment with Ubuntu on Azure",
-      slug="azure-cloud-init-whitepaper",
-      type="whitepaper" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
+    {% with title="Utilising cloud-init on Microsoft Azure",
+    description="Simplify cloud instance deployment with Ubuntu on Azure",
+    slug="azure-cloud-init-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-      {% with title="Migrating your infrastructure to Ubuntu 20.04 LTS",
-      description="How, when and why?",
-      slug="migrating-to-20.04",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
-    </div>
+    {% with title="Migrating your infrastructure to Ubuntu 20.04 LTS",
+    description="How, when and why?",
+    slug="migrating-to-20.04",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 
-    <div class="row u-equal-height u-clearfix">
-      {% with title="A technical intro to Ubuntu Pro",
-      description="Join us to discuss how this phenomenon has changed the way the IT and Security need to approach software provenance, patching and compliance, and how Ubuntu Pro for Azure can help address those challenges.",
-      slug="ubuntu-pro-intro",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
+  <div class="row u-equal-height u-clearfix">
+    {% with title="A technical intro to Ubuntu Pro",
+    description="Join us to discuss how this phenomenon has changed the way the IT and Security need to approach software provenance, patching and compliance.",
+    slug="ubuntu-pro-intro",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-      {% with title="Scaling on Azure with Ubuntu Pro",
-      description="Scale your open-source infrastructure with speed, security, and compliance",
-      slug="scaling-securely-ubuntu-azure",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
+    {% with title="Scaling on Azure with Ubuntu Pro",
+    description="Scale your open-source infrastructure with speed, security, and compliance",
+    slug="scaling-securely-ubuntu-azure",
+    type="eBook" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-      {% with title="Kubernetes from Cloud to Edge",
-      description="On 31 July, learn how to streamline your Kubernetes deployment and operations from Canonical's experts.",
-      slug="kubernetes-event-us",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
-    </div>
+    {% with title="Kubernetes from Cloud to Edge",
+    description="On 31 July, learn how to streamline your Kubernetes deployment and operations from Canonical's experts.",
+    slug="kubernetes-event-us",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 
-    <div class="row u-equal-height u-clearfix">
-      {% with title="Accelerating IoT device time to market",
-      description="Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process",
-      slug="smart-start-whitepaper",
-      type="webinar" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
-    </div>
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Accelerating IoT device time to market",
+    description="Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process",
+    slug="smart-start-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
 
-    <div class="row u-equal-height u-clearfix">
-      {% with title="Scale Android applications economically in the cloud with Anbox Cloud",
-      description="Discover Canonical&rsquo;s scalable, hardware-agnostic mobile cloud computing platform",
-      slug="intro-to-anbox-cloud-whitepaper",
-      type="whitepaper" %}
-        {% include "engage/_article-card.html" %}
-      {% endwith %}
-    </div>
+    {% with title="Scale Android applications economically in the cloud with Anbox Cloud",
+    description="Discover Canonical&rsquo;s scalable, hardware-agnostic mobile cloud computing platform",
+    slug="intro-to-anbox-cloud-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+
+    {% with title="Building powerful customer solutions",
+    description="A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments",
+    slug="gsi-webinar-series",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
 
 </section>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
   {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_ubuntu-pro-intro.html" %}
   {% include "takeovers/_us-kubernetes-event.html" %}
+  {% include "takeovers/_gsi-webinar-series-takeover.html" %}
 
   {# FRENCH #}
   {% include "takeovers/fr/_cio-guide-to-multipass.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,6 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
-  {% include "takeovers/_moving-to-opensource-whitepaper.html" %}
   {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_ubuntu-pro-intro.html" %}
   {% include "takeovers/_us-kubernetes-event.html" %}

--- a/templates/takeovers/_gsi-webinar-series-takeover.html
+++ b/templates/takeovers/_gsi-webinar-series-takeover.html
@@ -1,0 +1,16 @@
+{% with title="Building powerful customer solutions",
+subtitle="A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/1224031f-1-Discovery.svg",
+image_height="198",
+image_width="325",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/engage/gsi-webinar-series?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Partner_GSISeries_WBN_PrivateCloud_Takeover",
+primary_cta="Register now",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -154,4 +154,6 @@
 {% include "takeovers/pt/_vmware-para-o-openstack.html" %}
 <p>22 July 2020 - Anbox whitepaper</p>
 {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
+<p>23 July 2020 - GSI Webinar series</p>
+{% include "takeovers/_gsi-webinar-series-takeover.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Add gsi webinar takeover and engage page
- Fix up /engage to not require a group to add the class (it was always a bit odd as it used groups that were unrelated to the engage pages, just borrowing blog classes)
- Shortened a few engage descriptions
- Fixed a few that were the wrong type

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/, http://0.0.0.0:8001/takeovers, http://0.0.0.0:8001/engage/gsi-webinar-series and http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [brief](https://docs.google.com/spreadsheets/d/11lbp6jOe_HCdl2vNkqk0_lsV8bWHOjBp6S84xaZVcRg/edit#gid=1595677042) and [copy doc](https://docs.google.com/document/d/1ZweTXyHO9kIU9aE8pw2_Ni_NoBShM_KseY5H2XtGueg/edit)

## Issue / Card

Fixes #7967

## Screenshots

![image](https://user-images.githubusercontent.com/441217/88371211-80023d00-cd8b-11ea-9241-f66a6f69802d.png)

