### PR TITLE
Add patches and tags to cve

### DIFF
--- a/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
+++ b/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
@@ -1,0 +1,30 @@
+"""add_cve_patch_column
+
+Revision ID: 10c24cb270ff
+Revises: 765ed540939b
+Create Date: 2020-08-20 14:53:19.249005
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "10c24cb270ff"
+down_revision = "765ed540939b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "cve", sa.Column("patches", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "cve", sa.Column("tags", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("cve", "patches")
+    op.drop_column("cve", "tags")

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -55,6 +55,8 @@ class CVE(Base):
     )
     cvss3 = Column(Float)
     references = Column(JSON)
+    patches = Column(JSON)
+    tags = Column(JSON)
     bugs = Column(JSON)
     status = Column(
         Enum("not-in-ubuntu", "active", "rejected", name="cve_statuses")

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -119,3 +119,9 @@ class CVESchema(Schema):
     packages = List(Nested(CvePackage))
     references = List(String())
     bugs = List(String())
+    patches = Dict(
+        keys=String(), values=List(String(), required=False), allow_none=True,
+    )
+    tags = Dict(
+        keys=String(), values=List(String(), required=False), allow_none=True,
+    )

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -563,6 +563,8 @@ def bulk_upsert_cve():
         cve.notes = data.get("notes")
         cve.references = data.get("references")
         cve.bugs = data.get("bugs")
+        cve.patches = data.get("patches")
+        cve.tags = data.get("tags")
 
         statuses = update_statuses(
             cve, data, packages, releases=db_session.query(Release)


### PR DESCRIPTION
Adds tags and patches columns to cve. 

## QA 
1. [Terminal 1]: Reset your database 
```bash
docker-compose down
docker-compose up -d
dotrun
```

2. [Terminal 2]: Populate database
If you do not have the `ubuntu-cve-tracker` repo locally:
```bash
git clone -b send-cve-patches git@github.com:albertkol/ubuntu-cve-tracker.git # fetch testing branch
```

If you already have the project just fetch the fork
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu-cve-tracker.git  # get my fork
git fetch albert-fork  # fetch the branches
git checkout send-cve-patches  # checkout the testing branch
```

3. [Terminal 2]: Run importer
```bash
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

4. [Terminal 1]:
Check ubuntu.com database 
```bash
docker exec -it db psql -U postgres
```
```SQL
select id,tags from cve where tags::text <> '{}'::text;
```
You will get a list of cves with tags.

```SQL
select id,patches from cve where patches::text <> '{}'::text;
```
You will get a list of cves with patches.

## Issue
Fixes #7975