### PR TITLE
Remove sticky from the newsletter sign up on the blog

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -89,7 +89,7 @@
       <div class="col-4">
         {% include 'blog/product-cards.html' %}
 
-        <div style="position: sticky; top: 2rem;">
+        <div>
           {% include 'blog/newsletter-form.html' %}
         </div>
       </div>


### PR DESCRIPTION
## Done
Remove sticky from the newsletter sign up on the blog

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- **Join the VPN**
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/canonical-enables-linux-desktop-app-support-with-flutter
- See the Newsletter sign up card stays put and allows people with smaller screens to submit.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8231

