### PR TITLE
Update oval page copy

### DIFF
--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -224,7 +224,7 @@ bunzip2 oci.com.ubuntu.focal.cve.oval.xml.bz2</code></pre>
                   Public date of USN
                 </td>
                 <td>
-                  The date on which a security patch was announced or provided
+                  The date on which a USN was published
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
## Done

Updated the copy on /security/oval

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/oval
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the change requested by Lech in [the copy doc](https://docs.google.com/document/d/1hBG6NIfBIrixIV753fsOiEymmeuFIF-KOhiDkV68PRY/edit#) has been made and resolve the comment


## Issue / Card

Fixes #8146 