### PR TITLE
Replace Launchpad username with Github username the legal copy

### DIFF
--- a/templates/legal/contributors/agreement.html
+++ b/templates/legal/contributors/agreement.html
@@ -197,7 +197,7 @@ defer>
     <div class="row">
       <div class="col-8">
         <h1>Contributor agreement form</h1>
-        <p>Before you contribute to one of our open source projects, you must complete all the fields in this form, sign it and return it to Canonical. Please make sure you have your Launchpad ID at the ready. If you don&rsquo;t have one, you can create one now at <a href="https://launchpad.net">launchpad.net</a>.</p>
+        <p>Before you contribute to one of our open source projects, you must complete all the fields in this form, sign it and return it to Canonical. Please make sure you have your GitHub username at the ready. If you don&rsquo;t have one, you can create one now at <a href="https://github.com">GitHub</a>.</p>
         <p>All fields are required.</p>
       </div>
     </div>
@@ -370,7 +370,7 @@ defer>
                   <input type="hidden" id="tfa_Openid" name="tfa_Openid" value="" class="">
                   <input type="hidden" id="tfa_LPid" name="tfa_LPid" value="" class="">
                   <div class="oneField field-container-D    " id="tfa_1-D">
-                    <label id="tfa_1-L" class="label preField " for="tfa_1">GitHub Username</label>
+                    <label id="tfa_1-L" class="label preField " for="tfa_1">GitHub username</label>
                     <br>
                     <div class="inputWrapper">
                       <input type="text" id="tfa_1" name="tfa_1" value="" title="GitHub Username" class="">

--- a/templates/legal/contributors/index.html
+++ b/templates/legal/contributors/index.html
@@ -34,7 +34,7 @@
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3>Sign the contributor agreement</h3>
-      <p>When you&rsquo;re ready to contribute to a project at Canonical, we have two forms: one for individual contributors and one for companies and other organisations. Before you make your first contribution, please ensure you&rsquo;ve already created a <a href="https://launchpad.net">Launchpad</a> account, then complete the appropriate form.</p>
+      <p>When you&rsquo;re ready to contribute to a project at Canonical, we have two forms: one for individual contributors and one for companies and other organisations. Before you make your first contribution, please ensure you&rsquo;ve already created a <a href="https://github.com">GitHub</a> account, then complete the appropriate form.</p>
       <p><a href="/legal/contributors/agreement">Sign the contributor agreement&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-card">


### PR DESCRIPTION
## Done
Replace Launchpad username with Github username the legal copy

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/contributors/agreement
- Check the copy changes match the [copy doc](https://docs.google.com/document/d/1MfgTzlAxiFE6VUW1qAPmrks2ui1zzsX5T7d-DZJlOAw/edit)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3165

