### PR TITLE
Update the link in the hero of Kubernetes event

### DIFF
--- a/templates/engage/kubernetes-event-us.md
+++ b/templates/engage/kubernetes-event-us.md
@@ -10,7 +10,7 @@ context:
   header_image: "https://assets.ubuntu.com/v1/67b862a1-k8s+microk8s.svg"
   header_image_width: "419"
   header_image_height: "172"
-  header_url: "https://www.brighttalk.com/webcast/6793/421884?utm_source=Canonical&utm_medium=brighttalk&utm_campaign=421884"
+  header_url: "#register-section"
   header_cta: Register now
   header_cta_class: p-button--positive
   header_cta_all_sizes: true


### PR DESCRIPTION
## Done
Update the link in the hero of Kubernetes event

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/kubernetes-event-us
- Click in the "Register now" button at the top and see it jumps to the BrightTalk webinar embed

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7995

