### PR TITLE
Update powerful to scalable in the GSI engagement

### DIFF
--- a/templates/engage/gsi-webinar-series.html
+++ b/templates/engage/gsi-webinar-series.html
@@ -1,6 +1,6 @@
 {% extends "engage/base_engage.html" %}
 
-{% block title %}Building powerful customer solutions{% endblock %}
+{% block title %}Building scalable customer solutions{% endblock %}
 
 {% block meta_description %}A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments{% endblock %}
 
@@ -33,7 +33,7 @@
     <div class="col-7  u-vertically-center">
       <div>
         <h1>
-          Building powerful customer solutions
+          Building scalable customer solutions
         </h1>
         <h4>
           A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -977,7 +977,7 @@
     {% include "engage/_article-card.html" %}
     {% endwith %}
 
-    {% with title="Building powerful customer solutions",
+    {% with title="Building scalable customer solutions",
     description="A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments",
     slug="gsi-webinar-series",
     type="webinar" %}

--- a/templates/takeovers/_gsi-webinar-series-takeover.html
+++ b/templates/takeovers/_gsi-webinar-series-takeover.html
@@ -1,4 +1,4 @@
-{% with title="Building powerful customer solutions",
+{% with title="Building scalable customer solutions",
 subtitle="A webinar series for GSIs seizing new models for scalable, automated and repeatable deployments",
 class="p-takeover--dark",
 header_image="https://assets.ubuntu.com/v1/1224031f-1-Discovery.svg",


### PR DESCRIPTION
## Done
- Update the copy based on a request in [the copy doc](https://docs.google.com/document/d/1ZweTXyHO9kIU9aE8pw2_Ni_NoBShM_KseY5H2XtGueg/edit).

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/gsi-webinar-series
- Check the word has changed

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8214

