### PR TITLE
Initial version of the /security/oval page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1123,6 +1123,8 @@ security:
     - title: Notices
       path: /security/notices
       persist: True
+    - title: OVAL
+      path: /security/oval
     # Hidden for soft launch
     # - title: CVEs
     # path: /security/cve

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -1,0 +1,321 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Ubuntu Oval{% endblock %}
+
+{% block meta_description %}Parameters and methods for consuming Ubuntu OVAL data. OVAL is used by the Ubuntu Security Team for CVE tracking and management.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1hBG6NIfBIrixIV753fsOiEymmeuFIF-KOhiDkV68PRY/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--suru-bottomed">
+  <div class="row u-equal-height">
+    <div class="col-7 u-vertically-center">
+      <h1>
+        Ubuntu OVAL data
+      </h1>
+      <p>
+        Canonical's Security Team produces Ubuntu OVAL, a structured, machine-readable dataset for all <a href="https://ubuntu.com/about/release-cycle">supported Ubuntu releases</a>.  It can be used to evaluate and manage security risk related to any existing Ubuntu components. It is based on the Open Vulnerability and Assessment Language (OVAL).
+      </p>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/eb653b8e-oval_logo.png",
+        alt="",
+        width="250",
+        height="164",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-7">
+      <h2>
+        How we use Ubuntu OVAL
+      </h2>
+      <p>
+        Ubuntu OVAL uses the OVAL vulnerability and patch definitions to enable auditing for Common Vulnerabilities and Exposures (CVEs) and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.
+      </p>
+      <p>
+        Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu OCI image for vulnerabilities.
+      </p>
+    </div>
+    <div class="col-5 u-hide--small u-align--center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
+  <div class="row u-vertically-center">
+    <div class="col-5 u-hide--small u-align--center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/74859dc8-control-thin.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>
+        Ubuntu OVAL's coverage
+      </h2>
+      <p>
+        Each Ubuntu release comes with thousands of open source packages maintained in two repositories - Main and Universe.
+      </p>
+      <p>
+        Historically, Canonical committed to applying critical, high and medium security patches to the Ubuntu Main repository, which consists of around 2,500 packages. This data can be found in Ubuntu OVAL as well as in the Ubuntu Security Notices.
+      </p>
+      <p>
+        Canonical has now expanded the scope of CVE patching to high and critical vulnerabilities in the Ubuntu Universe repository, which consists of over 28,000 open source packages.
+      </p>
+      <p>
+        <a href="/security/notices">
+          See the Ubuntu Security Notices&nbsp;&rsaquo;
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered" id="instructions">
+  <div class="row">
+    <div class="col-8">
+      <h2>
+        Using Ubuntu’s OVAL data
+      </h2>
+      <ol class="p-stepped-list">
+        <li class="p-stepped-list__item">
+          <h3 class="p-stepped-list__title">
+            Using OpenSCAP
+          </h3>
+          <div class="p-stepped-list__content">
+            <p>
+              Download the compressed XML:
+            </p>
+            <pre><code>wget https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2</code></pre>
+            <p>
+              Uncompress the data:
+            </p>
+            <pre><code>bunzip2 com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2</code></pre>
+            <p>
+              Use OpenSCAP to evaluate the OVAL and generate an html report:
+            </p>
+            <pre><code>oscap oval eval --report report.htm com.ubuntu.$(lsb_release -cs).cve.oval.xml</code></pre>
+            <p>
+              The output is generated in the file report.htm, open it using your browser:
+            </p>
+            <pre><code>xdg-open report.htm</code></pre>
+            <p>
+              File naming convention:
+            </p>
+            <pre><code>com.ubuntu.releaseName.cve.oval.xml.bz2
+com.ubuntu.releaseName.usn.oval.xml.bz2</code></pre>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <h3 class="p-stepped-list__title">
+              Scanning an OCI Image
+            </h3>
+            <div class="p-stepped-list__content">
+              <p>
+                To scan an Ubuntu Official Cloud Image for known vulnerabilities, the manifest file and xml data can be used together. Unlike above where we were able to use the <code>lsb_release</code> command, you will need to manually enter the URL for the OVAL data.
+              </p>
+              <p>
+                In the example below we are using focal/20.04, you would replace 'focal' with the version you are inspecting.
+              </p>
+              <pre><code>wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.cve.oval.xml.bz2
+bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
+                <p>
+                  Download the manifest file for the image
+                </p>
+                <pre><code>wget -O manifest https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64-root.manifest</code></pre>
+                <p>
+                  Use OpenSCAP to evaluate the OVAL and generate an html report
+                </p>
+                <pre><code>oscap oval eval --report report.htm oci.com.ubuntu.focal.cve.oval.xml</code></pre>
+                <p>
+                  The output is generated in the file <code>report.htm</code>, open it using your browser
+                </p>
+                <pre><code>xdg-open report.htm</code></pre>
+                <p>
+                  File naming convention:
+                </p>
+                <pre><code>oci.com.ubuntu.releaseName.cve.oval.xml.bz2</code></pre>
+              </div>
+            </li>
+          </ol>
+        </div>
+        <div class="col-4 u-hide--small">
+          <p class="p-heading--two">&nbsp;</p>
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/2670bd16-OpenScap-logo.svg",
+            alt="",
+            width="210",
+            height="46",
+            hi_def=True,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+      </div>
+    </section>
+
+    <section class="p-strip--light">
+      <div class="row">
+        <div class="col-7">
+          <h2>
+            Ubuntu OVAL data parameters
+          </h2>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col" style="width: 33%;">
+                  Parameter
+                </th>
+                <th scope="col">
+                  Description
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  CVE_ID
+                </td>
+                <td>
+                  CVE number as reported by MITRE
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  USN
+                </td>
+                <td>
+                  Corresponding Ubuntu Security Notice
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Description
+                </td>
+                <td>
+                  A short description of the security risk addressed
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Severity
+                </td>
+                <td>
+                  CVE or USN severity as defined by the Ubuntu Security team
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Affected Platform
+                </td>
+                <td>
+                  Affected Ubuntu release(s), incl ESM
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Title
+                </td>
+                <td>
+                  CVE number, affected Ubuntu release(s), and Severity
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Public date
+                </td>
+                <td>
+                  The date on which a CVE was publicly announced
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Public date of USN
+                </td>
+                <td>
+                  The date on which a security patch was announced or provided
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Reference
+                </td>
+                <td>
+                  Links to more information about the issue
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  BugReport
+                </td>
+                <td>
+                  Link to bugreport about the issue
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <small>
+              Note: The above parameters are included in the OVAL xml file, but not all are shown in the resulting generated OpenSCAP report.
+            </small>
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="p-strip">
+      <div class="row">
+        <div class="col-7">
+          <h2>
+            How Ubuntu OVAL data works
+          </h2>
+          <p>
+            As software vulnerabilities are discovered, they are assigned CVE identifiers by MITRE and other organizations. Canonical triages these CVEs to determine whether the vulnerabilities affect software distributed within Ubuntu. The results of this triage are then used to generate the CVE OVAL. The CVE OVAL can be used to assess the local system for vulnerabilities.
+          </p>
+          <p>
+            When the Ubuntu Security Team patches software to address one or more CVEs, an Ubuntu Security Notice (USN) is published announcing the update. The USN OVAL data is generated from information encapsulated within the USN, and can be used to assess the system for missing patches.
+          </p>
+        </div>
+      </div>
+      <div class="u-fixed-width">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/d2fa34ef-how-OVAL-data-works-diagram.svg",
+          alt="",
+          width="682",
+          height="290",
+          hi_def=True,
+          loading="lazy",
+
+          ) | safe
+        }}
+      </div>
+    </section>
+
+    {% endblock content %}

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -96,7 +96,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered" id="instructions">
+<section class="p-strip is-deep" id="instructions">
   <div class="u-fixed-width">
     <h2>
       Using Ubuntu’s OVAL data
@@ -307,7 +307,7 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
       <div class="u-fixed-width">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/d2fa34ef-how-OVAL-data-works-diagram.svg",
+          url="https://assets.ubuntu.com/v1/ce2c3422-how-OVAL-data-works-diagram.svg",
           alt="",
           width="682",
           height="290",

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -119,11 +119,11 @@
             <p>
               Use OpenSCAP to evaluate the OVAL and generate an html report:
             </p>
-            <pre><code>oscap oval eval --report report.htm com.ubuntu.$(lsb_release -cs).cve.oval.xml</code></pre>
+            <pre><code>oscap oval eval --report report.html com.ubuntu.$(lsb_release -cs).cve.oval.xml</code></pre>
             <p>
-              The output is generated in the file report.htm, open it using your browser:
+              The output is generated in the file report.html, open it using your browser:
             </p>
-            <pre><code>xdg-open report.htm</code></pre>
+            <pre><code>xdg-open report.html</code></pre>
             <p>
               File naming convention:
             </p>
@@ -137,10 +137,10 @@ com.ubuntu.releaseName.usn.oval.xml.bz2</code></pre>
             </h3>
             <div class="p-stepped-list__content">
               <p>
-                To scan an Ubuntu Official Cloud Image for known vulnerabilities, the manifest file and xml data can be used together. Unlike above where we were able to use the <code>lsb_release</code> command, you will need to manually enter the URL for the OVAL data.
+                To scan an <a class="p-link--external" href="https://cloud-images.ubuntu.com">Ubuntu Official Cloud Image</a> for known vulnerabilities, the manifest file and xml data can be used together. Unlike above where we were able to use the <code>lsb_release</code> command, you will need to manually enter the URL for the OVAL data.
               </p>
               <p>
-                In the example below we are using focal/20.04, you would replace 'focal' with the version you are inspecting.
+                <i class="p-icon--information">Note:</i> In the example below we are using focal/20.04, you would replace 'focal' with the version you are inspecting.
               </p>
               <pre><code>wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.cve.oval.xml.bz2
 bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
@@ -151,11 +151,11 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
                 <p>
                   Use OpenSCAP to evaluate the OVAL and generate an html report
                 </p>
-                <pre><code>oscap oval eval --report report.htm oci.com.ubuntu.focal.cve.oval.xml</code></pre>
+                <pre><code>oscap oval eval --report report.html oci.com.ubuntu.focal.cve.oval.xml</code></pre>
                 <p>
-                  The output is generated in the file <code>report.htm</code>, open it using your browser
+                  The output is generated in the file <code>report.html</code>, open it using your browser
                 </p>
-                <pre><code>xdg-open report.htm</code></pre>
+                <pre><code>xdg-open report.html</code></pre>
                 <p>
                   File naming convention:
                 </p>
@@ -282,7 +282,7 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
           </table>
           <p>
             <small>
-              Note: The above parameters are included in the OVAL xml file, but not all are shown in the resulting generated OpenSCAP report.
+              <i class="p-icon--information">Note:</i> The above parameters are included in the OVAL xml file, but not all are shown in the resulting generated OpenSCAP report.
             </small>
           </p>
         </div>

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -97,11 +97,13 @@
 </section>
 
 <section class="p-strip is-deep is-bordered" id="instructions">
+  <div class="u-fixed-width">
+    <h2>
+      Using Ubuntu’s OVAL data
+    </h2>
+  </div>
   <div class="row">
     <div class="col-8">
-      <h2>
-        Using Ubuntu’s OVAL data
-      </h2>
       <ol class="p-stepped-list">
         <li class="p-stepped-list__item">
           <h3 class="p-stepped-list__title">
@@ -165,7 +167,6 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
           </ol>
         </div>
         <div class="col-4 u-hide--small">
-          <p class="p-heading--two">&nbsp;</p>
           {{
             image(
             url="https://assets.ubuntu.com/v1/2670bd16-OpenScap-logo.svg",

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -127,8 +127,8 @@
             <p>
               File naming convention:
             </p>
-            <pre><code>com.ubuntu.releaseName.cve.oval.xml.bz2
-com.ubuntu.releaseName.usn.oval.xml.bz2</code></pre>
+            <pre><code>com.ubuntu.&lt;example release name&gt;.cve.oval.xml.bz2
+com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
             </div>
           </li>
           <li class="p-stepped-list__item">
@@ -159,7 +159,7 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
                 <p>
                   File naming convention:
                 </p>
-                <pre><code>oci.com.ubuntu.releaseName.cve.oval.xml.bz2</code></pre>
+                <pre><code>oci.com.ubuntu.&lt;example release name&gt;.cve.oval.xml.bz2</code></pre>
               </div>
             </li>
           </ol>


### PR DESCRIPTION
## Done

- Build the oval page
- Added it to the navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/oval
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [design](https://user-images.githubusercontent.com/65166314/90130821-04c8f100-dd63-11ea-9b28-e05c2dfab573.png) and the [copy doc](https://docs.google.com/document/d/1hBG6NIfBIrixIV753fsOiEymmeuFIF-KOhiDkV68PRY/edit#heading=h.4vy8ll249k4p)


## Issue / Card

Fixes [#2900](https://github.com/canonical-web-and-design/web-squad/issues/2900)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/90159268-107ade80-dd88-11ea-8175-3e164fd2ba12.png)
