### PR TITLE
Search cves by component

### DIFF
--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -17,10 +17,10 @@
   </thead>
   <tbody>
     {% for cve in cves %}
-      {% for package_name, statuses in cve.status_tree.items() %}
+      {% for package_name, statuses in cve.packages.items() %}
         <tr>
           {% if loop.index == 1 %}
-            <td rowspan="{{ cve.status_tree | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
+            <td rowspan="{{ cve.packages | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
           {% endif %}
           <td>{{ package_name }}</td>
           {% for release in releases %}


### PR DESCRIPTION
Enable component filter.

Display only packages of the cve that match the search criteria.

## QA

1. Have the latest CVEs imported in your local database. `CVE-2020-8834` should be the most recent cve on `/security/cve`
2. All the packages should have the component `main` right now. We have to create a `universe` component to test the filter.
```bash
docker exec -it db psql -U postgres # go to the databse
```
```SQL
UPDATE status SET component='universe' WHERE cve_id='CVE-2020-8834' AND release_codename='focal' AND package_name='linux' 
```
3. Fetch my branch changes: 
```bash 
git fetch albert-fork
git checkout search-cves-by-component
```

4. Browse to `/security/cve`. Filter by component, you should only see one row.

## Issue / Card

Fixes #7926
