### PR TITLE
New video chat id on /kubeconeurope2020

### DIFF
--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -28,7 +28,7 @@
         <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/live_stream?channel=UCJ65UG_WgFa_O_odbiBWZoA" frameborder="0" allowfullscreen></iframe>
       </div>
       <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" src="https://www.youtube.com/live_chat?v=gSaBNf7EtBw&embed_domain=ubuntu.com" frameborder="0"></iframe>
+        <iframe class="u-embedded-media__element" src="https://www.youtube.com/live_chat?v=vmF9bOEbDuc&embed_domain=ubuntu.com" frameborder="0"></iframe>
       </div>
       <h4>
         Want to talk Kubernetes with our field engineering team?


### PR DESCRIPTION
## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeconeurope2020
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it uses a new video id