### PR TITLE
Add Bosch rtp to blog posts tagged "Bosch"

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -34,7 +34,7 @@
     <a href="/internet-of-things">Ubuntu for the Internet of Things</a>
   </h3>
   <p>From smart homes to smart drones, robots, and industrial systems, Ubuntu is the new standard for embedded Linux. Get the world’s best security, a custom app store, a huge developer community and reliable updates.</p>
-  <p><a href="/internet-of-things">Learn more ›</a></p>
+  <p><a href="/internet-of-things">Learn more&nbsp;&rsaquo;</a></p>
 </div>
 {% elif article.group and article.group.slug == "kubernetes" %}
 <div class="p-card" id="rtp-k8s">

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -28,7 +28,7 @@
 </div>
 {% elif article.tags and 3680 in article.tags %}
 <div class="p-card" id="rtp-bosch">
-<img alt="IoT infographic" src="https://assets.ubuntu.com/v1/53163a88-IOT_core_infographic.svg" class="">
+<img alt="IoT infographic" src="https://assets.ubuntu.com/v1/53163a88-IOT_core_infographic.svg">
 <hr class="u-sv1">
   <h3>
     <a href="/internet-of-things">Ubuntu for the Internet of Things</a>

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -26,6 +26,16 @@
   <p>Kubernetes, or K8s for short, is an open source platform pioneered by Google, which started as a simple container orchestration tool but has grown into a platform for deploying, monitoring and managing apps and services across clouds.</p>
   <p><a href="/kubernetes/what-is-kubernetes">Learn more about Kubernetes &rsaquo;</a></p>
 </div>
+{% elif article.tags and 3680 in article.tags %}
+<div class="p-card" id="rtp-bosch">
+<img alt="IoT infographic" src="https://assets.ubuntu.com/v1/53163a88-IOT_core_infographic.svg" class="">
+<hr class="u-sv1">
+  <h3>
+    <a href="/internet-of-things">Ubuntu for the Internet of Things</a>
+  </h3>
+  <p>From smart homes to smart drones, robots, and industrial systems, Ubuntu is the new standard for embedded Linux. Get the world’s best security, a custom app store, a huge developer community and reliable updates.</p>
+  <p><a href="/internet-of-things">Learn more ›</a></p>
+</div>
 {% elif article.group and article.group.slug == "kubernetes" %}
 <div class="p-card" id="rtp-k8s">
   <h3>


### PR DESCRIPTION
## Done

- Add Bosch rtp to blog posts tagged "Bosch"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the RTP box on the right of the [Bosch blog post](https://ubuntu-com-8038.demos.haus/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform) shows an IoT message