### PR TITLE
Removed Anbox introduction takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,6 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
-  {% include "takeovers/_2004-migration-takeover.html" %}
   {% include "takeovers/_gsi-webinar-series-takeover.html" %}
   {% include "takeovers/_redhat-openstack.html" %}
   {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}


### PR DESCRIPTION
## Done

- Removed Anbox introduction takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

