### PR TITLE
Update releases.yaml for Ubuntu 20.04.1 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -9,7 +9,7 @@ lts:
   slug: FocalFossa
   name: "Focal Fossa"
   short_version: "20.04"
-  full_version: "20.04"
+  full_version: "20.04.1"
   release_date: "April 2020"
   eol: April 2025
 openstack_lts:
@@ -25,10 +25,10 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "20.04": "e5b72e9cfe20988991c9cd87bde43c0b691e3b67b01f76d23f8150615883ce11 *ubuntu-20.04-desktop-amd64.iso"
+    "20.04.1": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso"
   live-server:
-    "20.04": "caf3fd69c77c439f162e2ba6040e9c320c4ff0d69aad1340a514319a9264df9f *ubuntu-20.04-live-server-amd64.iso"
+    "20.04.1": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso"
   arm64+raspi:
-    "20.04": "48167067d65c5192ffe041c9cc4958cb7fcdfd74fa15e1937a47430ed7b9de99 *ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz"
+    "20.04.1": "aadc64a1d069c842e56a4289fe1a6b4b5a0af4efcf95bcce78eb2a80fe5270f4 *ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz"
   armhf+raspi:
-    "20.04": "e86a9043d5394c4ae3d22d3ba62cd07d400156ec2319270d1e238ba5a0d17d9b *ubuntu-20.04-preinstalled-server-armhf+raspi.img.xz"
+    "20.04.1": "bfd1eee56f7e346e1645666fc184af854c536b3ab4e1ce49d06c266f21b1ee46 *ubuntu-20.04.1-preinstalled-server-armhf+raspi.img.xz"


### PR DESCRIPTION
## Done

- Updated the releases.yaml with 20.04.1 and the correct checksums

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/download/desktop
    - http://0.0.0.0:8001/download/server
    - http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the thank-you page points to 20.04.1 and the verify your checksums has the new numbers


## Issue / Card

Fixes #8037

