### PR TITLE
Build IT da-vmware-a-openstack engagment

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1022,6 +1022,13 @@
     type="whitepaper" %}
     {% include "engage/_article-card.html" %}
     {% endwith %}
+
+    {% with title="Da VMware a OpenStack",
+    description=" Come la migrazione a Charmed OpenStack può ridurre significativamente il TCO",
+    slug="it/da-vmware-a-openstack",
+    type="whitepaper" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
   </div>
 
 </section>

--- a/templates/engage/it/da-vmware-a-openstack.md
+++ b/templates/engage/it/da-vmware-a-openstack.md
@@ -1,0 +1,33 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Da VMware a OpenStack"
+     meta_description: "Migrate da VMware a Charmed OpenStack per ridurre i costi e aumentare l'efficienza dell'infrastruttura."
+     meta_image: https://assets.ubuntu.com/v1/3b41cf7c-da-vmware-a-openstack.jpg
+     meta_copydoc: https://docs.google.com/spreadsheets/d/1wBLTslfNHJrEK4mwhIitXj_2qWtlf4JAoZJjefe0fe4/edit#gid=123679107
+     header_title: "Da VMware a OpenStack"
+     header_subtitle: "Come la migrazione a Charmed OpenStack può ridurre significativamente il TCO"
+     header_image: "https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg"
+     header_image_width: "250"
+     header_image_height: "160"
+     header_url: '#register-section'
+     header_cta: "Scarica il whitepaper"
+     header_class: p-engage-banner--dark
+     header_lang: it
+     form_include: it
+     form_id: 3682
+     form_return_url: "https://pages.ubuntu.com/CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack_LPWhitepaperVMwaretoOpenStackES-TYvanilla.html"
+---
+
+A causa dei costi associati alle licenze, all'assistenza e ai servizi professionali VMware, molti non sono in grado di raggiungere il loro obiettivo primario: ridurre significativamente il TCO. Alla ricerca di soluzioni alternative, le organizzazioni hanno recentemente iniziato a esplorare altre piattaforme open-source come OpenStack.
+
+Questo whitepaper:
+
+<ul class="p-list">
+     <li class="p-list__item is-ticked">Confronta l'offerta di virtualizzazione proprietaria di VMware con un approccio open-source, l'OpenStack Charmed di Canonical.</li>
+     <li class="p-list__item is-ticked">Presenta i vantaggi economici e di efficienza derivanti dall'adozione di un approccio open-source.</li>
+     <li class="p-list__item is-ticked">Fornisce un'analisi dettagliata dei costi che evidenzia i risparmi che un'organizzazione può realizzare migrando da VMware a Charmed OpenStack.</li>
+</ul>
+Inoltre, guardate il webinar "Da VMware a Charmed OpenStack" per una dimostrazione che mostra come migrare un carico di lavoro IT da VMware a Charmed OpenStack utilizzando la migrazione del cloud come strumento di servizio delle soluzioni Cloudbase - Coriolis®.
+
+Coriolis è il modo più semplice per migrare le macchine virtuali Windows o Linux insieme alle relative configurazioni di archiviazione e di rete su più piattaforme cloud. Tra i vantaggi di Coriolis vi sono l'architettura scalabile, il design senza agenti, il pianificatore integrato e le API REST che consentono operazioni automatizzate.

--- a/templates/engage/it/da-vmware-a-openstack.md
+++ b/templates/engage/it/da-vmware-a-openstack.md
@@ -16,7 +16,7 @@ context:
      header_lang: it
      form_include: it
      form_id: 3682
-     form_return_url: "https://pages.ubuntu.com/CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack_LPWhitepaperVMwaretoOpenStackES-TYvanilla.html"
+     form_return_url: "https://pages.ubuntu.com/CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack_DA-VMware-a-OpenStack.html"
 ---
 
 A causa dei costi associati alle licenze, all'assistenza e ai servizi professionali VMware, molti non sono in grado di raggiungere il loro obiettivo primario: ridurre significativamente il TCO. Alla ricerca di soluzioni alternative, le organizzazioni hanno recentemente iniziato a esplorare altre piattaforme open-source come OpenStack.

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,0 +1,71 @@
+<!-- MARKETO FORM -->
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <ul class="p-list">
+      <li class="mktFormReq mktField p-list__item">
+        <label for="FirstName" class="mktoLabel">Nome:</label>
+        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+          aria-label="Nome">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="LastName" class="mktoLabel ">Cognome:</label>
+        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+          aria-label="Cognome">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Email" class="mktoLabel ">E-mail lavorativa:</label>
+        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+          aria-label="E-mail lavorativa">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Company" class="mktoLabel ">Nome società:</label>
+        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+          aria-label="Nome società">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Title" class="mktoLabel ">Titolo lavorativo:</label>
+        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Titolo lavorativo">
+      </li>
+      <li class="mktFormReq mktField">
+        <label for="Phone" class="mktoLabel ">Numero di telefono:</label>
+        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+          aria-label="Numero di telefono">
+      </li>
+      <li class="mktField">
+        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+          type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+      </li>
+      <li class="mktField">
+        <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
+          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">Accetto di ricevere informazioni sui prodotti e servizi Canonical.</label>
+      </li>
+      <li class="mktField">
+        <p>Inviando questo modulo, confermo di aver letto e di accettare la Nota sulla <a href="/legal/data-privacy/contact">Privacy e l'Informativa</a> sulla <a href="/legal/data-privacy">Privacy di Canonical.</a>
+          <input name="RichText" aria-label="RichText" type="hidden">
+        </p>
+      </li>
+      <li class="mktField">
+        <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
+      </li>
+      <li class="mktField">
+        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      </li>
+      <li class="mktField">
+        <button type="submit" class="mktoButton u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Scarica il whitepaper{% endif %}</button>
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+        <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+        <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
+        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+      </li>
+    </ul>
+  </fieldset>
+</form>
+<!-- /MARKETO FORM -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,9 @@
 
   {# PORTUGUESE #}
   {% include "takeovers/pt/_vmware-para-o-openstack.html" %}
+
+  {# ITALIAN #}
+  {% include "takeovers/it/_da-vmware-a-openstack.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -166,4 +166,6 @@
 {% include "takeovers/_smartstart.html" %}
 <p>27 August 2020</p>
 {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
+<p>2 September 2020</p>
+{% include "takeovers/it/_da-vmware-a-openstack.html" %}
 {% endblock %}

--- a/templates/takeovers/it/_da-vmware-a-openstack.html
+++ b/templates/takeovers/it/_da-vmware-a-openstack.html
@@ -1,0 +1,15 @@
+{% with title="Da VMware a OpenStack",
+subtitle="Come la migrazione a Charmed OpenStack può ridurre significativamente il TCO",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+image_style="width: 300px;",
+image_hide_small="",
+equal_cols="true",
+primary_url="/engage/it/da-vmware-a-openstack?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack",
+primary_cta="Scarica il whitepaper",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+lang="it" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done
- Build the engage page
- Build the takeover page
- Add them to all three indexes
- Added IT engage form

**Blocked** Waiting for the TY page content to be updated: https://pages.ubuntu.com/CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack_LPWhitepaperVMwaretoOpenStackES-TYvanilla.html

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/it/da-vmware-a-openstack and check the content matches [the copy doc](https://docs.google.com/spreadsheets/d/1wBLTslfNHJrEK4mwhIitXj_2qWtlf4JAoZJjefe0fe4/edit#gid=1833127475) and [brief](https://docs.google.com/spreadsheets/d/1lY3C-8GJ4oboM8dyozvnKtib6p_EVD3F3VzMWR58hFc/edit#gid=2113339190)
- Change your browser lang to "it" and refresh the homepage to see the "Da VMware a OpenStack" takeover
- See its added to the /takeovers and /engage indexes.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8183

