### PR TITLE
Removed Ubuntu OVAL's coverage

### DIFF
--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -58,42 +58,6 @@
       }}
     </div>
   </div>
-  <div class="u-fixed-width">
-    <hr class="p-separator">
-  </div>
-  <div class="row u-vertically-center">
-    <div class="col-5 u-hide--small u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/74859dc8-control-thin.svg",
-        alt="",
-        width="200",
-        height="200",
-        hi_def=True,
-        loading="lazy",
-        ) | safe
-      }}
-    </div>
-    <div class="col-7">
-      <h2>
-        Ubuntu OVAL's coverage
-      </h2>
-      <p>
-        Each Ubuntu release comes with thousands of open source packages maintained in two repositories - Main and Universe.
-      </p>
-      <p>
-        Historically, Canonical committed to applying critical, high and medium security patches to the Ubuntu Main repository, which consists of around 2,500 packages. This data can be found in Ubuntu OVAL as well as in the Ubuntu Security Notices.
-      </p>
-      <p>
-        Canonical has now expanded the scope of CVE patching to high and critical vulnerabilities in the Ubuntu Universe repository, which consists of over 28,000 open source packages.
-      </p>
-      <p>
-        <a href="/security/notices">
-          See the Ubuntu Security Notices&nbsp;&rsaquo;
-        </a>
-      </p>
-    </div>
-  </div>
 </section>
 
 <section class="p-strip is-deep" id="instructions">


### PR DESCRIPTION
## Done

Removed Ubuntu OVAL's coverage section

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the demo against the [copy doc](https://docs.google.com/document/d/1hBG6NIfBIrixIV753fsOiEymmeuFIF-KOhiDkV68PRY/edit) and accept correct changes 

