### PR TITLE
create debounce util module

### DIFF
--- a/static/js/src/desktop-statistics.js
+++ b/static/js/src/desktop-statistics.js
@@ -1,18 +1,5 @@
 import dummyData from "./dummy-data";
-
-function debounce(func, wait, immediate) {
-  var timeout;
-  return function () {
-    var context = this,
-      args = arguments;
-    clearTimeout(timeout);
-    timeout = setTimeout(function () {
-      timeout = null;
-      if (!immediate) func.apply(context, args);
-    }, wait);
-    if (immediate && !timeout) func.apply(context, args);
-  };
-}
+import { debounce } from "./utils/debounce.js";
 
 function calcPercentage(dataset, datum) {
   var sum = d3.sum(dataset, function (d) {

--- a/static/js/src/imageBuilder.js
+++ b/static/js/src/imageBuilder.js
@@ -1,3 +1,5 @@
+import { debounce } from "./utils/debounce.js";
+
 window.renderImageBuilder = function () {
   // State management
   class StateArray extends Array {
@@ -350,22 +352,6 @@ window.renderImageBuilder = function () {
       }
     }
     return false;
-  }
-
-  function debounce(func, wait, immediate) {
-    var timeout;
-    return function () {
-      var context = this,
-        args = arguments;
-      var later = function () {
-        timeout = null;
-        if (!immediate) func.apply(context, args);
-      };
-      var callNow = immediate && !timeout;
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-      if (callNow) func.apply(context, args);
-    };
   }
 
   render();

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -1,4 +1,5 @@
 import { createChart } from "./chart";
+import { debounce } from "./utils/debounce.js";
 import {
   smallReleases,
   serverAndDesktopReleases,
@@ -30,22 +31,8 @@ import {
   kernelReleaseNamesLTS,
   kernelReleaseNamesALL,
   openStackReleaseNames,
-  kubernetesReleaseNames
+  kubernetesReleaseNames,
 } from "./chart-data";
-
-function debounce(func, wait, immediate) {
-  var timeout;
-  return function() {
-    var context = this,
-      args = arguments;
-    clearTimeout(timeout);
-    timeout = setTimeout(function() {
-      timeout = null;
-      if (!immediate) func.apply(context, args);
-    }, wait);
-    if (immediate && !timeout) func.apply(context, args);
-  };
-}
 
 function buildCharts() {
   if (document.querySelector("#small-eol")) {
@@ -192,7 +179,7 @@ var mediumBreakpoint = 875;
 // This will need looking into but this fix will work for now
 if (window.innerWidth >= mediumBreakpoint) {
   buildCharts();
-  setTimeout(function() {
+  setTimeout(function () {
     clearCharts();
     buildCharts();
   }, 0);
@@ -200,7 +187,7 @@ if (window.innerWidth >= mediumBreakpoint) {
 
 window.addEventListener(
   "resize",
-  debounce(function() {
+  debounce(function () {
     if (window.innerWidth >= mediumBreakpoint) {
       clearCharts();
       buildCharts();

--- a/static/js/src/utils/debounce.js
+++ b/static/js/src/utils/debounce.js
@@ -1,0 +1,16 @@
+export function debounce(func, wait, immediate) {
+  var timeout;
+
+  return function () {
+    var context = this,
+      args = arguments;
+    var later = function () {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}


### PR DESCRIPTION
## Done

Consolidated the various debounce functions into one module that can be imported into any file.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Consider adding a `console.log` to the function returned by the debounce util
- View the site locally in your web browser at: http://0.0.0.0:8001/core/build
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Progress through the form and type something into the snap search box, see that it doesn't start searching while you're actively typing.
- Visit /kernel/lifecycle and /desktop/statistics
- Resize the window, see that the charts are being resized correctly, but not constantly
- (if you added the console log, see that there is a corresponding output in your browser console in each of these cases)

## Issue / Card

Fixes #7998 
