### PR TITLE
Update global-nav to the v2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@canonical/cookie-policy": "2.1.0",
-    "@canonical/global-nav": "2.4.1",
+    "@canonical/global-nav": "2.4.3",
     "@canonical/latest-news": "1.0.3",
     "url-polyfill": "1.1.9",
     "url-search-params-polyfill": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,12 +1140,12 @@
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-2.1.0.tgz#77b96e3f2e29ba2d6e9d654bdb4729dc21e93612"
   integrity sha512-Z26080BBDjE2YkQSaP1iDenBwhsiU3jrmvIkZQcE5EgCf+4uqtka3LDZKxwRg7liZQATVxZqDwPV9IYtV8G9XQ==
 
-"@canonical/global-nav@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.1.tgz#c30c2c8e6e1b81a037ee9ff566f5ef7c07803435"
-  integrity sha512-NLtlv8ODbPrGK14FaBoFj2Hmr9EKfwnvcwu6kHatel+osDs1IIL6TwhEwqWeufEGdfPQdCAFhS7oX24gdBGVwA==
+"@canonical/global-nav@2.4.3":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"
+  integrity sha512-8ttxoViIlE16dKBIcuVsvBF2GhsJbC/c7fxLf93EXmn5DKoUYf+rjyhXvEDaRGCtTAnS4finwBwMMo7nQFOSEA==
   dependencies:
-    vanilla-framework "2.8.0"
+    vanilla-framework "2.13.0"
 
 "@canonical/latest-news@1.0.3":
   version "1.0.3"
@@ -8566,15 +8566,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vanilla-framework@2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.13.0.tgz#ac73e745150bcef183eb35e3ee47f3fd079ddd3e"
+  integrity sha512-EuxlGxO4SmCGL4GVzcye5aas2HGVqRhPxlTHg84Lfw1e1E4F/Coxs78i3xxkPGw3LOcfea0KU096ar1PnLNuXQ==
+
 vanilla-framework@2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.14.1.tgz#33fd21f3e546e1905f5c59c2dc5d04ae456d3e20"
   integrity sha512-AHqqvbixiCKW6pHxsYh2WXPNMWvpiE0BNPxpFLP+mNigISGKghv+TB/OzJFhozfz2Zub+uGrlPjN2ysPON9G9w==
-
-vanilla-framework@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.8.0.tgz#ec20ed3bf4fc2f1ce2d42075edb7a58c26f56982"
-  integrity sha512-fIxO7/BtCmj7aMAFCxxk19fqRB9HVZBv1typ7YL4AEiJhq8Za3qDCLuxjiSP0tFvKzXUtrI7y4KGHYMrFIevKg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done
- Update global-nav to the v2.4.3

## QA
- Check out this feature branch
- Run `./run clean`
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Shrink screen to small screen
- See that the border on the body is not visible over the navigation.

| Before | After | 
| --- | --- |
| ![Screenshot from 2020-07-30 23-41-51](https://user-images.githubusercontent.com/1413534/88981685-6e0a2800-d2be-11ea-9c41-dfd62f96e1bf.png) | ![image](https://user-images.githubusercontent.com/1413534/88981567-24b9d880-d2be-11ea-80e6-63046c004ef3.png) |