### PR TITLE
Fix CVE order

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -12,7 +12,7 @@ from marshmallow import EXCLUDE
 from marshmallow.exceptions import ValidationError
 from mistune import Markdown
 from sortedcontainers import SortedDict
-from sqlalchemy import asc, desc, or_, and_, func
+from sqlalchemy import asc, desc, or_, and_, func, case
 from sqlalchemy.exc import IntegrityError, DataError
 from sqlalchemy.orm import contains_eager
 
@@ -430,7 +430,13 @@ def cve_index():
 
     cves_query = (
         cves_query.group_by(CVE.id)
-        .order_by(desc(CVE.published))
+        .order_by(
+            case(
+                [(CVE.published.is_(None), 1)],
+                else_=0,
+            ),
+            desc(CVE.published),
+        )
         .limit(limit)
         .offset(offset)
         .from_self()


### PR DESCRIPTION
CVEs are ordered desc by `published` date. Some old CVEs do not have a
published date, so null gets inserted in the database. When these get
ordered NULL values are listed at the top.

This change will list the NULL values at the end.

## QA

0. Do not fetch changes.
1. Have the CVEs imported. 
2. Update some CVEs to have published date NULL
```bash
docker exec -it db psql -U postgres
```
And run:
```sql
UPDATE cve SET published=NULL WHERE id='CVE-2012-0937'; 
UPDATE cve SET published=NULL WHERE id='CVE-2012-1191'; 
UPDATE cve SET published=NULL WHERE id='CVE-2012-1148'; 
```
3. Browse to `/security/cve`. You will see these cves at the top.
4. Fetch changes:
```bash
git fetch albert-fork
git checkout cve-fix-order-if-published-null
```
5. Browse to `/security/cve`. You will not see these cves at the top.

## Issue / Card

Fixes #8263 
