### PR TITLE
Update managed k8s, openstack and ceph pricing

### DIFF
--- a/templates/shared/pricing/_openstack-kubernetes-lma.html
+++ b/templates/shared/pricing/_openstack-kubernetes-lma.html
@@ -11,18 +11,28 @@
       <tbody>
         <tr>
           <td><a href="/kubernetes/managed">Managed Kubernetes</a> on public cloud, VMware or OpenStack</td>
-          <td class="u-align--center">$1,060</td>
-          <td class="u-align--center">$2,190 <sup><a href="#k8s-per-host">*</a></sup></td>
+          <td class="u-align--center">$1,305</td>
+          <td class="u-align--center">$2,925 <sup><a href="#k8s-per-host">*</a></sup></td>
         </tr>
         <tr>
-          <td><a href="/openstack/managed">Managed OpenStack</a>, Kubernetes or Ceph on bare metal</td>
+          <td><a href="/openstack/managed">Managed OpenStack</a> on bare metal</td>
           <td class="u-align--center">&nbsp;</td>
-          <td class="u-align--center">$4,275</td>
+          <td class="u-align--center">$5,010</td>
+        </tr>
+        <tr>
+          <td><a href="/kubernetes/managed">Managed Kubernetes</a> on bare metal</td>
+          <td class="u-align--center">&nbsp;</td>
+          <td class="u-align--center">$3,985</td>
+        </tr>
+        <tr>
+          <td><a href="/ceph">Managed Ceph</a> on bare metal</td>
+          <td class="u-align--center">&nbsp;</td>
+          <td class="u-align--center">$3,485</td>
         </tr>
         <tr>
           <td>Combined offering - managed on-demand K8s on fully managed OpenStack</td>
           <td class="u-align--center">&nbsp;</td>
-          <td class="u-align--center">$6,465</td>
+          <td class="u-align--center">$6,324</td>
         </tr>
       </tbody>
     </table>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7211,6 +7211,11 @@ prettier@2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
+pretty-bytes@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
+  integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
+
 pretty-format@^26.2.0:
   version "26.2.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.2.0.tgz#83ecc8d7de676ff224225055e72bd64821cec4f1"


### PR DESCRIPTION
## Done

- Update managed k8s, openstack and ceph pricing

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/infra
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#)


## Issue / Card

Fixes #8145

