### PR TITLE
Advantage shop VAT

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_API_URL=https://contracts.develop.canonical.com/
-STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
+STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_API_URL=https://contracts.develop.canonical.com/
-STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
+STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.develop.canonical.com/
+CONTRACTS_API_URL=https://contracts.staging.canonical.com/
 STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do

--- a/.env
+++ b/.env
@@ -3,8 +3,8 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.staging.canonical.com/
-STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
+CONTRACTS_API_URL=https://contracts.develop.canonical.com/
+STRIPE_PUBLISHABLE_KEY=pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,7 +3,7 @@ env:
   SECRET_KEY: insecure_test_key
   DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
   PORT: 8001
-  CONTRACTS_API_URL: contracts.staging.canonical.com
+  CONTRACTS_API_URL: contracts.develop.canonical.com
 
 on:
   schedule:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,7 +3,7 @@ env:
   SECRET_KEY: insecure_test_key
   DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
   PORT: 8001
-  CONTRACTS_API_URL: contracts.develop.canonical.com
+  CONTRACTS_API_URL: contracts.staging.canonical.com
 
 on:
   schedule:

--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -119,3 +119,27 @@ export async function postCustomerInfoToStripeAccount(
   let data = await response.json();
   return data;
 }
+
+export async function postCustomerInfoForPurchasePreview(
+  accountID,
+  address,
+  taxID
+) {
+  let response = await fetch("/advantage/customer-info-anon", {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: accountID,
+      address: address,
+      tax_id: taxID,
+    }),
+  });
+
+  let data = await response.json();
+  return data;
+}

--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -68,6 +68,30 @@ export async function postPurchaseData(
   return data;
 }
 
+export async function postPurchasePreviewData(
+  accountID,
+  products,
+  previousPurchaseId
+) {
+  let response = await fetch(`/advantage/subscribe/preview`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: accountID,
+      products: products,
+      previous_purchase_id: previousPurchaseId,
+    }),
+  });
+
+  let data = await response.json();
+  return data;
+}
+
 export async function postCustomerInfoToStripeAccount(
   paymentMethodID,
   accountID,

--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -68,6 +68,21 @@ export async function postPurchaseData(
   return data;
 }
 
+export async function postRenewalPreviewData(renewalID) {
+  let response = await fetch(`/advantage/renewals/${renewalID}/preview`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
+
+  let data = await response.json();
+  return data;
+}
+
 export async function postPurchasePreviewData(
   accountID,
   products,

--- a/static/js/src/advantage/error-handler.js
+++ b/static/js/src/advantage/error-handler.js
@@ -86,7 +86,7 @@ function customErrorResponse(errorData) {
   } else if (INCORRECT_VAT_CODES.includes(code)) {
     error.message =
       "That VAT number is invalid. Check the number and try again.";
-    error.type = "notification";
+    error.type = "vat";
   } else if (code === "card_not_supported") {
     error.message =
       "That card doesn’t allow this kind of payment. Please contact your card issuer, or try a different card.";

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -132,14 +132,6 @@ export function getOrderInformation(listings) {
         label: planLabel,
         value: listing.product.name,
       },
-      start: {
-        label: "Starts:",
-        value: format(startDate, DATE_FORMAT),
-      },
-      end: {
-        label: "Ends:",
-        value: format(endDate, DATE_FORMAT),
-      },
       quantity: {
         label: "Machines:",
         value: buildQuantityString(
@@ -147,6 +139,14 @@ export function getOrderInformation(listings) {
           listing.product.price.value,
           currency
         ),
+      },
+      start: {
+        label: "Starts:",
+        value: format(startDate, DATE_FORMAT),
+      },
+      end: {
+        label: "Ends:",
+        value: format(endDate, DATE_FORMAT),
       },
     });
   });
@@ -189,14 +189,6 @@ export function getRenewalInformation(data) {
           label: "Plan type:",
           value: getProductsString(data.products),
         },
-        start: {
-          label: "Will continue from:",
-          value: format(startDate, DATE_FORMAT),
-        },
-        end: {
-          label: "Ends:",
-          value: format(endDate, DATE_FORMAT),
-        },
         quantity: {
           label: "Machines:",
           value: buildQuantityString(
@@ -204,6 +196,14 @@ export function getRenewalInformation(data) {
             data.unitPrice,
             data.currency
           ),
+        },
+        start: {
+          label: "Continues from:",
+          value: format(startDate, DATE_FORMAT),
+        },
+        end: {
+          label: "Ends:",
+          value: format(endDate, DATE_FORMAT),
         },
       },
     ],

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -213,10 +213,12 @@ export function setOrderTotal(taxAmount, totalAmount, modal) {
 
   totalsContainer.innerHTML = "";
 
-  totalsContainer.innerHTML += buildInfoRow({
-    label: "VAT: ",
-    value: formattedCurrency(taxAmount, vatCurrency, "en-US"),
-  });
+  if (taxAmount > 0) {
+    totalsContainer.innerHTML += buildInfoRow({
+      label: "VAT: ",
+      value: formattedCurrency(taxAmount, vatCurrency, "en-US"),
+    });
+  }
 
   totalsContainer.innerHTML += buildInfoRow({
     label: "Total: ",

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -243,7 +243,10 @@ export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
     let taxAmount = purchasePreview.taxAmount || 0;
 
     if (purchasePreview.subscriptionEndOfCycle) {
-      proratedEndDate = new Date(purchasePreview.subscriptionEndOfCycle);
+      proratedEndDate = format(
+        new Date(purchasePreview.subscriptionEndOfCycle),
+        DATE_FORMAT
+      );
     }
 
     if (purchasePreview.total > 0) {
@@ -277,9 +280,17 @@ export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
   subtotalElement.innerHTML = subtotalValue;
 
   if (proratedEndDate) {
-    endDateElements.forEach((endDateEl) => {
-      endDateEl.innerHTML = format(proratedEndDate, DATE_FORMAT);
-    });
+    for (let i = 0; i < endDateElements.length; i++) {
+      let endDateEl = endDateElements[i];
+
+      if (i === 0 && endDateEl.innerHTML !== proratedEndDate) {
+        // if these are different, it means prorating
+        // is in effect, so inform the user
+        endDateEl.innerHTML = `${proratedEndDate}<br /><small>The same date as your existing annual subscription.</small>`;
+      } else {
+        endDateEl.innerHTML = proratedEndDate;
+      }
+    }
   }
 
   if (vatApplicable) {

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -21,9 +21,9 @@ const PRODUCT_NAMES = {
 };
 
 function buildInfoRow(item) {
-  return `<div class="row u-no-padding u-sv1">
+  return `<div class="row u-no-padding u-sv1 ${item.extraClasses || ""}">
     <div class="col-3 u-text-light">${item.label}</div>
-    <div class="col-9">${item.value}</div>
+    <div class="col-9 js-info-value">${item.value}</div>
   </div>`;
 }
 
@@ -96,7 +96,18 @@ function setSummaryInfo(summaryObject, modal) {
 
   infoContainer.innerHTML += buildInfoRow({
     label: "Subtotal: ",
-    value: summaryObject.subtotal,
+    value: "...",
+    extraClasses: "js-subtotal",
+  });
+
+  totalsContainer.innerHTML += buildInfoRow({
+    label: "VAT:",
+    value: "...",
+  });
+
+  totalsContainer.innerHTML += buildInfoRow({
+    label: "Total:",
+    value: "...",
   });
 
   infoContainer.classList.remove("u-hide");
@@ -205,24 +216,39 @@ export function setOrderInformation(listings, modal) {
   setSummaryInfo(orderSummary, modal);
 }
 
-export function setOrderTotal(taxAmount, totalAmount, modal) {
+export function setOrderTotals(country, taxAmount, totalAmount, modal) {
   const currency = "USD";
   const totalsContainer = modal.querySelector("#order-totals");
-  // TODO: get VAT in local currency
-  const vatCurrency = "USD";
+  const subtotalElement = modal.querySelector(".js-subtotal .js-info-value");
+  let subtotalValue = "...";
+  let taxValue = "...";
+  let totalValue = "...";
+
+  if (totalAmount > 0) {
+    subtotalValue = formattedCurrency(
+      totalAmount - taxAmount,
+      currency,
+      "en-US"
+    );
+  }
+
+  if (country && totalAmount > 0) {
+    taxValue = formattedCurrency(taxAmount, currency, "en-US");
+    totalValue = formattedCurrency(totalAmount, currency, "en-US");
+  }
 
   totalsContainer.innerHTML = "";
 
-  if (taxAmount > 0) {
-    totalsContainer.innerHTML += buildInfoRow({
-      label: "VAT: ",
-      value: formattedCurrency(taxAmount, vatCurrency, "en-US"),
-    });
-  }
+  subtotalElement.innerHTML = subtotalValue;
+
+  totalsContainer.innerHTML += buildInfoRow({
+    label: "VAT: ",
+    value: taxValue,
+  });
 
   totalsContainer.innerHTML += buildInfoRow({
     label: "Total: ",
-    value: formattedCurrency(totalAmount, currency, "en-US"),
+    value: totalValue,
   });
 
   totalsContainer.classList.remove("u-hide");

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -216,7 +216,13 @@ export function setOrderInformation(listings, modal) {
   setSummaryInfo(orderSummary, modal);
 }
 
-export function setOrderTotals(country, taxAmount, totalAmount, modal) {
+export function setOrderTotals(
+  country,
+  vatApplicable,
+  taxAmount,
+  totalAmount,
+  modal
+) {
   const currency = "USD";
   const totalsContainer = modal.querySelector("#order-totals");
   const subtotalElement = modal.querySelector(".js-subtotal .js-info-value");
@@ -230,21 +236,27 @@ export function setOrderTotals(country, taxAmount, totalAmount, modal) {
       currency,
       "en-US"
     );
-  }
 
-  if (country && totalAmount > 0) {
-    taxValue = formattedCurrency(taxAmount, currency, "en-US");
-    totalValue = formattedCurrency(totalAmount, currency, "en-US");
+    if (!vatApplicable) {
+      totalValue = subtotalValue;
+    }
+
+    if (vatApplicable && country !== "") {
+      taxValue = formattedCurrency(taxAmount, currency, "en-US");
+      totalValue = formattedCurrency(totalAmount, currency, "en-US");
+    }
   }
 
   totalsContainer.innerHTML = "";
 
   subtotalElement.innerHTML = subtotalValue;
 
-  totalsContainer.innerHTML += buildInfoRow({
-    label: "VAT: ",
-    value: taxValue,
-  });
+  if (vatApplicable) {
+    totalsContainer.innerHTML += buildInfoRow({
+      label: "VAT: ",
+      value: taxValue,
+    });
+  }
 
   totalsContainer.innerHTML += buildInfoRow({
     label: "Total: ",

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -99,24 +99,12 @@ function setSummaryInfo(summaryObject, modal) {
     value: summaryObject.subtotal,
   });
 
-  totalsContainer.innerHTML += buildInfoRow({
-    label: "VAT: ",
-    value: summaryObject.vat,
-  });
-
-  totalsContainer.innerHTML += buildInfoRow({
-    label: "Total: ",
-    value: summaryObject.total,
-  });
-
   infoContainer.classList.remove("u-hide");
-  totalsContainer.classList.remove("u-hide");
 }
 
 export function getOrderInformation(listings) {
   const items = [];
   const currency = "USD";
-  const vatCurrency = "GBP";
   const startDate = new Date();
   const endDate = add(new Date(), { months: 12 });
   let subtotal = 0;
@@ -151,9 +139,6 @@ export function getOrderInformation(listings) {
   return {
     items: items,
     subtotal: formattedCurrency(subtotal, currency, "en-US"),
-    total: formattedCurrency(subtotal, currency, "en-US"),
-    // TODO: handle actual VAT
-    vat: formattedCurrency(0, vatCurrency, "en-US"),
   };
 }
 
@@ -218,6 +203,27 @@ export function setOrderInformation(listings, modal) {
 
   setModalTitle("Complete purchase", modal);
   setSummaryInfo(orderSummary, modal);
+}
+
+export function setOrderTotal(taxAmount, totalAmount, modal) {
+  const currency = "USD";
+  const totalsContainer = modal.querySelector("#order-totals");
+  // TODO: get VAT in local currency
+  const vatCurrency = "USD";
+
+  totalsContainer.innerHTML = "";
+
+  totalsContainer.innerHTML += buildInfoRow({
+    label: "VAT: ",
+    value: formattedCurrency(taxAmount, vatCurrency, "en-US"),
+  });
+
+  totalsContainer.innerHTML += buildInfoRow({
+    label: "Total: ",
+    value: formattedCurrency(totalAmount, currency, "en-US"),
+  });
+
+  totalsContainer.classList.remove("u-hide");
 }
 
 export function setPaymentInformation(paymentMethod, modal) {

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -302,7 +302,7 @@ export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
 
   totalsContainer.innerHTML += buildInfoRow({
     label: "Total: ",
-    value: totalValue,
+    value: `<b>${totalValue}</b>`,
   });
 
   totalsContainer.classList.remove("u-hide");

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -232,6 +232,13 @@ export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
   let taxValue = "...";
   let totalValue = "...";
 
+  if (subtotalElement.innerHTML !== "...") {
+    // if this is true, it means subtotal was
+    // already filled in, and since it won't change,
+    // force it to persist
+    subtotalValue = subtotalElement.innerHTML;
+  }
+
   if (purchasePreview) {
     let taxAmount = purchasePreview.taxAmount || 0;
 

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -119,13 +119,17 @@ export function getOrderInformation(listings) {
   const startDate = new Date();
   const endDate = add(new Date(), { months: 12 });
   let subtotal = 0;
+  let planLabel = "Plan type:";
 
   listings.forEach((listing, i) => {
     subtotal = subtotal + listing.quantity * listing.product.price.value;
+    if (listings.length > 1) {
+      planLabel = `Plan ${i + 1}:`;
+    }
 
     items.push({
       plan: {
-        label: `Plan ${i + 1}:`,
+        label: planLabel,
         value: listing.product.name,
       },
       start: {

--- a/static/js/src/advantage/tests/error-handler.test.js
+++ b/static/js/src/advantage/tests/error-handler.test.js
@@ -117,7 +117,7 @@ describe("parseForErrorObject", () => {
     it("should return an appropriate error object", () => {
       expect(parseForErrorObject(contractsErrorObjects.invalidVat)).toEqual({
         message: "That VAT number is invalid. Check the number and try again.",
-        type: "notification",
+        type: "vat",
       });
     });
   });

--- a/static/js/src/advantage/tests/set-modal-info.test.js
+++ b/static/js/src/advantage/tests/set-modal-info.test.js
@@ -114,8 +114,6 @@ describe("getOrderInformation", () => {
           },
         ],
         subtotal: "$1,000",
-        total: "$1,000",
-        vat: "£0",
       });
     });
   });

--- a/static/js/src/advantage/tests/set-modal-info.test.js
+++ b/static/js/src/advantage/tests/set-modal-info.test.js
@@ -45,6 +45,7 @@ describe("getRenewalInformation", () => {
             end: {
               label: "Ends:",
               value: "20 May 2021",
+              extraClasses: "js-end-date",
             },
             plan: {
               label: "Plan type:",
@@ -55,7 +56,7 @@ describe("getRenewalInformation", () => {
               value: "5 &#215; US$25/year",
             },
             start: {
-              label: "Will continue from:",
+              label: "Continues from:",
               value: "21 May 2020",
             },
           },
@@ -80,6 +81,7 @@ describe("getOrderInformation", () => {
             end: {
               label: "Ends:",
               value: endDate,
+              extraClasses: "js-end-date",
             },
             plan: {
               label: "Plan 1:",
@@ -98,6 +100,7 @@ describe("getOrderInformation", () => {
             end: {
               label: "Ends:",
               value: endDate,
+              extraClasses: "js-end-date",
             },
             plan: {
               label: "Plan 2:",

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -30,6 +30,7 @@ const progressIndicator = document.getElementById("js-progress-indicator");
 
 const countryDropdown = modal.querySelector("select");
 const termsCheckbox = modal.querySelector(".js-terms");
+const vatInput = modal.querySelector('input[name="tax"]');
 const addPaymentMethodButton = modal.querySelector(".js-payment-method");
 const processPaymentButton = modal.querySelector(".js-process-payment");
 const changePaymentMethodButton = modal.querySelector(
@@ -182,8 +183,6 @@ function attachCustomerInfoToStripeAccount(paymentMethod) {
 }
 
 function attachFormEvents() {
-  const vatInput = modal.querySelector('input[name="tax"]');
-
   for (let i = 0; i < form.elements.length; i++) {
     const input = form.elements[i];
 
@@ -204,7 +203,7 @@ function attachFormEvents() {
     }
   });
 
-  vatInput.addEventListener("keyup", () => {
+  vatInput.addEventListener("input", () => {
     checkVATdebounce();
   });
 
@@ -286,6 +285,7 @@ function checkVAT() {
   } else {
     vatApplicable = false;
     vatContainer.classList.add("u-hide");
+    vatInput.value = "";
   }
 
   applyTotals();

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -33,6 +33,7 @@ const termsCheckbox = modal.querySelector(".js-terms");
 const vatInput = modal.querySelector('input[name="tax"]');
 const addPaymentMethodButton = modal.querySelector(".js-payment-method");
 const processPaymentButton = modal.querySelector(".js-process-payment");
+const vatContainer = modal.querySelector(".js-vat-container");
 const changePaymentMethodButton = modal.querySelector(
   ".js-change-payment-method"
 );
@@ -112,6 +113,7 @@ function attachCTAevents() {
 
     if (isRenewalCTA || isShopCTA) {
       e.preventDefault();
+      modal.classList.add("is-processing");
       currentTransaction.accountId = data.accountId;
     }
 
@@ -121,7 +123,6 @@ function attachCTAevents() {
       currentTransaction.transactionId = data.renewalId;
 
       setRenewalInformation(data, modal);
-      checkVAT();
     } else if (isShopCTA) {
       const cartItems = JSON.parse(data.cart);
 
@@ -139,10 +140,10 @@ function attachCTAevents() {
       });
 
       setOrderInformation(cartItems, modal);
-      checkVAT();
     }
 
     if (isRenewalCTA || isShopCTA) {
+      checkVAT();
       toggleModal();
       card.focus();
       sendGAEvent("opened payment modal");
@@ -206,7 +207,7 @@ function attachFormEvents() {
     checkVATdebounce();
   });
 
-  countryDropdown.addEventListener("change", (e) => {
+  countryDropdown.addEventListener("change", () => {
     checkVAT();
   });
 
@@ -274,8 +275,6 @@ function attachModalButtonEvents() {
 }
 
 function checkVAT() {
-  const vatContainer = modal.querySelector(".js-vat-container");
-
   if (vatCountries.includes(countryDropdown.value)) {
     vatApplicable = true;
     vatContainer.classList.remove("u-hide");
@@ -325,12 +324,14 @@ function applyTotals() {
           currentTransaction.previousPurchaseId
         ).then((data) => {
           purchasePreview = data;
+          modal.classList.remove("is-processing");
           setOrderTotals(country, vatApplicable, purchasePreview, modal);
         });
       } else if (currentTransaction.type === "renewal") {
         postRenewalPreviewData(currentTransaction.transactionId).then(
           (data) => {
             purchasePreview = data;
+            modal.classList.remove("is-processing");
             setOrderTotals(country, vatApplicable, purchasePreview, modal);
           }
         );

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -666,7 +666,8 @@ function presentError(errorObject) {
     vatContainer.classList.add("is-error");
     vatErrorElement.innerHTML = errorObject.message;
     vatErrorElement.classList.remove("u-hide");
-    showDetailsMode();
+    vatInput.focus();
+    disableProcessingState();
   } else {
     console.error(`invalid argument: ${errorObject}`);
   }

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -34,6 +34,9 @@ const vatInput = modal.querySelector('input[name="tax"]');
 const addPaymentMethodButton = modal.querySelector(".js-payment-method");
 const processPaymentButton = modal.querySelector(".js-process-payment");
 const vatContainer = modal.querySelector(".js-vat-container");
+const vatErrorElement = vatContainer.querySelector(
+  ".p-form-validation__message"
+);
 const changePaymentMethodButton = modal.querySelector(
   ".js-change-payment-method"
 );
@@ -275,6 +278,8 @@ function attachModalButtonEvents() {
 }
 
 function checkVAT() {
+  vatContainer.classList.remove("is-error");
+
   if (vatCountries.includes(countryDropdown.value)) {
     vatApplicable = true;
     vatContainer.classList.remove("u-hide");
@@ -657,6 +662,11 @@ function presentError(errorObject) {
   } else if (errorObject.type === "dialog") {
     errorDialog.innerHTML = errorObject.message;
     showDialogMode();
+  } else if (errorObject.type === "vat") {
+    vatContainer.classList.add("is-error");
+    vatErrorElement.innerHTML = errorObject.message;
+    vatErrorElement.classList.remove("u-hide");
+    showDetailsMode();
   } else {
     console.error(`invalid argument: ${errorObject}`);
   }

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -96,7 +96,6 @@ let customerInfo = {
 let cardValid = false;
 let changingPaymentMethod = false;
 let submitted3DS = false;
-let totalsApplied = false;
 let vatApplicable = false;
 
 let pollingTimer;
@@ -277,8 +276,6 @@ function attachModalButtonEvents() {
 function checkVAT() {
   const vatContainer = modal.querySelector(".js-vat-container");
 
-  totalsApplied = false;
-
   if (vatCountries.includes(countryDropdown.value)) {
     vatApplicable = true;
     vatContainer.classList.remove("u-hide");
@@ -303,7 +300,6 @@ function applyTotals() {
   let purchasePreview = null;
 
   setOrderTotals(country, vatApplicable, purchasePreview, modal);
-  addPaymentMethodButton.disabled = true;
 
   if (formData.get("tax")) {
     taxObject = {
@@ -330,16 +326,12 @@ function applyTotals() {
         ).then((data) => {
           purchasePreview = data;
           setOrderTotals(country, vatApplicable, purchasePreview, modal);
-          totalsApplied = true;
-          validateForm();
         });
       } else if (currentTransaction.type === "renewal") {
         postRenewalPreviewData(currentTransaction.transactionId).then(
           (data) => {
             purchasePreview = data;
             setOrderTotals(country, vatApplicable, purchasePreview, modal);
-            totalsApplied = true;
-            validateForm();
           }
         );
       }
@@ -824,7 +816,7 @@ function validateForm() {
     inputsValidity.push(isValid);
   }
 
-  if (inputsValidity.includes(false) || !totalsApplied) {
+  if (inputsValidity.includes(false)) {
     addPaymentMethodButton.disabled = true;
   } else {
     addPaymentMethodButton.disabled = false;

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -124,6 +124,11 @@ function attachCTAevents() {
       checkVAT();
     } else if (isShopCTA) {
       const cartItems = JSON.parse(data.cart);
+
+      // make sure the product array is empty
+      // before we start adding to it
+      currentTransaction.products = [];
+
       currentTransaction.type = "purchase";
       currentTransaction.previousPurchaseId = data.previousPurchaseId;
       cartItems.forEach((item) => {
@@ -295,10 +300,9 @@ function applyTotals() {
   let country = formData.get("Country");
   let addressObject = null;
   let taxObject = null;
-  let tax = 0;
-  let total = 0;
+  let purchasePreview = null;
 
-  setOrderTotals(country, vatApplicable, 0, 0, modal);
+  setOrderTotals(country, vatApplicable, purchasePreview, modal);
 
   if (formData.get("tax")) {
     taxObject = {
@@ -323,17 +327,15 @@ function applyTotals() {
           currentTransaction.products,
           currentTransaction.previousPurchaseId
         ).then((data) => {
-          tax = data.taxAmount || 0;
-          total = data.total;
-          setOrderTotals(country, vatApplicable, tax, total, modal);
+          purchasePreview = data;
+          setOrderTotals(country, vatApplicable, purchasePreview, modal);
           totalsApplied = true;
         });
       } else if (currentTransaction.type === "renewal") {
         postRenewalPreviewData(currentTransaction.transactionId).then(
           (data) => {
-            tax = data.taxAmount || 0;
-            total = data.total;
-            setOrderTotals(country, vatApplicable, tax, total, modal);
+            purchasePreview = data;
+            setOrderTotals(country, vatApplicable, purchasePreview, modal);
             totalsApplied = true;
           }
         );

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -23,7 +23,6 @@ import {
 } from "./advantage/set-modal-info.js";
 
 const modal = document.getElementById("ua-payment-modal");
-const modalBody = modal.querySelector(".p-modal__body");
 
 const form = document.getElementById("details-form");
 const errorDialog = document.getElementById("payment-error-dialog");
@@ -275,7 +274,6 @@ function checkVAT() {
   const vatContainer = modal.querySelector(".js-vat-container");
 
   totalsApplied = false;
-  modalBody.classList.add("u-disable");
 
   if (vatCountries.includes(countryDropdown.value)) {
     vatApplicable = true;
@@ -328,7 +326,6 @@ function applyTotals() {
           tax = data.taxAmount || 0;
           total = data.total;
           setOrderTotals(country, vatApplicable, tax, total, modal);
-          modalBody.classList.remove("u-disable");
           totalsApplied = true;
         });
       } else if (currentTransaction.type === "renewal") {
@@ -337,7 +334,6 @@ function applyTotals() {
             tax = data.taxAmount || 0;
             total = data.total;
             setOrderTotals(country, vatApplicable, tax, total, modal);
-            modalBody.classList.remove("u-disable");
             totalsApplied = true;
           }
         );

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -303,6 +303,7 @@ function applyTotals() {
   let purchasePreview = null;
 
   setOrderTotals(country, vatApplicable, purchasePreview, modal);
+  addPaymentMethodButton.disabled = true;
 
   if (formData.get("tax")) {
     taxObject = {
@@ -330,6 +331,7 @@ function applyTotals() {
           purchasePreview = data;
           setOrderTotals(country, vatApplicable, purchasePreview, modal);
           totalsApplied = true;
+          validateForm();
         });
       } else if (currentTransaction.type === "renewal") {
         postRenewalPreviewData(currentTransaction.transactionId).then(
@@ -337,6 +339,7 @@ function applyTotals() {
             purchasePreview = data;
             setOrderTotals(country, vatApplicable, purchasePreview, modal);
             totalsApplied = true;
+            validateForm();
           }
         );
       }

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -283,10 +283,6 @@ function productSelector() {
         }
       });
     }
-
-    if (formStage && input.value > 0) {
-      scrollToStep("version");
-    }
   }
 
   function handleStepSpecificAction(inputElement) {
@@ -310,7 +306,6 @@ function productSelector() {
         } else {
           quantityTypeEl.innerHTML = `How many ${inputElement.dataset.productName}s?`;
           state.set(inputElement.name, [inputElement.value]);
-          scrollToStep("quantity");
         }
 
         break;
@@ -321,11 +316,9 @@ function productSelector() {
         break;
       case "support":
         state.set(inputElement.name, [inputElement.value]);
-        scrollToStep("add");
         break;
       case "add":
         state.set(inputElement.name, [inputElement.value]);
-        scrollToStep("cart");
         break;
       default:
         state.set(inputElement.name, [inputElement.value]);
@@ -363,15 +356,6 @@ function productSelector() {
     state.reset("support");
     state.reset("add");
     form.reset();
-  }
-
-  function scrollToStep(step) {
-    const stepWrapper = document.querySelector(`${stepClassPrefix}${step}`);
-
-    window.scrollTo({
-      top: stepWrapper.offsetTop,
-      behavior: "smooth",
-    });
   }
 
   function setActiveSteps() {

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -95,7 +95,7 @@ function productSelector() {
       <div class="col-10">
         <div class="row u-vertically-center">
           <div class="col-2 col-small-2 col-start-large-7">
-            <h3 class="p-heading--four">Subtotal:</h3>
+            <h3 class="p-heading--four">Yearly cost:</h3>
           </div>
 
           <div class="col-2 col-small-2 u-align--right">

--- a/static/sass/_pattern_renewal-modal.scss
+++ b/static/sass/_pattern_renewal-modal.scss
@@ -62,6 +62,7 @@
     .p-modal__body {
       max-height: 70vh;
       overflow-y: scroll;
+      position: relative;
     }
 
     .p-modal__header {
@@ -80,6 +81,25 @@
 
       @media (min-width: $breakpoint-medium) {
         bottom: 1rem;
+      }
+    }
+
+    #order-processing {
+      bottom: 0;
+      display: none;
+      left: 0;
+      margin: auto;
+      position: absolute;
+      right: 0;
+      top: 0;
+
+      .p-icon--spinner {
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        position: absolute;
+        right: 0;
+        top: 0;
       }
     }
 
@@ -134,6 +154,19 @@
       color: $color-negative;
     }
 
+    &.is-processing {
+      .p-modal__body section {
+        visibility: hidden;
+      }
+
+      #order-processing {
+        animation: 1s delayedShow;
+        animation-fill-mode: forwards;
+        display: block;
+        visibility: hidden;
+      }
+    }
+
     button,
     label {
       @media (min-width: $breakpoint-medium) {
@@ -156,5 +189,15 @@
         float: right;
       }
     }
+  }
+}
+
+@keyframes delayedShow {
+  99% {
+    visibility: hidden;
+  }
+
+  100% {
+    visibility: visible;
   }
 }

--- a/static/sass/_pattern_renewal-modal.scss
+++ b/static/sass/_pattern_renewal-modal.scss
@@ -155,8 +155,12 @@
     }
 
     &.is-processing {
-      .p-modal__body section {
-        visibility: hidden;
+      .p-modal__body {
+        overflow: hidden;
+
+        section {
+          visibility: hidden;
+        }
       }
 
       #order-processing {

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -88,13 +88,13 @@
             </div>
           </div>
 
-          <div class="p-form__group row u-no-padding u-vertically-center u-hide js-vat-container">
+          <div class="p-form__group p-form-validation row u-no-padding u-vertically-center u-hide js-vat-container">
             <div class="col-3">
               <label class="u-no-padding--top" >VAT number:</label>
             </div>
 
             <div class="col-7">
-              <input name="tax" type="text" />
+              <input class="p-form-validation__input" name="tax" type="text" />
             </div>
 
             <div class="col-2">
@@ -102,11 +102,11 @@
             </div>
 
             <div class="col-9 col-start-large-4">
-              <small>e.g. GB101111, CY99999999L</small>
-            </div>
-            
-            <div class="col-9 col-start-large-4">
               <span class="p-form-validation__message u-hide"></span>
+            </div>
+
+            <div class="col-9 col-start-large-4">
+              <small>e.g. GB101111, CY99999999L</small>
             </div>
           </div>
         </form>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -15,7 +15,7 @@
           </p>
         </div>
 
-        <form class="p-form p-form--stacked" id="details-form">
+        <form class="p-form p-form--stacked u-sv3" id="details-form">
           <div class="p-form__group p-form-validation row u-no-padding u-vertically-center">
             <div class="col-3">
               <label class="u-no-padding--top" for="email">Email my invoice to:</label>
@@ -111,7 +111,7 @@
           </div>
         </form>
 
-        <div id="order-totals" class="p-strip is-shallow u-hide">
+        <div id="order-totals" class="u-hide u-sv1">
         </div>
 
         <div id="order-summary">

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -167,8 +167,12 @@
           </div>
         </div>
       </section>
-    </div>
 
+      <div id="order-processing" class="u-align--center">
+        <i class="p-icon--spinner u-animation--spin"></i>
+      </div>
+    </div>
+    
     <footer class="p-modal__footer u-align--right">
       <span id="js-progress-indicator" class="p-modal__progress u-hide">
         <i class="p-icon--success u-hide"></i>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -111,6 +111,9 @@
           </div>
         </form>
 
+        <div id="order-totals" class="p-strip is-shallow u-hide">
+        </div>
+
         <div id="order-summary">
           <div class="row u-no-padding">
             <div class="col-3">
@@ -152,9 +155,6 @@
         <div id="payment-error-dialog">
           <p></p>
         </div>
-      </section>
-
-      <section id="order-totals" class="p-strip is-shallow u-hide">
       </section>
 
       <section id="order-terms" class="p-strip is-shallow u-no-padding--top">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -147,9 +147,7 @@
                               </tr>
 
                               {% if contract['contractInfo']['effectiveTo'] %}
-                                {% if contract["renewal"] %}
-                                  {% include "advantage/table/_expiry-date.html" %}
-                                {% endif %}
+                                {% include "advantage/table/_expiry-date.html" %}
                               {% endif %}
 
                               {% if contract["renewal"] %}

--- a/templates/advantage/subscribe.html
+++ b/templates/advantage/subscribe.html
@@ -148,7 +148,7 @@
         </div>
         
         <div class="col-2">
-          <input autocomplete="off" class="js-product-input" type="number" name="quantity" value="0" step="1" data-stage="form" />
+          <input autocomplete="off" class="js-product-input" type="number" name="quantity" value="0" step="1" data-stage="form" onwheel="this.blur()" />
         </div>
       </div>
     </section>

--- a/templates/advantage/subscribe.html
+++ b/templates/advantage/subscribe.html
@@ -218,7 +218,7 @@
       {% endfor %}
     };
 
-    var accountId = "{{ account.id }}";
+    var accountId = "{% if account %}{{ account.id }}{% endif %}";
     var previousPurchaseId = "{% if previous_purchase_id%}{{ previous_purchase_id }}{% endif %}"
   </script>
   

--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -1,6 +1,6 @@
 <td class="u-no-padding{% if open_subscription == contract['contractInfo']['id'] %} p-table--open{% endif %}">
   <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-    {% if contract["contractInfo"]["id"] == new_subscription_id %}
+    {% if contract["contractInfo"]["id"] == new_subscription_id and contract["contractInfo"]["daysTillExpiry"] > 0%}
       <div class="p-label--new">New</div>
     {% endif %}
     

--- a/templates/advantage/table/_renewal-actions.html
+++ b/templates/advantage/table/_renewal-actions.html
@@ -5,7 +5,7 @@
       <a
         id="showModal"
         href="#ua-payment-modal"
-        class="js-ua-payment-cta p-button--positive u-no-margin--bottom"
+        class="js-ua-renewal-cta p-button--positive u-no-margin--bottom"
         data-transaction-type="renewal"
         data-contract-id="{{ contract['contractInfo']['id'] }}"
         data-account-id="{{ enterprise_contracts[account][0].accountInfo.id }}"

--- a/tests/cassettes/TestRoutes.test_advantage.yaml
+++ b/tests/cassettes/TestRoutes.test_advantage.yaml
@@ -11,7 +11,7 @@ interactions:
         User-Agent:
           - python-requests/2.23.0
       method: GET
-      uri: https://contracts.develop.canonical.com/v1/accounts
+      uri: https://contracts.staging.canonical.com/v1/accounts
     response:
       body:
         string: '{"code":"unauthorized","message":"unauthorized","traceId":"cc123f07-176b-49a3-bac2-9429c876f888"}'

--- a/tests/cassettes/TestRoutes.test_advantage.yaml
+++ b/tests/cassettes/TestRoutes.test_advantage.yaml
@@ -11,7 +11,7 @@ interactions:
         User-Agent:
           - python-requests/2.23.0
       method: GET
-      uri: https://contracts.staging.canonical.com/v1/accounts
+      uri: https://contracts.develop.canonical.com/v1/accounts
     response:
       body:
         string: '{"code":"unauthorized","message":"unauthorized","traceId":"cc123f07-176b-49a3-bac2-9429c876f888"}'

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -137,14 +137,16 @@ class AdvantageContracts:
 
     def get_account_purchases(self, account_id: str) -> dict:
         response = self._request(
-            method="get", path=f"v1/accounts/{account_id}/purchases",
+            method="get",
+            path=f"v1/accounts/{account_id}/purchases",
         )
 
         return response.json()
 
     def get_purchase(self, purchase_id: str) -> dict:
         response = self._request(
-            method="get", path=f"v1/purchase/{purchase_id}",
+            method="get",
+            path=f"v1/purchase/{purchase_id}",
         )
 
         return response.json()

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -99,10 +99,7 @@ class AdvantageContracts:
             response = self._request(
                 method="put",
                 path=f"v1/accounts/{account_id}/customer-info/stripe",
-                json={
-                    "address": address,
-                    "taxID": tax_id,
-                },
+                json={"address": address, "taxID": tax_id},
             )
         except HTTPError as http_error:
             return http_error.response.json()
@@ -149,8 +146,7 @@ class AdvantageContracts:
 
     def get_marketplace_product_listings(self, marketplace: str) -> dict:
         response = self._request(
-            method="get",
-            path=f"v1/marketplace/{marketplace}/product-listings",
+            method="get", path=f"v1/marketplace/{marketplace}/product-listings"
         )
 
         return response.json()
@@ -170,14 +166,14 @@ class AdvantageContracts:
 
     def get_account_purchases(self, account_id: str) -> dict:
         response = self._request(
-            method="get", path=f"v1/accounts/{account_id}/purchases",
+            method="get", path=f"v1/accounts/{account_id}/purchases"
         )
 
         return response.json()
 
     def get_purchase(self, purchase_id: str) -> dict:
         response = self._request(
-            method="get", path=f"v1/purchase/{purchase_id}",
+            method="get", path=f"v1/purchase/{purchase_id}"
         )
 
         return response.json()

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -6,7 +6,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.staging.canonical.com",
+        api_url="https://contracts.develop.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -46,6 +46,17 @@ class AdvantageContracts:
 
         return response.json().get("contracts", [])
 
+    def get_subscriptions(self, account, marketplace):
+        response = self._request(
+            method="get",
+            path=(
+                f"v1/accounts/{account}/marketplace/"
+                f"{marketplace}/subscriptions"
+            ),
+        )
+
+        return response.json()
+
     def get_contract_token(self, contract):
         contract_id = contract["contractInfo"]["id"]
         response = self._request(

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -140,6 +140,13 @@ class AdvantageContracts:
 
         return {}
 
+    def post_renewal_preview(self, renewal_id):
+        response = self._request(
+            method="post", path=f"v1/renewals/{renewal_id}/purchase/preview"
+        )
+
+        return response.json()
+
     def get_marketplace_product_listings(self, marketplace: str) -> dict:
         response = self._request(
             method="get",

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -148,16 +148,14 @@ class AdvantageContracts:
 
     def get_account_purchases(self, account_id: str) -> dict:
         response = self._request(
-            method="get",
-            path=f"v1/accounts/{account_id}/purchases",
+            method="get", path=f"v1/accounts/{account_id}/purchases",
         )
 
         return response.json()
 
     def get_purchase(self, purchase_id: str) -> dict:
         response = self._request(
-            method="get",
-            path=f"v1/purchase/{purchase_id}",
+            method="get", path=f"v1/purchase/{purchase_id}",
         )
 
         return response.json()

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -137,16 +137,14 @@ class AdvantageContracts:
 
     def get_account_purchases(self, account_id: str) -> dict:
         response = self._request(
-            method="get",
-            path=f"v1/accounts/{account_id}/purchases",
+            method="get", path=f"v1/accounts/{account_id}/purchases",
         )
 
         return response.json()
 
     def get_purchase(self, purchase_id: str) -> dict:
         response = self._request(
-            method="get",
-            path=f"v1/purchase/{purchase_id}",
+            method="get", path=f"v1/purchase/{purchase_id}",
         )
 
         return response.json()

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -94,6 +94,21 @@ class AdvantageContracts:
 
         return response.json()
 
+    def put_anonymous_customer_info(self, account_id, address, tax_id):
+        try:
+            response = self._request(
+                method="put",
+                path=f"v1/accounts/{account_id}/customer-info/stripe",
+                json={
+                    "address": address,
+                    "taxID": tax_id,
+                },
+            )
+        except HTTPError as http_error:
+            return http_error.response.json()
+
+        return response.json()
+
     def post_stripe_invoice_id(self, tx_type, tx_id, invoice_id):
         try:
             response = self._request(

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -6,7 +6,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.develop.canonical.com",
+        api_url="https://contracts.staging.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -84,6 +84,9 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
+    "CONTRACTS_API_URL", "https://contracts.develop.canonical.com"
+).rstrip("/")
+app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"
 
 session = talisker.requests.get_session()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,6 +44,7 @@ from webapp.views import (
     post_anonymised_customer_info,
     post_customer_info,
     post_stripe_invoice_id,
+    post_renewal_preview,
     post_build,
     releasenotes_redirect,
     search_snaps,
@@ -194,7 +195,16 @@ app.add_url_rule(
     methods=["POST"],
 )
 app.add_url_rule(
-    "/download/<regex('cloud|raspberry-pi|desktop'):category>/thank-you",
+    "/advantage/renewals/<renewal_id>/preview",
+    view_func=post_renewal_preview,
+    methods=["POST"],
+)
+app.add_url_rule(
+    (
+        "/download"
+        "/<regex('server|desktop|cloud|raspberry-pi'):category>"
+        "/thank-you"
+    ),
     view_func=download_thank_you,
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -158,6 +158,11 @@ app.add_url_rule(
     defaults={"preview": True},
 )
 app.add_url_rule(
+    "/advantage/subscribe",
+    view_func=post_advantage_subscriptions,
+    methods=["POST"],
+)
+app.add_url_rule(
     "/advantage/customer-info", view_func=post_customer_info, methods=["POST"]
 )
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -84,11 +84,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.staging.canonical.com"
-).rstrip("/")
-app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"
-).rstrip("/")
 
 session = talisker.requests.get_session()
 discourse_api = DiscourseAPI(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,6 +41,7 @@ from webapp.views import (
     get_purchase,
     get_renewal,
     post_advantage_subscriptions,
+    post_anonymised_customer_info,
     post_customer_info,
     post_stripe_invoice_id,
     post_build,
@@ -167,6 +168,11 @@ app.add_url_rule(
 )
 app.add_url_rule(
     "/advantage/customer-info", view_func=post_customer_info, methods=["POST"]
+)
+app.add_url_rule(
+    "/advantage/customer-info-anon",
+    view_func=post_anonymised_customer_info,
+    methods=["POST"],
 )
 app.add_url_rule(
     "/advantage/<tx_type>/<tx_id>/invoices/<invoice_id>",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -86,7 +86,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.develop.canonical.com"
+    "CONTRACTS_API_URL", "https://contracts.staging.canonical.com"
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -163,11 +163,6 @@ app.add_url_rule(
     defaults={"preview": True},
 )
 app.add_url_rule(
-    "/advantage/subscribe",
-    view_func=post_advantage_subscriptions,
-    methods=["POST"],
-)
-app.add_url_rule(
     "/advantage/customer-info", view_func=post_customer_info, methods=["POST"]
 )
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -90,7 +90,7 @@ app.config["CONTRACTS_API_URL"] = os.getenv(
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"
-
+)
 session = talisker.requests.get_session()
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/", session=session

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -319,9 +319,7 @@ tutorials_docs.init_app(app)
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api,
-        index_topic_id=17250,
-        url_prefix="/ceph/docs",
+        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
     ),
     document_template="/ceph/document.html",
     url_prefix="/ceph/docs",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -339,7 +339,7 @@ tutorials_docs.init_app(app)
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
+        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs"
     ),
     document_template="/ceph/document.html",
     url_prefix="/ceph/docs",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -319,7 +319,9 @@ tutorials_docs.init_app(app)
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
+        api=discourse_api,
+        index_topic_id=17250,
+        url_prefix="/ceph/docs",
     ),
     document_template="/ceph/document.html",
     url_prefix="/ceph/docs",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -323,9 +323,7 @@ tutorials_docs.init_app(app)
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api,
-        index_topic_id=17250,
-        url_prefix="/ceph/docs",
+        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
     ),
     document_template="/ceph/document.html",
     url_prefix="/ceph/docs",

--- a/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
+++ b/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
@@ -18,10 +18,12 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        "cve", sa.Column("patches", sa.JSON(), nullable=True),
+        "cve",
+        sa.Column("patches", sa.JSON(), nullable=True),
     )
     op.add_column(
-        "cve", sa.Column("tags", sa.JSON(), nullable=True),
+        "cve",
+        sa.Column("tags", sa.JSON(), nullable=True),
     )
 
 

--- a/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
+++ b/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
@@ -18,12 +18,10 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        "cve",
-        sa.Column("patches", sa.JSON(), nullable=True),
+        "cve", sa.Column("patches", sa.JSON(), nullable=True),
     )
     op.add_column(
-        "cve",
-        sa.Column("tags", sa.JSON(), nullable=True),
+        "cve", sa.Column("tags", sa.JSON(), nullable=True),
     )
 
 

--- a/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
+++ b/webapp/security/alembic/versions/10c24cb270ff_add_cve_patch_column.py
@@ -17,12 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        "cve", sa.Column("patches", sa.JSON(), nullable=True),
-    )
-    op.add_column(
-        "cve", sa.Column("tags", sa.JSON(), nullable=True),
-    )
+    op.add_column("cve", sa.Column("patches", sa.JSON(), nullable=True))
+    op.add_column("cve", sa.Column("tags", sa.JSON(), nullable=True))
 
 
 def downgrade():

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -224,7 +224,9 @@ class Status(Base):
         )
     )
     description = Column(String)
-    component = Column(Enum("main", "universe", name="components"),)
+    component = Column(
+        Enum("main", "universe", name="components"),
+    )
     pocket = Column(
         Enum("security", "updates", "esm-infra", "esm-apps", name="pockets"),
     )

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -224,9 +224,9 @@ class Status(Base):
         )
     )
     description = Column(String)
-    component = Column(Enum("main", "universe", name="components"),)
+    component = Column(Enum("main", "universe", name="components"))
     pocket = Column(
-        Enum("security", "updates", "esm-infra", "esm-apps", name="pockets"),
+        Enum("security", "updates", "esm-infra", "esm-apps", name="pockets")
     )
 
     cve = relationship("CVE", back_populates="statuses")

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -224,9 +224,7 @@ class Status(Base):
         )
     )
     description = Column(String)
-    component = Column(
-        Enum("main", "universe", name="components"),
-    )
+    component = Column(Enum("main", "universe", name="components"),)
     pocket = Column(
         Enum("security", "updates", "esm-infra", "esm-apps", name="pockets"),
     )

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -134,8 +134,12 @@ class CVESchema(Schema):
     references = List(String())
     bugs = List(String())
     patches = Dict(
-        keys=String(), values=List(String(), required=False), allow_none=True,
+        keys=String(),
+        values=List(String(), required=False),
+        allow_none=True,
     )
     tags = Dict(
-        keys=String(), values=List(String(), required=False), allow_none=True,
+        keys=String(),
+        values=List(String(), required=False),
+        allow_none=True,
     )

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -134,8 +134,8 @@ class CVESchema(Schema):
     references = List(String())
     bugs = List(String())
     patches = Dict(
-        keys=String(), values=List(String(), required=False), allow_none=True,
+        keys=String(), values=List(String(), required=False), allow_none=True
     )
     tags = Dict(
-        keys=String(), values=List(String(), required=False), allow_none=True,
+        keys=String(), values=List(String(), required=False), allow_none=True
     )

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -134,12 +134,8 @@ class CVESchema(Schema):
     references = List(String())
     bugs = List(String())
     patches = Dict(
-        keys=String(),
-        values=List(String(), required=False),
-        allow_none=True,
+        keys=String(), values=List(String(), required=False), allow_none=True,
     )
     tags = Dict(
-        keys=String(),
-        values=List(String(), required=False),
-        allow_none=True,
+        keys=String(), values=List(String(), required=False), allow_none=True,
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -430,6 +430,9 @@ def advantage_view():
 
         for account in accounts:
             account["contracts"] = advantage.get_account_contracts(account)
+            subscriptions = advantage.get_subscriptions(
+                account["id"], "canonical-ua"
+            )
 
             for contract in account["contracts"]:
                 contract["token"] = advantage.get_contract_token(contract)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -887,19 +887,6 @@ def get_purchase(purchase_id):
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def get_purchase(purchase_id):
-    if user_info(flask.session):
-        advantage = AdvantageContracts(
-            session,
-            flask.session["authentication_token"],
-            api_url=flask.current_app.config["CONTRACTS_API_URL"],
-        )
-
-        return advantage.get_purchase(purchase_id)
-    else:
-        return flask.jsonify({"error": "authentication required"}), 401
-
-
 def get_renewal(renewal_id):
     if user_info(flask.session):
         advantage = AdvantageContracts(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -652,7 +652,7 @@ def post_advantage_subscriptions(preview):
             purchase = advantage.preview_purchase_from_marketplace(
                 marketplace="canonical-ua", purchase_request=purchase_request
             )
-    except HTTPError as http_error:
+    except HTTPError:
         flask.current_app.extensions["sentry"].captureException(
             extra={"purchase_request": purchase_request}
         )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -652,7 +652,8 @@ def post_advantage_subscriptions(preview):
             purchase = advantage.preview_purchase_from_marketplace(
                 marketplace="canonical-ua", purchase_request=purchase_request
             )
-    except HTTPError:
+    except HTTPError as http_error:
+        print(http_error.response.content)
         flask.current_app.extensions["sentry"].captureException(
             extra={"purchase_request": purchase_request}
         )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -430,9 +430,6 @@ def advantage_view():
 
         for account in accounts:
             account["contracts"] = advantage.get_account_contracts(account)
-            subscriptions = advantage.get_subscriptions(
-                account["id"], "canonical-ua"
-            )
 
             for contract in account["contracts"]:
                 contract["token"] = advantage.get_contract_token(contract)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -887,6 +887,19 @@ def get_purchase(purchase_id):
         return flask.jsonify({"error": "authentication required"}), 401
 
 
+def get_purchase(purchase_id):
+    if user_info(flask.session):
+        advantage = AdvantageContracts(
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
+        )
+
+        return advantage.get_purchase(purchase_id)
+    else:
+        return flask.jsonify({"error": "authentication required"}), 401
+
+
 def get_renewal(renewal_id):
     if user_info(flask.session):
         advantage = AdvantageContracts(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -649,8 +649,7 @@ def post_advantage_subscriptions(preview):
             purchase = advantage.preview_purchase_from_marketplace(
                 marketplace="canonical-ua", purchase_request=purchase_request
             )
-    except HTTPError as http_error:
-        print(http_error.response.content)
+    except HTTPError:
         flask.current_app.extensions["sentry"].captureException(
             extra={"purchase_request": purchase_request}
         )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -835,6 +835,34 @@ def make_renewal(advantage, contract_info):
     return renewal
 
 
+def post_anonymised_customer_info():
+    if user_info(flask.session):
+        advantage = AdvantageContracts(
+            session,
+            flask.session["authentication_token"],
+            api_url=flask.current_app.config["CONTRACTS_API_URL"],
+        )
+
+        if not flask.request.is_json:
+            return flask.jsonify({"error": "JSON required"}), 400
+
+        account_id = flask.request.json.get("account_id")
+        if not account_id:
+            return flask.jsonify({"error": "account_id required"}), 400
+
+        address = flask.request.json.get("address")
+        if not address:
+            return flask.jsonify({"error": "address required"}), 400
+
+        tax_id = flask.request.json.get("tax_id")
+
+        return advantage.put_anonymous_customer_info(
+            account_id, address, tax_id
+        )
+    else:
+        return flask.jsonify({"error": "authentication required"}), 401
+
+
 def post_customer_info():
     if user_info(flask.session):
         advantage = AdvantageContracts(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -392,7 +392,7 @@ def advantage_view():
     new_subscription_id = None
     open_subscription = flask.request.args.get("subscription", None)
     stripe_publishable_key = os.getenv(
-        "STRIPE_PUBLISHABLE_KEY", "pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46"
+        "STRIPE_PUBLISHABLE_KEY", "pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp"
     )
 
     if user_info(flask.session):
@@ -652,7 +652,8 @@ def post_advantage_subscriptions(preview):
             purchase = advantage.preview_purchase_from_marketplace(
                 marketplace="canonical-ua", purchase_request=purchase_request
             )
-    except HTTPError:
+    except HTTPError as http_error:
+        print(http_error.response.content)
         flask.current_app.extensions["sentry"].captureException(
             extra={"purchase_request": purchase_request}
         )
@@ -687,7 +688,7 @@ def advantage_shop_view():
     account = None
     previous_purchase_id = None
     stripe_publishable_key = os.getenv(
-        "STRIPE_PUBLISHABLE_KEY", "pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46"
+        "STRIPE_PUBLISHABLE_KEY", "pk_test_LbxZRQZdP7xsZenWT1TAhbkX00VioMBflp"
     )
 
     if user_info(flask.session):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -653,7 +653,6 @@ def post_advantage_subscriptions(preview):
                 marketplace="canonical-ua", purchase_request=purchase_request
             )
     except HTTPError as http_error:
-        print(http_error.response.content)
         flask.current_app.extensions["sentry"].captureException(
             extra={"purchase_request": purchase_request}
         )
@@ -663,6 +662,25 @@ def post_advantage_subscriptions(preview):
         )
 
     return flask.jsonify(purchase), 200
+
+
+def post_renewal_preview(renewal_id):
+    advantage = AdvantageContracts(
+        session,
+        flask.session["authentication_token"],
+        api_url=flask.current_app.config["CONTRACTS_API_URL"],
+    )
+
+    try:
+        preview = advantage.post_renewal_preview(renewal_id=renewal_id)
+    except HTTPError as http_error:
+        flask.current_app.extensions["sentry"].captureException()
+        return (
+            http_error.response.content,
+            500,
+        )
+
+    return flask.jsonify(preview), 200
 
 
 def advantage_shop_view():


### PR DESCRIPTION
## Done

Implemented a VAT/purchase preview endpoint that returns a VAT total (when applicable) and actual total and presents it to the user during the payment modal journey.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Whilst logged in, make a product selection, add it to the cart, and click "Buy Now" and QA the following two flows:

#### VAT
- In the payment modal, select United Kingdom (VAT is always applicable)
- After a short wait, VAT and total should appear below the form
- Change the country to United States (VAT is not applicable)
- After a short wait, VAT should disappear and total should update
- Change the country to France (VAT is applicable without a VAT number)
- After a short wait, VAT and total should appear below the form
- Fill out the VAT number field with "FR77784608416" (Credit Agricole's VAT number)
- After a short wait, VAT should disappear and total should update

#### Prorating
- In the payment modal, allow a moment for the subtotal to appear
- If you have an existing subscription that ends in less than a year, the end date of each plan should change to reflect that, and the first plan will contain a note explaining the change.
  - If you don't have such a subscription, ask Scott to set you up with one.

## Issue / Card

Fixes #7647 and #8235 
