### PR TITLE
Add datasheet to /openstack page

### DIFF
--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -64,7 +64,7 @@
   <div class="u-no-fixed-width">
     <p id="os-footnote">
       <small>
-      <sup><a href="#os-footnote">*</a></sup> Additional features, functionality and integrations are available via add-ons
+      <sup>*</sup> Additional features, functionality and integrations are available via add-ons
       </small>
     </p>
       <p class="p-button">

--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -4,7 +4,7 @@
     <p><span class="p-heading--two">$75,000</span> fixed price</p>
     <hr class="u-sv1" />
     <p>Design and deployment of OpenStack reference architecture.</p>
-    <p>What&rsquo;s included:</p>
+    <p>What&rsquo;s included: <sup><a href="#os-footnote">*</a></sup></p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
       <li class="p-list__item is-ticked">Reference architecture</li>
@@ -25,7 +25,7 @@
     <p><span class="p-heading--two">$150,000</span> fixed price</p>
     <hr class="u-sv1" />
     <p>Design and Deployment of a secure, carrier grade, feature rich OpenStack custom architecture.</p>
-    <p>What&rsquo;s included:</p>
+    <p>What&rsquo;s included: <sup><a href="#os-footnote">*</a></sup></p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">Workload analysis</li>
       <li class="p-list__item is-ticked">Customised architecture</li>
@@ -47,6 +47,7 @@
     <p><span class="p-heading--two">$15</span> per server per day</p>
     <hr class="u-sv1" />
     <p>Full remote operations of your Canonical OpenStack at half the price of VMware.</p>
+    <p>What&rsquo;s included: <sup><a href="#os-footnote">*</a></sup></p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">24/7 monitoring</li>
       <li class="p-list__item is-ticked">Proactive management</li>
@@ -60,4 +61,16 @@
     <p><a href="/openstack/managed">Fully Managed OpenStack&nbsp;&rsaquo;</a></p>
   </div>
   {% endif %}
+  <div class="u-no-fixed-width">
+    <p id="os-footnote">
+      <small>
+      <sup><a href="#os-footnote">*</a></sup> Additional features, functionality and integrations are available via add-ons
+      </small>
+    </p>
+      <p class="p-button">
+        <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf">
+          Read the datasheet
+        </a>
+      </p>
+  </div>
 </div>


### PR DESCRIPTION
## Done

- Add datasheet to /openstack page
- Ant can you re-approve, I had to redo it.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#) and resolve comments

## Issue / Card

Fixes #8161

## Screenshots

![image](https://user-images.githubusercontent.com/441217/91294028-cdaa0500-e790-11ea-97ce-46eedf082451.png)

