### PR TITLE
Show machine allowances on /renewals when possible

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
-CONTRACTS_API_URL=https://contracts.canonical.com/
+CONTRACTS_API_URL=https://contracts.staging.canonical.com/
 STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do

--- a/tests/cassettes/TestRoutes.test_advantage.yaml
+++ b/tests/cassettes/TestRoutes.test_advantage.yaml
@@ -1,36 +1,36 @@
 interactions:
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.23.0
-    method: GET
-    uri: https://contracts.canonical.com/v1/accounts
-  response:
-    body:
-      string: '{"code":"unauthorized","message":"unauthorized","traceId":"cc123f07-176b-49a3-bac2-9429c876f888"}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '97'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 02 Jul 2020 21:29:46 GMT
-      Server:
-      - openresty/1.15.8.2
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Trace-Id:
-      - cc123f07-176b-49a3-bac2-9429c876f888
-    status:
-      code: 401
-      message: Unauthorized
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.23.0
+      method: GET
+      uri: https://contracts.staging.canonical.com/v1/accounts
+    response:
+      body:
+        string: '{"code":"unauthorized","message":"unauthorized","traceId":"cc123f07-176b-49a3-bac2-9429c876f888"}'
+      headers:
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "97"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 02 Jul 2020 21:29:46 GMT
+        Server:
+          - openresty/1.15.8.2
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        X-Trace-Id:
+          - cc123f07-176b-49a3-bac2-9429c876f888
+      status:
+        code: 401
+        message: Unauthorized
 version: 1

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -6,7 +6,7 @@ class AdvantageContracts:
         self,
         session,
         authentication_token,
-        api_url="https://contracts.canonical.com",
+        api_url="https://contracts.staging.canonical.com",
     ):
         """
         Expects a Talisker session in most circumstances,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -80,7 +80,7 @@ app = FlaskBase(
 
 # Settings
 app.config["CONTRACTS_API_URL"] = os.getenv(
-    "CONTRACTS_API_URL", "https://contracts.canonical.com"
+    "CONTRACTS_API_URL", "https://contracts.staging.canonical.com"
 ).rstrip("/")
 app.config["CANONICAL_LOGIN_URL"] = os.getenv(
     "CANONICAL_LOGIN_URL", "https://login.ubuntu.com"


### PR DESCRIPTION
**⛔ revert API environment back to prod before merging ⛔**

## Done

- if a contract has info on its machine allowance, present it to the user on /advantage as "X/Y" where X is the number of attached machines, and Y is the number of machines they have paid for.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Login
- If you don't have contract staging data already, talk to Scott and he'll set you up with what you need
- See that under "attached", you can see how many machines you have, and how many have been attached.

and/or: 

- see that the tests pass, and that the screenshot looks good

## Screenshots

![Screenshot from 2020-09-15 15-30-00](https://user-images.githubusercontent.com/2376968/93224034-98c61800-f768-11ea-9211-86b4ab4b5669.png)

