### PR TITLE
Check Stripe env when attempting to send GA events on /advantage

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -668,7 +668,7 @@ function sendGAEvent(label) {
     dataLayer.push({
       event: "GAEvent",
       eventCategory: "advantage",
-      eventAction: "renewal",
+      eventAction: currentTransaction.type,
       eventLabel: label,
       eventValue: undefined,
     });

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -664,13 +664,15 @@ function resetProgressIndicator() {
 }
 
 function sendGAEvent(label) {
-  dataLayer.push({
-    event: "GAEvent",
-    eventCategory: "advantage",
-    eventAction: "renewal",
-    eventLabel: label,
-    eventValue: undefined,
-  });
+  if (window.stripePublishableKey.includes("pk_live_")) {
+    dataLayer.push({
+      event: "GAEvent",
+      eventCategory: "advantage",
+      eventAction: "renewal",
+      eventLabel: label,
+      eventValue: undefined,
+    });
+  }
 }
 
 function setupCardElements() {


### PR DESCRIPTION
## Done

For shop & renewals, added a check to see whether we're using the Stripe prod or test environment (Stripe key in prod begins with "pk_live", and in test it's "pk_test"), and prevent GA events from being fired outside of production.

Also updated the event action, so we know whether the transaction was a renewal or a purchase.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Install and activate the [GA debugger](https://addons.mozilla.org/en-GB/firefox/addon/ga-debugger/)
- Open your browser's console
- Select a product, add it to cart, and open the payment modal
- The console should show no GA activity when you open the modal
