### PR TITLE
Display cve package sources

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -189,10 +189,10 @@
                     {% endif %}
                     <br>
                     <small>
-                      {% if statuses[release.codename].component == "esm-infra" %}
+                      {% if statuses[release.codename].pocket == "esm-infra" %}
                       Requires <a href="/advantage" target="_blank">UA Infra, UA Desktop</a>
                       {% endif %}
-                      {% if statuses[release.codename].component == "esm-apps" %}
+                      {% if statuses[release.codename].pocket == "esm-apps" %}
                       Requires <a href="/advantage" target="_blank">UA Apps, UA Desktop</a>
                       {% endif %}
                     </small>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -138,7 +138,14 @@
                 <tr>
                   {% if release.codename in statuses %}
                     {% if loop.index == 1 %}
-                      <td rowspan="{{ releases | length }}">{{ package_name }}</td>
+                      <td rowspan="{{ releases | length }}">
+                        <a href="/security/cve?q=&package={{ package_name }}" target="_blank">{{ package_name }}</a><br>
+                        <small>
+                        <a href="https://launchpad.net/distros/ubuntu/+source/{{ package_name }}" target="_blank">Launchpad</a>,
+                        <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package_name }}" target="_blank">Ubuntu</a>,
+                        <a href="https://tracker.debian.org/{{ package_name }}" target="_blank">Debian</a>
+                        </small>
+                      </td>
                     {% endif %}
                     <td>
                       {% if release.name == "Upstream" %}


### PR DESCRIPTION
Display cve packages sources on the cve page.

FX: 
https://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-8834.html You can see `source` under every package
https://ubuntu.com/security/CVE-2020-8834 does not have it

## QA

1. Fetch changes 
```bash
git fetch albert-fork
git checkout add-cve-package-source
```

2. Browse to `/security/CVE-2020-8834` you will see the source listed under the name of the package.

## Issue / Card

Fixes #8264 

