### PR TITLE
Update copy on OpenStack consulting page

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -33,8 +33,8 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-8">
-        <p>Building and running an OpenStack cloud requires specialised expertise and low-level Linux OS knowledge. Canonical brings the full stack &mdash; from kernel to containers to applications - along with operating experience from hundreds of OpenStack deployments around the world to get you started efficiently.</p>
-        <p>Once you are certain OpenStack is the right choice we can deliver your cloud in two weeks. Only then do you need to commit the devops talent required to run your cloud, or <a href="/openstack/managed">outsource that to Canonical</a> as well.</p>
+        <p>Building and running an OpenStack cloud requires specialised expertise and low-level Linux OS knowledge. Canonical brings the full stack &mdash; from kernel to containers to applications &mdash; along with operating experience from hundreds of OpenStack deployments around the world to get you started efficiently.</p>
+        <p>Once you are certain OpenStack is the right choice we can deliver your cloud for you. Only then do you need to commit the devops talent required to run your cloud, or <a href="/openstack/managed">outsource that to Canonical</a> as well.</p>
       </div>
       <div class="col-4 u-hide--small u-vertically-center">
         {{
@@ -59,7 +59,7 @@
     <div class="row">
       <div class="col-6">
         <ul class="p-list">
-          <li class="p-list__item is-ticked">Two-day onsite workshop for introductions, requirements gathering and architecture design</li>
+          <li class="p-list__item is-ticked">Onsite workshop for introductions, requirements gathering and architecture design</li>
           <li class="p-list__item is-ticked">Existing VMware, public cloud and on-prem workload assessment</li>
           <li class="p-list__item is-ticked">Ongoing operations automation for scaling, node replacement, upgrades</li>
           <li class="p-list__item is-ticked">Full high availability of all OpenStack control plane and API services</li>
@@ -73,7 +73,7 @@
         <ul class="p-list">
           <li class="p-list__item is-ticked">Observability, log analysis and monitoring dashboards with Prometheus, Grafana, Nagios, Elastic Search and Kibana included as standard</li>
           <li class="p-list__item is-ticked">Complete handover with tenant onboarding, documentation, and details of ongoing support</li>
-          <li class="p-list__item is-ticked">Disaster recover and third-party tenant storage backup solutions available</li>
+          <li class="p-list__item is-ticked">Backup and recovery from TrilioVault for OpenStack provides integrated data protection capabilities</li>
           <li class="p-list__item is-ticked">Automated re-deployment guide and scripts</li>
           <li class="p-list__item is-ticked">Option to have Canonical provide operations and management remotely for a period</li>
           <li class="p-list__item is-ticked">OpenStack upgrades by Canonical on demand</li>
@@ -174,7 +174,7 @@
   <section class="p-strip is-bordered">
     <div class="u-fixed-width">
       <h2>Consulting, design and delivery pricing</h2>
-      <p>Our consulting delivery package comes in two flavours &mdash; Cloud Build and Cloud Build Plus, with the latter offering more consulting time to evaluate and integrate a wider range of custom architectural possibilities.</p>
+      <p>Our consulting delivery package comes in two flavours &mdash; Private Cloud Build and Private Cloud Build Plus, with the latter offering more consulting time to evaluate and integrate a wider range of custom architectural possibilities.</p>
     </div>
     {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
     <div class="u-fixed-width">


### PR DESCRIPTION
## Done

Updated the copy on /openstack/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page has been updated according to comments from Tytus in [the copy doc](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit#) and resolve the comments


## Issue / Card

Fixes #3069