### PR TITLE
Fix page jump as global nav loads

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -414,7 +414,6 @@ summary {
   td {
     flex: 1 !important;
   }
-  /* stylelint-enable no-descending-specificity */
 }
 
 .p-table--advantage {
@@ -756,4 +755,21 @@ h4.p-stepped-list__title + .p-stepped-list__content {
 
 .p-icon--dark-tick {
   background-image: url("#{$assets-path}f1a7515d-tick-darkaubergine.svg");
+}
+
+// Prevent the page from jumping as the global nav loads
+.global-nav__placeholder {
+  background-color: #262626;
+  height: 32px;
+
+  @media only screen and (min-width: $breakpoint-x-large) {
+    height: 36px;
+  }
+}
+
+.global-nav {
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -758,12 +758,11 @@ h4.p-stepped-list__title + .p-stepped-list__content {
 }
 
 // Prevent the page from jumping as the global nav loads
-.global-nav__placeholder {
-  background-color: #262626;
-  height: 32px;
+body {
+  border-top: 32px solid #262626;
 
   @media only screen and (min-width: $breakpoint-x-large) {
-    height: 36px;
+    border-top-width: 36px;
   }
 }
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -71,8 +71,6 @@
   </noscript>
   <!-- end google tag manager -->
 
-  <div class="global-nav__placeholder"></div>
-
   {% if not(hide_nav == True) %}
     {% include "templates/_navigation.html" %}
   {% endif %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -71,6 +71,8 @@
   </noscript>
   <!-- end google tag manager -->
 
+  <div class="global-nav__placeholder"></div>
+
   {% if not(hide_nav == True) %}
     {% include "templates/_navigation.html" %}
   {% endif %}


### PR DESCRIPTION
## Done

- Fixed the page jump as the page loads
- Removed an SCSS comment that was causing a linting error

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Load the page and compare the experience to ubuntu.com
- The page should no longer jump when the global nav loads