### PR TITLE
Correctly send form submission GA event

### DIFF
--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -142,7 +142,7 @@
       };
 
       if (submitButton) {
-        closeModal.addEventListener("click", function () {
+        submitButton.addEventListener("click", function () {
           ga(
             "send",
             "event",


### PR DESCRIPTION
## Done
Correctly send form submission GA event

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Install [the browser extension "Google Analytics Debugger"
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Click the envelope icon in the extension tray to turn it out
- Open the your browser console
- Refresh and you should see a bunch of events. Clear them.
- Click contact us button and see the form opens and triggers an `open` event
- Click close X and see it triggers a single "interactive-forms" event of "close"
- Click on the contact button again 
- Set your console to Persist
- Click through the form and fill out the final contact us form
- Once you land on the thank you ensure there was a single "interactive-forms" event of "submitted"

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3159
