### PR TITLE
Clean up robotics page titles

### DIFF
--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -1,6 +1,6 @@
 {% extends "robotics/base_robotics.html" %}
 
-{% block title %}Join the ROS and Ubuntu community| Ubuntu{% endblock %}
+{% block title %}Join the ROS and Ubuntu community{% endblock %}
 {% block meta_description %}ROS exists because of contributions from tens of thousands of developers.  Learn about Canonical's role in ROS and how you can join the community.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1A3iBoD_AAoerI0VwbByl8fR55ljNOjamHtJlkOuaaeA/edit{% endblock meta_copydoc %}

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -1,6 +1,6 @@
 {% extends "robotics/base_robotics.html" %}
 
-{% block title %}Robotics | Ubuntu {% endblock %}
+{% block title %}Robotics{% endblock %}
 
 {% block meta_description %}Canonical supports robots. Whether that means providing an embedded OS, security patches or support with snaps and ROS. Build security into your robots future.{% endblock meta_description %}
 

--- a/templates/robotics/what-is-ros.html
+++ b/templates/robotics/what-is-ros.html
@@ -1,7 +1,7 @@
 {% extends "robotics/base_robotics.html" %}
 
 
-{% block title %}What is ROS | Ubuntu for the Internet of Things {% endblock %}
+{% block title %}What is ROS?{% endblock %}
 {% block meta_description %}With hundreds of thousands of drones and robots deployed the world over, Ubuntu Core is the perfect robust, reliable and secure OS for the robotics sector. {% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1yX2Ikcn1fgIKX3el8fKWQt7SGxSwY633TfW5V1lwUuc/edit{% endblock meta_copydoc %}
 
@@ -10,7 +10,7 @@
 <section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
     <div class="col-8">
-      <h1>What is ROS</h1>
+      <h1>What is ROS?</h1>
       <h2>ROS is powering the future of robotics in industry, in the enterprise and for developers</h2>
       <p>At the offset, ROS chose Ubuntu as its primary supported platform and today it remains the platform of choice for the majority of ROS developers.</p>
       <p>ROS is led by Open Robotics, similar to how Canonical supports Ubuntu, Open Robotics steers the ship but it is driven by the community.</p>


### PR DESCRIPTION
## Done

- Clean up /robotics page titles
- Add question mark to what is page title (because it worked well for Ceph)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure page titles are nice and tidy
