### PR TITLE
[Engage] Build desktop authentication page

### DIFF
--- a/templates/engage/desktop-authentication-whitepaper.md
+++ b/templates/engage/desktop-authentication-whitepaper.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Optimised authentication methods for Ubuntu Desktop"
+     meta_description: "Securing enterprise desktops with modern authentication options"
+     meta_image: 
+     meta_copydoc: "https://docs.google.com/document/d/1V7rE4urAmP_AWEOPMGut27kaJOeip3kfkEqJHZf7wQg/edit?usp=sharing"
+     header_title: "Optimised authentication methods for Ubuntu Desktop"
+     header_subtitle: "Securing enterprise desktops with modern authentication options"
+     header_image: 
+     header_image_width:
+     header_image_height:
+     header_url: "#register-section"
+     header_cta: "Download the whitepaper"
+     header_class: p-engage-banner--grad
+     header_lang: en
+     form_include: en
+     form_id: 3621
+     form_return_url: https://pages.ubuntu.com/rs/066-EOV-335/images/Canonical_Authentication%20for%20Ubuntu%20Desktop_V6.pdf
+---
+
+Passwords have been around as long as multi-user operating systems and still serve as the default local authentication method – but they are far from the only option. Today, desktop users have access to a number of friendlier and more effective authentication methods that can complement, or even replace, traditional passwords.
+
+This whitepaper describes how to implement and configure these modern authentication options on Ubuntu Desktop 18.04 LTS, and offers guidance on combining authenticators to enhance security and improve the overall login experience. These principles are well suited to both personal desktop use and enterprise desktop environments. 
+
+This whitepaper includes:
+
+- Technical walkthroughs for implementing YubiKey, Google Authenticator, and Duo on Ubuntu Desktop 18.04 LTS
+- Best practice advice for improving password authentication, remote access, and desktop login without passwords
+- For enterprise users, a review of authentication recommendations covered in the National Institute of Standards and Technology’s Digital Identity Guidelines (NIST 800-63B)

--- a/templates/engage/desktop-authentication-whitepaper.md
+++ b/templates/engage/desktop-authentication-whitepaper.md
@@ -3,15 +3,15 @@ wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "Optimised authentication methods for Ubuntu Desktop"
      meta_description: "Securing enterprise desktops with modern authentication options"
-     meta_image: 
+     meta_image: https://assets.ubuntu.com/v1/187e8242-facebook_and_linkedin_banner+%281%29.jpeg
      meta_copydoc: "https://docs.google.com/document/d/1V7rE4urAmP_AWEOPMGut27kaJOeip3kfkEqJHZf7wQg/edit?usp=sharing"
      header_title: "Optimised authentication methods for Ubuntu Desktop"
      header_subtitle: "Securing enterprise desktops with modern authentication options"
-     header_image: 
-     header_image_width:
-     header_image_height:
+     header_image: https://assets.ubuntu.com/v1/32c95287-desktop-security-white.svg
+     header_image_width: 250
+     header_image_height: 138
      header_url: "#register-section"
-     header_cta: "Download the whitepaper"
+     header_cta: "Download whitepaper"
      header_class: p-engage-banner--grad
      header_lang: en
      form_include: en

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -992,6 +992,13 @@
     type="whitepaper" %}
     {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Optimised authentication methods for Ubuntu Desktop",
+    description="Securing enterprise desktops with modern authentication options",
+    slug="desktop-authentication-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
 </section>


### PR DESCRIPTION
## Done

- Built "Optimised authentication methods for Ubuntu Desktop" engage page
- Added a link to the page on /engage/index.html

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/desktop-authentication-whitepaper
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the content and metadata matches the [brief](https://docs.google.com/spreadsheets/d/1hcCt87AyGOo2emRTdRJ6AlB3yS0XRfmPr4qR4BxPXbk/edit#gid=1271849439), [copy doc](https://docs.google.com/document/d/1V7rE4urAmP_AWEOPMGut27kaJOeip3kfkEqJHZf7wQg/edit) and [design](https://github.com/canonical-web-and-design/web-squad/issues/3019)
- Navigate to http://0.0.0.0:8001/engage and ensure that the card for the new page is appropriate


## Issue / Card

Fixes #8012 