### PR TITLE
Create unilateral nda privacy notice page

### DIFF
--- a/templates/legal/confidentiality-agreement.html
+++ b/templates/legal/confidentiality-agreement.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Confidentiality agreement{% endblock %}
-{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/123_RbbqhDzsiWrLQkl1c_1aqr2uT6hKeq0LuNDl21Ms/edit#{% endblock meta_copydoc %}
 
 {% block head_extra %}
 <script type="text/javascript" src="https://www.tfaforms.com/wForms/3.7/js/wforms.js"></script>
@@ -498,7 +498,7 @@
                     </li>
                     <li class="p-list__item">
                       <div class="htmlSection" id="tfa_5">
-                        <p>By clicking "I agree" below, I confirm that I have read and understood the terms and warrant that I have authority to enter into the <a href="https://assets.ubuntu.com/v1/05d55fbc-Canonical+NDA_Online+Form_202008.pdf" target="_blank">confidentiality agreement</a>
+                        <p>By clicking "I agree" below, I confirm that I have read and understood the terms of the confidentiality agreement, <a href="/legal/data-privacy">privacy policy</a> and <a href="/legal/data-privacy/unilateral-nda">privacy notice</a> and warrant that I have authority to enter into the <a href="https://assets.ubuntu.com/v1/05d55fbc-Canonical+NDA_Online+Form_202008.pdf" target="_blank">confidentiality agreement</a>
                         </p>
                       </div>
                     </li>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -38,6 +38,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/survey">Survey privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/events">Events privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/online-competitions">Online competitions privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/unilateral-nda">Confidentiality agreement privacy notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">

--- a/templates/legal/data-privacy/online-competitions.md
+++ b/templates/legal/data-privacy/online-competitions.md
@@ -18,7 +18,8 @@ This Privacy Notice tells you about the information collected from you when you 
 We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
-What personal data do we collect?
+
+## What personal data do we collect?
 
 When you enter into an online competition, we may ask you for your name, address, contact telephone number and email address. If you are entering on behalf of a company, in accordance with the terms and conditions of the online competition, we may ask you for your company name, your job title, your work email and additional information about your company. We will retain your details in order to carry out the online competition, to contact you about the prize and/or notify you about the final winner. For the purposes of administering the online competition, the collection, use and processing of personal data may be completed by Canonical, its group companies or other third parties.
 
@@ -44,7 +45,7 @@ We may contact you from time to time with information about products and service
 
 ### Your consent
 
-If you enter into an online  competition, you will have the option to provide your consent to us sending you information about the products and services that we offer (see <a href="/legal/data-privacy/partner-portal#mkt-comms">Email Marketing Communications</a>). You can withdraw your consent at any time.
+If you enter into an online competition, you will have the option to provide your consent to us sending you information about the products and services that we offer (see <a href="/legal/data-privacy/partner-portal#mkt-comms">Email Marketing Communications</a>). You can withdraw your consent at any time.
 
 ## How long do we keep your information for?
 

--- a/templates/legal/data-privacy/unilateral-nda.md
+++ b/templates/legal/data-privacy/unilateral-nda.md
@@ -1,0 +1,62 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Privacy Notice – Unilateral NDA"
+  description: This privacy notice tells you about the information we collect from you when you submit your information to us via the confidentiality agreement form on our website.
+  copydoc: https://docs.google.com/document/d/1MzxiuSwLvT440Ew5-3aPsFHo2zy2QVt1ZEJJpVEaZho/edit?ts=5f33e3f5#
+---
+
+<h4 class="p-muted-heading">Version - August 2020</h4>
+<hr style="margin-bottom: 2rem;" />
+
+# Privacy Notice – Confidentiality agreement
+
+This privacy notice tells you about the information we collect from you when you submit your information to us via the confidentiality agreement form on our website. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
+
+## Who are we?
+
+We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.
+
+We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
+
+## What personal data do we collect?
+
+When you submit your information to us using the confidentiality agreement form we ask you for your name, your address, your organisation name and title, if applicable and related information.
+
+## Why do we collect this information?
+
+By signing the confidentiality agreement you are entering into a legally binding agreement. We will use your information to fully execute the confidentiality agreement.
+
+We ask for your consent to do this, and we will only contact you in relation to the confidentiality agreement for the duration of the term of the confidentiality agreement.
+
+## What do we do with your information?
+
+Your information is stored in our database and is not shared with any third parties, except as reasonably required for Canonical to process and store your data. It is sent outside of the European Economic Area for our own internal processing purposes only.
+
+## How long do we keep your information for?
+
+Your information is kept for the term of the confidentiality agreement and for so long as reasonably required thereafter in accordance with our record retention policy.
+
+## Your rights over your information
+
+By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.
+
+You can also ask for it to be erased and you can ask for us to give you a copy of the information.
+
+You can also ask us to stop using your information for newsletters, news or product updates – the simplest way to do this is to withdraw your consent, which you can do at any time, either by clicking the unsubscribe link at the end of any newsletter or email, or by emailing, writing or telephoning us using the contact details above.
+
+## Your right to complain
+
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a class="p-link--external" href="https://ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:
+
+<div style="margin: 2rem;">
+  <p>
+    Information Commissioner's Office<br />
+    Wycliffe House<br />
+    Water Lane<br />
+    Wilmslow<br />
+    Cheshire<br />
+    SK9 5AF<br />
+    United Kingdom
+  </p>
+</div>


### PR DESCRIPTION
## Done

- Drive by: Fix heading on /legal/data-privacy/online-competitions
- Add Unilateral NDA data privacy page
- Add NDA page to data privacy page
- Update confidentiality agreement page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/data-privacy/unilateral-nda
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page matches [the copydoc](https://docs.google.com/document/d/1MzxiuSwLvT440Ew5-3aPsFHo2zy2QVt1ZEJJpVEaZho/edit?ts=5f33e3f5#)
- Go to /legal/data-privacy and check that it has been updated according to [the copy doc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit#heading=h.a41ehw5ql4g) and resolve the comment
- Go to /legal/confidentiality-agreement and check that it has been updated according to [the copy doc](https://docs.google.com/document/d/123_RbbqhDzsiWrLQkl1c_1aqr2uT6hKeq0LuNDl21Ms/edit#) and resolve the comment


## Issue / Card

Fixes #8102, #8103, #8104