### PR TITLE
Kubernetes 1.19 blog redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -815,6 +815,7 @@ blog/home/?: /
 # specific article redirects
 blog/event/mobile-world-congress-2018/?:  /blog/nvidia-gtc-2018
 blog/(2019/02/05/)?ubuntu-14-04-trusty-tahr-end-of-life/?: /blog/ubuntu-14-04-trusty-tahr
+blog/kubernetes-1-19-available-from-canonical%EF%BB%BF: /blog/kubernetes-1-19-available-from-canonical
 
 # Move snappy topic to snapcraft
 blog/topics/snappy/?: /blog/topics/snapcraft


### PR DESCRIPTION
## Done

- Redirect initial messed up blog post URL to new URL (because already posted on social :( )

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the redirect works (won't work on the demo)
