### PR TITLE
Revert using localstorage to store UTMs

### DIFF
--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -106,17 +106,18 @@
     }
 
     function setUTMs() {
+      var params = new URLSearchParams(window.location.search);
       var utm_campaign = document.getElementById("utm_campaign");
       if (utm_campaign) {
-        utm_campaign.value = localStorage.getItem("utm_campaign");
+        utm_campaign.value = params.get("utm_campaign");
       }
       var utm_source = document.getElementById("utm_source");
       if (utm_source) {
-        utm_source.value = localStorage.getItem("utm_source");
+        utm_source.value = params.get("utm_source");
       }
       var utm_medium = document.getElementById("utm_medium");
       if (utm_medium) {
-        utm_medium.value = localStorage.getItem("utm_medium");
+        utm_medium.value = params.get("utm_medium");
       }
     }
 

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -161,34 +161,13 @@ function addGAImpressionEvents(target) {
 addUTMToForms();
 
 function addUTMToForms() {
+  var params = new URLSearchParams(window.location.search);
   const utm_names = ["campaign", "source", "medium"];
   for (let i = 0; i < utm_names.length; i++) {
     var utm_fields = document.getElementsByName("utm_" + utm_names[i]);
     for (let j = 0; j < utm_fields.length; j++) {
-      if (utm_fields[j] && localStorage.getItem("utm_" + utm_names[i])) {
-        utm_fields[j].value = localStorage.getItem("utm_" + utm_names[i]);
-      }
-    }
-  }
-}
-
-addUTMToLocalStorage();
-
-function addUTMToLocalStorage() {
-  if (window.localStorage && window.sessionStorage) {
-    var params = new URLSearchParams(window.location.search);
-    var utm_campaign = params.get("utm_campaign");
-    var utm_source = params.get("utm_source");
-    var utm_medium = params.get("utm_medium");
-    if (utm_source != "Takeover" && utm_source != "takeover") {
-      if (utm_source) {
-        localStorage.setItem("utm_source", utm_source);
-      }
-      if (utm_campaign) {
-        localStorage.setItem("utm_campaign", utm_campaign);
-      }
-      if (utm_medium) {
-        localStorage.setItem("utm_medium", utm_medium);
+      if (utm_fields[j]) {
+        utm_fields[j].value = params.get("utm_" + utm_names[i]);
       }
     }
   }


### PR DESCRIPTION
## Done

- Reverting https://github.com/canonical-web-and-design/ubuntu.com/pull/7367 and https://github.com/canonical-web-and-design/ubuntu.com/pull/7834 as they are not sturdy enough and seem to be causing UTM confusion in some cases (notably mobile webviews) and disrupting Marketing workflows. To be reworked at a later time.
- UTMs in forms are now back to only being pulled from current URL.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open a modal contact form on [a page with `utm_campaign=foo`](https://ubuntu-com-8034.demos.haus/openstack?utm_campaign=foo#get-in-touch) ensure the form source contains this UTM value.
- Open a modal contact form on [a page without UTMs](https://ubuntu-com-8034.demos.haus/openstack#get-in-touch), ensure the form source doesn't contain UTMs.
- Open [a whitepaper /engage page with `utm_campaign=bar`](https://ubuntu-com-8034.demos.haus/engage/redhat-openstack-comparison-whitepaper?utm_campaign=bar) ensure the form source contains this UTM value.
- Open [a whitepaper /engage page without UTMs](https://ubuntu-com-8034.demos.haus/engage/redhat-openstack-comparison-whitepaper), ensure the form source doesn't contain UTMs.

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
