### PR TITLE
Remove MAAS monthly pricing (see /pricing/infra)

### DIFF
--- a/templates/shared/pricing/_maas-pricing.html
+++ b/templates/shared/pricing/_maas-pricing.html
@@ -11,12 +11,6 @@
       </thead>
       <tbody>
         <tr>
-          <td>Per managed machine - monthly</td>
-          <td class="u-align--center">$3</td>
-          <td class="u-align--center">$5</td>
-          <td class="u-align--center">$10</td>
-        </tr>
-        <tr>
           <td>Per managed machine - annual</td>
           <td class="u-align--center">$30</td>
           <td class="u-align--center">$50</td>


### PR DESCRIPTION
## Done

- Remove MAAS monthly pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/infra
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#)

