### PR TITLE
Search cves by version status

### DIFF
--- a/templates/security/cve/_status-fields.html
+++ b/templates/security/cve/_status-fields.html
@@ -5,7 +5,7 @@
 <option value="needs-triage" {% if statuses[index] == "needs-triage" %}selected{% endif %}>
   Needs triage
 </option>
-<option value="not-vulnerable" {% if statuses[index] == "not-vulnerable" %}selected{% endif %}>
+<option value="not-affected" {% if statuses[index] == "not-affected" %}selected{% endif %}>
   Not vulnerable
 </option>
 <option value="needed" {% if statuses[index] == "needed" %}selected{% endif %}>

--- a/templates/security/cve/_version-fields.html
+++ b/templates/security/cve/_version-fields.html
@@ -1,6 +1,6 @@
 <option value="current" {% if versions[index] == "current" %}selected{% endif %}>Any current release</option>
-{% for release in releases %}
-  <option value="{{ release.version }}" {% if versions[index] == release.version %}selected{% endif %}>
+{% for release in all_releases %}
+  <option value="{{ release.codename }}" {% if versions[index] == release.codename %}selected{% endif %}>
     {{ release.name }} {{ release.version }} {{ release.support_tag }}
   </option>
 {% endfor %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -133,7 +133,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for package_name, statuses in cve.status_tree.items() %}
+            {% for package_name, statuses in cve.packages.items() %}
               {% for release in releases %}
                 <tr>
                   {% if release.codename in statuses %}

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -67,18 +67,18 @@ class CVE(Base):
     )
 
     @hybrid_property
-    def status_tree(self):
-        status_tree = defaultdict(dict)
+    def packages(self):
+        packages = defaultdict(dict)
         for status in self.statuses:
-            status_tree[status.package_name][status.release_codename] = status
+            packages[status.package_name][status.release_codename] = status
 
-        return status_tree
+        return packages
 
     @hybrid_property
     def active_status_tree(self):
         active_package_statuses = {}
 
-        for package_name, release_statuses in self.status_tree.items():
+        for package_name, release_statuses in self.packages.items():
             for status in release_statuses.values():
                 if (
                     status.status in Status.active_statuses

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -12,7 +12,7 @@ from marshmallow import EXCLUDE
 from marshmallow.exceptions import ValidationError
 from mistune import Markdown
 from sortedcontainers import SortedDict
-from sqlalchemy import asc, desc, or_
+from sqlalchemy import asc, desc, or_, and_
 from sqlalchemy.exc import IntegrityError, DataError
 
 # Local
@@ -324,17 +324,64 @@ def cve_index():
     limit = flask.request.args.get("limit", default=20, type=int)
     offset = flask.request.args.get("offset", default=0, type=int)
     component = flask.request.args.get("component")
+    versions = flask.request.args.getlist("version")
+    statuses = flask.request.args.getlist("status")
 
     is_cve_id = re.match(r"^CVE-\d{4}-\d{4,7}$", query.upper())
 
     if is_cve_id and db_session.query(CVE).get(query.upper()):
         return flask.redirect(f"/security/{query.lower()}")
 
-    cves_query = (
-        db_session.query(CVE)
-        .filter(CVE.statuses.any(Status.status.in_(Status.active_statuses)))
-        .filter(CVE.status == "active")
+    all_releases = (
+        db_session.query(Release)
+        .order_by(desc(Release.release_date))
+        .filter(Release.codename != "upstream")
+        .all()
     )
+
+    releases_query = db_session.query(Release).order_by(
+        desc(Release.release_date)
+    )
+
+    if versions and not any(a in ["", "current"] for a in versions):
+        releases_query = releases_query.filter(Release.codename.in_(versions))
+    else:
+        releases_query = releases_query.filter(
+            or_(
+                Release.support_expires > datetime.now(),
+                Release.esm_expires > datetime.now(),
+            )
+        )
+
+    releases = releases_query.all()
+
+    should_filter_by_version_and_status = (
+        versions and statuses and len(versions) == len(statuses)
+    )
+
+    clean_versions = []
+    clean_statuses = []
+    if should_filter_by_version_and_status:
+        raw_all_statuses = db_session.execute(
+            "SELECT unnest(enum_range(NULL::statuses));"
+        ).fetchall()
+        all_statuses = ["".join(s) for s in raw_all_statuses]
+
+        clean_versions = [
+            (
+                [version]
+                if version not in ["", "current"]
+                else [r.codename for r in releases]
+            )
+            for version in versions
+        ]
+
+        clean_statuses = [
+            ([status] if status != "" else all_statuses) for status in statuses
+        ]
+
+    # query cves by filters
+    cves_query = db_session.query(CVE).filter(CVE.status == "active")
 
     if priority:
         cves_query = cves_query.filter(CVE.priority == priority)
@@ -350,6 +397,28 @@ def cve_index():
     if component:
         cves_query = cves_query.filter(
             CVE.statuses.any(Status.component == component)
+        )
+
+    if should_filter_by_version_and_status:
+        conditions = []
+        for key, version in enumerate(clean_versions):
+            condition = Package.statuses.any(
+                and_(
+                    Status.release_codename.in_(version),
+                    Status.status.in_(clean_statuses[key]),
+                    CVE.id == Status.cve_id,
+                )
+            )
+            conditions.append(condition)
+
+        cves_query = cves_query.filter(
+            CVE.statuses.any(
+                Status.package.has(and_(*[c for c in conditions]))
+            )
+        )
+    else:
+        cves_query = cves_query.filter(
+            CVE.statuses.any(Status.status.in_(Status.active_statuses))
         )
 
     # Pagination
@@ -368,19 +437,33 @@ def cve_index():
         # filter by package name
         if package:
             status_tree = {
-                package_name: statuses
-                for package_name, statuses in status_tree.items()
+                package_name: package_statuses
+                for package_name, package_statuses in status_tree.items()
                 if package_name == package
             }
 
         # filter by component
         if component:
             status_tree = {
-                package_name: statuses
-                for package_name, statuses in status_tree.items()
+                package_name: package_statuses
+                for package_name, package_statuses in status_tree.items()
                 if any(
                     status.component == component
-                    for status in statuses.values()
+                    for status in package_statuses.values()
+                )
+            }
+
+        if should_filter_by_version_and_status:
+            status_tree = {
+                package_name: package_statuses
+                for package_name, package_statuses in status_tree.items()
+                if all(
+                    any(
+                        package_status.release_codename in version
+                        and package_status.status in clean_statuses[key]
+                        for package_status in package_statuses.values()
+                    )
+                    for key, version in enumerate(clean_versions)
                 )
             }
 
@@ -396,21 +479,10 @@ def cve_index():
 
         cves.append(cve)
 
-    releases = (
-        db_session.query(Release)
-        .order_by(desc(Release.release_date))
-        .filter(
-            or_(
-                Release.support_expires > datetime.now(),
-                Release.esm_expires > datetime.now(),
-            )
-        )
-        .all()
-    )
-
     return flask.render_template(
         "security/cve/index.html",
         releases=releases,
+        all_releases=all_releases,
         cves=cves,
         total_results=total_results,
         total_pages=ceil(total_results / limit),
@@ -420,8 +492,8 @@ def cve_index():
         query=query,
         package=package,
         component=component,
-        versions=flask.request.args.getlist("version"),
-        statuses=flask.request.args.getlist("status"),
+        versions=versions,
+        statuses=statuses,
     )
 
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -432,21 +432,21 @@ def cve_index():
 
     cves = []
     for raw_cve in raw_cves:
-        status_tree = raw_cve.status_tree
+        packages = raw_cve.packages
 
         # filter by package name
         if package:
-            status_tree = {
+            packages = {
                 package_name: package_statuses
-                for package_name, package_statuses in status_tree.items()
+                for package_name, package_statuses in packages.items()
                 if package_name == package
             }
 
         # filter by component
         if component:
-            status_tree = {
+            packages = {
                 package_name: package_statuses
-                for package_name, package_statuses in status_tree.items()
+                for package_name, package_statuses in packages.items()
                 if any(
                     status.component == component
                     for status in package_statuses.values()
@@ -454,9 +454,9 @@ def cve_index():
             }
 
         if should_filter_by_version_and_status:
-            status_tree = {
+            packages = {
                 package_name: package_statuses
-                for package_name, package_statuses in status_tree.items()
+                for package_name, package_statuses in packages.items()
                 if all(
                     any(
                         package_status.release_codename in version
@@ -468,13 +468,13 @@ def cve_index():
             }
 
         # do not return cve if it has no packages left
-        if not status_tree:
+        if not packages:
             continue
 
         cve = {
             "id": raw_cve.id,
             "priority": raw_cve.priority,
-            "packages": status_tree,
+            "packages": packages,
         }
 
         cves.append(cve)


### PR DESCRIPTION
Enable version-status filter.

Display only packages of the cve that match the search all the version-status criteria.

## QA

1. Have CVEs imported in your local database.
2. Fetch my changes:
```bash
git fetch albert-fork
git checkout search-cves-by-component
```
3. Browse to `/security/cve`. Play with the version-status filter.

## Issue / Card

Fixes #7928