### PR TITLE
Add takeover and engage page for enterprise kubernetes

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1015,6 +1015,13 @@
     type="event" %}
     {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Five strategies to accelerate Kubernetes in the enterprise",
+    description="How to choose the best approach to Kubernetes for your business",
+    slug="kubernetes-deployment-enterprise-whitepaper",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
 </section>

--- a/templates/engage/kubernetes-deployment-enterprise-whitepaper.md
+++ b/templates/engage/kubernetes-deployment-enterprise-whitepaper.md
@@ -1,0 +1,32 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Five strategies to accelerate Kubernetes deployment in the enterprise"
+  meta_description: "How to choose the best approach to Kubernetes for your business"
+  meta_image: "https://assets.ubuntu.com/v1/61675dc7-enterprise_kubernetes.jpg"
+  meta_copydoc: "https://docs.google.com/document/d/13N3GiKatgyCyrPyWBer3hTsJHoS7J0H51hVTJC8GAc4/edit"
+  header_title: "Five strategies to<br />accelerate Kubernetes<br />in the enterprise"
+  header_subtitle: "How to choose the best approach to Kubernetes<br />for your business"
+  header_image: "https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg"
+  header_image_width: "240"
+  header_image_height: "234"
+  header_url: "#register-section"
+  header_cta: "Download whitepaper"
+  header_class: p-engage-banner--dark
+  form_id: 3648
+  form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/five-kubernetes-strategies-enterprise.pdf"
+---
+
+As Kubernetes adoption spreads from early adopters to slower-moving enterprises, many companies are discovering that while containers and Kubernetes offer advantages around development, velocity, agility, and cost management, they also create a new set of challenges to overcome.
+
+While there are commonalities in the types of challenges enterprises encounter with Kubernetes, there’s no true one-size-fits-all way to manage them but rather a number of potential approaches, each with its own advantages and drawbacks.
+
+In this white paper and webinar, we examine the motivations most enterprises have when they adopt Kubernetes, the approaches available and the considerations to be taken into account depending on an enterprises’ own size, technical sophistication, current infrastructure and budget.
+
+Download or watch today to:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Learn the main benefits of Kubernetes for the enterprise, and why it has taken the containerisation space by storm.</li>
+  <li class="p-list__item is-ticked">Discover the most common challenges businesses face in the Kubernetes adoption process.</li>
+  <li class="p-list__item is-ticked">Get a thorough comparison of the most prominent Kubernetes solutions on the market, including: Vanilla, PaaS, public cloud Kubernetes distributions, managed, and Enterprise Kubernetes platform.</li>
+</ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
   {% include "takeovers/_redhat-openstack.html" %}
   {% include "takeovers/_telco-virtual-event.html" %}
   {% include "takeovers/_smartstart.html" %}
+  {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
 
 
   {# FRENCH #}

--- a/templates/takeovers/_kubernetes-enterprise-whitepaper-takeover.html
+++ b/templates/takeovers/_kubernetes-enterprise-whitepaper-takeover.html
@@ -1,0 +1,15 @@
+{% with title="Five strategies to<br />accelerate Kubernetes<br />in the enterprise",
+subtitle="How to choose the best approach to Kubernetes<br />for your business ",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg",
+image_width="240",
+image_height="234",
+image_hide_small="true",
+equal_cols="true",
+primary_url="/engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges",
+primary_cta="Download whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -164,4 +164,6 @@
 {% include "takeovers/_telco-virtual-event.html" %}
 <p>26 August 2020</p>
 {% include "takeovers/_smartstart.html" %}
+<p>27 August 2020</p>
+{% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Added takeover and engage page for enterprise kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see the "Five strategies to accelerate Kubernetes in the enterprise" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1dboZFvt4v3-xxru2_0ub3uLYQIPT3ouOWcxfjHuKHug/edit#gid=2113339190)
- Click through to the engage page
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1dboZFvt4v3-xxru2_0ub3uLYQIPT3ouOWcxfjHuKHug/edit#gid=1271849439) and [the copy doc](https://docs.google.com/document/d/13N3GiKatgyCyrPyWBer3hTsJHoS7J0H51hVTJC8GAc4/edit)


## Issue / Card

Fixes #8115 