### PR TITLE
Updates for 18.04.5 and 16.04.7 point releases

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -17,11 +17,11 @@ openstack_lts:
 previous_lts:
   name: "Bionic Beaver"
   short_version: "18.04"
-  full_version: "18.04.4"
+  full_version: "18.04.5"
 previous_previous_lts:
   name: "Xenial Xerus"
   short_version: "16.04"
-  full_version: "16.04.6"
+  full_version: "16.04.7"
 
 checksums:
   desktop:

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -146,31 +146,31 @@
     <div class="col-3">
       <p class="u-hide--small u-sv2">&nbsp;</p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=armhf+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
         </a>
       </p>
     </div>
     <div class="col-3">
       <p>
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=arm64+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=arm64+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
         </a>
       </p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=armhf+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
         </a>
       </p>
     </div>
     <div class="col-3">
       <p>
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=arm64+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=arm64+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
         </a>
       </p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}.1&amp;architecture=armhf+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=armhf+raspi" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
         </a>
       </p>
@@ -179,41 +179,41 @@
 </section>
 {% endif %}
 
-{# 18.04 row #}
+{# previous_lts row #}
 <section class="p-strip is-bordered is-shallow u-no-padding--bottom">
   <div class="row u-equal-height">
     <div class="col-3">
-      <h4>Ubuntu 18.04</h4>
+      <h4>Ubuntu {{ releases.previous_lts.full_version }}</h4>
       <p>The previous LTS version of Ubuntu for projects without 20.04 support.</p>
     </div>
     <div class="col-3">
       <p class="u-hide--small u-sv2">&nbsp;</p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=armhf+raspi2" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 2 32-bit', 'eventLabel' : '{{ releases.previous_lts.short_version }}', 'eventValue' : undefined });">
           Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 2</span>
         </a>
       </p>
     </div>
     <div class="col-3">
       <p>
-        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 64-bit', 'eventLabel' : '{{ releases.previous_lts.short_version }}', 'eventValue' : undefined });">
           Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
         </a>
       </p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 3 32-bit', 'eventLabel' : '{{ releases.previous_lts.short_version }}', 'eventValue' : undefined });">
           Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 3</span>
         </a>
       </p>
     </div>
     <div class="col-3">
       <p>
-        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=arm64+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=arm64+raspi4" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 64-bit', 'eventLabel' : '{{ releases.previous_lts.short_version }}', 'eventValue' : undefined });">
           Download 64-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
         </a>
       </p>
       <p>
-        <a href="/download/raspberry-pi/thank-you?version=18.04&amp;versionPatch=.4&amp;architecture=armhf+raspi3" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '18.04', 'eventValue' : undefined });">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=armhf+raspi4" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 4 32-bit', 'eventLabel' : '{{ releases.previous_lts.short_version }}', 'eventValue' : undefined });">
           Download 32-bit<span class="u-hide--medium u-hide--large"> for Raspberry Pi 4</span>
         </a>
       </p>

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {% if start_download %}
-<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}{{ versionPatch }}-preinstalled-server-{{ architecture }}.img.xz">
+<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">
@@ -22,7 +22,7 @@
       <h1>Thank you for downloading<br />
         Ubuntu Server {{ version }}<br />
         for Raspberry Pi</h1>
-      <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}{{ versionPatch }}-preinstalled-server-{{ architecture }}.img.xz">download now</a>.</p>
+      <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">download now</a>.</p>
       {% with version=version, system=architecture, architecture=architecture %}{% include "download/shared/_verify-checksums.html" %}{% endwith %}
       {% else %}
       <h1>Thank you</h1>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -36,7 +36,6 @@ def download_thank_you(category):
     context = {"http_host": flask.request.host}
 
     version = flask.request.args.get("version", "")
-    versionPatch = flask.request.args.get("versionPatch", "")
     architecture = flask.request.args.get("architecture", "")
 
     # Sanitise for paths
@@ -48,7 +47,6 @@ def download_thank_you(category):
     if architecture and version_pattern.match(version):
         context["start_download"] = version and architecture
         context["version"] = version
-        context["versionPatch"] = versionPatch
         context["architecture"] = architecture
 
     # Add mirrors


### PR DESCRIPTION
## Done

- Updated releases.yaml
- Got rid of the versionPatch hack

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/download/raspberry-pi
    - http://0.0.0.0:8001/download/alternative-downloads
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all the downloads are for either 18.04.5 or 16.04.7


## Issue / Card

Fixes #8079

