### PR TITLE
K8sDocs: Add k8s snap reference page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -389,6 +389,9 @@ kubernetes:
         - title: Snap refresh
           path: /kubernetes/docs/snap-refresh
           hidden: True
+        - title: Kubernetes Snaps
+          path: /kubernetes/docs/snaps
+          hidden: True
         - title: AWS IAM auth
           path: /kubernetes/docs/aws-iam-auth
           hidden: True

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -60,4 +60,5 @@
   - [Certificates and trust](/kubernetes/docs/certs-and-trust)
   - [CIS compliance](/kubernetes/docs/cis-compliance)
   - [Snap refresh settings](/kubernetes/docs/snap-refresh)
+  - [Kubernetes Snaps](/kubernetes/docs/snaps)
   - [Get in touch](/kubernetes/docs/get-in-touch)

--- a/templates/kubernetes/docs/snaps.md
+++ b/templates/kubernetes/docs/snaps.md
@@ -1,0 +1,164 @@
+---
+wrapper_template: "kubernetes/docs/base_docs.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "Kubernetes Snaps"
+  description: How to manage and refresh snaps
+keywords: snaps
+tags: [reference]
+sidebar: k8smain-sidebar
+permalink: snaps.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+**Charmed Kubernetes** makes extensive use of [snaps], both for Kubernetes
+services and for client-side tools to operate a cluster. This page details some
+of the Kubernetes-related snaps available and how they are used.
+
+## Client-side Snaps
+
+The following client tools are available. Note that it is not _required_ that
+you use the Snap version of these tools to work with Charmed Kubernetes, they
+are just provided as a maintained and tested way of keeping up to date.
+
+`kubectl` - client for running commands on a Kubernetes cluster. [Docs][kubectl] &#124; [Snap][kubectl-snap]
+
+`kubeadm` - a tool for bootstrapping a Kubernetes cluster. [Docs][kubeadm] &#124; [Snap][kubeadm-snap]
+
+These are installed in the same way. For example:
+
+```bash
+sudo snap install kubectl --classic
+```
+
+## Server Snaps
+
+When installing **Charmed Kubernetes**, various necessary services are actually
+installed from snap packages. The installation and management of these snaps is
+undertaken by the charms; there is no need for a user to interact with the
+snaps directly. The details here are provided for information only.
+
+
+| Snap | Type | Store page |
+| kube-apiserver | strict | <https://snapcraft.io/kube-apiserver> |
+| kube-controller-manager | strict  | <https://snapcraft.io/kube-controller-manager>  |
+| kube-proxy | classic | <https://snapcraft.io/kube-proxy> |
+| kube-scheduler  |  strict  | <https://snapcraft.io/kube-scheduler>  |
+| kubelet  | classic  | <https://snapcraft.io/kubelet>  |
+
+### Example: kube-apiserver
+
+We will use kube-apiserver as an example. The other services generally work the
+same way.
+
+Install with `snap install`:
+
+```
+sudo snap install kube-apiserver
+```
+
+This creates a systemd service named `snap.kube-apiserver.daemon`. Initially,
+it will be in an error state because it's missing important configuration:
+
+Running:
+
+```bash
+systemctl status snap.kube-apiserver.daemon
+```
+
+... will return status similar to:
+
+```no-highlight
+● snap.kube-apiserver.daemon.service - Service for snap application kube-apiserver.daemon
+   Loaded: loaded (/etc/systemd/system/snap.kube-apiserver.daemon.service; enabled; vendor preset: enabled)
+   Active: inactive (dead) (Result: exit-code) since Fri 2020-09-01 15:54:39 UTC; 11s ago
+   ...
+```
+
+The snap can be configured using `snap set`:
+
+```bash
+sudo snap set kube-apiserver args="
+--etcd-servers=https://172.31.9.254:2379
+--etcd-certfile=/root/certs/client.crt
+--etcd-keyfile=/root/certs/client.key
+--etcd-cafile=/root/certs/ca.crt
+--service-cluster-ip-range=10.123.123.0/24
+--cert-dir=/root/certs
+"
+```
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+  Note: Any files used by the service, such as certificate files, must be
+  placed within the /root/ directory to be visible to the service. This
+  limitation allows us to run a few of the services in a strict confinement
+  mode that offers better isolation and security.
+  </p>
+</div>
+
+
+After configuring, restart the service and you should see it running:
+
+```bash
+sudo snap restart kube-apiserver
+systemctl status snap.kube-apiserver.daemon
+```
+```no-highlight
+● snap.kube-apiserver.daemon.service - Service for snap application kube-apiserver.daemon
+   Loaded: loaded (/etc/systemd/system/snap.kube-apiserver.daemon.service; enabled; vendor preset: enabled)
+   Active: active (running) since Fri 2017-09-01 16:02:33 UTC; 6s ago
+   ...
+```
+
+## Going further
+
+Want to know more? Here are a couple good things to know:
+
+If you're confused about what `snap set ...` is actually doing, you can read
+the snap configure hooks in `/snap/<snap-name>/current/meta/hooks/configure` to
+see how they work.
+
+The configure hook creates an args file at `/var/snap/<snap-name>/current/args`.
+This contains the actual arguments that get passed to the service by the snap:
+```
+--cert-dir "/root/certs"
+--etcd-cafile "/root/certs/ca.crt"
+--etcd-certfile "/root/certs/client.crt"
+--etcd-keyfile "/root/certs/client.key"
+--etcd-servers "https://172.31.9.254:2379"
+--service-cluster-ip-range "10.123.123.0/24"
+```
+
+<div class="p-notification--information">
+  <p class="p-notification__response">
+  Note: While you can technically bypass `snap set` and edit the args file
+  directly, it's best not to do so. The next time the configure hook runs, it
+  will obliterate your changes. This can occur not only from a call to
+  snap set` but also during a background refresh of the snap.
+  </p>
+</div>
+
+The source code for the snaps can be found here:
+
+<https://launchpad.net/snap-kubectl>
+<https://launchpad.net/snap-kubeadm>
+<https://launchpad.net/snap-kube-apiserver>
+<https://launchpad.net/snap-kube-controller-manager>
+<https://launchpad.net/snap-kube-scheduler>
+<https://launchpad.net/snap-kubelet>
+<https://launchpad.net/snap-kube-proxy>
+
+
+
+<!-- LINKS -->
+
+[snaps]: https://snapcraft.io/docs
+[kubectl]: https://kubernetes.io/docs/reference/kubectl/overview/
+[kubeadm]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/
+[kubefed]: https://github.com/kubernetes-sigs/kubefed
+[kubeadm-snap]: https://snapcraft.io/kubeadm
+[kubefed-snap]: https://snapcraft.io/kubefed
+[kubectl-snap]: https://snapcraft.io/kubectl

--- a/templates/kubernetes/docs/snaps.md
+++ b/templates/kubernetes/docs/snaps.md
@@ -134,10 +134,10 @@ This contains the actual arguments that get passed to the service by the snap:
 
 <div class="p-notification--information">
   <p class="p-notification__response">
-  Note: While you can technically bypass `snap set` and edit the args file
+  Note: While you can technically bypass <code>snap set</code> and edit the args file
   directly, it's best not to do so. The next time the configure hook runs, it
   will obliterate your changes. This can occur not only from a call to
-  snap set` but also during a background refresh of the snap.
+  <code>snap set</code> but also during a background refresh of the snap.
   </p>
 </div>
 

--- a/templates/kubernetes/docs/snaps.md
+++ b/templates/kubernetes/docs/snaps.md
@@ -42,6 +42,7 @@ snaps directly. The details here are provided for information only.
 
 
 | Snap | Type | Store page |
+|------|------|------------|
 | kube-apiserver | strict | <https://snapcraft.io/kube-apiserver> |
 | kube-controller-manager | strict  | <https://snapcraft.io/kube-controller-manager>  |
 | kube-proxy | classic | <https://snapcraft.io/kube-proxy> |
@@ -59,7 +60,7 @@ Install with `snap install`:
 sudo snap install kube-apiserver
 ```
 
-This creates a systemd service named `snap.kube-apiserver.daemon`. Initially,
+This creates a `systemd` service named `snap.kube-apiserver.daemon`. Initially,
 it will be in an error state because it's missing important configuration:
 
 Running:
@@ -123,6 +124,7 @@ see how they work.
 
 The configure hook creates an args file at `/var/snap/<snap-name>/current/args`.
 This contains the actual arguments that get passed to the service by the snap:
+
 ```
 --cert-dir "/root/certs"
 --etcd-cafile "/root/certs/ca.crt"
@@ -144,11 +146,17 @@ This contains the actual arguments that get passed to the service by the snap:
 The source code for the snaps can be found here:
 
 <https://launchpad.net/snap-kubectl>
+
 <https://launchpad.net/snap-kubeadm>
+
 <https://launchpad.net/snap-kube-apiserver>
+
 <https://launchpad.net/snap-kube-controller-manager>
+
 <https://launchpad.net/snap-kube-scheduler>
+
 <https://launchpad.net/snap-kubelet>
+
 <https://launchpad.net/snap-kube-proxy>
 
 

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -20,9 +20,68 @@ Current Release: **1.18**
 
 Supported releases: **1.18.x, 1.17.x, 1.16.x**
 
+## Charmed Kubernetes bundle versions
+
+The **Juju Charm Store** hosts the **Charmed Kubernetes** bundles as well as
+individual charms. To deploy the latest, stable bundle, run the command:
+
+```bash
+juju deploy charmed-kubernetes
+```
+
+It is also possible to deploy a specific version of the bundle by including the
+revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.14
+release, you could run:
+
+```bash
+juju deploy cs:~containers/charmed-kubernetes-124
+```
+
+<div class="p-notification--positive">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Older Versions:</span>
+Previous versions of <strong>Charmed Kubernetes</strong> used the name
+<code>canonical-kubernetes</code>. These versions are still available under that name
+and links in the charm store. Versions from 1.14 onwards will use
+<code>charmed-kubernetes</code>.
+  </p>
+</div>
+
+
+The revision numbers for bundles are generated automatically when the bundle is
+updated, including for testing and beta versions, so it isn't always the case
+that a higher revision number is 'better'. The revision numbers for the release
+versions of the **Charmed Kubernetes** bundle are shown in the table below:
+
+<a  id="table"></a>
+
+| Kubernetes version | Charmed Kubernetes bundle |
+| --- | --- |
+| 1.18.x         | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |
+| 1.17.x         | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |
+| 1.16.x         | [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-316/archive/bundle.yaml) |
+| 1.15.x         | [charmed-kubernetes-209](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-209/archive/bundle.yaml) |
+| 1.14.x         | [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml) |
+| 1.13.x         | [canonical-kubernetes-435](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-435/archive/bundle.yaml?channel=stable) |
+| 1.12.x         | [canonical-kubernetes-357](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-357/archive/bundle.yaml?channel=stable) |
+| 1.11.x         | [canonical-kubernetes-254](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-254/archive/bundle.yaml?channel=stable) |
+| 1.10.x         | [canonical-kubernetes-211](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-211/archive/bundle.yaml?channel=stable)  |
+| 1.9.x        | [canonical-kubernetes-179](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-179/archive/bundle.yaml?channel=stable) |
+| 1.8.x | [canonical-kubernetes-132](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-132/archive/bundle.yaml?channel=stable) |
+| 1.7.x | [canonical-kubernetes-101](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-101/archive/bundle.yaml?channel=stable) |
+| 1.6.x | [canonical-kubernetes-38](https://api.jujucharms.com/charmstore/v5/~containers/bundle/canonical-kubernetes-38/archive/bundle.yaml?channel=stable) |
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Note:</span>
+Only the latest three versions of Charmed Kubernetes are supported at any time.
+  </p>
+</div>
+
+
 ## Finding version info
 
-To check which versions are available, use the `snap info` command:
+To check which versions of Kubernetes are available, use the `snap info` command:
 
 ```bash
 snap info kube-apiserver


### PR DESCRIPTION
## Done

Update supported versions: https://github.com/charmed-kubernetes/kubernetes-docs/pull/460
Add reference page for K8s snaps: https://github.com/charmed-kubernetes/kubernetes-docs/pull/453

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


