### PR TITLE
/download/server Impressions tracking

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -160,6 +160,25 @@ function addGAImpressionEvents(target, category) {
   }
 }
 
+addGADownloadImpressionEvents(".js-download-option", "download-option");
+
+function addGADownloadImpressionEvents(target, category) {
+  var t = [].slice.call(document.querySelectorAll(target));
+  if (t) {
+    t.forEach(function (section) {
+      if (!section.classList.contains("u-hide")) {
+        dataLayer.push({
+          event: "NonInteractiveGAEvent",
+          eventCategory: "www.ubuntu.com-impression-" + category,
+          eventAction: "Display option",
+          eventLabel: section.innerText,
+          eventValue: undefined,
+        });
+      }
+    });
+  }
+}
+
 addUTMToForms();
 
 function addUTMToForms() {

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -166,15 +166,13 @@ function addGADownloadImpressionEvents(target, category) {
   var t = [].slice.call(document.querySelectorAll(target));
   if (t) {
     t.forEach(function (section) {
-      if (!section.classList.contains("u-hide")) {
-        dataLayer.push({
-          event: "NonInteractiveGAEvent",
-          eventCategory: "www.ubuntu.com-impression-" + category,
-          eventAction: "Display option",
-          eventLabel: section.innerText,
-          eventValue: undefined,
-        });
-      }
+      dataLayer.push({
+        event: "NonInteractiveGAEvent",
+        eventCategory: "www.ubuntu.com-impression-" + category,
+        eventAction: "Display option",
+        eventLabel: section.innerText,
+        eventValue: undefined,
+      });
     });
   }
 }

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <p class="p-muted-heading">Get Ubuntu server</p>
-      <h1>Option 3: Manual install</h1>
+      <h1 class="js-download-option">Option 3: Manual install</h1>
       <p class="p-heading--four">Download and install Ubuntu Server {{ releases.lts.short_version }} LTS using a USB stick or a DVD burner</p>
       <p>The long-term support version of Ubuntu Server, including the {{ releases.openstack_lts.slug }} release of OpenStack and support guaranteed until {{ releases.lts.eol }}.</p>
       <p>

--- a/templates/download/server/download.html
+++ b/templates/download/server/download.html
@@ -20,7 +20,7 @@
     <div class="p-strip--suru-topped">
       <div class="row">
         <div class="col-6">
-          <h1>Thank you!</h1>
+          <h1 class="js-download-option">Thank you!</h1>
           <p>Your download of Ubuntu Server {{ version }} should start in the background.</p>
           <p>
             If your download doesn&rsquo;t start automatically,

--- a/templates/download/server/step1.html
+++ b/templates/download/server/step1.html
@@ -19,7 +19,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <p class="p-muted-heading">Get Ubuntu server</p>
-      <h1>Option 1: Multipass</h1>
+      <h1 class="js-download-option">Option 1: Multipass</h1>
       <p class="p-heading--four">On-demand Ubuntu Server VMs for Mac, Windows and Linux</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Multipass provides instant Ubuntu VMs</li>

--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -22,7 +22,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <p class="p-muted-heading">Get Ubuntu server</p>
-      <h1>Option 2: MAAS</h1>
+      <h1 class="js-download-option">Option 2: MAAS</h1>
       <p class="p-heading--four">Provision bare metal machines with Ubuntu Server in a fully automated way</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">MAAS turns your data centre into a bare metal cloud</li>


### PR DESCRIPTION
## Done

- Track impressions of new /download/server options

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Option 1: Google Analytics
  - Filter location and page (/download/server) on yourself in Google Analytics -> Combo tracker -> Real time
  - Navigate through /download/server options, go to "Events (last 30 min)" - to view non-interaction events, such as impressions - ensure "Display option" events are received
- Option 2: Google Analytics Debugger on Chrome
  - Install and activate the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) on Chrome
  - Open the console and navigate through /download/server options
  - Ensure you are seeing "Display option" events being sent