### PR TITLE
Remove small tag around footer links for consistent sizing

### DIFF
--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -1,6 +1,6 @@
 {% if (section.children|length < 3) and (section.path != "/security") %}
 <li class="p-footer-list--margin p-footer-list-single-child">
-  <a class="p-link--soft" href="{{ section.path }}"><small>{{ section.title }}</small></a>
+  <a class="p-link--soft" href="{{ section.path }}">{{ section.title }}</a>
 {% else %}
 <li class="p-footer__item">
   <h2 class="p-footer__title">


### PR DESCRIPTION
## Done

Remove `small` tag from footer sitemap links to keep font-size consistent

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the links in the footer site map are all the same font-size


## Issue / Card

Fixes #8091 