### PR TITLE
Takeovers geo targeting using timezones

### DIFF
--- a/templates/0_docs/takeovers.html
+++ b/templates/0_docs/takeovers.html
@@ -70,7 +70,8 @@ primary_cta_class="",
 secondary_url="",
 secondary_cta="",
 lang="",
-locale="" %}
+locale="",
+timezone="" %}
 &#123;% include "takeovers/_template.html" %}
 &#123;% endwith %}</code></pre>
       <h3>Details</h3>
@@ -88,6 +89,7 @@ locale="" %}
         <li class="p-list__item"><strong>secondary_url</strong>: the url for the secondary cta, which will be a text link and a <code>p-link--external</code> will be added automatically <em>optional</em></li>
         <li class="p-list__item"><strong>lang</strong>: the language of the takeover, default is 'en'   <em>optional</em></li>
         <li class="p-list__item"><strong>locale</strong>: the locale of the takeover, default is 'en-GB'  <em>optional</em></li>
+         <li class="p-list__item"><strong>timezone</strong>: One or several IANA timezone continent, country, region or city names (<a href="https://home.kpn.nl/vanadovv/time/TZworld.html">reference</a>) for the takeover, eg. "London", "Europe", "Kentucky, Indiana", "London, Paris, Berlin", etc. defaults to null  <em>optional</em></li>
       </ul>
     </div>
   </div>

--- a/templates/0_docs/takeovers.html
+++ b/templates/0_docs/takeovers.html
@@ -89,7 +89,7 @@ timezone="" %}
         <li class="p-list__item"><strong>secondary_url</strong>: the url for the secondary cta, which will be a text link and a <code>p-link--external</code> will be added automatically <em>optional</em></li>
         <li class="p-list__item"><strong>lang</strong>: the language of the takeover, default is 'en'   <em>optional</em></li>
         <li class="p-list__item"><strong>locale</strong>: the locale of the takeover, default is 'en-GB'  <em>optional</em></li>
-         <li class="p-list__item"><strong>timezone</strong>: One or several IANA timezone continent, country, region or city names (<a href="https://home.kpn.nl/vanadovv/time/TZworld.html">reference</a>) for the takeover, eg. "London", "Europe", "Kentucky, Indiana", "London, Paris, Berlin", etc. defaults to null  <em>optional</em></li>
+         <li class="p-list__item"><strong>timezone</strong>: One or several IANA timezone area and location names(<a href="https://home.kpn.nl/vanadovv/time/TZworld.html">reference</a>) for the takeover, eg. "London", "Europe", "Kentucky, Indiana", "London, Paris, Berlin", etc. defaults to null  <em>optional</em></li>
       </ul>
     </div>
   </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -271,7 +271,7 @@
         // First, select takeovers that don't specify a timezone, a language and don't exclude the users language
         var takeoverSelectors = [".js-takeover:not([data-timezone]).js-takeover:not([lang]).js-takeover:not([lang-skip*=" + language + "])"]
 
-        // Add selectors to find takeovers for any of the user's languages and timezone if available
+        // Add selectors to find takeovers for any of the user's languages, excluding timezones settings
         takeoverSelectors.push(".js-takeover:not([data-timezone]).js-takeover[lang=" + language + "]");
         takeoverSelectors.push(".js-takeover:not([data-timezone]).js-takeover[data-lang-extra*=" + language + "]");
         

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -263,17 +263,30 @@
 
         var baseTakeover = document.getElementById('takeover');  // The base takeover element
         var takeovers = document.getElementById('takeovers');  // The list of current takeovers to choose from
+        var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;  // Get the timezone name (eg.Europe/Paris)
 
         // For browsers that support <template> (all but IE), grab the template's ".content"
         takeovers = 'content' in takeovers ? takeovers.content: takeovers;
 
-        // First, select takeovers that don't specify a language and don't exclude the users language
-        var takeoverSelectors = [".js-takeover:not([lang]).js-takeover:not([lang-skip*=" + language + "])"]
+        // First, select takeovers that don't specify a timezone, a language and don't exclude the users language
+        var takeoverSelectors = [".js-takeover:not([data-timezone]).js-takeover:not([lang]).js-takeover:not([lang-skip*=" + language + "])"]
 
-        // Add selectors to find takeovers for any of the user's languages
-        takeoverSelectors.push(".js-takeover[lang=" + language + "]");
-        takeoverSelectors.push(".js-takeover[data-lang-extra*=" + language + "]");
-
+        // Add selectors to find takeovers for any of the user's languages and timezone if available
+        takeoverSelectors.push(".js-takeover:not([data-timezone]).js-takeover[lang=" + language + "]");
+        takeoverSelectors.push(".js-takeover:not([data-timezone]).js-takeover[data-lang-extra*=" + language + "]");
+        
+        // Refine results using timezone format: (continent or country)/region/city, can also be (continent or country)/city
+        if (timezone.split("/")[0]) {
+          takeoverSelectors.push(".js-takeover[data-timezone*=" + timezone.split("/")[0] + "]");
+        }
+        if (timezone.split("/")[1]) {
+          takeoverSelectors.push(".js-takeover[data-timezone*=" + timezone.split("/")[1] + "]");
+        }
+        if (timezone.split("/")[2]) {
+          takeoverSelectors.push(".js-takeover[data-timezone*=" + timezone.split("/")[2] + "]");
+        }
+        
+        
         // Get the selected takeovers
         var selectedTakeovers = (takeovers.querySelectorAll(takeoverSelectors.join(',')));
 

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -275,7 +275,7 @@
         takeoverSelectors.push(".js-takeover:not([data-timezone]).js-takeover[lang=" + language + "]");
         takeoverSelectors.push(".js-takeover:not([data-timezone]).js-takeover[data-lang-extra*=" + language + "]");
         
-        // Refine results using timezone format: (continent or country)/region/city, can also be (continent or country)/city
+        // Refine results, mapping user timezone area and location parameters against takeover timezone
         if (timezone.split("/")[0]) {
           takeoverSelectors.push(".js-takeover[data-timezone*=" + timezone.split("/")[0] + "]");
         }

--- a/templates/takeovers/_gsi-webinar-series-takeover.html
+++ b/templates/takeovers/_gsi-webinar-series-takeover.html
@@ -10,7 +10,8 @@ primary_url="/engage/gsi-webinar-series?utm_source=Takeover&utm_medium=Takeover&
 primary_cta="Register now",
 primary_cta_class="",
 secondary_url="",
-secondary_cta=""
+secondary_cta="",
+timezone="Kolkata"
 %}
 {% include "takeovers/_template.html" %}
 {% endwith %}

--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -1,4 +1,4 @@
-<section {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
+<section {% if timezone %}data-timezone="{{ timezone }}"{% endif %} {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover">
   <div class="row u-equal-height">
     <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %} u-vertically-center">
       <div>


### PR DESCRIPTION
## Done

- Adds the notion of timezones to takeovers
- Target India only for the GSI takeover ("Kolkata" is the timezone city name for all of India)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure you are **not in India** and that takeovers work as expected, you should not see the GSI webinar takeover.
- Change the timezone value of the GSI takeover (templates/takeovers/_gsi-webinar-series-takeover.html) to something matching your location.
  - You target a timezone based on any portion of its IANA timezone name ([reference](https://home.kpn.nl/vanadovv/time/TZworld.html#eur)).
  - Eg. for the "Europe/London" timezone, you can use "London" to target all of UK.
  - If you use "Europe", you'll target all timezones containing "Europe".
  - You can also combine names to target multiple selected countries, such as "London, Paris, Berlin"
