### PR TITLE
Fix desktop contributions

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -231,69 +231,70 @@
               <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
               <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
             </div>
-          </form>
-        </div>
-        <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-        <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-        <script>
-          $("#mktoForm_1212").validate({
-            errorPlacement: function(error, element) {
-              error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
-              error.appendTo( element.addClass( "p-form-validation__input" ));
-            },
-            errorElement: "span",
-            errorClass: "p-form-validation__message"
-          });
-        </script>
+          </div>
+        </form>
       </div>
-    </div>
-  </section>
-  {% endif %}
-
-  <div class="p-strip is-shallow">
-    <div class="row u-equal-height">
-      <div class="col-4 p-card--highlighted">
-        <h3>Learn how to try Ubuntu before you install</h3>
-        <p class="p-card__content">Run Ubuntu directly from either a USB stick or a DVD for a quick and easy way to experience how Ubuntu works.</p>
-        <p class="p-card__content"><a class="p-link--external"  href="/tutorials/try-ubuntu-before-you-install">Follow our simple guide</a></p>
-      </div>
-      <div class="col-4 p-card--highlighted">
-        <h3>Do you want to upgrade your OS?</h3>
-        <p class="p-card__content">If you are already running Ubuntu, you can upgrade with the Software Updater.</p>
-        <p class="p-card__content"><a href="/tutorials/tutorial-upgrading-ubuntu-desktop" class="p-link--external">How to upgrade</a></p>
-      </div>
-      <div class="col-4 p-card--highlighted">
-        <h3>Let’s connect</h3>
-        <p class="p-card__content">If you get stuck, help is always at hand.</p>
-        <p class="p-card__content"><a href="https://askubuntu.com" class="p-link--external">Ask Ubuntu</a></p>
-        <p class="p-card__content"><a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a></p>
-        <p class="p-card__content"><a href="https://wiki.ubuntu.com/IRC/ChannelList" class="p-link--external">IRC-based support</a></p>
-      </div>
+      <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+      <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+      <script>
+        $("#mktoForm_1212").validate({
+          errorPlacement: function(error, element) {
+            error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
+            error.appendTo( element.addClass( "p-form-validation__input" ));
+          },
+          errorElement: "span",
+          errorClass: "p-form-validation__message"
+        });
+      </script>
     </div>
   </div>
+</section>
+{% endif %}
 
-  {% with first_item="_download_verify_your_download", second_item="_download_desktop_guide", third_item="_download_enterprise_support" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+<div class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-4 p-card--highlighted">
+      <h3>Learn how to try Ubuntu before you install</h3>
+      <p class="p-card__content">Run Ubuntu directly from either a USB stick or a DVD for a quick and easy way to experience how Ubuntu works.</p>
+      <p class="p-card__content"><a class="p-link--external"  href="/tutorials/try-ubuntu-before-you-install">Follow our simple guide</a></p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3>Do you want to upgrade your OS?</h3>
+      <p class="p-card__content">If you are already running Ubuntu, you can upgrade with the Software Updater.</p>
+      <p class="p-card__content"><a href="/tutorials/tutorial-upgrading-ubuntu-desktop" class="p-link--external">How to upgrade</a></p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3>Let’s connect</h3>
+      <p class="p-card__content">If you get stuck, help is always at hand.</p>
+      <p class="p-card__content"><a href="https://askubuntu.com" class="p-link--external">Ask Ubuntu</a></p>
+      <p class="p-card__content"><a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a></p>
+      <p class="p-card__content"><a href="https://wiki.ubuntu.com/IRC/ChannelList" class="p-link--external">IRC-based support</a></p>
+    </div>
+  </div>
+</div>
+
+{% with first_item="_download_verify_your_download", second_item="_download_desktop_guide", third_item="_download_enterprise_support" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 
-  {% endblock content %}
+{% endblock content %}
 
-  {% block footer_extra %}
-  <script src="{{ versioned_static('js/src/contributions.js') }}"></script>
+{% block footer_extra %}
+<script src="{{ versioned_static('js/src/contributions.js') }}"></script>
 
-  {% if version %}
-    <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
-    <script defer>
-      var architecture = '{{ architecture }}';
-      var mirrors = {{ mirror_list | safe }};
-      var version = '{{ version }}';
+{% if version %}
+  <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+  <script defer>
+    var architecture = '{{ architecture }}';
+    var mirrors = {{ mirror_list | safe }};
+    var version = '{{ version }}';
 
-      if (version && architecture && architecture != 'amd64+mac') {
-        var GAlabel = version + '-desktop-' + architecture;
-        var imagePath = version + '/ubuntu-' + version + '-desktop-' + architecture + '.iso';
+    if (version && architecture && architecture != 'amd64+mac') {
+      var GAlabel = version + '-desktop-' + architecture;
+      var imagePath = version + '/ubuntu-' + version + '-desktop-' + architecture + '.iso';
 
-        window.initImageDownload(mirrors, imagePath, GAlabel);
-      }
-    </script>
-  {% endif %}
+      window.initImageDownload(mirrors, imagePath, GAlabel);
+    }
+  </script>
+{% endif %}
 
-  {% endblock footer_extra %}
+{% endblock footer_extra %}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -48,6 +48,7 @@
   </div>
 </section>
 
+{% if version %}
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-7">
@@ -247,6 +248,7 @@
       </div>
     </div>
   </section>
+  {% endif %}
 
   <div class="p-strip is-shallow">
     <div class="row u-equal-height">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -90,6 +90,19 @@ class TestRoutes(VCRTestCase):
 
         self.assertIn(b"ubuntu-20.04-desktop-amd64.iso", desktop_response.data)
 
+    def test_contribution(self):
+        """
+        Check contribution thank-you pages render
+        """
+
+        thank_you_response = self.client.get("/download/desktop/thank-you")
+
+        self.assertEqual(thank_you_response.status_code, 200)
+
+        self.assertIn(
+            b"Thank you for your contribution", thank_you_response.data
+        )
+
     def test_advantage(self):
         """
         When given the advantage URL,

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -96,10 +96,10 @@ def download_harness(category):
 
 
 def download_thank_you(category):
-    version = flask.request.args.get("version")
-    architecture = flask.request.args.get("architecture").replace(" ", "+")
+    version = flask.request.args.get("version", "")
+    architecture = flask.request.args.get("architecture", "").replace(" ", "+")
 
-    if not (version and architecture):
+    if version and not architecture:
         flask.abort(400)
 
     return (
@@ -556,7 +556,7 @@ def make_renewal(advantage, contract_info):
         return None
 
     sorted_renewals = sorted(
-        renewals, key=lambda renewal: dateutil.parser.parse(renewal["start"]),
+        renewals, key=lambda renewal: dateutil.parser.parse(renewal["start"])
     )
 
     renewal = sorted_renewals[0]


### PR DESCRIPTION
## Done
- Do not assume the thank-you page will recieve an archtecture. 
- Added a test to ensure this view continues to function. 
- Added a missing closing div to the template

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop/thank-you
- See that you are thanked for your contribution
- Go to /download and ensure both dekstop and server downloads work as expected
- Check the tests pass

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8329
