### PR TITLE
Add install video to the Kubeflow install page

### DIFF
--- a/templates/kubeflow/install.html
+++ b/templates/kubeflow/install.html
@@ -28,17 +28,22 @@
 </section>
 
 <div class="p-strip is-deep is-bordered" id="instructions">
-  <div class="u-fixed-width">
-    <h2>How to deploy Kubeflow</h2>
-    <p>
-      If you already have Ubuntu or another Linux, the following instructions are all you need. However, if you are on Windows or Mac, consider using <a class="p-link--external" href="https://multipass.run">Multipass</a> to easily create an Ubuntu VM to work with.
-    </p>
-    <p>
-      For a more detailed guide, consider following the <a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Deploy Kubeflow on Ubuntu, Windows and macOS</a> tutorial.
-    </p>
-    <p>
-      The following step assumes you want to install <a class="p-link--external" href="https://microk8s.io/">MicroK8s</a> as your Kubernetes cluster.
-    </p>
+  <div class="row">
+    <div class="col-8">
+      <h2>How to deploy Kubeflow</h2>
+      <p>
+        If you already have Ubuntu or another Linux, the following instructions are all you need. However, if you are on Windows or Mac, consider using <a class="p-link--external" href="https://multipass.run">Multipass</a> to easily create an Ubuntu VM to work with.
+      </p>
+      <p>
+        For a more detailed guide, consider following the <a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Deploy Kubeflow on Ubuntu, Windows and macOS</a> tutorial, or follow the video tutorial below:
+      </p>
+      <p class="u-embedded-media">
+        <iframe title="How to Install Kubeflow on Windows, macOS or Ubuntu" class="u-embedded-media__element" src="https://www.youtube.com/embed/KPEGKKNB63Q" allowfullscreen="" frameborder="0"></iframe>
+      </p>
+      <p>
+        The following steps assume you want to install <a class="p-link--external" href="https://microk8s.io/">MicroK8s</a> as your Kubernetes cluster.
+      </p>
+    </div>
     <ol class="p-stepped-list--detailed">
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">Requirements</h3>


### PR DESCRIPTION
## Done
- Add install video to the Kubeflow install page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/install
- Check that the changes make [the copy doc](https://docs.google.com/document/d/1KVyyvZsDyrfoi5tK2m5SLWs9YuHg9hgqVz0c8cWHsf8/edit?ts=5f4e5feb#)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8203

