### PR TITLE
Add webinar to the enterprise kubernetes engagement

### DIFF
--- a/templates/engage/kubernetes-deployment-enterprise-whitepaper.md
+++ b/templates/engage/kubernetes-deployment-enterprise-whitepaper.md
@@ -10,9 +10,11 @@ context:
   header_image: "https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg"
   header_image_width: "240"
   header_image_height: "234"
-  header_url: "#register-section"
-  header_cta: "Download whitepaper"
+  header_url:
+  header_cta:
   header_class: p-engage-banner--dark
+  header_supplemental: '<br /><p><a href="#register-section" class="p-button--positive">Download the whitepaper</a> <a href="#webinar" class="p-button--neutral">Watch the webinar</a></p>'
+  webinar_code: '<div id="webinar" class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 435999, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
   form_id: 3648
   form_return_url: "https://pages.ubuntu.com/rs/066-EOV-335/images/five-kubernetes-strategies-enterprise.pdf"
 ---


### PR DESCRIPTION
## Done
Add webinar to the enterprise kubernetes engagement

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/kubernetes-deployment-enterprise-whitepaper
- Check there is a secondary webinar CTA
- Click it to see the embedded webinar
- Check it matches [the brief](https://docs.google.com/document/d/1vDjaIyerf_5TB3y1wP93kU8gOtd8PMYsNVJYMfne_4k/edit)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3110

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/92009787-edb56780-ed40-11ea-9f75-da4ae544d45b.png)

