### PR TITLE
Update K8s release chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1243,13 +1243,13 @@ export var kubernetesReleases = [
     startDate: new Date("2019-06-14T00:00:00"),
     endDate: new Date("2020-03-02T00:00:00"),
     taskName: "Kubernetes 1.15",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2019-10-22T00:00:00"),
     endDate: new Date("2020-07-22T00:00:00"),
     taskName: "Kubernetes 1.16",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2020-01-07T00:00:00"),

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1253,19 +1253,19 @@ export var kubernetesReleases = [
   },
   {
     startDate: new Date("2020-01-07T00:00:00"),
-    endDate: new Date("2020-10-07T00:00:00"),
+    endDate: new Date("2020-12-07T00:00:00"),
     taskName: "Kubernetes 1.17",
     status: "CHARMED_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2020-03-24T00:00:00"),
-    endDate: new Date("2020-12-23T00:00:00"),
+    endDate: new Date("2021-02-23T00:00:00"),
     taskName: "Kubernetes 1.18",
     status: "CHARMED_KUBERNETES_SUPPORT",
   },
   {
-    startDate: new Date("2020-06-16T00:00:00"),
-    endDate: new Date("2021-04-16T00:00:00"),
+    startDate: new Date("2020-08-16T00:00:00"),
+    endDate: new Date("2021-06-16T00:00:00"),
     taskName: "Kubernetes 1.19",
     status: "CHARMED_KUBERNETES_SUPPORT",
   },

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -598,7 +598,7 @@
             <tr>
               <td><strong>Kubernetes 1.18</strong></td>
               <td align='right'>Mar 2020</td>
-              <td align='right'>Feb 2020</td>
+              <td align='right'>Feb 2021</td>
             </tr>
             <tr>
               <td><strong>Kubernetes 1.17</strong></td>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -592,18 +592,18 @@
           <tbody>
             <tr>
               <td><strong>Kubernetes 1.19</strong></td>
-              <td align='right'>Jun 2020</td>
-              <td align='right'>Apr 2021</td>
+              <td align='right'>Aug 2020</td>
+              <td align='right'>Jun 2021</td>
             </tr>
             <tr>
               <td><strong>Kubernetes 1.18</strong></td>
               <td align='right'>Mar 2020</td>
-              <td align='right'>Dec 2020</td>
+              <td align='right'>Feb 2020</td>
             </tr>
             <tr>
               <td><strong>Kubernetes 1.17</strong></td>
               <td align='right'>Jan 2020</td>
-              <td align='right'>Oct 2020</td>
+              <td align='right'>Dec 2020</td>
             </tr>
             <tr>
               <td><strong>Kubernetes 1.16</strong></td>


### PR DESCRIPTION
## Done

The delayed release of Kubernetes 1.19 has a knock-on effect for the support chart on https://ubuntu.com/about/release-cycle
This fixes the dates on that chart

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


