### PR TITLE
Ubuntu 18.04 also needs --devmode for MicroStack

### DIFF
--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -131,7 +131,7 @@
           <p>You can install MicroStack right away by running the following command from the terminal:</p>
 
           <div class="p-code-copyable">
-            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --classic --edge --devmode" readonly="readonly">
+            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --edge --devmode" readonly="readonly">
             <button class="p-code-copyable__action">Copy to clipboard</button>
           </div>
 
@@ -357,7 +357,7 @@ You can also visit the openstack dashboard at 'http://10.20.20.1/</code></pre>
                 <p>You can install MicroStack right away by running the following command from the terminal:</p>
 
                 <div class="p-code-copyable">
-                  <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --classic --edge --devmode" readonly="readonly">
+                  <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --edge --devmode" readonly="readonly">
                   <button class="p-code-copyable__action">Copy to clipboard</button>
                 </div>
 

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -128,14 +128,7 @@
       <li class="p-stepped-list__item">
         <h4 class="p-stepped-list__title">Install MicroStack</h4>
         <div class="p-stepped-list__content">
-          <p>If you are using Ubuntu 18.04 LTS, which we highly recommend, you can install MicroStack right away by running the following command from the terminal:</p>
-
-          <div class="p-code-copyable">
-            <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --classic --beta" readonly="readonly">
-            <button class="p-code-copyable__action">Copy to clipboard</button>
-          </div>
-
-          <p>In case you are using Ubuntu 19.10 or Ubuntu 20.04 LTS, use the following command instead:</p>
+          <p>You can install MicroStack right away by running the following command from the terminal:</p>
 
           <div class="p-code-copyable">
             <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --classic --edge --devmode" readonly="readonly">
@@ -361,14 +354,7 @@ You can also visit the openstack dashboard at 'http://10.20.20.1/</code></pre>
             <li class="p-stepped-list__item">
               <h4 class="p-stepped-list__title">Install MicroStack</h4>
               <div class="p-stepped-list__content">
-                <p>If you are using Ubuntu 18.04 LTS, which we highly recommend, you can install MicroStack right away by running the following command from the terminal:</p>
-
-                <div class="p-code-copyable">
-                  <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --classic --edge" readonly="readonly">
-                  <button class="p-code-copyable__action">Copy to clipboard</button>
-                </div>
-
-                <p>In case you are using Ubuntu 19.10 or Ubuntu 20.04 LTS, use the following command instead:</p>
+                <p>You can install MicroStack right away by running the following command from the terminal:</p>
 
                 <div class="p-code-copyable">
                   <input aria-label="code snippet" class="p-code-copyable__input" value="sudo snap install microstack --classic --edge --devmode" readonly="readonly">


### PR DESCRIPTION
MicroStack snap also needs --devmode for 18.04 and not just for 20.04.

## Done

- fix installation command to install microstack on Ubuntu 18.04
