### PR TITLE
Add mavencode logo to kubeflow consulting page

### DIFF
--- a/templates/kubeflow/consulting.html
+++ b/templates/kubeflow/consulting.html
@@ -58,8 +58,8 @@
   <div class="row">
     <div class="col-12">
       <h5 class="p-muted-heading u-sv3">Our consulting partners</h5>
-      <ul class="row">
-        <li class="col-2 col-small-2 col-medium-2">
+      <ul class="row u-equal-height">
+        <li class="col-2 col-small-2 col-medium-2 u-vertically-center">
           {{
             image(
               url="https://assets.ubuntu.com/v1/e9e4d429-Manceps.png",
@@ -71,12 +71,24 @@
             ) | safe
           }}
         </li>
-        <li class="col-2 col-small-2 col-medium-2">
+        <li class="col-2 col-small-2 col-medium-2 u-vertically-center">
           {{
             image(
               url="https://assets.ubuntu.com/v1/99d8f79e-deepsense.png",
               alt="",
               height="27",
+              width="147",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+          }}
+        </li>
+        <li class="col-2 col-small-2 col-medium-2 u-vertically-center">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/4566e59b-mavencode-logo.png",
+              alt="",
+              height="17",
               width="147",
               hi_def=True,
               loading="lazy",


### PR DESCRIPTION
## Done

Added mavencode logo to /kubeflow/consulting

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the mavencode logo has been added as requested in [the copy doc](https://docs.google.com/document/d/19Mx1zRJKqH2hz5kRF_oDsgyFUw67FgJvW4I_OGda-wk/edit#) and resolve the comment


## Issue / Card

Fixes #8141 