### PR TITLE
Display esm-apps and esm-infra for CVE

### DIFF
--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -88,6 +88,15 @@
                 {% else %}
                   &mdash;
                 {% endif %}
+                <br>
+                <small>
+                  {% if statuses[release.codename].component == "esm-infra" %}
+                    <a href="/advantage" target="_blank">UA Infra, UA Desktop</a>
+                  {% endif %}
+                  {% if statuses[release.codename].component == "esm-apps" %}
+                    <a href="/advantage" target="_blank">UA Apps, UA Desktop</a>
+                  {% endif %}
+                </small>
               </div>
             </td>
             {% else %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -180,6 +180,15 @@
                     {% if statuses[release.codename].description %}
                       ({{ statuses[release.codename].description }})
                     {% endif %}
+                    <br>
+                    <small>
+                      {% if statuses[release.codename].component == "esm-infra" %}
+                      Requires <a href="/advantage" target="_blank">UA Infra, UA Desktop</a>
+                      {% endif %}
+                      {% if statuses[release.codename].component == "esm-apps" %}
+                      Requires <a href="/advantage" target="_blank">UA Apps, UA Desktop</a>
+                      {% endif %}
+                    </small>
                     </td>
                   {% endif %}
                 </tr>


### PR DESCRIPTION
Display link to ESM for apps and ESM for infra for statuses with the respective components.

## QA

1. Have the latest CVEs imported in your local database. `CVE-2020-8834` should be the most recent cve on `/security/cve`
2. All the packages should have the component `main` right now. We have to create some `esm-apps` and `esm-infra` components for testing.
```bash
docker exec -it db psql -U postgres # go to the databse
```
```SQL
UPDATE status SET component='esm-infra' WHERE cve_id='CVE-2020-8834' AND release_codename='precise' AND package_name='linux';

UPDATE status SET component='esm-apps' WHERE cve_id='CVE-2020-8834' AND release_codename='trusty' AND package_name='linux';
```
3. Fetch my branch changes: 
```bash 
git fetch albert-fork
git checkout cve-display-component
```

4. Browse to `/security/cve` check the design. 
Browse to `/security/CVE-2020-8834` check the design

## Issue / Card

Fixes #7931 
