### PR TITLE
Add Ceph resources row + misc resources changes

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -59,7 +59,7 @@
       }}
       <hr class="u-sv1">
       <p class="p-card__content">In the early days of Ceph, Yahoo! Japan searched for a local company who could support them in the implementation of an open-source distributed storage solution from the Linux operating system all the way to Ceph. Canonical provided not only Ceph but also the tooling and expertise that reduced the OPEX associated with  managing a large storage cluster.</p>
-      <a href="/engage/yahoo-japan-case-study">Find out more about Yahoo! Japan’s Ceph cluster&nbsp;&rsaquo;</a>
+      <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Yahoo%21%20JAPAN%20User%20case%20study-v2_AW.pdf">Find out more about Yahoo! Japan’s Ceph cluster&nbsp;&rsaquo;</a>
     </div>
 
     <div class="col-6 p-card">
@@ -76,7 +76,7 @@
       }}
       <hr class="u-sv1">
       <p class="p-card__content">The Wellcome Sanger Institute initially opted for self-maintained Ceph storage, but as their capacity needs grew from 3 PB to over 20 PB, they turned to Canonical to resolve their scaling issues. With the help of Canonical support, the Institute’s latest Ceph rollout decreased from a month to just four days.</p>
-      <a href="/engage/wellcome-sanger-case-study">Find out about Wellcome Sanger’s path to a cost-effective Ceph infrastructure&nbsp;&rsaquo;</a>
+      <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Wellcome%20Sanger%20Institute%20Case%20Study.pdf">Find out about Wellcome Sanger’s path to a cost-effective Ceph infrastructure&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>
@@ -219,5 +219,8 @@
   <div class="u-fixed-width">
     <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a>
   </div>
+</section>
+<section class="p-strip--light is-deep is-bordered">
+  {% include "shared/_resources_ceph.html"%}
 </section>
 {% endblock content %}

--- a/templates/ceph/what-is-ceph.html
+++ b/templates/ceph/what-is-ceph.html
@@ -17,7 +17,8 @@
         <p>
           Ceph is a software-defined storage solution designed to address the object, block, and file storage needs of data centres adopting open source as the new norm for high-growth block storage, object stores and data lakes. Ceph provides enterprise scalable storage while keeping CAPEX and OPEX costs in line with underlying bulk commodity disk prices.
         </p>
-        <p><a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch&nbsp;&rsaquo;</a></p>
+        <p><a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a></p>
+        <p><a class="p-link--external" href=" https://www.brighttalk.com/webcast/6793/428078 ">Watch the webinar - Redefine your enterprise storage with Ceph</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{
@@ -331,5 +332,8 @@
               </ul>
             </div>
           </div>
+        </section>
+        <section class="p-strip is-deep is-bordered">
+          {% include "shared/_resources_ceph.html"%}
         </section>
         {% endblock content %}

--- a/templates/shared/_resources_ceph.html
+++ b/templates/shared/_resources_ceph.html
@@ -1,0 +1,74 @@
+<div class="u-fixed-width">
+  <h3>Learn more about Ceph</h3>
+  <div class="row p-divider u-no-padding--left u-no-padding--right">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h4 class="p-heading-icon__title">Webinar</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--four">
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/428078">
+          Redefine your enterprise storage with Ceph
+      </a>
+    </h3>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h4 class="p-heading-icon__title">Case study</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--four">
+        <a href="/engage/yahoo-japan-case-study">
+          How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu&nbsp;&rsaquo;
+      </a>
+    </h3>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h4 class="p-heading-icon__title">Case study</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--four">
+        <a href="/engage/wellcome-sanger-case-study">
+          Genomic research centre turns to Ceph for growing storage needs&nbsp;&rsaquo;
+        </a>
+      </h3>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Resources row for /ceph and /what-is-ceph
- Small resources related changes: link to PDF for top of page case studies, webinar link in what-is hero)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure pages match their copy docs and that new links are working


