### PR TITLE
WIP Smart Start links

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1241,3 +1241,11 @@ robotics:
       path: /robotics/what-is-ros
     - title: Community
       path: /robotics/community
+
+smartstart:
+  title: Smart Start
+  path: /smart-start
+
+  children:
+    - title: What is Smart Start
+      path: /smart-start

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -11,7 +11,8 @@
   <div class="u-fixed-width">
     <h1>Ubuntu IoT and device services</h1>
     <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge. Get ten years of security coverage and dedicated app stores for your smart connected devices.</p>
-    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+    <a href="/smart-start" class="p-button--positive is-inline u-no-margin--left">Learn more about SMART START</a>
+    <a href="/support/contact-us" class="js-invoke-modal">Get in touch&nbsp;&rsaquo;</a>
   </div>
 </section>
 

--- a/templates/shared/pricing/_smart-start-prices.html
+++ b/templates/shared/pricing/_smart-start-prices.html
@@ -75,6 +75,7 @@
   </div>
 
   <div class="u-fixed-width">
-    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Start your embedded project</a>
+    <a href="/smart-start" class="p-button--positive is-inline u-no-margin--left">Get started with SMART START</a>
+    <a href="/support/contact-us" class="js-invoke-modal">Contact us about your embedded project&nbsp;&rsaquo;</a>
   </div>
 </section>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -87,6 +87,9 @@
               {% with section=nav_sections.tutorials %}
               {% include 'templates/_footer_item.html' %}
               {% endwith %}
+              {% with section=nav_sections.smartstart %}
+              {% include 'templates/_footer_item.html' %}
+              {% endwith %}
             </ul>
           </li>
         </ul>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -89,6 +89,7 @@
             <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
             <li class="p-list__item"><a href="/automotive">Automotive with Ubuntu</a></li>
             <li class="p-list__item"><a href="/internet-of-things/networking">Networking with Ubuntu</a></li>
+            <li class="p-list__item"><a href="/smart-start">Get started with SMART START</a></li>
           </ul>
         </div>
         <!-- Support and services -->


### PR DESCRIPTION
## Done

- Added links to footer, top navigation dropdown.

## QA

- Visit https://ubuntu-com-8317.demos.haus
- [ ] Top navigation drop down shows "Get started with SMART START"
- [ ] Footer shows Smart Start
- [ ] https://ubuntu-com-8317.demos.haus/pricing/devices contains new buttons. Click them and make sure they work


## Issue / Card

Fixes #8258 
