### PR TITLE
Fix images to improve Calibre score

### DIFF
--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -9,7 +9,17 @@
       <h3 class="p-heading--five u-no-padding--top">OpenHAB</h3>
       <hr />
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png" style="height:32px; margin-top:2rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png",
+            alt="",
+            height="32",
+            width="146",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-top: 2rem;"}
+          ) | safe
+        }}
       </div>
     </a>
   </div>
@@ -18,7 +28,17 @@
       <h3 class="p-heading--five u-no-padding--top">Plex<span class="u-hide--medium"> Media Server</span></h3>
       <hr />
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/3cd85693-Plex.png" alt="" style="height:32px; margin-top:2rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3cd85693-Plex.png",
+            alt="",
+            height="32",
+            width="99",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-top: 2rem;"}
+          ) | safe
+        }}
       </div>
     </a>
   </div>
@@ -27,7 +47,17 @@
       <h3 class="p-heading--five u-no-padding--top">Nextcloud</h3>
       <hr />
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png" alt="" style="height:62px; margin-top:1.25rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png",
+            alt="",
+            height="62",
+            width="87",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-top: 1.25rem;"}
+          ) | safe
+        }}
       </div>
     </a>
   </div>
@@ -36,7 +66,17 @@
       <h3 class="p-heading--five u-no-padding--top">AdGuard</h3>
       <hr />
       <div class="u-align--center">
-        <img src="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png" alt="" style="height:62px; margin-top:1.25rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png",
+            alt="",
+            height="62",
+            width="62",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-top: 1.25rem;"}
+          ) | safe
+        }}
       </div>
     </a>
   </div>
@@ -45,7 +85,17 @@
       <h3 class="p-heading--five u-no-padding--top">Mosquitto</h3>
       <hr />
       <div class="u-align--center">
-        <img src="https://dashboard.snapcraft.io/site_media/appmedia/2018/08/mosquitto-logo-only.svg.png" alt="" style="height:72px; margin-top:1rem;">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
+            alt="",
+            height="72",
+            width="72",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-top: 1rem;"}
+          ) | safe
+        }}
       </div>
     </a>
   </div>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -22,7 +22,7 @@
       <div class="col-8">
         <div class="p-media-object">
           {% if article.author %}
-            <img src="{% if article.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ article.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round">
+            <img src="{% if article.author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ article.author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="">
           {% endif %}
 
           <div class="p-media-object__details">

--- a/templates/blog/author.html
+++ b/templates/blog/author.html
@@ -9,7 +9,7 @@
   <div class="row">
     <div class="col-8">
       <div class="p-media-object u-no-margin--bottom">
-        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round">
+        <img src="{% if author.id == 217 %}https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg{% else %}{{ author.avatar_urls['96'] }}{% endif %}" class="p-media-object__image is-round" alt="">
 
         <div class="p-media-object__details">
           <h1 class="p-media-object__title">


### PR DESCRIPTION
## Done

Some pages that we are monitoring with [Calibre](https://calibreapp.com) have scores below 100 because there are images without `alt` attributes. This PR addresses that, and where appropriate replaces `img` tags with the image template.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Check that on the following pages the openhab, plex, nextcloud, adguard, and mosquitto all load and have empty `alt` attributes:
    - /appliance
    - /appliance/hardware
    - /appliance/portfolio
    - /appliance/vm
    - /download/iot
    - /download/raspberry-pi
    - /download/server
- Check that the avatar on a [blog post page](http://localhost:8001/blog/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available) has an empty `alt` attribute
- Click through to the [author page](http://localhost:8001/blog/author/canonical) has an empty `alt` attribute