### PR TITLE
Change user auth config

### DIFF
--- a/webapp/security/auth.py
+++ b/webapp/security/auth.py
@@ -7,7 +7,12 @@ from launchpadlib.launchpad import Launchpad
 from macaroonbakery import bakery, checkers, httpbakery
 from functools import wraps
 
-AUTHORIZED_TEAMS = ["canonical-security", "canonical-webmonkeys"]
+AUTHORIZED_TEAMS = [
+    "canonical-security-web",
+    "canonical-security",
+    "canonical-webmonkeys",
+]
+
 IDENTITY_CAVEATS = [
     checkers.need_declared_caveat(
         checkers.Caveat(
@@ -78,7 +83,7 @@ def authorization_required(func):
         except bakery._error.DischargeRequiredError:
             macaroon = macaroon_bakery.oven.macaroon(
                 version=bakery.VERSION_2,
-                expiry=datetime.utcnow() + timedelta(days=1),
+                expiry=datetime.utcnow() + timedelta(weeks=4),
                 caveats=IDENTITY_CAVEATS,
                 ops=[bakery.LOGIN_OP],
             )


### PR DESCRIPTION
Add `canonical-security-web` group to the list of groups allowed to make
api calls.

Make the life the of the token longer. This way the import of the data
will be able to go uninterrupted for longer.

## Issue / Card

Fixes #8216 
