### PR TITLE
Updated the download link

### DIFF
--- a/templates/engage/redhat-openstack-comparison-whitepaper.md
+++ b/templates/engage/redhat-openstack-comparison-whitepaper.md
@@ -14,7 +14,7 @@ context:
   header_cta: "Download whitepaper"
   header_class: p-engage-banner--dark
   form_id: 3606
-  form_return_url: "https://assets.ubuntu.com/v1/dbaaef05-comparing_openstack.pdf"
+  form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/Comparing%20OpenStack_24.07.20.pdf"
 ---
 
 OpenStack is an essential component of every modern organisation which uses private cloud infrastructure for better economics, improved security and a higher level of flexibility. Red Hat and Canonical each offer their own production-grade OpenStack distribution, however, this has been achieved using a completely different approach towards OpenStack deployments, operations and support.


### PR DESCRIPTION


## Done

Changed the PDF download link to https://pages.ubuntu.com/rs/066-EOV-335/images/Comparing%20OpenStack_24.07.20.pdf

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

Fixes #3011