### PR TITLE
Remove extraneous closing tag on index

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -132,7 +132,6 @@
       </ul>
     </div>
   </div>
-</div>
 </section>
 
 <noscript>


### PR DESCRIPTION
## Done

- Removed extra closing tag breaking the #main-content div where it shouldn't

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the #main-content div on the homepage contains everything that's between nav areas (mega menu, footer)
- Ensure link clicks in main-content are received as GA events ( :heavy_check_mark:  Yes, they are now)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8221

