### PR TITLE
Add notification banner to ESM page

### DIFF
--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -38,9 +38,9 @@
       <div class="p-heading-icon__header">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/9e59756d-shield-ESM.svg",
+            url="https://assets.ubuntu.com/v1/d7e4ac90-shield-ESM.svg",
             alt="",
-            height="90",
+            height="225",
             width="195",
             hi_def=True,
             loading="auto",

--- a/templates/esm/index.html
+++ b/templates/esm/index.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
+<section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
     <div class="col-8">
       <span class="u-sv3"><h1>Extended Security Maintenance</h1></span>
@@ -31,6 +31,27 @@
     </div>
   </div>
 </section>
+
+<div class="p-strip is-shallow">
+  <div class="u-fixed-width">
+    <div class="p-heading-icon--small">
+      <div class="p-heading-icon__header">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/9e59756d-shield-ESM.svg",
+            alt="",
+            height="90",
+            width="195",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-heading-icon__img"},
+          ) | safe
+        }}
+        <h4 class="p-heading-icon__title u-no-max-width u-no-margin--bottom">Extended Security Maintenance for Ubuntu 16.04 LTS will be available April 2021 until 2024</h4>
+      </div>
+    </div>
+  </div>
+</div>
 
 <section class="p-strip--suru-accent is-dark">
   <div class="row">


### PR DESCRIPTION
## Done
Add notification banner to ESM page

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/esm
- Check the second strip is a shallow notification banner

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3162

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/92709573-f31d3e00-f34e-11ea-9951-ae3cddc66a8c.png)

