### PR TITLE
Remove automatic appliance downloads

### DIFF
--- a/templates/appliance/shared/_install_instructions_vm_macos.html
+++ b/templates/appliance/shared/_install_instructions_vm_macos.html
@@ -1,4 +1,3 @@
-<hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">

--- a/templates/appliance/shared/_install_instructions_vm_ubuntu.html
+++ b/templates/appliance/shared/_install_instructions_vm_ubuntu.html
@@ -1,4 +1,3 @@
-<hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">A PC running Ubuntu 18.04 LTS or later</li>

--- a/templates/appliance/shared/_install_instructions_vm_windows.html
+++ b/templates/appliance/shared/_install_instructions_vm_windows.html
@@ -1,4 +1,3 @@
-<hr>
 <h4>What you&rsquo;ll need</h4>
 <ul class="p-list is-split">
   <li class="p-list__item is-ticked">

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -1,16 +1,12 @@
-{% if appliance.iso_url.pc %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pc }}">
-{% endif %}
-
 <section class="p-strip--suru-topped" style="overflow: visible;">
   <div class="row u-vertically-center">
     <div class="col-8">
       {% if appliance.iso_url.pc %}
       <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for an Intel NUC</h1>
-      <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
-        <a href="{{ appliance.iso_url.pc }}">download now</a>.
-        {% include "appliance/shared/_verify-checksums-pc.html" %}
+      <p class="u-no-margin--bottom">
+        <a class="p-button--positive is-inline u-no-margin--left" href="{{ appliance.iso_url.pc }}">Download the {{ appliance.appliance_name }} image</a>
       </p>
+      {% include "appliance/shared/_verify-checksums-pc.html" %}
       {% else %}
       <h1>Setup your Ubuntu {{ appliance.name }} appliance for an Intel NUC</h1>
       {% endif %}

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -1,16 +1,12 @@
-{% if appliance.iso_url.raspberrypi %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.raspberrypi }}">
-{% endif %}
-
 <section class="p-strip--suru-topped" style="overflow: visible;">
   <div class="row u-vertically-center">
     <div class="col-8">
       {% if appliance.iso_url.raspberrypi %}
-      <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Raspberry Pi</h1>
-      <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
-        <a href="{{ appliance.iso_url.raspberrypi }}">download now</a>.
-        {% include "appliance/shared/_verify-checksums.html" %}
+      <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Raspberry&nbsp;Pi</h1>
+      <p class="u-no-margin--bottom">
+        <a class="p-button--positive is-inline u-no-margin--left" href="{{ appliance.iso_url.raspberrypi }}">Download the {{ appliance.appliance_name }} image</a>
       </p>
+      {% include "appliance/shared/_verify-checksums.html" %}
       {% else %}
       <h1>Setup your Ubuntu {{ appliance.appliance_name }} appliance for Raspberry Pi</h1>
       {% endif %}

--- a/templates/appliance/shared/_raspberry-pi2.html
+++ b/templates/appliance/shared/_raspberry-pi2.html
@@ -1,16 +1,12 @@
-{% if appliance.iso_url.raspberrypi %}
-<meta http-equiv="refresh" content="3;url={{ appliance.iso_url.pi2 }}">
-{% endif %}
-
 <section class="p-strip--suru-topped" style="overflow: visible;">
   <div class="row u-vertically-center">
     <div class="col-8">
       {% if appliance.iso_url.pi2 %}
       <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Raspberry Pi 2</h1>
-      <p class="u-no-margin--bottom">Your download should start automatically. If it doesn&rsquo;t,
-        <a href="{{ appliance.iso_url.pi2 }}">download now</a>.
-        {% include "appliance/shared/_verify-checksums.html" %}
+      <p class="u-no-margin--bottom">
+        <a class="p-button--positive is-inline u-no-margin--left" href="{{ appliance.iso_url.pi2 }}">Download the {{ appliance.appliance_name }} image</a>
       </p>
+      {% include "appliance/shared/_verify-checksums.html" %}
       {% else %}
       <h1>Setup your Ubuntu {{ appliance.appliance_name }} appliance for Raspberry Pi 2</h1>
       {% endif %}

--- a/templates/appliance/shared/_steps-multipass-find-ip-macos.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-macos.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Find your appliance

--- a/templates/appliance/shared/_steps-multipass-find-ip-ubuntu.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-ubuntu.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Find your appliance

--- a/templates/appliance/shared/_steps-multipass-find-ip-windows.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-windows.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Find and connect to your appliance

--- a/templates/appliance/shared/_steps-multipass-launch.html
+++ b/templates/appliance/shared/_steps-multipass-launch.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Launch your Ubuntu Appliance

--- a/templates/appliance/shared/_steps_install_openssh_windows.html
+++ b/templates/appliance/shared/_steps_install_openssh_windows.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Install OpenSSH

--- a/templates/appliance/shared/_steps_multipass_macos.html
+++ b/templates/appliance/shared/_steps_multipass_macos.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Install Multipass

--- a/templates/appliance/shared/_steps_multipass_ubuntu.html
+++ b/templates/appliance/shared/_steps_multipass_ubuntu.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Install Multipass

--- a/templates/appliance/shared/_steps_multipass_windows.html
+++ b/templates/appliance/shared/_steps_multipass_windows.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Install Multipass

--- a/templates/appliance/shared/_steps_nuc_first_boot.html
+++ b/templates/appliance/shared/_steps_nuc_first_boot.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     First boot

--- a/templates/appliance/shared/_steps_nuc_flash_usb.html
+++ b/templates/appliance/shared/_steps_nuc_flash_usb.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Flash the USB drives

--- a/templates/appliance/shared/_steps_nuc_install_appliance.html
+++ b/templates/appliance/shared/_steps_nuc_install_appliance.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Install your appliance image

--- a/templates/appliance/shared/_steps_nuc_thats-it.html
+++ b/templates/appliance/shared/_steps_nuc_thats-it.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     That’s it

--- a/templates/appliance/shared/_steps_pi_boot-raspberry-pi.html
+++ b/templates/appliance/shared/_steps_pi_boot-raspberry-pi.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Boot your Raspberry Pi from the microSD card

--- a/templates/appliance/shared/_steps_pi_prep-sd-card.html
+++ b/templates/appliance/shared/_steps_pi_prep-sd-card.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Prepare the microSD card

--- a/templates/appliance/shared/_steps_pi_ssh-in.html
+++ b/templates/appliance/shared/_steps_pi_ssh-in.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     SSH in

--- a/templates/appliance/shared/_steps_pi_thats-it.html
+++ b/templates/appliance/shared/_steps_pi_thats-it.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     That’s it

--- a/templates/appliance/shared/_steps_setup-kvm.html
+++ b/templates/appliance/shared/_steps_setup-kvm.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Set up and install KVM

--- a/templates/appliance/shared/_steps_ssh-keys_macos.html
+++ b/templates/appliance/shared/_steps_ssh-keys_macos.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Generate Secure Shell (SSH) keys

--- a/templates/appliance/shared/_steps_ssh-keys_ubuntu.html
+++ b/templates/appliance/shared/_steps_ssh-keys_ubuntu.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Generate Secure Shell (SSH) keys

--- a/templates/appliance/shared/_steps_ssh-keys_windows.html
+++ b/templates/appliance/shared/_steps_ssh-keys_windows.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Generate Secure Shell (SSH) keys

--- a/templates/appliance/shared/_steps_sso.html
+++ b/templates/appliance/shared/_steps_sso.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Create an Ubuntu SSO account

--- a/templates/appliance/shared/_steps_sso_windows.html
+++ b/templates/appliance/shared/_steps_sso_windows.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     Create an Ubuntu SSO account

--- a/templates/appliance/shared/_steps_vm_thats-it.html
+++ b/templates/appliance/shared/_steps_vm_thats-it.html
@@ -1,4 +1,3 @@
-<hr>
 <li class="p-stepped-list__item">
   <h4 class="p-stepped-list__title">
     That’s it

--- a/templates/appliance/shared/_verify-checksums.html
+++ b/templates/appliance/shared/_verify-checksums.html
@@ -1,6 +1,6 @@
 <p>
-  <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;You can verify your download.</a>
+<span class="p-contextual-menu--left">
+    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;Verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem; z-index: 10;">
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />


### PR DESCRIPTION
## Done

- Replace auto-downloading of appliance images with a download button so people who visit the page do not have to keep stopping the download
- Updated the [copy sheet](https://docs.google.com/spreadsheets/d/1eZD3zISXBSNwAwkxlIRtV1UqP8GKPi0YAis8IRLZ9Po/edit#gid=0)
- Removed extra `<hr>` on instructions as vanilla must have added line now.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/plex/raspberry-pi2, http://0.0.0.0:8001/appliance/plex/raspberry-pi and http://0.0.0.0:8001/appliance/plex/intel-nuc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the download doesn't automatically start and there is a button instead.


## Issue / Card

Fixes #8021 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/89301892-1246f280-d662-11ea-8a1b-ee3ce3ec2228.png)

