### PR TITLE
update /advantage customer info API call

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -205,7 +205,7 @@
                                         {% if expired_renewable %}
                                           data-contract-end="{{ contract['contractInfo']['expired_restart_date']}}"
                                         {% else %}
-                                          data-contract-end="contract['contractInfo']['effectiveTo'] }}"
+                                          data-contract-end="{{ contract['contractInfo']['effectiveTo'] }}"
                                         {% endif %}
                                         data-products="{{ contract['contractInfo']['products'] }}"
                                         data-months="{{ contract['renewal']['renewalItems'][0]['priceTotal']['months'] }}"

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -66,6 +66,7 @@ class AdvantageContracts:
                 method="put",
                 path=f"v1/accounts/{account_id}/customer-info/stripe",
                 json={
+                    "defaultPaymentMethod": {"Id": payment_method_id},
                     "paymentMethodID": payment_method_id,
                     "address": address,
                     "name": name,


### PR DESCRIPTION
## Done

The contracts API was updated in [this PR](https://github.com/CanonicalLtd/ua-contracts/pull/1078) to include a new means of sending the payment method ID when a customer enters their payment details on the renewals modal. 

The change was made so that we have the ability to fetch information about a customer's payment method if we require it (ID, expiry date, brand, last 4 digits etc) e.g. to allow a user to set and update payment methods for use in later purchases.

A subsequent PR introduced [backwards compatibility](https://github.com/CanonicalLtd/ua-contracts/pull/1090) with the previous schema, and once both this and the updated contract API are live, we can remove the outdated `paymentMethodID` parameter.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Login
- Get Scott to set you up with test data if you see no enterprise contracts or renewals
- Find the expiring contract, and click the "Renew" button within the row
- Fill out payment details with:
  - card number: 4242 4242 4242 4242
  - expiry: 04/24
  - zip: 42424
- Fill out the rest of the form, and click "Continue"
- See that you are taken to the next step of the payment process and there are no network errors in your browser's dev tools
