### PR TITLE
Add endpoint to read notices

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -51,6 +51,8 @@ from webapp.security.views import (
     create_notice,
     delete_notice,
     notice,
+    read_notice,
+    read_notices,
     notices,
     notices_feed,
     update_notice,
@@ -199,6 +201,14 @@ app.add_url_rule(
 app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 
 # usn section
+app.add_url_rule(
+    "/security/api/notices/<notice_id>",
+    view_func=read_notice,
+)
+app.add_url_rule(
+    "/security/api/notices",
+    view_func=read_notices,
+)
 app.add_url_rule("/security/notices", view_func=notices)
 app.add_url_rule(
     "/security/notices", view_func=create_notice, methods=["POST"]

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -152,6 +152,19 @@ class Notice(Base):
 
         return set(sorted(package_list))
 
+    def as_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "published": self.published,
+            "summary": self.summary,
+            "details": self.details,
+            "instructions": self.instructions,
+            "references": self.references,
+            "release_packages": self.release_packages,
+            "cves": [c.id for c in self.cves],
+        }
+
 
 class Release(Base):
     __tablename__ = "release"

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -226,6 +226,50 @@ def _update_notice_object(notice, data):
     return notice
 
 
+def read_notice(notice_id):
+    """
+    GET method to get notice by id
+    """
+
+    notice = db_session.query(Notice).get(notice_id)
+
+    if not notice:
+        return (
+            flask.jsonify({"message": f"Notice {notice_id} does not exist"}),
+            404,
+        )
+
+    return flask.jsonify({"data": notice.as_dict()}), 200
+
+
+def read_notices():
+    """
+    GET method to get notices
+    """
+
+    limit = flask.request.args.get("limit", default=20, type=int)
+    offset = flask.request.args.get("offset", default=0, type=int)
+
+    notices = (
+        db_session.query(Notice)
+        .order_by(Notice.published)
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+    return (
+        flask.jsonify(
+            {
+                "data": [notice.as_dict() for notice in notices],
+                "limit": limit,
+                "offset": offset,
+            }
+        ),
+        200,
+    )
+
+
 @authorization_required
 def create_notice():
     """


### PR DESCRIPTION
Get notice:
`/security/api/notices/<notice_id>`
- returns notice with id `<notice_id>`
- `400` if no notice found with the id

`/security/api/notices`
- accepts two get parameters: `limit`, `offset`
These will paginate the results returned.
Offset defaults to 0.
Limit defaults to 20.

## QA

0) Have notices imported
1) Fetch changes
2) Browse to routes and see that you get 200

## Issue / Card

Fixes #7916 
