### PR TITLE
Improve titles and descriptions on the /download/server section

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Ubuntu for ARM | Download{% endblock %}
+{% block meta_description %}Download Ubuntu Server for ARM with support for the very latest ARM-based server systems powered by certified 64-bit processors.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -1,6 +1,7 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Download Ubuntu Server | Download{% endblock %}
+{% block title %}Get Ubuntu Server | Download{% endblock %}
+{% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1FFQQUtzFGH88hA30qnZm-3pwVqcVl9UYyrNT4qQWrSM/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Get MAAS to run your physical cloud | Download | Ubuntu{% endblock %}
-{% block meta_description %}{% endblock meta_description %}
+{% block meta_description %}Get MAAS from Canonical and automated your bare metal server provisioning and easy network setup as easily as setup machines in the cloud.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/12GXYcP9WrOgoso6Sf3bQql6nALRUzpdlcRW3Gbu-npM/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -9,8 +9,9 @@
   <div class="row">
     <div class="col-10">
       <div>
-        <h1>Get Metal as a Service</h1>
-        <p>Metal as a Service (MAAS) gives you automated server provisioning and easy network setup for your physical servers for amazing data centre operational efficiency &mdash; on premises, open source and supported.</p>
+        <h1>Get Metal as a Service (MAAS)</h1>
+        <p>MAAS gives you automated server provisioning and easy network setup for your physical servers for amazing data centre operational efficiency &mdash; on premises, open source and supported.</p>
+        <p><a href="https://maas.io" class="p-link--external p-button--positive">Learn more about MAAS</a></p>
       </div>
     </div>
   </div>

--- a/templates/download/server/step1.html
+++ b/templates/download/server/step1.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Download Ubuntu Server  | Download{% endblock %}
-{% block meta_description %}Ubuntu for POWER brings the Ubuntu Server and Ubuntu ecosystem to POWER.{% endblock meta_description %}
+{% block title %}Get Ubuntu Server  | Download{% endblock %}
+{% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1e-vav_b54KlKsi92w3rDu9J14O0gpp8yAanEAIImlE8/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -1,7 +1,7 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Download Ubuntu Server  | Download{% endblock %}
-{% block meta_description %}Ubuntu for POWER brings the Ubuntu Server and Ubuntu ecosystem to POWER.{% endblock meta_description %}
+{% block title %}Get Ubuntu Server  | Download{% endblock %}
+{% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1e-vav_b54KlKsi92w3rDu9J14O0gpp8yAanEAIImlE8/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- Improve titles and descriptions on the /download/server section
- Updated the copy docs as well

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the /download/server pages have the same meta data (and in the [copy doc](https://docs.google.com/document/d/12kr3JvN3ALMdr5IPOheMwOaf-ygvEulFo5D7x-0ag0k/edit#))
```
{% block title %}Get Ubuntu Server | Download{% endblock %}
{% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
```
- See that /download/server/provisioning looks more like the [copy doc](https://docs.google.com/document/d/12GXYcP9WrOgoso6Sf3bQql6nALRUzpdlcRW3Gbu-npM/edit#)
- See that the /download/server/arm page has the meta desc from the [copy doc](https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit#)

## Issue / Card

Fixes #8336

