### PR TITLE
SMART START guide

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -36,6 +36,16 @@ env:
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: api-key
+      name: discourse-api
+
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key:  api-username
+      name: discourse-api
+
 memoryLimit: 512Mi
 
 extraHosts:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==6.2.3
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.2.0
-canonicalwebteam.discourse-docs==1.0.1
+canonicalwebteam.discourse==2.0.1
 canonicalwebteam.launchpad==0.7.7
 python-dateutil==2.8.1
 pytz==2020.1

--- a/templates/smart-start/base_docs.html
+++ b/templates/smart-start/base_docs.html
@@ -1,0 +1,40 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+<div class="l-documentation">
+  <div class="l-documentation__sidebar">
+    <aside class="p-sidebar" id="navigation">
+      <div class="p-sidebar__banner u-hide--medium u-hide--large">
+        <i class="p-sidebar__toggle p-icon--menu"></i>
+      </div>
+      <div class="p-sidebar__content u-hide--small">
+        <nav class="p-sidebar-nav">
+          {{ navigation | safe }}
+        </nav>
+      </div>
+    </aside>
+  </div>
+
+  <div class="l-documentation__content p-content">
+    {% block content_docs %}{% endblock %}
+  </div>
+</div>
+
+<script>
+  const path = window.location.pathname;
+  const active = document.querySelector(`.p-sidebar a[href="${path}"]`);
+  if (active) {
+    active.classList.add("is-active");
+  }
+
+  const toggleSidebar = document.querySelector(".p-sidebar__toggle");
+  const sidebar = document.querySelector(".p-sidebar__content");
+  if (toggleSidebar) {
+    toggleSidebar.addEventListener("click", function(e) {
+      sidebar.classList.toggle("u-hide--small");
+      toggleSidebar.classList.toggle("p-icon--close");
+      toggleSidebar.classList.toggle("p-icon--menu");
+    });
+  }
+</script>
+{% endblock %}

--- a/templates/smart-start/document.html
+++ b/templates/smart-start/document.html
@@ -1,0 +1,23 @@
+
+{% extends "docs/base_docs.html" %}
+
+{% block title %} {{ document.title }} | Server documentation{% endblock %}
+
+{% block content_docs %}
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        {{ document.body_html | safe }}
+    </div>
+</div>
+
+<div class="p-strip is-shallow">
+    <div class="p-content__row">
+        <div class="p-notification--information">
+            <p class="p-notification__response">
+                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/smart-start/document.html
+++ b/templates/smart-start/document.html
@@ -1,22 +1,12 @@
 
 {% extends "docs/base_docs.html" %}
 
-{% block title %} {{ document.title }} | Server documentation{% endblock %}
+{% block title %} {{ document.title }} | Smart Start{% endblock %}
 
 {% block content_docs %}
 <div class="p-strip is-shallow">
     <div class="p-content__row">
         {{ document.body_html | safe }}
-    </div>
-</div>
-
-<div class="p-strip is-shallow">
-    <div class="p-content__row">
-        <div class="p-notification--information">
-            <p class="p-notification__response">
-                Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
-            </p>
-        </div>
     </div>
 </div>
 {% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -293,6 +293,20 @@ ceph_docs = DiscourseDocs(
 ceph_docs.init_app(app)
 
 
+# Smart Start
+smart_start = DiscourseDocs(
+    parser=DocParser(
+        api=discourse_api,
+        index_topic_id=15433,
+        url_prefix="/smart-start",
+    ),
+    document_template="/smart-start/document.html",
+    url_prefix="/smart-start",
+    blueprint_name="smart-start",
+)
+smart_start.init_app(app)
+
+
 @app.after_request
 def cache_headers(response):
     """

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -11,9 +11,9 @@ from canonicalwebteam.templatefinder import TemplateFinder
 from canonicalwebteam.search import build_search_view
 from canonicalwebteam import image_template
 from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
-from canonicalwebteam.discourse_docs import (
+from canonicalwebteam.discourse import (
     DiscourseAPI,
-    DiscourseDocs,
+    Docs,
     DocParser,
 )
 
@@ -91,6 +91,12 @@ discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/", session=session
 )
 
+authenticated_discourse_api = DiscourseAPI(
+    base_url="https://discourse.ubuntu.com/",
+    session=session,
+    api_key=os.getenv("DISCOURSE_API_KEY"),
+    api_username=os.getenv("DISCOURSE_API_USERNAME"),
+)
 
 # Error pages
 
@@ -240,7 +246,7 @@ app.add_url_rule(
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
 url_prefix = "/server/docs"
-server_docs = DiscourseDocs(
+server_docs = Docs(
     parser=DocParser(
         api=discourse_api,
         category_id=26,
@@ -263,7 +269,7 @@ app.add_url_rule(
 )
 
 tutorials_path = "/tutorials"
-tutorials_docs = DiscourseDocs(
+tutorials_docs = Docs(
     parser=DocParser(
         api=discourse_api,
         category_id=34,
@@ -280,7 +286,7 @@ app.add_url_rule(
 tutorials_docs.init_app(app)
 
 # Ceph docs
-ceph_docs = DiscourseDocs(
+ceph_docs = Docs(
     parser=DocParser(
         api=discourse_api,
         index_topic_id=17250,
@@ -294,9 +300,9 @@ ceph_docs.init_app(app)
 
 
 # Smart Start
-smart_start = DiscourseDocs(
+smart_start = Docs(
     parser=DocParser(
-        api=discourse_api,
+        api=authenticated_discourse_api,
         index_topic_id=15433,
         url_prefix="/smart-start",
     ),


### PR DESCRIPTION
## Done

- Add new discourse module with authentication

## QA

- Open the demo and navigate to `/docs`
- Might want to review the other `/docs` just in case, as there has been some renaming. i.e. `/server/docs`, `/tutorials`, `/ceph/docs`

## Issue / Card

Fixes #8254 #8255 
