### PR TITLE
Centre align logos on /security/certifications

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -126,7 +126,7 @@
       </p>
       <p>Ubuntu 18.04 has been submitted and is currently awaiting final certification from CSEC.  The evaluation was performed on Intel x86_64 and IBM Z hardware platforms.</p>
     </div>
-    <div class="col-4 u-hide--small">
+    <div class="col-4 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg?w=150" width="150" alt="">
     </div>
   </div>
@@ -147,7 +147,7 @@
         <li class="p-list__item"><a class="p-link--external" href="https://nvd.nist.gov/ncp/checklist/950">STIG checklist for Ubuntu 18.04 LTS</a></li>
       </ul>
     </div>
-    <div class="col-4 u-hide--small">
+    <div class="col-4 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/ff9e7377-disa-logo.svg" width="150" alt="">
     </div>
   </div>
@@ -163,7 +163,7 @@
         <a class="p-link--external" href="https://www.cisecurity.org/partner/canonical/">Read CIS Benchmarks for Ubuntu</a>
       </p>
     </div>
-    <div class="col-4 u-hide--small">
+    <div class="col-4 u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg?w=150" width="150" alt="">
     </div>
   </div>


### PR DESCRIPTION
## Done

- added `u-align--center` to the bottom few strips' logos

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all the logos align top to bottom on the page

