### PR TITLE
WordPress API under /blog

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -146,7 +146,7 @@ production:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
-    location /wp-json/wp/v2/ {
+    location /blog/wp-json/wp/v2/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-json/wp/v2/;
     }
     location /wp-content/uploads/ {
@@ -221,7 +221,7 @@ staging:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
-    location /wp-json/wp/v2/ {
+    location /blog/wp-json/wp/v2/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-json/wp/v2/;
     }
     location /wp-content/uploads/ {


### PR DESCRIPTION
## Done

- Change path for the blog API to `/blog/wp-json/wp/v2/`

