### PR TITLE
Add Any placeholder to CVE package field

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -22,7 +22,7 @@
       </div>
       <div class="col-2">
         <label for="package">Package:</label>
-        <input type="text" name="package" id="package" value="{{ package or '' }}">
+        <input type="text" name="package" id="package" value="{{ package or '' }}" placeholder="Any">
       </div>
       <div class="col-2">
         <label for="component">Component:</label>


### PR DESCRIPTION
## Done

Added "Any" placeholder to the CVE package search field

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the "Package" field in the search form has a placeholder of "Any"


## Issue / Card

Fixes #8097 