### PR TITLE
Advantage shop polish

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.develop.canonical.com/
+CONTRACTS_API_URL=https://contracts.staging.canonical.com/
 STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do

--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_API_URL=https://contracts.staging.canonical.com/
-STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
+STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.canonical.com/
+CONTRACTS_API_URL=https://contracts.develop.canonical.com/
 STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -178,7 +178,9 @@ function productSelector() {
         }">
           <button class="p-button${
             action === "add" ? "--positive" : ""
-          } u-no-margin--bottom js-cart-action" data-image-url="${imageURL}" data-action="${action}" data-product-id="${productId}" data-quantity=${quantity}>${action}</button>
+          } u-no-margin--bottom js-cart-action" data-image-url="${imageURL}" data-action="${action}" data-product-id="${productId}" data-quantity=${quantity} tabindex="${
+      productId ? "" : "-1"
+    }">${action}</button>
         </div>
       </div>
     `;
@@ -204,7 +206,14 @@ function productSelector() {
       const wrapper = form.querySelector(`${stepClassPrefix}${step}`);
 
       if (wrapper) {
+        const tabbableItems = wrapper.querySelectorAll(
+          "input, .p-tabs__link, button, a"
+        );
+
         wrapper.classList.add("u-disable");
+        tabbableItems.forEach((item) => {
+          item.setAttribute("tabindex", "-1");
+        });
       }
     });
   }
@@ -214,7 +223,14 @@ function productSelector() {
       const wrapper = form.querySelector(`${stepClassPrefix}${step}`);
 
       if (wrapper) {
+        const tabbableItems = wrapper.querySelectorAll(
+          "input, .p-tabs__link, button, a"
+        );
+
         wrapper.classList.remove("u-disable");
+        tabbableItems.forEach((item) => {
+          item.removeAttribute("tabindex");
+        });
       }
     });
   }
@@ -363,16 +379,20 @@ function productSelector() {
     let stepsToDisable;
     let i = 0;
 
-    steps.forEach((step) => {
-      if (stepsToEnable === undefined) {
-        if (!state.get(step)[0]) {
-          stepsToEnable = steps.slice(0, i + 1);
-          stepsToDisable = steps.slice(i + 1);
-        } else if (i < steps.length) {
-          i++;
+    if (window.accountId) {
+      steps.forEach((step) => {
+        if (stepsToEnable === undefined) {
+          if (!state.get(step)[0]) {
+            stepsToEnable = steps.slice(0, i + 1);
+            stepsToDisable = steps.slice(i + 1);
+          } else if (i < steps.length) {
+            i++;
+          }
         }
-      }
-    });
+      });
+    } else {
+      stepsToDisable = steps;
+    }
 
     if (stepsToEnable) {
       enableSteps(stepsToEnable);

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -267,6 +267,10 @@ function productSelector() {
         }
       });
     }
+
+    if (formStage && input.value > 0) {
+      scrollToStep("version");
+    }
   }
 
   function handleStepSpecificAction(inputElement) {
@@ -290,6 +294,7 @@ function productSelector() {
         } else {
           quantityTypeEl.innerHTML = `How many ${inputElement.dataset.productName}s?`;
           state.set(inputElement.name, [inputElement.value]);
+          scrollToStep("quantity");
         }
 
         break;
@@ -297,6 +302,14 @@ function productSelector() {
         debounce(function () {
           handleQuantityInputs(inputElement);
         }, 500)();
+        break;
+      case "support":
+        state.set(inputElement.name, [inputElement.value]);
+        scrollToStep("add");
+        break;
+      case "add":
+        state.set(inputElement.name, [inputElement.value]);
+        scrollToStep("cart");
         break;
       default:
         state.set(inputElement.name, [inputElement.value]);
@@ -334,6 +347,15 @@ function productSelector() {
     state.reset("support");
     state.reset("add");
     form.reset();
+  }
+
+  function scrollToStep(step) {
+    const stepWrapper = document.querySelector(`${stepClassPrefix}${step}`);
+
+    window.scrollTo({
+      top: stepWrapper.offsetTop,
+      behavior: "smooth",
+    });
   }
 
   function setActiveSteps() {

--- a/templates/advantage/subscribe.html
+++ b/templates/advantage/subscribe.html
@@ -14,14 +14,16 @@
       <div class="col-12 u-sv3">
         <h1>Subscribe to Ubuntu Advantage</h1>
 
-        {% if not user_info %}          
-          <p>If you have existing subscriptions or sales offers, <a href="/login" onclick="dataLayer.push({
+        {% if not user_info and not account %}          
+          <p>Sign in to begin.</p> 
+          
+          <a class="p-button" href="/login" onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage subscribe',
               'eventAction' : 'Authentication',
               'eventLabel' : 'Sign in',
               'eventValue' : undefined
-            });">sign in</a> to access them.</p>
+            });">Sign in</a></p>
         {% endif %}
       </div>
     </div>

--- a/tests/cassettes/TestRoutes.test_advantage.yaml
+++ b/tests/cassettes/TestRoutes.test_advantage.yaml
@@ -11,7 +11,7 @@ interactions:
         User-Agent:
           - python-requests/2.23.0
       method: GET
-      uri: https://contracts.canonical.com/v1/accounts
+      uri: https://contracts.develop.canonical.com/v1/accounts
     response:
       body:
         string: '{"code":"unauthorized","message":"unauthorized","traceId":"cc123f07-176b-49a3-bac2-9429c876f888"}'

--- a/tests/cassettes/TestRoutes.test_advantage.yaml
+++ b/tests/cassettes/TestRoutes.test_advantage.yaml
@@ -11,7 +11,7 @@ interactions:
         User-Agent:
           - python-requests/2.23.0
       method: GET
-      uri: https://contracts.develop.canonical.com/v1/accounts
+      uri: https://contracts.staging.canonical.com/v1/accounts
     response:
       body:
         string: '{"code":"unauthorized","message":"unauthorized","traceId":"cc123f07-176b-49a3-bac2-9429c876f888"}'

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -6,7 +6,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.canonical.com",
+        api_url="https://contracts.develop.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -6,7 +6,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.develop.canonical.com",
+        api_url="https://contracts.staging.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -83,7 +83,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.canonical.com"
+    "CONTRACTS_API_URL", "https://contracts.develop.canonical.com"
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -83,7 +83,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.develop.canonical.com"
+    "CONTRACTS_API_URL", "https://contracts.staging.canonical.com"
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -646,21 +646,25 @@ def advantage_shop_view():
         )
 
         try:
-            # TODO: this is placeholder, the CS team are working
-            # on returning more information in this request, such
-            # as whether the user is an admin on a given account.
-            # Until then, for demo purposes, we assume the first
-            # account in the returned array will suffice.
             accounts = advantage.get_accounts()
-            account = accounts[0]
-            subs = advantage.get_account_subscriptions_for_marketplace(
-                account["id"], "canonical-ua"
-            )
+            # At the moment, a user should only ever be admin on
+            # one account, but there's a desire to allow users
+            # to make purchases on multiple accounts
+            admin_accounts = get_admin_accounts(accounts)
+            account = None
 
-            if "subscriptions" in subs:
-                subscription = subs["subscriptions"][0]
-                if "lastPurchaseID" in subscription:
-                    previous_purchase_id = subscription["lastPurchaseID"]
+            if admin_accounts:
+                account = admin_accounts[0]
+
+            if account:
+                subs = advantage.get_account_subscriptions_for_marketplace(
+                    account["id"], "canonical-ua"
+                )
+
+                if "subscriptions" in subs:
+                    subscription = subs["subscriptions"][0]
+                    if "lastPurchaseID" in subscription:
+                        previous_purchase_id = subscription["lastPurchaseID"]
         except HTTPError as http_error:
             if http_error.response.status_code == 401:
                 # We got an unauthorized request, so we likely
@@ -719,6 +723,18 @@ def advantage_shop_view():
         account=account,
         previous_purchase_id=previous_purchase_id,
     )
+
+
+def get_admin_accounts(accounts):
+    admin_accounts = []
+
+    for account in accounts:
+        if "externalAccountIDs" in account:
+            for ext_account_id in account["externalAccountIDs"]:
+                if ext_account_id["origin"] == "Salesforce":
+                    admin_accounts.append(account)
+
+    return admin_accounts
 
 
 def make_renewal(advantage, contract_info):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -362,7 +362,7 @@ def advantage_view():
     new_subscription_id = None
     open_subscription = flask.request.args.get("subscription", None)
     stripe_publishable_key = os.getenv(
-        "STRIPE_PUBLISHABLE_KEY", "pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp"
+        "STRIPE_PUBLISHABLE_KEY", "pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46"
     )
 
     if user_info(flask.session):
@@ -635,7 +635,7 @@ def advantage_shop_view():
     account = None
     previous_purchase_id = None
     stripe_publishable_key = os.getenv(
-        "STRIPE_PUBLISHABLE_KEY", "pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp"
+        "STRIPE_PUBLISHABLE_KEY", "pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46"
     )
 
     if user_info(flask.session):


### PR DESCRIPTION
## Done

- Added a check to make sure a user is an admin on one of their accounts
- The product selection form now scrolls between steps
- If the user is not logged in, or doesn't have an account with admin permissions, prevents the user being able to select a product
  - Temporary, until guest checkout can be implemented
- Prevents tabbing to inputs within `u-disable` sections

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Assuming you are not signed in, the form should be disabled
  - You should also not be able to tab to any of the inputs
- Follow the link to login with SSO, and do so
- When you are returned to the page, you should see the first section of the form is enabled (if not, you don't have an account with admin permissions, Scott can help you)
- Try to tab to inputs in sections that are disabled, you should not be able to


## Issue / Card

Fixes #8182
