### PR TITLE
Fix a 500 on the German homepage

### DIFF
--- a/templates/index_de.html
+++ b/templates/index_de.html
@@ -4,6 +4,6 @@
 {% endblock %}
 
 {% block takeover_content %}
-  {% with nojs_fallback=True %}{% include "takeovers/_de-vmware-to-os.html" %}{% endwith %}
+  {% with nojs_fallback=True %}{% include "takeovers/de/_de-vmware-to-os.html" %}{% endwith %}
   {% include "takeovers/_financial-services.html" %}
 {% endblock takeover_content %}


### PR DESCRIPTION
## Done
Update the path to one of the German takeover includes

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/index_de
- See that it doesn't 500 as it does on live.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8242

