### PR TITLE
Fix contextual footer on /openstack/managed

### DIFF
--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -714,7 +714,7 @@
   </div>
 </section>
 
-{% with first_item="_cloud_bootstack", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_k8s_managed", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/shared/contextual_footers/_cloud_bootstack.html
+++ b/templates/shared/contextual_footers/_cloud_bootstack.html
@@ -1,7 +1,6 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Want fully managed private cloud?</h3>
-  <p>Canonical provides managed services option for OpenStack. Our experts take
-  responsibility for the design, deployment and operations</p>
-  <p><a href="/openstack/managed">Learn more &rsaquo;</a></p>
+  <p>Canonical provides a managed services option for OpenStack. Our experts take responsibility for the design, deployment and operations.</p>
+  <p><a href="/openstack/managed">Learn more&nbsp;&rsaquo;</a></p>
   <p><a class="p-button" href="/openstack/managed#get-in-touch" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'BootStack', 'eventLabel' : 'Want fully managed private cloud?', 'eventValue' : undefined });">Contact us</a></p>
 </div>

--- a/templates/shared/contextual_footers/_k8s_managed.html
+++ b/templates/shared/contextual_footers/_k8s_managed.html
@@ -1,0 +1,5 @@
+<div class="col-4 p-divider__block">
+  <h3 class="p-heading--four">Want fully managed Kubernetes?</h3>
+  <p>Canonical provides a managed services option for k8s. Our experts take responsibility for the design, deployment and operations.</p>
+  <p><a href="/kubernetes/managed">Learn more&nbsp;&rsaquo;</a></p>
+</div>


### PR DESCRIPTION
## Done

- Fixed grammar on OpenStack managed footer
- Created a k8s managed footer
- Used k8s managed footer on /openstack/managed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it doesn't refer to the page it self with the K8s footer instead


## Issue / Card

Fixes #8151

## Screenshots

![image](https://user-images.githubusercontent.com/441217/91155994-7e45d500-e6bb-11ea-8d19-2acd0b853538.png)
