### PR TITLE
Update time and Tim's name on /engage/kubernetes-event-us

### DIFF
--- a/templates/engage/kubernetes-event-us.md
+++ b/templates/engage/kubernetes-event-us.md
@@ -23,7 +23,7 @@ context:
 
 **Date and time**
 31 July, 2020
-[2:30-4:30pm CT]
+[1:30-3:30pm CT]
 
 **What it is**: A live, interactive virtual workshop with Canonical’s Kubernetes experts. This will include a presentation from our speakers, panel discussion incorporating live comments and questions from the audience, and free Kubernetes resources and demos to help you achieve your technology goals.
 
@@ -63,7 +63,7 @@ wanting to learn more about how to overcome common Kubernetes challenges in a va
     ) | safe
   }}
   <div class="p-media-object__details">
-    <h3 class="u-no-margin--bottom">Tim van Steenberg</h3>
+    <h3 class="u-no-margin--bottom">Tim Van Steenburgh</h3>
     <p>Engineering Manager (Kubernetes)</p>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Update time and Tim's name

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/kubernetes-event-us
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare and resolve the [copy doc](https://docs.google.com/document/d/1LClShZkNAZYCHhXah452SEFYdwetyPstodwRL0Y9ZV8/edit?ts=5f243f38)

## Issue / Card

Fixes #8024

