### PR TITLE
Blog module update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.2
 canonicalwebteam.flask_base==0.6.3
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.2.1
+canonicalwebteam.blog==6.2.2
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.2.0


### PR DESCRIPTION
Update blog module to hot fix bug when `width="100%"` is set for image.

## QA
Browse to: https://ubuntu.com/blog/top-10-linux-apps-for-entertainment-and-leisure
It throws a 500.

Browse to: https://ubuntu-com-8083.demos.haus/blog/top-10-linux-apps-for-entertainment-and-leisure
Confirm that it works.

## Issue

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8078