### PR TITLE
Disable CVE add row button if any is selected for both status and value

### DIFF
--- a/static/js/src/cve/cve-search.js
+++ b/static/js/src/cve/cve-search.js
@@ -68,15 +68,19 @@ function enableField(field) {
 }
 
 /**
- * attachRowEvents
+ * attachEvents
  *
- * Adds event listeners to search row buttons
+ * Adds event listeners to search row buttons and inputs
  *
  * @returns {undefined}
  */
-function attachRowEvents() {
+function attachEvents() {
   const addRowButtons = document.querySelectorAll(".js-add-row");
   const removeRowButtons = document.querySelectorAll(".js-remove-row");
+  const ubuntuVersionInputs = document.querySelectorAll(
+    ".js-ubuntu-version-input"
+  );
+  const statusInputs = document.querySelectorAll(".js-status-input");
 
   addRowButtons.forEach((addRowButton) => {
     addRowButton.addEventListener("click", addRow);
@@ -84,6 +88,18 @@ function attachRowEvents() {
 
   removeRowButtons.forEach((removeRowButton) => {
     removeRowButton.addEventListener("click", removeRow);
+  });
+
+  ubuntuVersionInputs.forEach((input) => {
+    input.addEventListener("change", () => {
+      handleButtons();
+    });
+  });
+
+  statusInputs.forEach((input) => {
+    input.addEventListener("change", () => {
+      handleButtons();
+    });
   });
 }
 
@@ -104,7 +120,26 @@ function addRow(e) {
 
   newRowContainer.appendChild(newRow);
 
-  attachRowEvents();
+  attachEvents();
+
+  handleButtons();
+
+  const ubuntuVersionInputs = document.querySelectorAll(
+    ".js-ubuntu-version-input"
+  );
+  const statusInputs = document.querySelectorAll(".js-status-input");
+
+  ubuntuVersionInputs.forEach((input) => {
+    input.addEventListener("change", () => {
+      handleButtons();
+    });
+  });
+
+  statusInputs.forEach((input) => {
+    input.addEventListener("change", () => {
+      handleButtons();
+    });
+  });
 }
 
 /**
@@ -121,6 +156,61 @@ function removeRow(e) {
   const row = e.currentTarget.closest(".js-version-field-row");
 
   row.parentNode.removeChild(row);
+
+  handleButtons();
 }
 
-export { isValidCveId, isDomNode, disableField, enableField, attachRowEvents };
+/**
+ * handleButtons
+ *
+ * Handles the enabled/disabled state of the add/remove row buttons
+ * from the CVE search form
+ */
+function handleButtons() {
+  const STATE = {
+    allowNewVersionStatusRow: false,
+    versionsAndStatuses: [],
+  };
+
+  const rows = document.querySelectorAll(".js-version-field-row");
+
+  STATE.versionsAndStatuses = [...rows].map((row) => {
+    const ubuntuVersionInput = row.querySelector(".js-ubuntu-version-input");
+    const statusInput = row.querySelector(".js-status-input");
+
+    return {
+      version: ubuntuVersionInput.value,
+      status: statusInput.value,
+    };
+  });
+
+  const values = STATE.versionsAndStatuses;
+
+  for (let i = 0, ii = values.length; i < ii; i++) {
+    if (values[i].version === "" && values[i].status === "") {
+      STATE.allowNewVersionStatusRow = false;
+      break;
+    } else {
+      STATE.allowNewVersionStatusRow = true;
+    }
+  }
+
+  const addButtons = document.querySelectorAll(".js-add-row");
+
+  addButtons.forEach((addButton) => {
+    if (STATE.allowNewVersionStatusRow) {
+      enableField(addButton);
+    } else {
+      disableField(addButton);
+    }
+  });
+}
+
+export {
+  isValidCveId,
+  isDomNode,
+  disableField,
+  enableField,
+  attachEvents,
+  handleButtons,
+};

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -2,7 +2,8 @@ import {
   isValidCveId,
   disableField,
   enableField,
-  attachRowEvents,
+  attachEvents,
+  handleButtons,
 } from "./cve-search.js";
 
 const searchInput = document.querySelector("#q");
@@ -47,7 +48,6 @@ function handleCveIdInput(value) {
     ubuntuVersionInputs.forEach((ubuntuVersionInput) =>
       enableField(ubuntuVersionInput)
     );
-    addRowButtons.forEach((addRowButton) => enableField(addRowButton));
     removeRowButtons.forEach((removeRowButton, index) => {
       if (index > 0) {
         enableField(removeRowButton);
@@ -67,4 +67,6 @@ function handleSearchInput(event) {
 
 searchInput.addEventListener("keyup", handleSearchInput);
 
-attachRowEvents();
+attachEvents();
+
+handleButtons();

--- a/templates/security/cve/_version-and-status-row.html
+++ b/templates/security/cve/_version-and-status-row.html
@@ -1,0 +1,34 @@
+{% if index == 0 %}
+{% set show_labels = true %}
+{% endif %}
+
+<div class="row js-version-field-row">
+  <div class="col-3">
+    {% if show_labels %}
+      <label for="version">Ubuntu version</label>
+    {% endif %}
+    <select name="version" class="js-ubuntu-version-input" {% if show_labels %}id="version"{% endif %}>
+      <option value="">Any</option>
+      {% with versions=versions, releases=releases, index=index %}
+      {% include "security/cve/_version-fields.html" %}
+      {% endwith %}
+    </select>
+  </div>
+  <div class="col-3">
+    {% if show_labels %}
+      <label for="version">Status</label>
+    {% endif %}
+    <select name="status" class="js-status-input" {% if show_labels %}id="status"{% endif %}>
+      {% with statuses=statuses, index=index %}
+      {% include "security/cve/_status-fields.html" %}
+      {% endwith %}
+    </select>
+  </div>
+  <div class="col-3">
+    {% if show_labels %}
+      <label>&nbsp;</label>
+    {% endif %}
+    <button class="js-remove-row" {% if index == 0 %}disabled{% endif %}>&minus;</button>
+    <button class="js-add-row" disabled>&plus;</button>
+  </div>
+</div>

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -54,55 +54,17 @@
         </select>
       </div>
     </div>
-    <div class="row">
-      <div class="col-3">
-        <label for="version">Ubuntu version</label>
-        <select name="version" id="version" class="js-ubuntu-version-input">
-          <option value="">Any</option>
-          {% with versions=versions, releases=releases, index=0 %}
-          {% include "security/cve/_version-fields.html" %}
-          {% endwith %}
-        </select>
-      </div>
-      <div class="col-3">
-        <label for="status">Status</label>
-        <select name="status" id="status" class="js-status-input">
-          {% with statuses=statuses, index=0 %}
-          {% include "security/cve/_status-fields.html" %}
-          {% endwith %}
-        </select>
-      </div>
-      <div class="col-3">
-        <label>&nbsp;</label> <!-- for layout purposes -->
-        <button class="js-remove-row" disabled>&minus;</button>
-        <button class="js-add-row">&plus;</button>
-      </div>
-    </div>
-    {% for status in statuses %}
-      {% if loop.index > 1 %}
-        <div class="row js-version-field-row">
-          <div class="col-3">
-            <select name="version" class="js-ubuntu-version-input">
-              <option value="">Any</option>
-              {% with versions=versions, releases=releases, index=loop.index - 1 %}
-              {% include "security/cve/_version-fields.html" %}
-              {% endwith %}
-            </select>
-          </div>
-          <div class="col-3">
-            <select name="status" class="js-status-input">
-              {% with statuses=statuses, index=loop.index - 1 %}
-              {% include "security/cve/_status-fields.html" %}
-              {% endwith %}
-            </select>
-          </div>
-          <div class="col-3">
-            <button class="js-remove-row" disabled>&minus;</button>
-            <button class="js-add-row">&plus;</button>
-          </div>
-        </div>
-      {% endif %}
-    {% endfor %}
+    {% if statuses | length > 0 %}
+      {% for status in statuses %}
+        {% with versions=versions, statuses=statuses, releases=releases, index=loop.index - 1 %}
+        {% include "security/cve/_version-and-status-row.html" %}
+        {% endwith %}
+      {% endfor %}
+    {% else %}
+      {% with versions=versions, statuses=statuses, releases=releases, index=0 %}
+      {% include "security/cve/_version-and-status-row.html" %}
+      {% endwith %}
+    {% endif %}
     <div id="new-row-container"></div>
     <div class="u-fixed-width">
       <button type="submit" class="p-button--positive" id="cve-search-button">
@@ -148,34 +110,9 @@
 </section>
 
 <template id="version-field-row-template">
-  <div class="row js-version-field-row">
-    <div class="col-3">
-      <select name="version" class="js-ubuntu-version-input">
-        <option value="">Any</option>
-        <option value="current">Any current release</option>
-        {% for release in releases %}
-          <option value="{{ release.version }}">{{ release.name }} {{ release.version }} {{ release.support_tag }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="col-3">
-      <select name="status" class="js-status-input">
-        <option value="">Any</option>
-        <option value="DNE">Does not exist</option>
-        <option value="needs-triage">Needs triage</option>
-        <option value="not-vulnerable">Not vulnerable</option>
-        <option value="needed">Needed</option>
-        <option value="deferred">Deferred</option>
-        <option value="ignored">Ignored</option>
-        <option value="pending">Pending</option>
-        <option value="released">Released</option>
-      </select>
-    </div>
-    <div class="col-3">
-      <button class="js-remove-row">&minus;</button>
-      <button class="js-add-row">&plus;</button>
-    </div>
-  </div>
+  {% with versions=versions, statuses=statuses, releases=releases %}
+  {% include "security/cve/_version-and-status-row.html" %}
+  {% endwith %}
 </template>
 
 <script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>


### PR DESCRIPTION
## Done

On a CVE search, if both the version and status are set to "Any" on any of the rows the "+" button should be disabled, otherwise it should be enabled.

## QA

- Check out this feature branch
- Run the site: `docker-compose up -d && dotrun`
- Go to http://localhost:8001/security/cve
- Check that both the "+" and "-" buttons are disabled next to the version/status fields
- Change the value of either field so that at least one isn't set to any
- Check that the "+" button is now enabled
- Add some more rows and play around with the values
- If any row has both value set to "Any" then all "+" buttons should be disabled
- Submit a search with and without fields set to "Any" and check that the "+" buttons behave as above

## Issue / Card

Fixes #8020 