### PR TITLE
Add new purchase preview endpoint for shop

### DIFF
--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -161,3 +161,14 @@ class AdvantageContracts:
         )
 
         return response.json()
+
+    def preview_purchase_from_marketplace(
+        self, marketplace: str, purchase_request: dict
+    ) -> dict:
+        response = self._request(
+            method="post",
+            path=f"v1/marketplace/{marketplace}/purchase/preview",
+            json=purchase_request,
+        )
+
+        return response.json()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -146,6 +146,13 @@ app.add_url_rule(
     "/advantage/subscribe",
     view_func=post_advantage_subscriptions,
     methods=["POST"],
+    defaults={"preview": False},
+)
+app.add_url_rule(
+    "/advantage/subscribe/preview",
+    view_func=post_advantage_subscriptions,
+    methods=["POST"],
+    defaults={"preview": True},
 )
 app.add_url_rule(
     "/advantage/customer-info", view_func=post_customer_info, methods=["POST"]

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -543,7 +543,7 @@ class MachineUsage(namedtuple("MachineUsage", ["attached", "allowed"])):
         return str(self.attached)
 
 
-def post_advantage_subscriptions():
+def post_advantage_subscriptions(preview):
     if user_info(flask.session):
         advantage = AdvantageContracts(
             session,
@@ -611,9 +611,14 @@ def post_advantage_subscriptions():
     }
 
     try:
-        purchase = advantage.purchase_from_marketplace(
-            marketplace="canonical-ua", purchase_request=purchase_request
-        )
+        if not preview:
+            purchase = advantage.purchase_from_marketplace(
+                marketplace="canonical-ua", purchase_request=purchase_request
+            )
+        else:
+            purchase = advantage.preview_purchase_from_marketplace(
+                marketplace="canonical-ua", purchase_request=purchase_request
+            )
     except HTTPError:
         flask.current_app.extensions["sentry"].captureException(
             extra={"purchase_request": purchase_request}


### PR DESCRIPTION
## Done
Add a new endpoint to we can get a preview of the purchase we are about to make(useful to get things like VAT to show the user)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Replace the current JS call to `/advantage/purchase` by `/advantage/purchase/preview` and see it returns a similar response without actually making the purchase.


## Issue / Card

Fixes #8186 