### PR TITLE
Add Ceph blog card

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -26,6 +26,19 @@
   <p>Kubernetes, or K8s for short, is an open source platform pioneered by Google, which started as a simple container orchestration tool but has grown into a platform for deploying, monitoring and managing apps and services across clouds.</p>
   <p><a href="/kubernetes/what-is-kubernetes">Learn more about Kubernetes &rsaquo;</a></p>
 </div>
+{% elif article.tags and 1780 in article.tags %}
+<div class="p-card" id="rtp-ceph">
+<img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/e0461e14-ceph-dark.svg" alt="ceph logo">
+<hr class="u-sv1">
+  <h3>
+    <a href="/ceph/what-is-ceph">
+     What is Ceph storage?
+
+    </a>
+  </h3>
+  <p>Ceph is a software-defined storage (SDS) solution designed to address the object, block, and file storage needs of both small and large data centres<br/><br/>It's an optimised and easy-to-integrate solution for companies adopting open source as the new norm for high-growth block storage, object stores and data lakes.</p>
+  <p><a href="/ceph/what-is-ceph">Learn more about Ceph &rsaquo;</a></p>
+</div>
 {% elif article.tags and 3680 in article.tags %}
 <div class="p-card" id="rtp-bosch">
 <img alt="IoT infographic" src="https://assets.ubuntu.com/v1/53163a88-IOT_core_infographic.svg">


### PR DESCRIPTION
## Done

- Add Ceph-related card on all blog posts tagged with "ceph"

## QA

- Ensure blog posts listed in [/blog/tag/ceph](https://ubuntu-com-8135.demos.haus/blog/tag/ceph) contain a Ceph-related card, and that it provides a good experience on mobile

## Screenshots

![Screenshot from 2020-08-20 00-25-56](https://user-images.githubusercontent.com/18480003/90695956-bbedcc80-e27b-11ea-95ee-106e8720ce28.png)
