### PR TITLE
Build Cassandra webinar takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,7 @@
   {% include "takeovers/_redhat-openstack.html" %}
   {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
   {% include "takeovers/_fips_certification_cis_compliance.html" %}
+  {% include "takeovers/_cassandra-webinar-takeover.html" %}
 
   {# FRENCH #}
   {% include "takeovers/fr/_cio-guide-to-multipass.html" %}

--- a/templates/takeovers/_cassandra-webinar-takeover.html
+++ b/templates/takeovers/_cassandra-webinar-takeover.html
@@ -1,0 +1,14 @@
+{% with title="Cassandra in production",
+subtitle="Reliability and scalability for Cassandra deployments",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
+image_width=250,
+image_height=250,
+image_hide_small=true,
+primary_url="https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -174,4 +174,6 @@
 {% include "takeovers/es/guía-implementación-openstack.html" %}
 <p>21 September 2020</p>
 {% include "takeovers/_fips_certification_cis_compliance.html" %}
+<p>22 September 2020</p>
+{% include "takeovers/_cassandra-webinar-takeover.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Build Cassandra webinar takeover
- Add to `templates/takeovers/index.html`
- Add to `templaltes/index.html`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check takeover matches description in [issue](https://github.com/canonical-web-and-design/web-squad/issues/3210#event-3788809503) 
- NOTE: Changed CTA from "Register" to "Register for the webinar", as this was requested in previous webinar takeover PR. 

## Issue / Card

Fixes [#3210](https://github.com/canonical-web-and-design/web-squad/issues/3210#event-3788809503)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/93868362-40d86580-fcc2-11ea-9695-31c5a814fa01.png)

