### PR TITLE
Change meta titles on managed apps and kafka page

### DIFF
--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -1,6 +1,6 @@
 {% extends "managed/_base_managed-apps.html" %}
 
-{% block title %}Canonical's managed apps{% endblock %}
+{% block title %}Canonical's Managed Apps | Multi-Cloud and On-Premise{% endblock %}
 
 {% block meta_description %}Our app and cloud experience lets you maintain business focus in a complex tech landscape. Rely on our expert engineers to set-up and operate your apps, with full lifecycle coverage.{% endblock meta_description %}
 

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -1,6 +1,6 @@
 {% extends "managed/_base_managed-apps.html" %}
 
-{% block title %}Managed Apache Kafka{% endblock %}
+{% block title %}Canonical's Managed Kafka | Multi-Cloud and On-Premise{% endblock %}
 
 {% block meta_description %}Our app and cloud experience lets you maintain business focus in a complex tech landscape. Rely on our expert engineers to set-up and operate your apps, with full lifecycle coverage.{% endblock meta_description %}
 


### PR DESCRIPTION
## Done

- Change meta titles on managed apps and kafka page to match the [issue](https://github.com/canonical-web-and-design/web-squad/issues/3031)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that the new meta title is reflected
- Navigate to http://0.0.0.0:8001/managed.kafka and do the same


## Issue / Card

Fixes web-squad#3031