### PR TITLE
Automotive corp logo

### DIFF
--- a/static/js/src/chassis-animation.js
+++ b/static/js/src/chassis-animation.js
@@ -1,0 +1,27 @@
+import { debounce } from "./utils/debounce.js";
+
+var element = document.querySelector(".js-chassis-animation");
+var elementHeight = element.clientHeight;
+
+document.addEventListener("scroll", debounce(animate, 50));
+
+function inView() {
+  var windowHeight = window.innerHeight;
+  var scrollY = window.scrollY || window.pageYOffset;
+
+  var scrollPosition = scrollY + windowHeight;
+  var elementPosition =
+    element.getBoundingClientRect().top + scrollY + elementHeight;
+
+  if (scrollPosition > elementPosition) {
+    return true;
+  }
+
+  return false;
+}
+
+function animate() {
+  if (inView()) {
+    element.classList.add("is-playing");
+  }
+}

--- a/templates/automotive/_chassis_animation.html
+++ b/templates/automotive/_chassis_animation.html
@@ -1567,46 +1567,5 @@
 
 </style>
 
-<script>
-  // get the element to animate
-var element = document.querySelector('.js-chassis-animation');
-var elementHeight = element.clientHeight;
+<script src="{{ versioned_static('js/dist/chassisAnimation.js') }}"></script>
 
-document.addEventListener('scroll', debounce(animate, 50));
-
-function inView() {
-  var windowHeight = window.innerHeight;
-  var scrollY = window.scrollY || window.pageYOffset;
-
-  var scrollPosition = scrollY + windowHeight;
-  var elementPosition = element.getBoundingClientRect().top + scrollY + elementHeight;
-
-  if (scrollPosition > elementPosition) {
-    return true;
-  }
-
-  return false;
-}
-
-function animate() {
-  if (inView()) {
-      element.classList.add('is-playing');
-  }
-}
-
-function debounce(func, wait, immediate) {
-	var timeout;
-	return function() {
-		var context = this, args = arguments;
-		var later = function() {
-			timeout = null;
-			if (!immediate) func.apply(context, args);
-		};
-		var callNow = immediate && !timeout;
-		clearTimeout(timeout);
-		timeout = setTimeout(later, wait);
-		if (callNow) func.apply(context, args);
-	};
-};
-
-</script>

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -38,7 +38,7 @@
               url="https://assets.ubuntu.com/v1/4f0688c6-Toyota_Logo_silver.png",
               alt="Toyota",
               height="88",
-              width="73",
+              width="105",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-inline-images__logo"},
@@ -132,7 +132,7 @@
               width="144",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-inline-images__logo", "style": "max-width: 7rem;"},
             ) | safe
           }}
       </li>
@@ -145,7 +145,7 @@
               width="124",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-inline-images__logo", "style": "max-width: 6rem;"},
             ) | safe
           }}
       </li>

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -509,8 +509,8 @@
         image(
           url="https://assets.ubuntu.com/v1/8dd99b80-ubuntu-logo14.png",
           alt="",
-          height="112",
-          width="250",
+          height="100",
+          width="223",
           hi_def=True,
         ) | safe
       }}
@@ -527,8 +527,8 @@
         image(
           url="https://assets.ubuntu.com/v1/7de55930-canonical-logo1.png",
           alt="",
-          height="112",
-          width="250",
+          height="100",
+          width="223",
           hi_def=True,
         ) | safe
       }}

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -507,10 +507,10 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/ed348358-logo-cof.svg",
+          url="https://assets.ubuntu.com/v1/8dd99b80-ubuntu-logo14.png",
           alt="",
-          height="120",
-          width="120",
+          height="112",
+          width="250",
           hi_def=True,
         ) | safe
       }}
@@ -525,10 +525,10 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/8dffa60d-canonical_aubergine_hex.svg",
+          url="https://assets.ubuntu.com/v1/7de55930-canonical-logo1.png",
           alt="",
-          height="120",
-          width="120",
+          height="112",
+          width="250",
           hi_def=True,
         ) | safe
       }}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -25,5 +25,6 @@ module.exports = {
   "renewal-modal": "./static/js/src/renewal-modal.js",
   "sticky-nav": "./static/js/src/sticky-nav.js",
   imageBuilder: "./static/js/src/imageBuilder.js",
+  chassisAnimation: "./static/js/src/chassis-animation.js",
   cve: "./static/js/src/cve/cve.js",
 };


### PR DESCRIPTION
## Done
Update the Canonical and Ubuntu logos at the bottom of the page
Refactored the JS to use the utility `debounce`

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/automotive
- Scroll down to the animation and check that works still
- Continue down to the last section
- Check the logos match [the copydoc](https://docs.google.com/document/d/1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw/edit#heading=h.65z06dpsvyz9)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8003

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/88720484-d9b48f80-d11c-11ea-9938-99beffdaba68.png)

