### PR TITLE
Optimise CVE filter

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -401,6 +401,17 @@ def cve_index():
     if should_filter_by_version_and_status:
         conditions = []
         for key, version in enumerate(clean_versions):
+            conditions.append(
+                and_(
+                    Status.release_codename.in_(version),
+                    Status.status.in_(clean_statuses[key]),
+                )
+            )
+
+        parameters.append(or_(*[c for c in conditions]))
+
+        conditions = []
+        for key, version in enumerate(clean_versions):
             sub_conditions = [
                 Status.release_codename.in_(version),
                 Status.status.in_(clean_statuses[key]),


### PR DESCRIPTION
## Done

- Add an extra query condition to reduce the number of `CVE.statuses` before
the more complex conditions get applied.

## QA

0. Do not fetch the changes yet
1. Go to `/security/cve` play with the version-status filters. You will notice it takes 1-2 seconds (on local) to get the page loading
2. Fetch the changes
```bash
git fetch albert-fork
git checkout optimise-cve-filter
```
3. Go to `/security/cve` play with the version-status filter. It should still work and the results should be return in less than half a second.  