### PR TITLE
Update the Contact us navigation tag

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -932,12 +932,13 @@ download:
       path: /download/flavours
 
 contact-us:
-  title: Contact Canonical
+  title: Contact us
   path: /contact-us
 
   children:
     - title: Contact us
       path: /contact-us
+      hidden: True
 
     - title: Contact us
       path: /contact-us/form


### PR DESCRIPTION
## Done
- Update the contact us navigation title to fix the container.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/contact-us
- See that the navigation section tag fits

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/89654911-41a76a80-d8c1-11ea-8785-eccd7a15e7fc.png) | ![image](https://user-images.githubusercontent.com/1413534/89654812-23416f00-d8c1-11ea-9dcc-9e195b23d804.png) |

