### PR TITLE
Remove bluefin fax number

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -71,7 +71,6 @@
       </div>
       <ul class="p-list">
         <li><strong>Main switchboard number:</strong><span itemprop="telephone"> <a href="tel:+44 20 7630 2400">+44 20 7630 2400</a></span></li>
-        <li><strong>Main fax number:</strong><span itemprop="faxNumber"> <a href="tel:+44 20 7630 2401">+44 20 7630 2401</a></span></li>
       </ul>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">


### PR DESCRIPTION
## Done

- Remove bluefin fax number from site and [copy doc](https://docs.google.com/document/d/1LK7lJlhke8hKesVSglHxNSfUCDw0bfddzM4vezeXvBQ/edit#)
- Scanned other sites and didn't find the number

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/contact-us
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the fax number is no longer listed


## Issue / Card

Fixes #8076

