### PR TITLE
Change to work email and mobile number on /kubeconeurope2020

### DIFF
--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -294,22 +294,22 @@
 
       <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3675" class="marketo-form">
         <fieldset>
-          <label for="FirstName" id="LblFirstName" class="mktoLabel " >First Name</label>
+          <label for="FirstName" id="LblFirstName" class="mktoLabel " >First name</label>
           <input id="FirstName" name="FirstName" maxlength="255" aria-describedby="ValidMsgFirstName" aria-labelledby="LblFirstName InstructFirstName" type="text" class="mktoField  " >
 
-          <label for="LastName" id="LblLastName" class="mktoLabel " >Last Name</label>
+          <label for="LastName" id="LblLastName" class="mktoLabel " >Last name</label>
           <input id="LastName" name="LastName" maxlength="255" aria-describedby="ValidMsgLastName" aria-labelledby="LblLastName InstructLastName" type="text" class="mktoField  " >
 
-          <label for="Email" id="LblEmail" class="mktoLabel " >Email Address</label>
+          <label for="Email" id="LblEmail" class="mktoLabel " >Work email</label>
           <input id="Email" name="Email" maxlength="255" aria-describedby="ValidMsgEmail" aria-labelledby="LblEmail InstructEmail" type="email" class="mktoField mktoEmailField " >
 
-          <label for="Title" id="LblTitle" class="mktoLabel " >Job Title</label>
+          <label for="Title" id="LblTitle" class="mktoLabel " >Job title</label>
           <input id="Title" name="Title" maxlength="255" aria-describedby="ValidMsgTitle" aria-labelledby="LblTitle InstructTitle" type="text" class="mktoField   mktoValid"  aria-invalid="false">
 
-          <label for="Company" id="LblCompany" class="mktoLabel " >Company Name</label>
+          <label for="Company" id="LblCompany" class="mktoLabel " >Company name</label>
           <input id="Company" name="Company" maxlength="255" aria-describedby="ValidMsgCompany" aria-labelledby="LblCompany InstructCompany" type="text" class="mktoField  " >
 
-          <label for="Phone" id="LblPhone" class="mktoLabel " >Phone Number</label>
+          <label for="Phone" id="LblPhone" class="mktoLabel " >Mobile/cell phone number</label>
           <input id="Phone" name="Phone" maxlength="255" aria-describedby="ValidMsgPhone" aria-labelledby="LblPhone InstructPhone" type="tel" class="mktoField mktoTelField " >
 
           <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />


### PR DESCRIPTION
## Done

- changed email to work email
- phone to moble phone
- used title case on labels

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeconeurope2020
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the labels have been updated

