### PR TITLE
Display related notices

### DIFF
--- a/templates/security/notice.html
+++ b/templates/security/notice.html
@@ -99,6 +99,21 @@
     </div>
   </div>
   {% endif %}
+  {% if notice.related_notices|length > 0 %}
+  <div class="row">
+    <div class="col-8">
+      <h2>Related notices</h2>
+      <ul class="p-list">
+        {% for notice in notice.related_notices %}
+          <li class="p-list__item">
+            <a href="/security/notices/{{ notice.id }}">{{ notice.id }}</a>: {{ notice.package_list }}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
+
 </section>
 
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -140,6 +140,18 @@ class Notice(Base):
         back_populates="notices",
     )
 
+    @hybrid_property
+    def package_list(self):
+        if not self.release_packages:
+            return []
+
+        package_list = []
+        for codename, packages in self.release_packages.items():
+            for package in packages:
+                package_list.append(package["name"])
+
+        return set(sorted(package_list))
+
 
 class Release(Base):
     __tablename__ = "release"


### PR DESCRIPTION
## Done

Add two new hybrid notices for Notice:
1) `related_notices`: to fetch related notices of the current notice
2) `package_list`: to fetch an array of all the packages part of the
notice

## QA

1. Fetch changes
```bash
git fetch albert-fork
git checkout display-related-notices
```
2. Have notices imported
3. Launch website (`dotrun`) and browse to `/security/notices/USN-4328-1` and scroll down you will see the Related Notices section.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2576
