### PR TITLE
Changed takeovers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,8 +28,7 @@
 
 {% block takeover_content %}
   {# ALL #}
-  {% include "takeovers/_intro-to-anbox-cloud-whitepaper.html" %}
-  {% include "takeovers/_gsi-webinar-series-takeover.html" %}
+  {% include "takeovers/_telco-virtual-event.html" %}
   {% include "takeovers/_redhat-openstack.html" %}
   {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
 


### PR DESCRIPTION
## Done
Removed intro-to-anbox-cloud-whitepaper and gsi-webinar-series-takeover. Added _telco-virtual-event.html (https://github.com/canonical-web-and-design/ubuntu.com/blob/master/templates/engage/telco-virtual-event.md)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]
