### PR TITLE
Fix CVE page for missing status

### DIFF
--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -30,8 +30,6 @@
               {% else %}
                 <td class="cve-table-cell">
               {% endif %}
-            {% endif %}
-            {% if release.codename in statuses %}
               {% if statuses[release.codename].status == "DNE" %}
                 <div class="cve-color-strip--dne"></div>
               {% elif statuses[release.codename].status == "needs-triage" %}
@@ -49,7 +47,6 @@
               {% elif statuses[release.codename].status == "released" %}
                 <div class="cve-color-strip--released"></div>
               {% endif %}
-            {% endif %}
               <div class="icon-container__icon">
                 {% if statuses[release.codename].status == 'DNE' or statuses[release.codename].status == 'not-affected' %}
                   <i class="p-icon--placeholder"></i>
@@ -72,31 +69,35 @@
                 {% endif %}
               </div>
               <div class="icon-container__text">
-                {% if release.codename in statuses %}
-                  {% if statuses[release.codename].status == "DNE" %}
-                    Does not exist
-                  {% elif statuses[release.codename].status == "needs-triage" %}
-                    Needs triage
-                  {% elif statuses[release.codename].status == "not-affected" %}
-                    Not vulnerable
-                  {% elif statuses[release.codename].status == "needed" %}
-                    Needed
-                  {% elif statuses[release.codename].status == "deferred" %}
-                    Deferred
-                  {% elif statuses[release.codename].status == "ignored" %}
-                    Ignored
-                  {% elif statuses[release.codename].status == "pending" %}
-                    Pending
-                  {% elif statuses[release.codename].status == "released" %}
-                    Released
-                  {% else %}
-                    &mdash;
-                  {% endif %}
+                {% if statuses[release.codename].status == "DNE" %}
+                  Does not exist
+                {% elif statuses[release.codename].status == "needs-triage" %}
+                  Needs triage
+                {% elif statuses[release.codename].status == "not-affected" %}
+                  Not vulnerable
+                {% elif statuses[release.codename].status == "needed" %}
+                  Needed
+                {% elif statuses[release.codename].status == "deferred" %}
+                  Deferred
+                {% elif statuses[release.codename].status == "ignored" %}
+                  Ignored
+                {% elif statuses[release.codename].status == "pending" %}
+                  Pending
+                {% elif statuses[release.codename].status == "released" %}
+                  Released
                 {% else %}
                   &mdash;
                 {% endif %}
               </div>
             </td>
+            {% else %}
+              <td class="cve-table-cell--muted">
+                <div class="cve-color-strip--dne"></div>
+                <div class="u-align--center">
+                  &mdash;
+                </div>
+              </td>
+            {% endif %}
           {% endfor %}
         </tr>
       {% endfor %}


### PR DESCRIPTION
The page with throw a 500, if a package is missing a status on a release.

## QA

0. Do not fetch my changes yet.

1. Reset local database
```bash
docker-compose down
docker-compose up -d
```

2. Run migration and serve website
```bash
dotrun exec python3 scripts/create-releases.py # to populate release table
dotrun # serve the website
```

3. In another terminal

If you do not have the project yet:
```bash
git clone -b test-status-component-field git@github.com:albertkol/ubuntu-cve-tracker.git # fetch testing branch
```
or if you already have the project just fetch the fork
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu-cve-tracker.git  # get my fork
git fetch albert-fork  # fetch the branches
git checkout test-status-component-field  # checkout the testing branch
```

4. Run import
```bash 
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```
Authenticate and then see the CVEs import. See the time is hopefully less than 5 minutes depending on how quickly you got through the auth step).

5. After the import is done browse locally on `/security/cve` everything should load correctly.
**Note:** The latest CVE id is **CVE-2020-8834** and the package `linux` has the status `Not vulnerable` on release `20.04`

6. In a new terminal go to your local `ubuntu.com` repo run
```bash
docker exec -it db psql -h localhost -U postgres
```
And run
```SQL
DELETE FROM status WHERE cve_id='CVE-2020-8834' AND release_codename='focal' AND package_name='linux';
```
This will delete for the last the status for the 20.04 release from the package `linux` from cve `CVE-2020-8834`.

7. Refresh the `/security/cve` tab. You will get an error.

8. Fetch my changes
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu.com.git  # get my fork if you don't have it
git fetch albert-fork  # fetch the branches
git checkout fix-cve-page-for-missing-status  # checkout the branch
``` 

9. Re-run the website 
```bash
dotrun
```

10. Refresh `/security/cve` tab. It will work and you will see a dash as the status.
![image](https://user-images.githubusercontent.com/6387619/88804936-7cfdb700-d1a6-11ea-8f00-77cb01d19d0f.png)
