### PR TITLE
Telco vevt takeover engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1006,7 +1006,15 @@
     type="webinar" %}
     {% include "engage/_article-card.html" %}
     {% endwith %}
-    
+  </div>
+
+  <div class="row u-equal-height u-clearfix">
+    {% with title="Transforming telco infrastructure: A virtual event",
+    description="Canonical's experts explore the telecommunication industry's latest technologies. Join us live on 24 September 2020.",
+    slug="telco-virtual-event",
+    type="event" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
 </section>

--- a/templates/engage/telco-virtual-event.md
+++ b/templates/engage/telco-virtual-event.md
@@ -1,0 +1,99 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+  title: "Transforming telco infrastructure: A virtual event"
+  meta_description: "Canonical's experts explore the telecommunication industry's latest technologies. Join us live on 24 September 2020."
+  meta_image: https://assets.ubuntu.com/v1/9a957056-telco-vevt-meta-image.png
+  meta_copydoc: https://docs.google.com/document/d/1xiyF0Kx6ISWiVp4gLrEYtwyaMo5iKPU01Vxq3SSb5lU/edit#
+  header_title: "Transforming telco infrastructure"
+  header_subtitle: "On 24 September, join our technical exploration of the industry’s latest technologies"
+  header_image: "https://assets.ubuntu.com/v1/4ba0e3a6-Joint+Lime-illustration-white.svg"
+  header_image_width: "280"
+  header_image_height: "294"
+  header_url: "#register-section"
+  header_cta: Register now
+  header_cta_class: p-button--positive
+  header_cta_all_sizes: true
+  header_class: p-engage-banner--grad
+  webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 433508, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+**Date and time**
+24 September, 2020
+[5:30-7:30pm BST]
+
+## About the event
+
+As TSPs (telecommunications service providers) worldwide strive to keep up with growing demand and evolving customer needs, the industry relies heavily on new technologies that allow for cost savings, more and more flexibility, speed, and robustness.
+
+Today, it is clear that the growth path for operators lies in the transition from traditional VNFs to cloud-native, containerised network services based on microservices architectures that can meet requirements for 5G and beyond.
+
+However, understanding infrastructure implications and design considerations for open source hardware and software development platforms, while remaining carrier-grade and maintaining operational excellence and capacity, requires careful planning and thorough understanding of the available options.
+
+Join our live virtual event and our telco experts to discuss:
+
+<ul class="p-list">
+  <li class="p-list__item is-ticked">Major trends and challenges in the current telco landscape</li>
+  <li class="p-list__item is-ticked">Best tools and strategies to reduce CAPEX and OPEX costs</li>
+  <li class="p-list__item is-ticked">Optimal solutions around Kubernetes, OpenStack, and OSM (Open Source MANO)</li>
+  <li class="p-list__item is-ticked">Opportunities for telcos at the edge</li>
+  <li class="p-list__item is-ticked">Canonical's portfolio of products and services for telcos</li>
+</ul>
+
+The speakers will also delve into notable use cases they have come across throughout their experience, as well as touch on topics and questions put forward by the audience live.
+
+## Speakers:
+
+<div class="p-media-object--large">
+  {{
+    image(
+      url="https://assets.ubuntu.com/v1/5bb73d70-arno.jpeg",
+      alt="",
+      height="100",
+      width="100",
+      hi_def=True,
+      attrs={"class": "p-media-object__image"},
+      loading="lazy",
+    ) | safe
+  }}
+  <div class="p-media-object__details">
+    <h3 class="u-no-margin--bottom">Arno Van Huyssteen</h3>
+    <p>Director, Field Engineering Telco EMEA-APAC</p>
+  </div>
+</div>
+
+<div class="p-media-object--large">
+  {{
+    image(
+      url="https://assets.ubuntu.com/v1/c8944793-greg.jpeg",
+      alt="",
+      height="100",
+      width="100",
+      hi_def=True,
+      attrs={"class": "p-media-object__image"},
+      loading="lazy",
+    ) | safe
+  }}
+  <div class="p-media-object__details">
+    <h3 class="u-no-margin--bottom">Greg Elkinbard</h3>
+    <p>Director, Field Engineering Americas</p>
+  </div>
+</div>
+
+<div class="p-media-object--large">
+  {{
+    image(
+      url="https://assets.ubuntu.com/v1/41dbe8cb-tytus.jpeg",
+      alt="",
+      height="100",
+      width="100",
+      hi_def=True,
+      attrs={"class": "p-media-object__image"},
+      loading="lazy",
+    ) | safe
+  }}
+  <div class="p-media-object__details">
+    <h3 class="u-no-margin--bottom">Tytus Kurek</h3>
+    <p>Product Manager</p>
+  </div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
   {% include "takeovers/_gsi-webinar-series-takeover.html" %}
   {% include "takeovers/_redhat-openstack.html" %}
   {% include "takeovers/_data-lake_2_server_webinar.html" %}
+  {% include "takeovers/_telco-virtual-event.html" %}
 
 
   {# FRENCH #}

--- a/templates/takeovers/_telco-virtual-event.html
+++ b/templates/takeovers/_telco-virtual-event.html
@@ -1,0 +1,15 @@
+{% with title="Transforming telco infrastructure",
+subtitle="A virtual event on the industry's latest technologies. Join live on September 24th.",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/4ba0e3a6-Joint+Lime-illustration-white.svg",
+image_height="280",
+image_width="294",
+image_hide_small=true,
+primary_url="/engage/telco-virtual-event?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_Telco_VEVT_TransformingTelco0",
+primary_cta="Register now",
+primary_cta_class="",
+secondary_url="",
+secondary_cta=""
+%}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -160,4 +160,6 @@
 {% include "takeovers/_redhat-openstack.html" %}
 <p>12 August 2020</p>
 {% include "takeovers/_data-lake_2_server_webinar.html" %}
+<p>25 August 2020</p>
+{% include "takeovers/_telco-virtual-event.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

Added Telco virtual event takeover and engage page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Reload the page until you see the "Transforming telco infrastructure" takeover
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1XAStuaJ_TlaVfvVZY6BGkwQgl64bLSFuCz7meRzRYME/edit#gid=2113339190)
- Click through to the engage page
- Check that it matches [the brief](https://docs.google.com/spreadsheets/d/1XAStuaJ_TlaVfvVZY6BGkwQgl64bLSFuCz7meRzRYME/edit#gid=1271849439) and [the copy doc](https://docs.google.com/document/d/1xiyF0Kx6ISWiVp4gLrEYtwyaMo5iKPU01Vxq3SSb5lU/edit#)
- Check that the takeover is included at the bottom of /takeovers
- Check that the engage page is included at the bottom of /engage


## Issue / Card

Fixes #8114