### PR TITLE
Removed /apps from Openstack nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -148,8 +148,6 @@ openstack:
       path: /tco-calculator
     - title: Install
       path: /openstack/install
-    - title: Apps
-      path: /managed
     - title: Thank you
       path: /openstack/newsletter-thank-you
       hidden: True


### PR DESCRIPTION
## Done
Removed /apps from Openstack nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
