### PR TITLE
Remove eoan from /download/alternative-downloads#bittorrents

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -4,14 +4,15 @@ latest:
   short_version: "19.10"
   full_version: "19.10"
   release_date: "October 2019"
-  eol: July 2020
+  eol: "July 2020"
+  past_eol_date: true
 lts:
   slug: FocalFossa
   name: "Focal Fossa"
   short_version: "20.04"
   full_version: "20.04.1"
   release_date: "April 2020"
-  eol: April 2025
+  eol: "April 2025"
 openstack_lts:
   slug: Ussuri
 previous_lts:

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -76,7 +76,7 @@
       <p>Looking for an older release of Ubuntu? Whether you need a POWER, IBMz (s390x), ARM, an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.previous_lts.full_version }}/">Ubuntu {{ releases.previous_lts.short_version }} LTS ({{ releases.previous_lts.name }})</a></li>
-        {% if releases.latest.short_version < releases.lts.short_version %}
+        {% if releases.latest.past_eol_date != true and releases.latest.short_version < releases.lts.short_version %}
         <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.latest.full_version }}/">Ubuntu {{ releases.latest.short_version }} ({{ releases.latest.name }})</a></li>
         {% endif %}
         <li class="p-list__item is-ticked"><a href="http://releases.ubuntu.com/{{ releases.previous_previous_lts.full_version }}/">Ubuntu {{ releases.previous_previous_lts.short_version }} LTS ({{ releases.previous_previous_lts.name }})</a></li>


### PR DESCRIPTION
## Done

- Remove eoan by adding a past_eol_date boolean

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/alternative-downloads#bittorrents
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that Eoan is removed from the bittorrents section


