### PR TITLE
Create data lake webinar engage page

### DIFF
--- a/templates/engage/data-lake_2_server_webinar.md
+++ b/templates/engage/data-lake_2_server_webinar.md
@@ -1,0 +1,27 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Production AI from data lake to server webinar"
+     meta_description: "Solving hardware challenges in ML environments"
+     meta_image: "https://assets.ubuntu.com/v1/57999cac-data-lake_2_server_webinar.png"
+     meta_copydoc: "https://docs.google.com/document/d/1A9BYXs8Wb-95ahpNJZ-KDloY3ni0v2kIA3O-OB81cW8/edit"
+     header_title: "Production AI from data lake to server"
+     header_subtitle: "Solving hardware challenges in ML environments"
+     header_image: "https://assets.ubuntu.com/v1/25363584-Ubuntu-Dell-AI%3AML.svg"
+     header_url: '#register-section'
+     header_cta: "Register for the webinar"
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--aqua
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 427925, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+Infrastructure is a critical component when enabling AI/ML teams to produce the fastest and most valuable results for high performance computing problems while maximising resource utilisation. Research capabilities can be accelerated to tackle complex workloads by leveraging the purpose-built workstations and servers that solve interrelated hardware problems, from prototyping on the workstation to deploying and scaling on the server.
+
+#### We will discuss
+
+- Design and practice considerations from workstation to server with practical examples
+- Security, performance and cost prioritizations
+- The role of Kubeflow in making AI work best for business needs
+
+#### Who should attend
+
+AI/ML data engineers, scientists, research leaders, product managers, developers and ops teams who want to maximise time spent on producing results.

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -999,6 +999,14 @@
     type="whitepaper" %}
     {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Production AI from data lake to server",
+    description="Solving hardware challenges in ML environments",
+    slug="data-lake_2_server_webinar",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+    
   </div>
 
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,8 @@
   {% include "takeovers/_us-kubernetes-event.html" %}
   {% include "takeovers/_gsi-webinar-series-takeover.html" %}
   {% include "takeovers/_redhat-openstack.html" %}
+  {% include "takeovers/_data-lake_2_server_webinar.html" %}
+
 
   {# FRENCH #}
   {% include "takeovers/fr/_cio-guide-to-multipass.html" %}

--- a/templates/takeovers/_data-lake_2_server_webinar.html
+++ b/templates/takeovers/_data-lake_2_server_webinar.html
@@ -1,0 +1,15 @@
+{% with title="Production AI from data lake to server",
+subtitle="Solving hardware challenges in ML environments",
+class="p-takeover--aqua",
+header_image="https://assets.ubuntu.com/v1/25363584-Ubuntu-Dell-AI%3AML.svg",
+image_style="width: 75%",
+image_hide_small=true,
+equal_cols=false,
+primary_url="/engage/data-lake_2_server_webinar?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Partner_AI_WBN_DellDataLaketoServer_Takeovere",
+primary_cta="Watch the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -158,4 +158,6 @@
 {% include "takeovers/_gsi-webinar-series-takeover.html" %}
 <p>28 July 2020</p>
 {% include "takeovers/_redhat-openstack.html" %}
+<p>12 August 2020</p>
+{% include "takeovers/_data-lake_2_server_webinar.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Create data lake webinar engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - takeover here: http://0.0.0.0:8001/
    - takeover index: http://0.0.0.0:8001/takeover
    - engage page: http://0.0.0.0:8001/engage/data-lake_2_server_webinar
    - engage index: http://0.0.0.0:8001/engage/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the design and the [copy doc](https://docs.google.com/document/d/1A9BYXs8Wb-95ahpNJZ-KDloY3ni0v2kIA3O-OB81cW8/edit#)


## Issue / Card

Fixes #8056

## Screenshots

![image](https://user-images.githubusercontent.com/441217/90040640-1a390f00-dcc0-11ea-9b72-680cf48c80ca.png)


![image](https://user-images.githubusercontent.com/441217/90040587-0a212f80-dcc0-11ea-9b91-46581d0fc942.png)

