### PR TITLE
CVE add pocket column

### DIFF
--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -90,10 +90,10 @@
                 {% endif %}
                 <br>
                 <small>
-                  {% if statuses[release.codename].component == "esm-infra" %}
+                  {% if statuses[release.codename].pocket == "esm-infra" %}
                     <a href="/advantage" target="_blank">UA Infra, UA Desktop</a>
                   {% endif %}
-                  {% if statuses[release.codename].component == "esm-apps" %}
+                  {% if statuses[release.codename].pocket == "esm-apps" %}
                     <a href="/advantage" target="_blank">UA Apps, UA Desktop</a>
                   {% endif %}
                 </small>

--- a/webapp/security/alembic/versions/88f1398da6c1_add_cve_pocket_column.py
+++ b/webapp/security/alembic/versions/88f1398da6c1_add_cve_pocket_column.py
@@ -1,0 +1,37 @@
+"""add-cve-pocket-column
+
+Revision ID: 88f1398da6c1
+Revises: 570b8ff188c4
+Create Date: 2020-08-25 16:39:40.109172
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "88f1398da6c1"
+down_revision = "570b8ff188c4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pockets_list = "'security', 'updates', 'esm-infra', 'esm-apps'"
+    op.execute(f"CREATE TYPE pockets AS ENUM ({pockets_list});")
+
+    op.add_column(
+        "status",
+        sa.Column(
+            "pocket",
+            sa.Enum(
+                "security", "updates", "esm-infra", "esm-apps", name="pockets"
+            ),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("status", "pocket")
+    op.execute("DROP TYPE pockets;")

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -169,6 +169,9 @@ class Status(Base):
     )
     description = Column(String)
     component = Column(Enum("main", "universe", name="components"),)
+    pocket = Column(
+        Enum("security", "updates", "esm-infra", "esm-apps", name="pockets"),
+    )
 
     cve = relationship("CVE", back_populates="statuses")
     package = relationship("Package", back_populates="statuses")

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -52,6 +52,21 @@ class Component(String):
         return super()._deserialize(value, attr, data, **kwargs)
 
 
+class Pocket(String):
+    default_error_messages = {
+        "unrecognised_component": (
+            "Pocket must be one of "
+            "'security', 'updates', 'esm-infra', 'esm-apps'"
+        )
+    }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value not in ["security", "updates", "esm-infra", "esm-apps"]:
+            raise self.make_error("unrecognised_pocket", input=value)
+
+        return super()._deserialize(value, attr, data, **kwargs)
+
+
 # Schemas
 # ===
 
@@ -89,6 +104,7 @@ class Status(Schema):
     status = String(required=True)
     description = String(allow_none=True)
     component = Component(required=False)
+    pocket = Pocket(required=False)
 
 
 class CvePackage(Schema):

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -484,6 +484,8 @@ def update_statuses(cve, data, packages, releases):
 
             if "component" in status_data:
                 status.component = status_data["component"]
+            if "pocket" in status_data:
+                status.pocket = status_data["pocket"]
 
             statuses[name][codename] = status
 


### PR DESCRIPTION
CVE add pocket column. It can be one of 'security', 'updates', 'esm-infra', 'esm-apps'.
It is optional and nuallable.

## QA

0. Fetch changes of this branch:
```bash
git fetch albert-fork
git checkout cve-add-pocket-column
```

1. [Terminal 1]: Reset your database 
```bash
docker-compose down
docker-compose up -d
dotrun
```

2. [Terminal 2]: Fetch changes
```bash
git remote add albert-fork git@github.com:albertkol/ubuntu-cve-tracker.git  # get my fork
git fetch albert-fork  # fetch the branches
git checkout test-pocket  # checkout the testing branch
```

3. [Terminal 2]: Run importer
```bash
cd ubuntu-cve-tracker/scripts
python3 -m venv .venv
source .venv/bin/activate
pip3 install requests cvss macaroonbakery
time python3 upload-cve.py ../active
```

If you browse to `/security/cve` you will see the `UA Infra, UA Desktop` or `UA Apps, UA Desktop` in the cells.


## Issue / Card

Fixes #8163
