### PR TITLE
K8sdocs: Updates  for 1.18ck1

### DIFF
--- a/templates/kubernetes/docs/1.18/release-notes.md
+++ b/templates/kubernetes/docs/1.18/release-notes.md
@@ -13,6 +13,55 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.18+ck1 Bugfix release
+
+### June 11, 2020 - [charmed-kubernetes-464](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-464/archive/bundle.yaml)
+
+Before upgrading from 1.17 or earlier, please read the
+[upgrade notes](/kubernetes/docs/upgrade-notes).
+
+## What's new
+
+- New options for custom TLS data in container runtime charms
+
+All container runtime subordinate charms now support a `custom-registry-ca`
+option that can be used to specify a `base64` encoded Certificate Authority
+(CA) certificate. The value set here will be installed as a system-wide
+trusted CA. See the
+[related issue](https://bugs.launchpad.net/layer-container-runtime-common/+bug/1831153)
+for more details.
+
+For users that require custom TLS configuration per registry, the `containerd`
+subordinate charm has expanded the `custom_registries` config option to
+support `ca_file`, `cert_file`, and `cert_key`. These can be set for each
+custom registry to enable TLS without altering the system-wide trusted CAs.
+See the
+[related issue](https://bugs.launchpad.net/charm-containerd/+bug/1879347)
+for more details.
+
+Both of the above options allow the container runtime located on
+`kubernetes-worker` units to pull containers from a registry that utilizes
+custom TLS certificates.
+
+- New memory constraint for `kubeapi-load-balancer`
+
+Deploying Charmed Kubernetes now requires a minimum of 4GB of RAM for the
+`kubeapi-load-balancer`. This addresses OOM errors reported in the
+[related issue](https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1873044).
+
+- Updated profile when deploying to LXD
+
+An updated LXD profile has been included in `kubernetes-master` and
+`kubernetes-worker` charms. This resolves an
+[issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1876618)
+where containers would fail to start in a LXD environment.
+
+## Fixes
+
+Bug fixes included in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck1).
+
+
 # 1.18
 
 ### April 13th, 2020 - [charmed-kubernetes-430](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-430/archive/bundle.yaml)

--- a/templates/kubernetes/docs/auth.md
+++ b/templates/kubernetes/docs/auth.md
@@ -79,7 +79,7 @@ juju config kubernetes-master authorization-mode="Node"
 It is possible to set more than one mode using a comma-separated list:
 
 ```bash
-juju config kubernetes-master authorization-mode="RBAC, Node"
+juju config kubernetes-master authorization-mode="RBAC,Node"
 ```
 
 <div class="p-notification--positive"><p markdown="1" class="p-notification__response">

--- a/templates/kubernetes/docs/certs-and-trust.md
+++ b/templates/kubernetes/docs/certs-and-trust.md
@@ -133,7 +133,6 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 [vault]: https://www.vaultproject.io
 [easyrsa-charm]: https://jujucharms.com/u/containers/easyrsa/
 [easy-rsa]: https://github.com/OpenVPN/easy-rsa
-[leadership]: https://docs.jujucharms.com/stable/en/authors-charm-leadership
 [install_ca_cert]: https://charm-helpers.readthedocs.io/en/latest/api/charmhelpers.core.host.html#charmhelpers.core.host.install_ca_cert
 [Comodo]: https://en.wikipedia.org/wiki/Comodo_Group
 [DigiCert]: https://en.wikipedia.org/wiki/DigiCert
@@ -143,15 +142,10 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 [CN]: https://knowledge.digicert.com/solution/SO7239.html
 [SANs]: https://en.wikipedia.org/wiki/Subject_Alternative_Name
 [network primitives]: https://docs.jujucharms.com/stable/en/developer-network-primitives
-[kubernetes-master]: https://jujucharms.com/u/containers/kubernetes-master/
-[`extra_sans`]: https://jujucharms.com/u/containers/kubernetes-master/#charm-config-extra_sans
+[kubernetes-master]: /docs/kubernetes/charm-kubernetes-master
+[`extra_sans`]:  /docs/kubernetes/charm-kubernetes-master#extra_sans
 [provides-tls]: https://jujucharms.com/q/?provides=tls-certificates
 [HA]: https://en.wikipedia.org/wiki/High_availability
-[vault-guide-csr]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-certificate-management.html
-[csr]: https://en.wikipedia.org/wiki/Certificate_signing_request
-[expose]: https://docs.jujucharms.com/stable/en/charms-exposing
-[hacluster]: https://jujucharms.com/stable/en/hacluster
-[vault-bug-ttl]: https://bugs.launchpad.net/vault-charm/+bug/1788945
 [vault-cdk]: /kubernetes/docs/using-vault
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/charm-docker-registry.md
+++ b/templates/kubernetes/docs/charm-docker-registry.md
@@ -244,7 +244,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-tls-cert-blob"> </a> tls-cert-blob | string |  | Base64 encoded TLS certificate (overwrites tls-cert-path file).  |
 | <a id="table-tls-cert-path"> </a> tls-cert-path | string | [See notes](#tls-cert-path-default) | Path to the TLS certificate.  |
 | <a id="table-tls-key-blob"> </a> tls-key-blob | string |  | Base64 encoded TLS certificate private key (overwrites tls-key-path file).  |
-| <a id="table-tls-key-path"> </a> tls-key-path | string | [See notes](#tls-key-path-default) | Path to the TLS certificate private key.  |
+| <a id="table-tls-key-path"> </a> tls-key-path | string | [See notes](#tls-key-path-default) | Path the the TLS certificate private key.  |
 
 ---
 

--- a/templates/kubernetes/docs/charm-docker-registry.md
+++ b/templates/kubernetes/docs/charm-docker-registry.md
@@ -244,7 +244,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-tls-cert-blob"> </a> tls-cert-blob | string |  | Base64 encoded TLS certificate (overwrites tls-cert-path file).  |
 | <a id="table-tls-cert-path"> </a> tls-cert-path | string | [See notes](#tls-cert-path-default) | Path to the TLS certificate.  |
 | <a id="table-tls-key-blob"> </a> tls-key-blob | string |  | Base64 encoded TLS certificate private key (overwrites tls-key-path file).  |
-| <a id="table-tls-key-path"> </a> tls-key-path | string | [See notes](#tls-key-path-default) | Path the the TLS certificate private key.  |
+| <a id="table-tls-key-path"> </a> tls-key-path | string | [See notes](#tls-key-path-default) | Path to the TLS certificate private key.  |
 
 ---
 

--- a/templates/kubernetes/docs/charm-kubeapi-load-balancer.md
+++ b/templates/kubernetes/docs/charm-kubeapi-load-balancer.md
@@ -98,3 +98,16 @@ this allows you to differentiate between them.
 
 
 <!-- CONFIG ENDS -->
+
+## Certificates and extra SANs
+
+See the [Certificates and trust documentation][certs-and-trust] for an overview of certificate
+handling in **Charmed Kubernetes**.
+
+For adding extra SANs and regenerating certificates, refer to the related
+[documentation of the kubernetes-master charm][kubernetes-master]
+
+<!-- LINKS -->
+
+[kubernetes-master]: /kubernetes/docs/charm-kubernetes-master#extra_sans
+[certs-and-trust]: /kubernetes/docs/certs-and-trust

--- a/templates/kubernetes/docs/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/charm-kubernetes-master.md
@@ -619,6 +619,32 @@ for example, to add the `PodSecurityPolicy` admission controller:
 Note that prior to Kubernetes 1.16 (kubernetes-master revision 778), the config
 setting was `admission-control`, rather than `enable-admission-plugins`.
 
+<a id="extra_sans"> </a>
+## Adding SANs and certificate regeneration
+
+As explained in the [Certificates and trust overview][certs-and-trust], the
+[`extra_sans`](#table-extra_sans) configuration settings can be used to add
+SANs and regenerate x509 certificate(s) for the API server running on the
+Kubernetes master node(s), and for the load balancer. When this configuration is
+changed, the master node(s) will regenerate its certificate and restart the API
+server to update the certificate used for communication. Note: This is
+disruptive and restarts the API server.
+
+The process is the same for both the `kubernetes-master` and the
+`kubeapi-load-balancer`. The configuration option takes a space-separated list
+of extra entries:
+
+```bash
+juju config kubernetes-master extra_sans="master.mydomain.com lb.mydomain.com"
+juju config kubeapi-load-balancer extra_sans="master.mydomain.com lb.mydomain.com"
+```
+To clear the entries out of the certificate, use an empty string:
+
+```bash
+juju config kubernetes-master extra_sans=""
+juju config kubeapi-load-balancer extra_sans=""
+```
+
 ## DNS for the cluster
 
 The DNS add-on allows pods to have DNS names in addition to IP addresses.
@@ -655,3 +681,5 @@ This action restarts the master processes `kube-apiserver`,
 [IPVS deep dive]: https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/
 [blog-admission]: https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/
 [Addons page]: /kubernetes/docs/cdk-addons
+[certs-and-trust]: /kubernetes/docs/certs-and-trust
+

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -179,9 +179,41 @@ You may need to start a new shell (or logout and login) for this to take effect:
 newgrp lxd
 ```
 
+### Services fail to start with errors related to missing files in the /proc filesystem
+
+For example, `systemctl status snap.kube-proxy.daemon` may report the following:
+
+```bash
+Error: open /proc/sys/net/netfilter/nf_conntrack_max: no such file or directory
+```
+
+This is most commonly caused when [lxd-profile.yaml][lxd-profile] is not applied.
+Verify the profile in use by the `kubernetes-worker` charm:
+
+```bash
+lxc profile list
+lxc profile show juju-[model]-kubernetes-worker-[revision]
+```
+
+Identify any missing fields from the above `lxd-profile.yaml` file and add them
+as needed with:
+
+```bash
+lxc profile edit juju-[model]-kubernetes-worker-[revision]
+```
+
+You may need to remove and re-add the affected unit for the changes to take
+effect:
+
+```bash
+juju remove-unit kubernetes-worker/[n]
+juju add-unit kubernetes-worker
+```
+
 <!-- LINKS -->
 
 [lxd-home]: https://linuxcontainers.org/
+[lxd-profile]: https://github.com/charmed-kubernetes/charm-kubernetes-worker/blob/master/lxd-profile.yaml
 [Juju]: https://jaas.ai
 [snap]: https://snapcraft.io/docs/installing-snapd
 [install]: /kubernetes/docs/install-manual

--- a/templates/kubernetes/docs/snap-refresh.md
+++ b/templates/kubernetes/docs/snap-refresh.md
@@ -44,7 +44,7 @@ or the special keyword *max*.
 
     An explicit timer may be a simple `mon` (scan every Monday) or a more
     complex `mon3,23:00` (scan on the third Monday of the month at 23:00). See
-    possible values for explicit timers in the the *refresh.timer* section of
+    possible values for explicit timers in the *refresh.timer* section of
     the [system options][system-snap-opts] documentation.
 
 - Empty string

--- a/templates/kubernetes/docs/snap-refresh.md
+++ b/templates/kubernetes/docs/snap-refresh.md
@@ -44,7 +44,7 @@ or the special keyword *max*.
 
     An explicit timer may be a simple `mon` (scan every Monday) or a more
     complex `mon3,23:00` (scan on the third Monday of the month at 23:00). See
-    possible values for explicit timers in the *refresh.timer* section of
+    possible values for explicit timers in the the *refresh.timer* section of
     the [system options][system-snap-opts] documentation.
 
 - Empty string
@@ -106,9 +106,9 @@ juju run --unit kubernetes-master/0 'snap refresh cdk-addons'
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/snap-refresh.md" class="p-notification__action">edit this page</a>
-    or
+    We appreciate your feedback on the documentation. You can 
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/snap-refresh.md" class="p-notification__action">edit this page</a> 
+    or 
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
   </p>
 </div>

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -72,13 +72,24 @@ juju add-relation ceph-fs ceph-mon
 **Charmed Kubernetes** will then deploy the CephFS provisioner pod
 and create a `cephfs` storage class in the cluster.
 
-<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
+<div class="p-notification--caution"><p markdown="1" class="p-notification__response">
 <span class="p-notification__status">Note:</span>
-Due to an upstream issue, containers running as a non-root user with a ReadWriteMany (RWX) CephFS volume
-will not be able to write to the mounted directory. This will be fixed with the next release after the
-next OpenStack charms release. In the meantime, you can work around this by adding a simple initContainer
-to your pod to adjust the mounted volume permissions, such as:
-<code>
+CephFS support in Kubernetes requires at least Ubuntu 18.04LTS and OpenStack
+Train. OpenStack Ussuri or newer is recommended.
+</p></div>
+
+When deploying **Charmed Kubernetes** on Ubuntu 18.04(Bionic), you will need 
+to explicitly set the `install_sources` config option on the `kubernetes-master`
+charm to include `cloud:bionic-ussuri` (or whatever OpenStack release you are
+using).
+
+When using OpenStack Train, ReadWriteMany (RWX) CephFS volumes on containers
+running as a non-root user will be mounted as owned by root instead of the
+container's user, potentially leading to permissions issues.  You can work
+around this by adding an initContainer to your pod to adjust the mounted
+volume's ownership or permissions. For example:
+
+```yaml
 initContainers:
   - name: fix-cephfs-rwx-volume-perm
     securityContext:
@@ -88,8 +99,7 @@ initContainers:
       - name: shared-data  # adjust volume name and mountPath
         mountPath: /data   # to match your pod spec
     command: ['chmod', '0777', '/data']
-</code>
-</p></div>
+```
 
 ### Relate to Charmed Kubernetes
 


### PR DESCRIPTION
## Done

Updates for K8s docs. Mainly release notes for 1.18ck1

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)



