### PR TITLE
Add cves in usn listings

### DIFF
--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -2,10 +2,31 @@
   <h3 class="u-no-margin p-heading--four" style="padding-bottom: 8px;"><a href="/security/notices/{{notice.id}}">{{ notice.id }}: {{ notice.title }} ›</a></h3>
   <p class="u-no-margin u-no-padding--top" style="color: #666; font-size: 14px; padding-bottom: 8px;">{{ notice.published.strftime("%d %B %Y") }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">{{ notice.summary | safe }}</p>
+  <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">
+    <small>
+      {% for cve in notice.cves %}
+        {% if loop.index <= 3 %}
+          <a href="/security/{{ cve.id }}">{{ cve.id }}</a>{% if loop.index < notice.cves|length or (notice.cves|length > 3 and loop.index == 3) %}<span style="color: #666; font-size: 14px; padding-bottom: 8px;">,</span>{% endif %}
+        {% endif %}
+        <span style="color: #666; font-size: 14px; padding-bottom: 8px;">
+          {% if loop.index == 3 %}
+            {% if notice.cves|length - 3 == 1 %}
+              and {{ notice.cves|length - 3}} other
+            {% endif %}
+            {% if notice.cves|length - 3 > 1 %}
+              and {{ notice.cves|length - 3}} others
+            {% endif %}
+          {% endif %}
+        </span>
+      {% endfor %}
+    </small>
+  </p>
   <ul class="p-inline-list u-no-margin">
     {% for release in notice.releases %}
       <li class="p-inline-list__item">
-        <a href="/security/notices?release={{release.codename}}" class="p-button--tag">Ubuntu {{ release.version }} {{ release.support_tag }}</a>
+        <a href="/security/notices?release={{release.codename}}">
+          <small>Ubuntu {{ release.version }} {{ release.support_tag }}</small>
+        </a>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Done

- Add cves to the usn listings. Spec: https://docs.google.com/document/d/183fLUXOLL17_baS617aX7Sj133n4lLfS6-rLhXXv9I0/edit#heading=h.z80bvqisakj6

## QA

**1)** Import the notices (root of the ubuntu.com repo):

Terminal 1 (root of the ubunut.com repo):
```bash
dotrun
```
Terminal 2 (root of the ubunut.com repo): 
```bash
python3 scripts/create-usns.py database.json # path to your database.json file might be somewhere else
```
Leave it only for 10-15 seconds. You only need a few notices in the database to QA these changes.

**2)** Fetch the changes:
```bash
git fetch albert-fork
git checkout display-cve-in-usn-listings
```
**3)** Browse to `/security/notices`. You will see the cves listed for each usn just above the ubuntu releases.

## Issue / Card

Fixes #2255

## Screenshots

![image](https://user-images.githubusercontent.com/6387619/93487754-7dd8dc80-f8fd-11ea-99fc-7664eebb5fd2.png)
