### PR TITLE
Remove hardcoded Launchpad account for image builder

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -13,14 +13,24 @@ env:
       key: google-custom-search-key
       name: google-api
 
-  - name: LAUNCHPAD_TOKEN
+  - name: LAUNCHPAD_IMAGE_BUILD_USER
+    secretKeyRef:
+      key: user
+      name: launchpad-imagebuild
+
+  - name: LAUNCHPAD_IMAGE_BUILD_TOKEN
     secretKeyRef:
       key: token
       name: launchpad-imagebuild
 
-  - name: LAUNCHPAD_SECRET
+  - name: LAUNCHPAD_IMAGE_BUILD_SECRET
     secretKeyRef:
       key: secret
+      name: launchpad-imagebuild
+
+  - name: LAUNCHPAD_IMAGE_BUILD_AUTH_CONSUMER
+    secretKeyRef:
+      key: auth-consumer
       name: launchpad-imagebuild
 
   - name: SENTRY_DSN

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -148,11 +148,11 @@ def post_build():
         flask.abort(401)
 
     launchpad = Launchpad(
-        username="imagebuild",
-        token=os.environ["LAUNCHPAD_TOKEN"],
-        secret=os.environ["LAUNCHPAD_SECRET"],
+        username=os.environ["LAUNCHPAD_IMAGE_BUILD_USER"],
+        token=os.environ["LAUNCHPAD_IMAGE_BUILD_TOKEN"],
+        secret=os.environ["LAUNCHPAD_IMAGE_BUILD_SECRET"],
         session=session,
-        auth_consumer="image.build",
+        auth_consumer=os.environ["LAUNCHPAD_IMAGE_BUILD_AUTH_CONSUMER"],
     )
 
     context = {}
@@ -253,11 +253,11 @@ def notify_build():
     )
 
     launchpad = Launchpad(
-        username="imagebuild",
-        token=os.environ["LAUNCHPAD_TOKEN"],
-        secret=os.environ["LAUNCHPAD_SECRET"],
+        username=os.environ["LAUNCHPAD_IMAGE_BUILD_USER"],
+        token=os.environ["LAUNCHPAD_IMAGE_BUILD_TOKEN"],
+        secret=os.environ["LAUNCHPAD_IMAGE_BUILD_SECRET"],
         session=session,
-        auth_consumer="image.build",
+        auth_consumer=os.environ["LAUNCHPAD_IMAGE_BUILD_AUTH_CONSUMER"],
     )
 
     build = launchpad.request(build_url).json()


### PR DESCRIPTION
## Done

- Launchpad username can be set now as an env variable.
- Launchpad auth consumer can be set now as an env variable.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the image builder functionality is working as expected with the Launchpad staging account.
