### PR TITLE
“varient” > “variant”

### DIFF
--- a/templates/kernel/variants.html
+++ b/templates/kernel/variants.html
@@ -54,7 +54,7 @@
 </section>
 <section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
-    <h2 id="current-variant-kernels">Current varient kernels</h2>
+    <h2 id="current-variant-kernels">Current variant kernels</h2>
     <table class="p-table--mobile-card" role="grid">
       <thead>
         <tr role="row">


### PR DESCRIPTION
## Done

- Fixed typo in /kernel/variants

## Issue / Card

None

[Noticed while researching [vanilla-framework#3190](https://github.com/canonical-web-and-design/vanilla-framework/issues/3190).]