### PR TITLE
Add Smart Start takeover

### DIFF
--- a/templates/engage/smart-start-whitepaper.md
+++ b/templates/engage/smart-start-whitepaper.md
@@ -1,22 +1,22 @@
 ---
 wrapper_template: "engage/_base_engage_markdown.html"
 context:
-     title: "Accelerating IoT device time to market"
-     meta_description: "Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process"
-     meta_image: https://assets.ubuntu.com/v1/e8e5fa6d-85998029-33347c00-ba02-11ea-8bd5-085d16b88553.png
-     meta_copydoc: https://docs.google.com/document/d/1XSGcMXhCT7FbGtLhlOLTDZBFTqz_dhW8ber72pmbpUM/edit
-     header_title: "Accelerating IoT device time to market"
-     header_subtitle: "Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process"
-     header_image: https://assets.ubuntu.com/v1/bc976d87-IoT-smart-start-time-to-market-white.svg
-     header_image_width: "393"
-     header_image_height: "384"
-     header_url: '#register-section'
-     header_cta: "Download the whitepaper"
-     header_class: "p-engage-banner--dark"
-     header_lang: en
-     form_include: en
-     form_id: 3574
-     form_return_url: https://pages.ubuntu.com/Timetomarket_TY.html
+  title: "Accelerating IoT device time to market"
+  meta_description: "Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process"
+  meta_image: https://assets.ubuntu.com/v1/e8e5fa6d-85998029-33347c00-ba02-11ea-8bd5-085d16b88553.png
+  meta_copydoc: https://docs.google.com/document/d/1XSGcMXhCT7FbGtLhlOLTDZBFTqz_dhW8ber72pmbpUM/edit
+  header_title: "Accelerating IoT device time to market"
+  header_subtitle: "Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process"
+  header_image: https://assets.ubuntu.com/v1/bc976d87-IoT-smart-start-time-to-market-white.svg
+  header_image_width: "393"
+  header_image_height: "384"
+  header_url: "#register-section"
+  header_cta: "Download the whitepaper"
+  header_class: "p-engage-banner--dark"
+  header_lang: en
+  form_include: en
+  form_id: 3574
+  form_return_url: https://pages.ubuntu.com/rs/066-EOV-335/images/IoT_Device_time2market_30.06.20.pdf
 ---
 
 The IoT market has immense potential: industry analysts 451 Research report that the IoT market opportunity will reach $648bn by 2024, and it is set to reach $1tn within the decade. But succeeding in the IoT arena is not without its challenges. Slow or rushed decision making, alongside mismanagement of resources and talent, frequently cause IoT projects to stall.
@@ -24,6 +24,7 @@ The IoT market has immense potential: industry analysts 451 Research report that
 This is why Canonical has introduced SMART START &mdash; a packaged IoT solution that reduces business and technical decision-making into a 2-week, fixed-cost process. SMART START fast tracks an enterprise’s IoT strategy by guiding it through hardware selection and delivering the infrastructure needed to develop and deploy software to fleets of devices, with consulting services to minimise risk and fill skill gaps.
 
 This whitepaper draws findings from more than 30 case studies, project summaries, and business cases to identify the central IoT pitfalls and their solutions. Read the whitepaper to learn about:
+
 <ul>
   <li>The three most significant challenges in bringing IoT devices to market: hardware decision making, infrastructure complexity, and risk management.</li>
   <li>Practical steps enterprises can take to overcome these challenges.</li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,8 +32,8 @@
   {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_gsi-webinar-series-takeover.html" %}
   {% include "takeovers/_redhat-openstack.html" %}
-  {% include "takeovers/_data-lake_2_server_webinar.html" %}
   {% include "takeovers/_telco-virtual-event.html" %}
+  {% include "takeovers/_smartstart.html" %}
 
 
   {# FRENCH #}

--- a/templates/takeovers/_smartstart.html
+++ b/templates/takeovers/_smartstart.html
@@ -1,0 +1,13 @@
+{% with title="Accelerating IoT device time to market",
+subtitle="Introducing a packaged solution to condense IoT decision-making into a 2-week, fixed cost process",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg",
+image_style="width: 350px;",
+image_hide_small="",
+primary_url="/engage/smart-start-whitepaper?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_IOT_SmartStart_WP_Timetomarket",
+primary_cta="Download whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -162,4 +162,6 @@
 {% include "takeovers/_data-lake_2_server_webinar.html" %}
 <p>25 August 2020</p>
 {% include "takeovers/_telco-virtual-event.html" %}
+<p>26 August 2020</p>
+{% include "takeovers/_smartstart.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Add Smart Start takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see a takeover "Accelerating IoT device time to market"
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/193Rdm62tRugCxkQ2YBRK2hlP4bctPi_AAuDFz7fvRsU/edit?ts=5f325452#gid=2113339190)


## Issue / Card

Fixes #8119 