### PR TITLE
Add information tool-tip for CVE statuses

### DIFF
--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -71,3 +71,71 @@ searchInput.addEventListener("keyup", handleSearchInput);
 attachEvents();
 handleButtons();
 disableSelectedVersions();
+
+const priorities = {
+  critical:
+    "<strong>Critical:</strong> A world-burning problem that is exploitable for most Ubuntu users. Examples include remote root privilege escalations or remote data theft.",
+  high:
+    "<strong>High:</strong> Exploitable for many users in the default configuration of the affected software. Examples include serious remote denial of service of the system, local root privilege escalations or local data theft.",
+  medium:
+    "<strong>Medium:</strong> Exploitable for many users of the affected software. Examples include network daemon denial of service, cross-site scripting and gaining user privileges.",
+  low:
+    "<strong>Low:</strong> Does very little damage or is otherwise hard to exploit, due to small user base or other factors such as requiring specific environment, uncommon configuration, or user assistance. These tend to be included in security updates only when higher priority issues require an update or if many low-priority issues have built up.",
+  negligible:
+    "<strong>Negligible:</strong> May be a problem, but does not impose a security risk due to various factors. Examples include when the vulnerability is only theoretical in nature, requires a very special situation, has almost no install base or does no real damage. These typically will not receive security updates unless there is an easy fix and some other issue causes an update.",
+  unknown:
+    "<strong>Unknown:</strong> Open vulnerability where the priority is currently unknown and needs to be triaged.",
+};
+
+const statuses = {
+  "not-affected":
+    "<strong>Not vulnerable:</strong> Packages which do not exist in the archive, are not affected by the vulnerability or have a fix applied in the archive.",
+  pending:
+    "<strong>Pending:</strong> A fix has been applied and updated packages are awaiting arrival into the archive. For example, this might be used when wider testing is requested for the updated package.",
+};
+
+const tooltipIconList = document.querySelectorAll(".cve-tooltip-icon");
+
+tooltipIconList.forEach(function (tooltipIcon) {
+  tooltipIcon.addEventListener(
+    "mouseover",
+    function (event) {
+      if (tooltipIcon.parentElement.querySelector(".cve-tooltip") == null) {
+        const priority = this.dataset.priority;
+        const status = this.dataset.status;
+
+        const tooltip = document.createElement("div");
+        tooltip.classList.add("cve-tooltip");
+
+        tooltip.innerHTML +=
+          "<div class='arrow-up back'></div><div class='arrow-up front'></div>";
+
+        if (priority in priorities) {
+          tooltip.innerHTML += priorities[priority];
+        }
+
+        if (priority in priorities && status in statuses) {
+          tooltip.innerHTML += "<br><br>";
+        }
+
+        if (status in statuses) {
+          tooltip.innerHTML += statuses[status];
+        }
+
+        tooltipIcon.parentElement.append(tooltip);
+      }
+    },
+    false
+  );
+  tooltipIcon.addEventListener(
+    "mouseout",
+    function (event) {
+      const tooltip = tooltipIcon.parentElement.querySelector(".cve-tooltip");
+
+      if (tooltip != null) {
+        tooltipIcon.parentElement.removeChild(tooltip);
+      }
+    },
+    false
+  );
+});

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -12,6 +12,15 @@
     color: $color-x-light;
   }
 
+  .u-overflow-inherit {
+    overflow-x: inherit !important;
+  }
+
+  .cve-table {
+    font-size: 0.8rem;
+    line-height: 1rem;
+  }
+
   .cve-table thead tr {
     border-bottom: 0;
   }
@@ -29,6 +38,70 @@
     border-top: 0;
     overflow: visible;
     padding-left: 0.75rem;
+  }
+
+  .cve-table .icon-cve-info {
+    margin: 0 0 0 0.5rem;
+  }
+
+  .cve-table .icon-container__text {
+    width: calc(100% - 3rem);
+  }
+
+  .cve-table .p-icon--information {
+    opacity: 0.6;
+  }
+
+  .cve-table-cell .p-icon--information {
+    visibility: hidden;
+  }
+
+  .cve-table-cell:hover .p-icon--information {
+    visibility: visible;
+  }
+
+  .cve-table-cell .cve-tooltip {
+    display: none;
+  }
+
+  .cve-table-cell:hover .p-icon--information:hover + .cve-tooltip {
+    display: block;
+  }
+
+  .cve-table .icon-container__icon {
+    position: relative;
+  }
+
+  .cve-tooltip {
+    z-index: 1;
+    background: #fff;
+    position: absolute;
+    top: 30px;
+    transform: translateX(-125px);
+    width: 275px;
+    border: 1px solid #b0b0b0;
+    padding: 10px;
+    box-shadow: 0 0 3px #b0b0b0;
+    color: #111;
+  }
+
+  .cve-tooltip .arrow-up {
+    position: absolute;
+    left: calc(50% - 13px);
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+  }
+
+  .cve-tooltip .arrow-up.front {
+    top: -9px;
+    border-bottom: 10px solid #fff;
+  }
+
+  .cve-tooltip .arrow-up.back {
+    top: -10px;
+    border-bottom: 10px solid #b0b0b0;
   }
 
   .cve-table-cell--muted {

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -98,6 +98,11 @@
                   {% endif %}
                 </small>
               </div>
+              <div class="icon-container__icon icon-cve-info">
+                {% if statuses[release.codename].status != 'DNE'%}
+                  <i class="p-icon--information cve-tooltip-icon" data-status="{{ statuses[release.codename].status }}" data-priority="{{ cve.priority }}"></i>
+                {% endif %}
+              </div>
             </td>
             {% else %}
               <td class="cve-table-cell--muted">

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -81,7 +81,7 @@
   </form>
 </section>
 
-<section class="p-strip is-shallow">
+<section class="p-strip is-shallow u-overflow-inherit">
   <div class="u-fixed-width">
     {% if query or package or priority %}
     <h2>


### PR DESCRIPTION
Add tool-tip to give details on CVE status and priority.

We have no texts for the following statuses:
needs triage, needed, deferred, ignored, released, DNE

Right now cells with those statuses will show no status explanation in the tool-tip.

`Not vulnerable` and `Does not exist` do not show any priority explanation in the tool-tip because it does not show a priority icon in the cell.

`Does not exist` does not display the information icon since it's missing status explanation and has no priority icon

## QA

- Have CVEs imported
- `dotrun`
- Browse to `/security/cve` hover over statuses

## Issue / Card

Fixes #7763

## Screenshots

![image.png](https://images.zenhubusercontent.com/5ee7415a47536a7869302593/3b7c680e-179d-4487-8e4c-57d348fedab7)

![image.png](https://images.zenhubusercontent.com/5ee7415a47536a7869302593/c56b23e9-0186-416c-89cd-28d3b5da4eea)

![image.png](https://images.zenhubusercontent.com/5ee7415a47536a7869302593/c40f65dd-e650-45a9-aa2e-3eeb73f10e24)

![image.png](https://images.zenhubusercontent.com/5ee7415a47536a7869302593/535353d6-3490-40d9-a2f0-bad29ae76368)

![image.png](https://images.zenhubusercontent.com/5ee7415a47536a7869302593/a3b7771a-37a7-46e0-9150-1a37c916a878)
