### PR TITLE
Update cdimage links to https

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -6,9 +6,9 @@ appliances:
     alias: "plexmediaserver"
     port: 32400
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"
-      pi2: "http://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi-armhf.img.xz"
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi-armhf.img.xz"
     checksum:
       raspberrypi: "a05439e8ff97f9542bb611d16be6469943b5285934a5dff4d3b98164fea8d3f9 *plexmediaserver-core18-pi.img.xz"
       pc: "fec85292571d68a08b12991e9e044840d7379c35333b3a2d44176daa25507f49 *plexmediaserver-core18-amd64.img.xz"
@@ -20,9 +20,9 @@ appliances:
     alias: "adguard-home"
     port: 3000
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-amd64.img.xz"
-      pi2: "http://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi-armhf.img.xz"
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi-armhf.img.xz"
     checksum:
       raspberrypi: "5c72286dee4c683dd24128455340285a6a7a0b82efaf004ccc7b2afe5ae2a1d8 *adguard-home-core18-pi.img.xz"
       pc: "6fc90a0695ec2b1e731be4cdd8583021aa284b4b829d99aba75e54d2da23fd14 *adguard-home-core18-amd64.img.xz"
@@ -34,9 +34,9 @@ appliances:
     alias: "openhab"
     port: 8080
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-amd64.img.xz"
-      pi2: "http://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi-armhf.img.xz"
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi-armhf.img.xz"
     checksum:
       raspberrypi: "757b834c103313637d6930ddf3ab1701a969e2af4f28373622dd21c6de6f6eef *openhab-core18-pi.img.xz"
       pc: "d56b97b4df707f5299b45f075fd9f29734ebd6cf22b2950276a98e795f805a36 *openhab-core18-amd64.img.xz"
@@ -48,9 +48,9 @@ appliances:
     alias: "mosquitto"
     port: 1883
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-amd64.img.xz"
-      pi2: "http://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi-armhf.img.xz"
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi-armhf.img.xz"
     checksum:
       raspberrypi: "0fe7c069190e0e9bd8a1727ecfec540367a0890b6030831d5216090649848bb4 *mosquitto-core18-pi.img.xz"
       pc: "5a67a1de6f68cc55f5b27fb0210a83246e47f535ec7fd714ba207a5f4a10ed65 *mosquitto-core18-amd64.img.xz"
@@ -62,9 +62,9 @@ appliances:
     alias: "nextcloud"
     port: 80
     iso_url:
-      raspberrypi: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi.img.xz"
-      pc: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-amd64.img.xz"
-      pi2: "http://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi-armhf.img.xz"
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi-armhf.img.xz"
     checksum:
       raspberrypi: "b123b94f9ccec67dd207c90c48ea96c68c3cf45d896bcc31a5b466f55fcfb05a *nextcloud-core18-pi.img.xz"
       pc: "090560765f61b5ab509a303a2778c3782f13fa2d7cadae3e95b84a33c9bc558c *nextcloud-core18-amd64.img.xz"

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -23,7 +23,7 @@
       <p>For 20.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked"><a class="p-link--external" href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the {{ releases.lts.short_version }} Ubuntu Live installer</a></li>
-        <li class="p-list__item is-ticked"><a class="p-link--external" href="http://cdimage.ubuntu.com/netboot/{{ releases.previous_lts.short_version }}/">Download the network installer for {{ releases.previous_lts.short_version }} LTS</a></li>
+        <li class="p-list__item is-ticked"><a class="p-link--external" href="https://cdimage.ubuntu.com/netboot/{{ releases.previous_lts.short_version }}/">Download the network installer for {{ releases.previous_lts.short_version }} LTS</a></li>
       </ul>
     </div>
   </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -17,7 +17,7 @@
 
 {% if start_download %}
 {% if architecture == 'amd64+mac' %}
-<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">
+<meta http-equiv="refresh" content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">
 {% else %}
 <noscript>
   <meta http-equiv="refresh" content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">
@@ -33,7 +33,7 @@
         <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
         <p>Your download should start automatically. If it doesn&rsquo;t,
           {% if architecture == 'amd64+mac' %}
-          <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
+          <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
           {% else %}
           <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
           {% endif %}

--- a/templates/download/intel-iei-tank-870.html
+++ b/templates/download/intel-iei-tank-870.html
@@ -42,8 +42,8 @@
           Download Ubuntu Core
         </h3>
         <div class="p-stepped-list__content">
-          <p>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64+kassel.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
-          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/MD5SUMS">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+          <p>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64+kassel.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
+          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/MD5SUMS">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
         </div>
       </li>
       <li class="p-stepped-list__item">

--- a/templates/download/intel-iei-tank-870.html
+++ b/templates/download/intel-iei-tank-870.html
@@ -43,7 +43,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <p>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64+kassel.img.xz">Ubuntu Core 18 image for the Intel IEI TANK 870</a>.</p>
-          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/MD5SUMS">MD5SUM file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
+          <p>You can then verify the integrity of the download using the associated <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUMS file</a> and the <code>md5sum</code> command on most Linux distributions.</p>
         </div>
       </li>
       <li class="p-stepped-list__item">

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -139,7 +139,7 @@
       </div>
       <div class="u-fixed-width" style="margin-top: 2rem;">
         <p>
-          <a class="p-button--neutral" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/">
+          <a class="p-button--neutral" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/">
             <span class="p-link--external">Browse all supported images</span>
           </a>
         </p>

--- a/templates/download/kvm.html
+++ b/templates/download/kvm.html
@@ -41,8 +41,8 @@
         </h3>
         <div class="p-stepped-list__content">
           <ul class="u-no-margin--left">
-            <li>Download the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
-            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+            <li>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
             <li>
               <p>Uncompress the image with the following command:</p>
               <pre><code>unxz ubuntu-core-18-amd64.img.xz</code></pre>

--- a/templates/download/qualcomm-dragonboard-410c.html
+++ b/templates/download/qualcomm-dragonboard-410c.html
@@ -48,8 +48,8 @@
         <div class="p-stepped-list__content">
           <p>Get the correct Ubuntu Core image for your board:</p>
           <ul class="u-no-margin--left">
-            <li><a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz">Ubuntu Core 18 image for DragonBoard 410c</a></li>
-            <li>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+            <li><a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-arm64+snapdragon.img.xz">Ubuntu Core 18 image for DragonBoard 410c</a></li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
           </ul>
         </div>
       </li>

--- a/templates/download/raspberry-pi-core.html
+++ b/templates/download/raspberry-pi-core.html
@@ -44,8 +44,8 @@
           Download Ubuntu Core
         </h3>
         <div class="p-stepped-list__content">
-          <p>Download <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi.img.xz">Ubuntu Core 18 image for Raspberry Pi</a>.</p>
-          <p>You can verify the integrity of the files using the <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="http://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</p>
+          <p>Download <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi.img.xz">Ubuntu Core 18 image for Raspberry Pi</a>.</p>
+          <p>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</p>
         </div>
       </li>
       {% with card="microSD card" %}{% include "download/iot/_flash-image.html" %}{% endwith %}

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 {% if start_download %}
-<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">
+<meta http-equiv="refresh" content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">
@@ -22,7 +22,7 @@
       <h1>Thank you for downloading<br />
         Ubuntu Server {{ version }}<br />
         for Raspberry Pi</h1>
-      <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">download now</a>.</p>
+      <p>Your download should start automatically. If it doesn&rsquo;t, <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-server-{{ architecture }}.img.xz">download now</a>.</p>
       {% with version=version, system=architecture, architecture=architecture %}{% include "download/shared/_verify-checksums.html" %}{% endwith %}
       {% else %}
       <h1>Thank you</h1>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -37,13 +37,13 @@
           This is the iso image of the Ubuntu Server installer.
         </p>
         <p>
-          <a href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          <a href="https://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
             Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
           </a>
         </p>
         {% if releases.latest.short_version > releases.lts.short_version %}
         <p>
-          <a href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-arm64.iso" class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          <a href="https://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-arm64.iso" class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
             Download Ubuntu {{ releases.latest.full_version }}
           </a>
         </p>

--- a/templates/download/server/power.html
+++ b/templates/download/server/power.html
@@ -22,13 +22,13 @@
           This is the iso image of the Ubuntu Server installer.
         </p>
         <p>
-          <a class="p-button--positive is-wide" href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-ppc64el.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          <a class="p-button--positive is-wide" href="https://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-ppc64el.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
             Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
           </a>
         </p>
         {% if releases.latest.short_version > releases.lts.short_version %}
         <p>
-          <a class="p-button--neutral is-wide" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-ppc64el.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          <a class="p-button--neutral is-wide" href="https://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-ppc64el.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
             Download Ubuntu {{ releases.latest.full_version }}
           </a>
         </p>

--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -20,11 +20,11 @@
   <div class="row">
     <div class="col-4">
       <p>
-        <a  class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" href="http://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
+        <a  class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" href="https://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
       </p>
       {% if releases.latest.short_version > releases.lts.short_version %}
       <p>
-        <a  class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });" href="http://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.latest.full_version }}</a>
+        <a  class="p-button--neutral is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });" href="https://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-s390x.iso">Download Ubuntu Server {{ releases.latest.full_version }}</a>
       </p>
       {% endif %}
     </div>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -12,7 +12,7 @@
         <small>Or follow this tutorial to learn <a class="p-link--external" href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
       {% else %}
-        <small>Please check the <a class="p-link--external" href="http://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</small>
+        <small>Please check the <a class="p-link--external" href="https://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</small>
       {% endif %}
     </span>
   </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -14,7 +14,7 @@
           <a href="https://canonical.com">canonical.com</a>
         </li>
         <li class="p-list__item">
-          <a href="http://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
+          <a href="https://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
         </li>
         <li class="p-list__item">
           <a href="https://certification.ubuntu.com">certification.ubuntu.com</a>


### PR DESCRIPTION
## Done

- According to [RT#107875](https://rt.admin.canonical.com/Ticket/Display.html?id=107875) cdimage is now https, so updated all links to that

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - appliances.yaml
    - https://0.0.0.0:8001/download/alternative-downloads.html
    - https://0.0.0.0:8001/download/desktop/thank-you.html
    - https://0.0.0.0:8001/download/intel-iei-tank-870.html
    - https://0.0.0.0:8001/download/iot/index.html
    - https://0.0.0.0:8001/download/kvm.html
    - https://0.0.0.0:8001/download/qualcomm-dragonboard-410c.html
    - https://0.0.0.0:8001/download/raspberry-pi-core.html
    - https://0.0.0.0:8001/download/raspberry-pi/thank-you.html
    - https://0.0.0.0:8001/download/server/arm.html
    - https://0.0.0.0:8001/download/server/power.html
    - https://0.0.0.0:8001/download/server/thank-you-s390x.html
    - https://0.0.0.0:8001/download/shared/_verify-checksums.html
    - https://0.0.0.0:8001/legal/websites.html
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all links are now `https`
