### PR TITLE
Fix single CVE page

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -135,8 +135,8 @@
           <tbody>
             {% for package_name, statuses in cve.status_tree.items() %}
               {% for release in releases %}
-                {% if release.codename in statuses %}
-                  <tr>
+                <tr>
+                  {% if release.codename in statuses %}
                     {% if loop.index == 1 %}
                       <td rowspan="{{ releases | length }}">{{ package_name }}</td>
                     {% endif %}
@@ -147,48 +147,42 @@
                         Ubuntu {{ release.version }} {{ release.support_tag }} ({{ release.name }})
                       {% endif %}
                     </td>
-                    {% if release.codename in statuses %}
-                        {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
-                          <td class="cve-table-cell--muted">
-                        {% else %}
-                          <td class="cve-table-cell">
-                        {% endif %}
-                      {% endif %}
-                      {% if release.codename in statuses %}
-                        {% if statuses[release.codename].status == "DNE" %}
-                          Does not exist
-                          <div class="cve-color-strip--dne"></div>
-                        {% elif statuses[release.codename].status == "needs-triage" %}
-                          Needs triage
-                          <div class="cve-color-strip--needs-triage"></div>
-                        {% elif statuses[release.codename].status == "not-affected" %}
-                          Not vulnerable
-                          <div class="cve-color-strip--not-affected"></div>
-                        {% elif statuses[release.codename].status == "needed" %}
-                          Needed
-                          <div class="cve-color-strip--needed"></div>
-                        {% elif statuses[release.codename].status == "deferred" %}
-                          Deferred
-                          <div class="cve-color-strip--deferred"></div>
-                        {% elif statuses[release.codename].status == "ignored" %}
-                          Ignored
-                          <div class="cve-color-strip--ignored"></div>
-                        {% elif statuses[release.codename].status == "pending" %}
-                          Pending
-                          <div class="cve-color-strip--pending"></div>
-                        {% elif statuses[release.codename].status == "released" %}
-                          <div class="cve-color-strip--released"></div>
-                          Released
-                        {% endif %}
-                        {% if statuses[release.codename].description %}
-                          ({{ statuses[release.codename].description }})
-                        {% endif %}
-                      {% else %}
-                        &mdash;
-                      {% endif %}
+                    {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
+                      <td class="cve-table-cell--muted">
+                    {% else %}
+                      <td class="cve-table-cell">
+                    {% endif %}
+                    {% if statuses[release.codename].status == "DNE" %}
+                      Does not exist
+                      <div class="cve-color-strip--dne"></div>
+                    {% elif statuses[release.codename].status == "needs-triage" %}
+                      Needs triage
+                      <div class="cve-color-strip--needs-triage"></div>
+                    {% elif statuses[release.codename].status == "not-affected" %}
+                      Not vulnerable
+                      <div class="cve-color-strip--not-affected"></div>
+                    {% elif statuses[release.codename].status == "needed" %}
+                      Needed
+                      <div class="cve-color-strip--needed"></div>
+                    {% elif statuses[release.codename].status == "deferred" %}
+                      Deferred
+                      <div class="cve-color-strip--deferred"></div>
+                    {% elif statuses[release.codename].status == "ignored" %}
+                      Ignored
+                      <div class="cve-color-strip--ignored"></div>
+                    {% elif statuses[release.codename].status == "pending" %}
+                      Pending
+                      <div class="cve-color-strip--pending"></div>
+                    {% elif statuses[release.codename].status == "released" %}
+                      <div class="cve-color-strip--released"></div>
+                      Released
+                    {% endif %}
+                    {% if statuses[release.codename].description %}
+                      ({{ statuses[release.codename].description }})
+                    {% endif %}
                     </td>
-                  </tr>
-                {% endif %}
+                  {% endif %}
+                </tr>
               {% endfor %}
             {% endfor %}
           </tbody>


### PR DESCRIPTION
Fix single CVE page so that if status is missing for a package, the table does not get messed up.

## QA

- Check out this feature branch
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu.com.git  # get my fork if you don't have it
git fetch albert-fork  # fetch the branches
git checkout fix-cve-page-for-missing-status  # checkout the branch
```

- Run website
```bash
dotrun
```

- browse to: `/security/CVE-2020-8834` check the table

Fixes #

## Screenshots

This is what it looks now:
![image](https://user-images.githubusercontent.com/6387619/88940294-7f800f80-d27f-11ea-9026-1f61468cfd8f.png)