### PR TITLE
Update Ubuntu Kylin link

### DIFF
--- a/templates/download/flavours.html
+++ b/templates/download/flavours.html
@@ -87,7 +87,7 @@
             ) | safe
           }}
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title"><a class="p-link--external" href="https://www.ubuntukylin.com/index.php-lang=en.htm">Ubuntu Kylin</a></h3>
+            <h3 class="p-matrix__title"><a class="p-link--external" href="https://www.ubuntukylin.com/downloads/show.php?&lang=en">Ubuntu Kylin</a></h3>
             <p class="p-matrix__desc">The Ubuntu Kylin project is tuned to the needs of Chinese users, providing a thoughtful and elegant Chinese experience out-of-the-box.</p>
           </div>
         </li>


### PR DESCRIPTION
Fix for Issue#8166 Ubuntu Kylin download link reports 404 Not Found for English language

## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #8166

## Screenshots

[If relevant, please include a screenshot.]
