### PR TITLE
[Engage] Update title and meta image of openstack adoption whitepaper

### DIFF
--- a/templates/engage/charmed-openstack-adoption-whitepaper.md
+++ b/templates/engage/charmed-openstack-adoption-whitepaper.md
@@ -1,11 +1,11 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-  title: "A guide to a successful OpenStack adoption and deployment"
+  title: "OpenStack deployment guide"
   meta_description: "A guide to a successful OpenStack adoption and deployment"
-  meta_image: "https://assets.ubuntu.com/v1/55aa7329-77673291-e44df500-6f81-11ea-81b1-ebae39ade688.png"
+  meta_image: "https://assets.ubuntu.com/v1/af8096ad-facebook_and_linkedin_banner.jpeg"
   meta_copydoc: "https://docs.google.com/document/d/1MDI2eg5DKHoytmUdXUCziQexEGiXRDml2TnqOwstBYQ/edit"
-  header_title: "A guide to a successful OpenStack adoption and deployment"
+  header_title: "OpenStack deployment guide"
   header_subtitle: "Discover Canonical’s proven OpenStack implementation process"
   header_url: "#register-section"
   header_cta: Download whitepaper

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -845,7 +845,7 @@
     {% endwith %}
   </div>
   <div class="row u-equal-height u-clearfix">
-    {% with title="A guide to a successful OpenStack adoption and deployment",
+    {% with title="OpenStack deployment guide",
     description="Discover Canonical’s proven OpenStack implementation process",
     slug="charmed-openstack-adoption-whitepaper",
     type="whitepaper" %}


### PR DESCRIPTION
## Done

- Updated title of /engage/charmed-openstack-adoption-whitepaper to match the [copy doc](https://docs.google.com/document/d/1MDI2eg5DKHoytmUdXUCziQexEGiXRDml2TnqOwstBYQ/edit)
- Changed the meta image to reflect the new title

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/charmed-openstack-adoption-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the page title matches the one in the copy doc, and that the meta image appropriately reflects the new title
- Navigate to http://0.0.0.0:8001/engage and ensure that the new title is reflected there as well


## Issue / Card

Fixes #8013 