### PR TITLE
Redhat takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -985,5 +985,14 @@
     {% endwith %}
   </div>
 
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack",
+    description="Improve security and efficiency at a reduced total cost of ownership with Charmed OpenStack",
+    slug="redhat-openstack-comparison-whitepaper",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
+
 </section>
 {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -989,7 +989,7 @@
     {% with title="Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack",
     description="Improve security and efficiency at a reduced total cost of ownership with Charmed OpenStack",
     slug="redhat-openstack-comparison-whitepaper",
-    type="webinar" %}
+    type="whitepaper" %}
     {% include "engage/_article-card.html" %}
     {% endwith %}
   </div>

--- a/templates/engage/redhat-openstack-comparison-whitepaper.md
+++ b/templates/engage/redhat-openstack-comparison-whitepaper.md
@@ -1,0 +1,28 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack"
+  meta_description: "Significantly reduce TCO with Charmed OpenStack"
+  meta_image: "https://assets.ubuntu.com/v1/e8cb687d-84380922-1c0f2500-abe0-11ea-854e-6372879bde70.png"
+  meta_copydoc: "https://docs.google.com/document/d/1xA-nVMBFTU1AcnBBAViIqqBWwhOpaiJEOLOYsVXf55o/edit#"
+  header_title: "Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack"
+  header_subtitle: "Improve security and efficiency at a reduced total cost of ownership with Charmed OpenStack"
+  header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+  header_image_width: "250"
+  header_image_height: "160"
+  header_url:
+  header_cta: "Download whitepaper"
+  header_class: p-engage-banner--dark
+  form_id: 3606
+  form_return_url: "https://assets.ubuntu.com/v1/dbaaef05-comparing_openstack.pdf"
+---
+
+OpenStack is an essential component of every modern organisation which uses private cloud infrastructure for better economics, improved security and a higher level of flexibility. Red Hat and Canonical each offer their own production-grade OpenStack distribution, however, this has been achieved using a completely different approach towards OpenStack deployments, operations and support.
+
+This whitepaper performs a detailed comparison of Red Hat OpenStack Platform and Canonical&rsquo;s Charmed OpenStack, including:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">A comprehensive cost analysis comparing Red Hat&rsquo;s per socket-pair pricing model to Canonical&rsquo;s per host pricing model</li>
+  <li class="p-list__item is-ticked">Detailed comparisons of the support and managed services available for deployment, upgrade and day-to-day maintenance of OpenStack</li>
+  <li class="p-list__item is-ticked">An overview of the integration capabilities of each distribution if used in a hybrid or multi-cloud environment</li>
+</ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,6 @@
   {# ALL #}
   {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
   {% include "takeovers/_2004-migration-takeover.html" %}
-  {% include "takeovers/_ubuntu-pro-intro.html" %}
   {% include "takeovers/_us-kubernetes-event.html" %}
   {% include "takeovers/_gsi-webinar-series-takeover.html" %}
   {% include "takeovers/_redhat-openstack.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
   {% include "takeovers/_ubuntu-pro-intro.html" %}
   {% include "takeovers/_us-kubernetes-event.html" %}
   {% include "takeovers/_gsi-webinar-series-takeover.html" %}
+  {% include "takeovers/_redhat-openstack.html" %}
 
   {# FRENCH #}
   {% include "takeovers/fr/_cio-guide-to-multipass.html" %}

--- a/templates/takeovers/_redhat-openstack.html
+++ b/templates/takeovers/_redhat-openstack.html
@@ -1,0 +1,15 @@
+{% with title="Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack",
+subtitle="Significantly reduce TCO with Charmed OpenStack",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+image_style="width: 300px;",
+image_hide_small="",
+equal_cols="true",
+primary_url="/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison",
+primary_cta="Download whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="pt" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/_redhat-openstack.html
+++ b/templates/takeovers/_redhat-openstack.html
@@ -9,7 +9,6 @@ primary_url="/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover&
 primary_cta="Download whitepaper",
 primary_cta_class="",
 secondary_url="",
-secondary_cta="",
-lang="pt" %}
+secondary_cta="" %}
 {% include "takeovers/_template.html" %}
 {% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -156,4 +156,6 @@
 {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
 <p>23 July 2020 - GSI Webinar series</p>
 {% include "takeovers/_gsi-webinar-series-takeover.html" %}
+<p>28 July 2020</p>
+{% include "takeovers/_redhat-openstack.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Add openstack redhat comparison engage page and takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see the "Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1DMozJ7XFMOFppwEOADCq52uSryWAVYqS4sdGyq9Mpkc/edit#gid=2113339190)
- Click through to the engage page
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1DMozJ7XFMOFppwEOADCq52uSryWAVYqS4sdGyq9Mpkc/edit#gid=1271849439) and [the copy doc](https://docs.google.com/document/d/1xA-nVMBFTU1AcnBBAViIqqBWwhOpaiJEOLOYsVXf55o/edit#)


## Issue / Card

Fixes #7666