### PR TITLE
Change text around CVE search

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -1,18 +1,32 @@
 {% extends "security/cve/base_cve.html" %}
 
-{% block title %}CVEs{% endblock %}
+{% block title %}
+  {% if query or package or component or priority or versions or statuses %}
+    CVE search results
+  {% else %}
+    CVEs
+  {% endif %}
+{% endblock %}
 
 {% block content %}
 
 <section class="p-strip--suru-topped u-no-padding--bottom">
   <div class="u-fixed-width">
-    <h1>CVE reports</h1>
+    {% if query or package or component or priority or versions or statuses %}
+      <h1>CVE search results</h1>
+    {% else %}
+      <h1>CVE reports</h1>
+    {% endif %}
   </div>
 </section>
 
 <section class="p-strip is-shallow">
   <div class="u-fixed-width">
-    <h2>Search</h2>
+    {% if query or package or component or priority or versions or statuses %}
+      <!-- has to be this way because query string can exist with empty values -->
+    {% else %}
+      <h2>Search</h2>
+    {% endif %}
   </div>
   <form>
     <div class="row">


### PR DESCRIPTION
## Done

Changed text around CVE search results

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page title is "CVEs | Ubuntu"
- Check that the main heading is "CVE reports"
- Check that there is a "Search" subheading
- Do a search (it can be an empty search if you have no CVEs)
- Check that the page title is "CVE search results | Ubuntu"
- Check that the main heading is "CVE search results"
- Check that there is no "Search" subheading


## Issue / Card

Fixes #8100 