### PR TITLE
send GA event when payment processing takes a while

### DIFF
--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -316,6 +316,7 @@ function enableProcessingState(mode) {
           // the renewal payment is taking time to process, reload the page
           // and highlight the in-progress renewal
           if (mode === "payment") {
+            sendGAEvent("page reload: payment processing > 30s");
             location.search = `subscription=${activeRenewal.contractId}`;
           }
 


### PR DESCRIPTION
## Done

If processing a renewal payment takes a long time (> 30 seconds), we reload the page and show a processing label on the relevant subscription. We weren't sending a related event to GA however, and we want more visibility over if/how often that is happening.

## QA

This isn't easily QA-able, we only send events in production to try to keep the data there clean. However, you can [see in GA](https://analytics.google.com/analytics/web/#/report/content-event-events/a1018242w108544136p159562819/_u.date00=20200808&_u.date01=20200819&_r.drilldown=analytics.eventCategory:advantage,analytics.eventAction:renewal&explorer-table.plotKeys=%5B%5D/) the other events being sent by the same `sendGAEvent()` function called here, so I'm confident this works.
