### PR TITLE
Remove environments from takeover

### DIFF
--- a/templates/takeovers/_fips_certification_cis_compliance.html
+++ b/templates/takeovers/_fips_certification_cis_compliance.html
@@ -1,5 +1,5 @@
 {% with title="FIPS certification and CIS compliance with Ubuntu",
-subtitle="Learn about Ubuntu CIS and FIPS certified components to enable operating environments under compliance regimes like FedRAMP, HIPAA, PCI and ISO.",
+subtitle="Learn about Ubuntu CIS and FIPS certified components to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO.",
 header_image="https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg",
 image_width="400",
 image_height="234",


### PR DESCRIPTION
## Done

- Remove "environments" from subtitle as requested by @Khutch25 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers
- Check "FIPS certification and CIS compliance with Ubuntu" takeover doesn't have the word environments in the subtitle. 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/94277188-1cd68780-ff41-11ea-9f8b-b5dd78a11a0d.png)

