### PR TITLE
Sharpen blog images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.2.4
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.image-template==1.2.0
+canonicalwebteam.image-template==1.3.0
 canonicalwebteam.discourse==2.0.1
 canonicalwebteam.launchpad==0.7.7
 python-dateutil==2.8.1


### PR DESCRIPTION
Sharpen blog images by applying the `e_sharpen` flag in Cloudinary.

## QA
Open in a tab: https://ubuntu.com/blog
Open in a tab: https://ubuntu-com-8353.demos.haus/blog
If you keep switching between the tabs you will see that the demo one has sharper images. Or you can inspect element and see the `e_sharpen` flag on the cloudinary url. 