### PR TITLE
Move strips up the page on /robotics/communtiy

### DIFF
--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -18,7 +18,7 @@
         ROS exists because of contributions from tens of thousands of developers. It started in Stanford, went on to be used in Universities around the world and is now a global community of roboticists who talk, code and meet-up every year.
       </p>
       <p>
-        <a class="p-button--positive is-inline" href="https://discourse.ros.org/"><span class="p-link--external">ROS Discourse</span></a>
+        <a class="p-button--positive" href="https://discourse.ros.org/"><span class="p-link--external">ROS Discourse</span></a>
         <a class="p-button--positive is-inline" href="https://discourse.ubuntu.com/"><span class="p-link--external">Ubuntu Discourse</span></a>
       </p>
     </div>
@@ -37,7 +37,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-7">
       <h2>
@@ -62,7 +62,7 @@
   </div>
 </section>
 
-<section class="p-strip--light u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <div class="row p-divider">
     <div class="col-12">
       <h4>Recent news</h4>
@@ -85,15 +85,13 @@
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
   <script>
-    canonicalLatestNews.fetchLatestNews(
-    {
+    canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#robot-articles",
       articleTemplateSelector: "#robot-template",
       gtmEventLabel: "ubuntu.com robotics community page",
       limit: "4",
       tagId: "1721",
-    }
-    )
+    })
   </script>
 </section>
 
@@ -101,6 +99,9 @@
 <section class="p-strip--light u-no-margin--bottom u-no-padding--bottom" style="overflow: hidden;">
   <div class="row">
     <div class="col-7">
+      <h2>
+        Where to start with ROS?
+      </h2>
       <p>
         The best place to start is in the <a class="p-link--external" href="https://discourse.ros.org/">ROS Discourse</a> where thousands of roboticists go to talk. If you have specific questions there’s the <a class="p-link--external" href="https://answers.ros.org/questions/">ROS Answers</a> forum with over 13,000 questions to date. And for more context, you can read the <a class="p-link--external" href="http://wiki.ros.org/">ROS Wiki</a> or the ROS 2 docs that have been worked on by almost 3,500 people.
       </p>

--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -37,6 +37,67 @@
   </div>
 </section>
 
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2>
+        Keep up on the State of Robotics
+      </h2>
+      <p>
+        Every week the Ubuntu robotics team contributes to the future of security in robotics. And every week there are countless new projects started and improved by the community that go under the radar. The State of Robotics is a monthly blog series produced by the Canonical team to highlight the work and advancements happening in the robotics ecosystem. Why not have a read or get in touch to talk about your project?
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/0f33d832-The-State-of-Robotics.jpg",
+        alt="",
+        width="300",
+        height="169",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light u-no-padding--top">
+  <div class="row p-divider">
+    <div class="col-12">
+      <h4>Recent news</h4>
+      <div id="robot-articles" class="row p-divider">
+        <div><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
+      </div>
+      <p>
+        <a href="/blog/topics/robotics">Read more articles&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+
+  <template style="display:none" id="robot-template">
+    <div class="col-3 p-divider__block">
+      <div class="article-image u-hide--small"></div>
+      <p><strong><a class="article-link article-title"></a></strong></p>
+      <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
+    </div>
+  </template>
+
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews(
+    {
+      articlesContainerSelector: "#robot-articles",
+      articleTemplateSelector: "#robot-template",
+      gtmEventLabel: "ubuntu.com robotics community page",
+      limit: "4",
+      tagId: "1721",
+    }
+    )
+  </script>
+</section>
+
+
 <section class="p-strip--light u-no-margin--bottom u-no-padding--bottom" style="overflow: hidden;">
   <div class="row">
     <div class="col-7">
@@ -211,66 +272,6 @@
       }}
     </div>
   </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2>
-        Keep up on the State of Robotics
-      </h2>
-      <p>
-        Every week the Ubuntu robotics team contributes to the future of security in robotics. And every week there are countless new projects started and improved by the community that go under the radar. The State of Robotics is a monthly blog series produced by the Canonical team to highlight the work and advancements happening in the robotics ecosystem. Why not have a read or get in touch to talk about your project?
-      </p>
-    </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/0f33d832-The-State-of-Robotics.jpg",
-        alt="",
-        width="300",
-        height="169",
-        hi_def=True,
-        loading="lazy",
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light u-no-padding--top">
-  <div class="row p-divider">
-    <div class="col-12">
-      <h4>Recent news</h4>
-      <div id="robot-articles" class="row p-divider">
-        <div><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
-      </div>
-      <p>
-        <a href="/blog/topics/robotics">Read more articles&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-
-  <template style="display:none" id="robot-template">
-    <div class="col-3 p-divider__block">
-      <div class="article-image u-hide--small"></div>
-      <p><strong><a class="article-link article-title"></a></strong></p>
-      <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
-    </div>
-  </template>
-
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
-    canonicalLatestNews.fetchLatestNews(
-    {
-      articlesContainerSelector: "#robot-articles",
-      articleTemplateSelector: "#robot-template",
-      gtmEventLabel: "ubuntu.com robotics community page",
-      limit: "4",
-      tagId: "1721",
-    }
-    )
-  </script>
 </section>
 
 <section class="p-strip">


### PR DESCRIPTION
## Done

- Move 'Keep up on the State of Robotics' and 'Recent news' up

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics/community
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1A3iBoD_AAoerI0VwbByl8fR55ljNOjamHtJlkOuaaeA/edit?ts=5f2d0d58#heading=h.o5srtkczcpn)


## Issue / Card

Fixes #8061
