### PR TITLE
Add engage pages forms conversion events

### DIFF
--- a/templates/engage/_base_engage_markdown.html
+++ b/templates/engage/_base_engage_markdown.html
@@ -113,7 +113,7 @@
         {% endwith %}
       {% else %}
         <!-- MARKETO FORM -->
-        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ form_id }}">
+        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ form_id }}" onSubmit="fbq('trackCustom', 'Download');">
           <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list u-no-margin--bottom">
       <li class="mktFormReq mktField p-list__item">

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
@@ -58,7 +58,7 @@
         <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
       </li>
       <li class="mktField">
-        <button type="submit" class="mktoButton u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
+        <button type="submit" class="mktoButton u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -1,4 +1,4 @@
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}" class="marketo-form">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}" class="marketo-form" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset>
     <h3>Prenons contact</h3>
     <ul class="p-list u-no-margin--bottom">

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}">
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">


### PR DESCRIPTION
## Done

- Adding FB conversion events on form submit for /engage/ pages
Why? With the progressive removal of ty pages for whitepapers, we need to have a way to register conversion events at the back of FB ads.
- The fbq() function is provided by GTM

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Hard to test, but here is a screenshot of the event being received in Facebook
![Screenshot from 2020-08-06 17-42-50](https://user-images.githubusercontent.com/18480003/89552374-5970e700-d80c-11ea-8c22-6f00d5894f5b.png)
