### PR TITLE
Changed the button text to "Download the pro tips"

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -27,7 +27,7 @@
       <label class="mktoLabel mktoHasWidth" for="CanonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
       <p><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></p>
       <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
-      <button type="submit" class="mktoButton p-button--positive">Download the cheat sheet</button>
+      <button type="submit" class="mktoButton p-button--positive">Download the pro tips</button>
       <input type="hidden" name="formid" class="mktoField" value="3485">
       <input type="hidden" name="formVid" class="mktoField" value="3485">
       <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">


### PR DESCRIPTION
## Done

Changed the button text to "Download the pro tips" on the /server/download/thankyou modal (https://ubuntu.com/download/server#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
