### PR TITLE
Add lang=es to Spanish takeover

### DIFF
--- a/templates/takeovers/es/guía-implementación-openstack.html
+++ b/templates/takeovers/es/guía-implementación-openstack.html
@@ -8,6 +8,7 @@ primary_url="/engage/es/guía-implementación-openstack?utm_source=Takeover&utm_
 primary_cta="Descargar el manual",
 primary_cta_class="",
 secondary_url="",
-secondary_cta="" %}
+secondary_cta="",
+lang="es" %}
 {% include "takeovers/_template.html" %}
 {% endwith %}


### PR DESCRIPTION
## Done

- Add lang=es to takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check Spanish takeover doesn't show unless language is changed to Spanish


## Issue / Card

Fixes #8315 

