### PR TITLE
Add missing fullstop on openstack pages

### DIFF
--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -24,7 +24,7 @@
     <h2 class="p-heading--four">Private Cloud Build Plus</h2>
     <p><span class="p-heading--two">$150,000</span> fixed price</p>
     <hr class="u-sv1" />
-    <p>Design and Deployment of a secure, carrier grade, feature rich OpenStack custom architecture</p>
+    <p>Design and Deployment of a secure, carrier grade, feature rich OpenStack custom architecture.</p>
     <p>What&rsquo;s included:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">Workload analysis</li>


### PR DESCRIPTION
## Done

Added missing fullstop on /openstack

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Search the page for the string "Design and Deployment of a secure, carrier grade, feature rich OpenStack custom architecture" and check that it ends with a fullstop