### PR TITLE
Update component to main or universe

### DIFF
--- a/webapp/security/alembic/versions/570b8ff188c4_update_cve_component_field.py
+++ b/webapp/security/alembic/versions/570b8ff188c4_update_cve_component_field.py
@@ -1,0 +1,55 @@
+"""update_cve_component_field
+
+Revision ID: 570b8ff188c4
+Revises: 765ed540939b
+Create Date: 2020-08-25 13:52:15.173429
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "570b8ff188c4"
+down_revision = "10c24cb270ff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("status", "component")
+    op.execute("DROP TYPE components")
+
+    new_components_list = "'main', 'universe'"
+
+    op.execute(f"CREATE TYPE components AS ENUM ({new_components_list});")
+
+    op.add_column(
+        "status",
+        sa.Column(
+            "component",
+            sa.Enum("main", "universe", name="components"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("status", "component")
+    op.execute("DROP TYPE components;")
+
+    old_components_list = "'main', 'universe', 'esm-infra', 'esm-apps'"
+
+    op.execute(f"CREATE TYPE components AS ENUM ({old_components_list});")
+
+    op.add_column(
+        "status",
+        sa.Column(
+            "component",
+            sa.Enum(
+                "main", "universe", "esm-infra", "esm-apps", name="components"
+            ),
+            nullable=False,
+            server_default="main",
+        ),
+    )

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -168,10 +168,7 @@ class Status(Base):
         )
     )
     description = Column(String)
-    component = Column(
-        Enum("main", "universe", "esm-infra", "esm-apps", name="components"),
-        server_default="main",
-    )
+    component = Column(Enum("main", "universe", name="components"),)
 
     cve = relationship("CVE", back_populates="statuses")
     package = relationship("Package", back_populates="statuses")

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -42,14 +42,11 @@ class ReleaseCodename(String):
 
 class Component(String):
     default_error_messages = {
-        "unrecognised_component": (
-            "Component must be one of "
-            "'main', 'universe', 'esm-infra' or 'esm-apps'"
-        )
+        "unrecognised_component": ("Component must be 'main' or 'universe'")
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in ["main", "universe", "esm-infra", "esm-apps"]:
+        if value not in ["main", "universe"]:
             raise self.make_error("unrecognised_component", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)


### PR DESCRIPTION
Update component to be nullable and have the enum type of only "main" and "universe".

Before it would have also "esm-infra" and "esm-apps" but that will be shifted to a new column called `pocket`.

## QA

0. [Terminal 1]: Fetch PR changes
```bash
git fetch albert-fork
git checkout cve-component-update
```
 
1. [Terminal 1]: Reset your database 
```bash
docker-compose down
docker-compose up -d
dotrun
```

2. [Terminal 2]: Fetch changes
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu-cve-tracker.git  # get my fork
git fetch albert-fork  # fetch the branches
git checkout test-component  # checkout the testing branch
```

3. [Terminal 2]: Run importer
```bash
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

4. [Terminal 1]:
Check ubuntu.com database 
```bash
docker exec -it db psql -U postgres
```


Check the following:

There are status of component `main`:
```sql
select cve_id,package_name,release_codename,component from status where component='main' limit 10;
```
There are status of component `universe`:
```sql
select cve_id,package_name,release_codename,component from status where component='universe' limit 10;
```
There are status has no component (null):
```sql
select cve_id,package_name,release_codename,component from status where component is null limit 10;
```
If you try to insert component `esm-infra` it fails:
```sql
update status set component='esm-infra' where cve_id='CVE-2002-2439' and package_name='gcc-4.1' and release_codename='upstream';
```

## Issue / Card

Fixes #8162
