### PR TITLE
Proxy Wordpress API

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -146,6 +146,9 @@ production:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
+    location /wp-json/wp/v2/ {
+      proxy_pass https://admin.insights.ubuntu.com/wp-json/wp/v2/;
+    }
     location /wp-content/uploads/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
     }
@@ -218,6 +221,9 @@ staging:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
+    location /wp-json/wp/v2/ {
+      proxy_pass https://admin.insights.ubuntu.com/wp-json/wp/v2/;
+    }
     location /wp-content/uploads/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
     }


### PR DESCRIPTION
## Done

- Proxy Wordpress API

## QA

1. Connect to the Canonical VPN
2. Add `127.0.0.1 ubuntu.com` to your `/etc/hosts` file
3. If you know what you are doing: `konf production konf/site.yaml --local-qa | microk8s.kubectl apply -f -`. If not read and follow the QA steps of this [other PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/7909) 
4. `curl -I --insecure https://ubuntu.com/wp-json/wp/v2/posts\?tags\=3110\&per_page\=12\&page\=1\&tags_exclude\=3\&_embed\=true` should return a 200 status code.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3155
