### PR TITLE
Disable version if previously selected in CVE search

### DIFF
--- a/static/js/src/cve/cve-search.js
+++ b/static/js/src/cve/cve-search.js
@@ -93,6 +93,7 @@ function attachEvents() {
   ubuntuVersionInputs.forEach((input) => {
     input.addEventListener("change", () => {
       handleButtons();
+      disableSelectedVersions();
     });
   });
 
@@ -132,6 +133,7 @@ function addRow(e) {
   ubuntuVersionInputs.forEach((input) => {
     input.addEventListener("change", () => {
       handleButtons();
+      disableSelectedVersions();
     });
   });
 
@@ -140,6 +142,8 @@ function addRow(e) {
       handleButtons();
     });
   });
+
+  disableSelectedVersions();
 }
 
 /**
@@ -206,6 +210,39 @@ function handleButtons() {
   });
 }
 
+/**
+ * disableOptionIfSelected
+ *
+ * @param {Object} option - A select option
+ * @param {Array} selectedVersions - All versions currently selected
+ */
+function disableOptionIfSelected(option, selectedVersions) {
+  if (option.value === "") {
+    return;
+  }
+
+  if (selectedVersions.includes(option.value) && !option.selected) {
+    option.disabled = true;
+  }
+}
+
+/**
+ * disableSelectedVersions
+ *
+ * Disables options in the Ubuntu version select box if
+ * that version is already selected in a previous row
+ */
+function disableSelectedVersions() {
+  const inputs = document.querySelectorAll(".js-ubuntu-version-input");
+  const selectedVersions = [...inputs].map((input) => input.value);
+
+  inputs.forEach((input) => {
+    [...input.options].forEach((option) => {
+      disableOptionIfSelected(option, selectedVersions);
+    });
+  });
+}
+
 export {
   isValidCveId,
   isDomNode,
@@ -213,4 +250,6 @@ export {
   enableField,
   attachEvents,
   handleButtons,
+  disableOptionIfSelected,
+  disableSelectedVersions,
 };

--- a/static/js/src/cve/cve-search.test.js
+++ b/static/js/src/cve/cve-search.test.js
@@ -3,6 +3,7 @@ import {
   isDomNode,
   disableField,
   enableField,
+  disableOptionIfSelected,
 } from "./cve-search.js";
 
 describe("isValidCveId", () => {
@@ -98,5 +99,27 @@ describe("enableField", () => {
     input.setAttribute("disabled", true);
     enableField(input);
     expect(input.getAttribute("disabled")).toBeFalsy();
+  });
+});
+
+describe("disableOptionIfSelected", () => {
+  it("has no effect if option has no value", () => {
+    const option = { value: "", selected: false, disabled: false };
+    disableOptionIfSelected(option, []);
+    expect(option.disabled).toBeFalsy();
+  });
+
+  it("has no effect if option is not selected and not in list", () => {
+    const selectedVersions = ["20.04", "14.04", "current"];
+    const option = { value: "18.04", selected: false, disabled: false };
+    disableOptionIfSelected(option, selectedVersions);
+    expect(option.disabled).toBeFalsy();
+  });
+
+  it("disables option if not selected and is in list", () => {
+    const selectedVersions = ["20.04", "14.04", "current"];
+    const option = { value: "14.04", selected: false, disabled: false };
+    disableOptionIfSelected(option, selectedVersions);
+    expect(option.disabled).toBeTruthy();
   });
 });

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -4,6 +4,7 @@ import {
   enableField,
   attachEvents,
   handleButtons,
+  disableSelectedVersions,
 } from "./cve-search.js";
 
 const searchInput = document.querySelector("#q");
@@ -68,5 +69,5 @@ function handleSearchInput(event) {
 searchInput.addEventListener("keyup", handleSearchInput);
 
 attachEvents();
-
 handleButtons();
+disableSelectedVersions();


### PR DESCRIPTION
## Done

Disable Ubuntu version in dropdown if already selected in a previous row

## QA

Check out this feature branch

```
docker-compose rm -fs
docker-compose up -d
dotrun exec alembic upgrade head
dotrun exec python3 scripts/create-releases.py
dotrun
```

In the directory containing ubuntu.com:

```
git clone -b test-status-component-field git@github.com:albertkol/ubuntu-cve-tracker
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

- Go to http://localhost:8001
- Select an Ubuntu version and add a new row
- Check that the previously selected version is disabled in the new row
- Change the previously selected version and check that it is now enabled in the new row
- Try a few combinations, the only option that should never be disabled is "Any"
- Check that the tests pass: `dotrun exec yarn test-js`

## Issue / Card

Fixes #8067