### PR TITLE
Update Kylin link on /download/flavours

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -87,7 +87,7 @@
             ) | safe
           }}
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link--external" href="https://www.ubuntukylin.com/index.php?lang=en">Ubuntu Kylin</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link--external" href="https://www.ubuntukylin.com/index.php-lang=en.htm">Ubuntu Kylin</a></h3>
             <p class="p-matrix__desc">The Ubuntu Kylin project is tuned to the needs of Chinese users, providing a thoughtful and elegant Chinese experience out-of-the-box.</p>
           </div>
         </li>


### PR DESCRIPTION
## Done

- Update Kylin link on /download/flavours

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/flavours
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link now works


## Issue / Card

Fixes #8094


