### PR TITLE
if a contract has multiple renewals, return earliest one

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -505,7 +505,12 @@ def make_renewal(advantage, contract_info):
     if not renewals:
         return None
 
-    renewal = renewals[0]
+    sorted_renewals = sorted(
+        renewals,
+        key=lambda renewal: dateutil.parser.parse(renewal["start"]),
+    )
+
+    renewal = sorted_renewals[0]
 
     # If the renewal is processing, we need to find out
     # whether payment failed and requires user action,


### PR DESCRIPTION
## Done

- When presenting a renewal to a user, sort the array of renewals by their `start` property, and return the earliest starting one to the view.

## QA

- Check out this feature branch
- In VS Code (or whichever editor you're using), open /tests/test_views.py
- Switch the values on lines 223 and 230 (`start_yesterday` and `start_last_week`)
- In your console, run `dotrun exec npm run test-python`
- See that that one test fails
- Undo your changes, and run the test again, it should pass
