### PR TITLE
Build the new internet-of-things modal

### DIFF
--- a/templates/core/build/index.html
+++ b/templates/core/build/index.html
@@ -236,7 +236,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 {% endif %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -853,7 +853,7 @@
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -406,7 +406,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="2639" data-lp-id="5811" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=appstore" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="2639" data-lp-id="5811" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=appstore" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -337,7 +337,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1422" data-lp-id="2166" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1422" data-lp-id="2166" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -377,7 +377,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below -->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=gateways" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=gateways" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -431,7 +431,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/internet-of-things/networking.html
+++ b/templates/internet-of-things/networking.html
@@ -96,7 +96,7 @@
     </div>
 
     <div class="col-5">
-      <ul class="p-list u-no-margin--bottom">          
+      <ul class="p-list u-no-margin--bottom">
         <li class="p-list__item is-ticked">Ecosystems for datacenter software vendors</li>
         <li class="p-list__item is-ticked">NFV as a service</li>
         <li class="p-list__item is-ticked">Lower development cost</li>
@@ -234,7 +234,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="3484" data-lp-id="" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=networking" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="3484" data-lp-id="" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=networking" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -26,16 +26,16 @@
           <h3 class="p-heading--five">When do you need to ship?</h3>
           <div class="row u-no-padding">
             <div class="col-4 u-sv3">
-              <input type="radio" id="shipping-time-next-3-months" name="shipping-time" value="In the next 3 months">
-              <label for="shipping-time-next-3-months">In the next 3 months</label>
-              <input type="radio" id="shipping-time-next-6-months" name="shipping-time" value="In the next 6 months">
-              <label for="shipping-time-next-6-months">In the next 6 months</label>
+              <input type="radio" id="shipping-time-next-3-months" name="shipping-time" value="Next 3 months">
+              <label for="shipping-time-next-3-months">Next 3 months</label>
+              <input type="radio" id="shipping-time-next-3-6-months" name="shipping-time" value="Next 3 - 6 months">
+              <label for="shipping-time-next-3-6-months">Next 3 - 6 months</label>
             </div>
             <div class="col-4 u-sv3">
-              <input type="radio" id="shipping-time-next-12-months" name="shipping-time" value="In the next 12 months">
-              <label for="shipping-time-next-12-months">In the next 12 months</label>
-              <input type="radio" id="shipping-time-do-not-know" name="shipping-time" value="Don't know">
-              <label for="shipping-time-do-not-know">Don&rsquo;t know</label>
+              <input type="radio" id="shipping-time-next-6-12-months" name="shipping-time" value="Next 6 - 12 months">
+              <label for="shipping-time-next-6-12-months">Next 6 - 12 months</label>
+              <input type="radio" id="shipping-time-no-timeline" name="shipping-time" value="No timeline - just researching">
+              <label for="shipping-time-no-timeline">No timeline - just researching</label>
             </div>
           </div>
           <div class="row u-no-padding">
@@ -70,7 +70,7 @@
                 <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
+                <label for="Email" class="mktoLabel">Work email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -1,0 +1,150 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Let’s get your project to market faster!</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <p id="modal-description" class="u-no-max-width">Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster.</p>
+      <p class="u-no-max-width u-no-margin--bottom">Tell us about your project so we can bring the right Canonical team members to the conversation to help you.</p>
+
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Do you have a commercial project?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="radio" id="commerical-project-yes" name="commercial-project" value="Yes">
+            <label for="commerical-project-yes">Yes</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="radio" id="commercial-project-no" name="commercial-project" value="No">
+            <label for="commercial-project-no">No</label>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <div class="u-sv3">
+          <h3 class="p-heading--five">When do you need to ship?</h3>
+          <div class="row u-no-padding">
+            <div class="col-4 u-sv3">
+              <input type="radio" id="shipping-time-next-3-months" name="shipping-time" value="In the next 3 months">
+              <label for="shipping-time-next-3-months">In the next 3 months</label>
+              <input type="radio" id="shipping-time-next-6-months" name="shipping-time" value="In the next 6 months">
+              <label for="shipping-time-next-6-months">In the next 6 months</label>
+            </div>
+            <div class="col-4 u-sv3">
+              <input type="radio" id="shipping-time-next-12-months" name="shipping-time" value="In the next 12 months">
+              <label for="shipping-time-next-12-months">In the next 12 months</label>
+              <input type="radio" id="shipping-time-do-not-know" name="shipping-time" value="Don't know">
+              <label for="shipping-time-do-not-know">Don&rsquo;t know</label>
+            </div>
+          </div>
+          <div class="row u-no-padding">
+            <div class="col-6 u-sv3">
+              <label for="about-project">Tell us more about your project</label>
+              <textarea name="about-project" id="about-project"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="pagination">
+          <a class="p-button--positive pagination__link--next" href="">Next</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Company" class="mktoLabel">Company:</label>
+                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Email address:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about embedded Ubuntu</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done
- Build the new internet-of-things modal
- Apply it to /core and /internet-of-things sections

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things#get-in-touch
- See that the contact modal matches the [copydoc](https://docs.google.com/document/d/1t8k61sE5AopyvsXuMoyNDAghdnrjH4TlRdDGT4tqAes/edit#)
- Jump to /core#get-in-touch and see its the same.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3126
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3127

