### PR TITLE
Update /download/cloud copy

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -17,7 +17,7 @@
           url="https://assets.ubuntu.com/v1/a9580e02-ubuntu-cloud-medium.svg",
           alt="",
           width="350",
-          height="296",
+          height="200",
           hi_def=True,
         ) | safe
       }}
@@ -57,7 +57,7 @@
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://help.ubuntu.com/community/EC2StartersGuide" class="p-link--external">Ubuntu's guide to using EC2</a></li>
         <li class="p-list__item"><a href="http://cloud-images.ubuntu.com/locator/ec2/" class="p-link--external">Amazon EC2 AMI Locator</a></li>
-        <li class="p-list__item"><a href="https://ubuntu.com/aws/pro">Launch Ubuntu Pro for AWS&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/aws/pro">Launch Ubuntu Pro for AWS&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
     <div class="p-card col-4">
@@ -81,8 +81,8 @@
       </div>
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://docs.microsoft.com/en-us/azure/virtual-machines/linux/" class="p-link--external">Guide to using Microsoft Azure</a></li>
-        <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer" class="p-link--external">Launch Ubuntu on Azure</a></li>
-        <li class="p-list__item"><a href="http://ubuntu.com/azure/pro">Launch Ubuntu Pro for Azure&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/azure" >Launch Ubuntu on Azure&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/azure/pro">Launch Ubuntu Pro for Azure&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
     <div class="p-card col-4">

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
-      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, Oracle, Rackspace and IBM Cloud. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
+      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud, Rackspace and Oracle. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
@@ -25,7 +25,9 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+{% include "/shared/_ubuntu_pro_on_public_cloud.html" %}
+
+<section class="p-strip is-deep">
   <div class="row">
     <div class="col-10">
       <h2>Use Ubuntu in the cloud</h2>
@@ -36,37 +38,13 @@
     <div class="p-card col-4">
       <div class="p-card__content">
         <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-            {{
-              image(
-                  url="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=211",
-                  alt="Google Cloud Platform",
-                  width="211",
-                  height="130",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"style": "lign-self: center; max-height: 10rem;"},
-                ) | safe
-            }}
-          </a>
-        </h4>
-        <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
-      </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu" class="p-link--external">Guide to using GCP</a></li>
-        <li class="p-list__item"><a href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free" class="p-link--external">Get started on GCP</a></li>
-      </ul>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="http://cloud-images.ubuntu.com/locator/ec2/">
             {{
               image(
-                  url="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg",
-                  alt="Amazon Web Services",
-                  width="160",
-                  height="60",
+                  url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+                  alt="Amazon Web Services logo",
+                  width="84",
+                  height="50",
                   hi_def=True,
                   loading="lazy",
                   attrs={"style": "align-self: center;max-height: 10rem; max-width:10rem;"},
@@ -79,6 +57,7 @@
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://help.ubuntu.com/community/EC2StartersGuide" class="p-link--external">Ubuntu's guide to using EC2</a></li>
         <li class="p-list__item"><a href="http://cloud-images.ubuntu.com/locator/ec2/" class="p-link--external">Amazon EC2 AMI Locator</a></li>
+        <li class="p-list__item"><a href="https://ubuntu.com/aws/pro">Launch Ubuntu Pro for AWS&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
     <div class="p-card col-4">
@@ -87,10 +66,10 @@
           <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer">
             {{
               image(
-                  url="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg",
-                  alt="Microsoft Azure",
-                  width="184",
-                  height="53",
+                  url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
+                  alt="Microsoft Azure logo",
+                  width="130",
+                  height="38",
                   hi_def=True,
                   loading="lazy",
                   attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
@@ -103,6 +82,31 @@
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://docs.microsoft.com/en-us/azure/virtual-machines/linux/" class="p-link--external">Guide to using Microsoft Azure</a></li>
         <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer" class="p-link--external">Launch Ubuntu on Azure</a></li>
+        <li class="p-list__item"><a href="http://ubuntu.com/azure/pro">Launch Ubuntu Pro for Azure&nbsp;&rsaquo;</a></li>
+      </ul>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__content">
+        <h4>
+          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
+            {{
+              image(
+                  url="https://assets.ubuntu.com/v1/e795fc84-Google_Cloud_Logo.svg",
+                  alt="Google Cloud Platform logo",
+                  width="259",
+                  height="40",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"style": "align-self: center; max-height: 10rem;"},
+                ) | safe
+            }}
+          </a>
+        </h4>
+        <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
+      </div>
+      <ul class="p-list">
+        <li class="p-list__item u-no-margin--top"><a href="https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu" class="p-link--external">Guide to using GCP</a></li>
+        <li class="p-list__item"><a href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free" class="p-link--external">Get started on GCP</a></li>
       </ul>
     </div>
   </div>

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -15,50 +15,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-8 p-card">
-      <h2>Ubuntu Pro on public cloud</h2>
-      <p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">10 years of package updates and security maintenance with Ubuntu Pro</li>
-          <li class="p-list__item is-ticked">Kernel <a href="/livepatch">Livepatch</a>, which allows for continuous security patching and higher uptime and availability by allowing kernel security updates to be applied without a reboot</li>
-          <li class="p-list__item is-ticked">Customised FIPS and Common Criteria EAL-compliant components for use in environments under compliance regimes such as FedRAMP, PCI, HIPAA and ISO</li>
-          <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
-        </ul>
-      </p>
-      <div class="row">
-        <div class="col-4">
-          <p>
-            <a class="p-link--external" href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf">Get the Ubuntu Pro for AWS datasheet</a>
-          </p>
-          <a class="p-button--positive" href="/aws/pro">Learn about Ubuntu Pro for AWS</a>
-        </div>
-        <div class="col-4">
-          <p>
-            <a class="p-link--external" href="https://assets.ubuntu.com/v1/27a386bc-Ubuntu_Pro_Azure_03.04.20.pdf">Get the Ubuntu Pro for Azure datasheet</a>
-          </p>
-          <a class="p-button--positive" href="/azure/pro">Learn about Ubuntu Pro for Azure</a>
-        </div>
-      </div>
-    </div>
-    <div class="col-4 p-card">
-      <h2>Ubuntu Server</h2>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Maintenance and security updates guaranteed for five years with Ubuntu LTS</li>
-        <li class="p-list__item is-ticked">Enterprise-grade support and management tools available direct from Canonical</li>
-        <li class="p-list__item is-ticked">Proven for enterprise-scale workloads on all leading public clouds</li>
-        <li class="p-list__item is-ticked">Free from licence fees, regardless of how many images you run</li>
-      </ul>
-      <a class="p-button p-link--external" href="https://aws.amazon.com/marketplace/pp/B087QQNGF1?qid=1591613411512&sr=0-2&ref_=srh_res_product_title">Ubuntu Server on AWS</a>
-      <a class="p-button p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview">Ubuntu Server on Azure</a>
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <p class="p-heading--six"><em>18.04 LTS certifications are in-progress and will be available Q2 2020. Certified components and kernel live patches are not available for Ubuntu 14.04 LTS.</em></p>
-  </div>
-</section>
+{% include "/shared/_ubuntu_pro_on_public_cloud.html" %}
 
 <section class="p-strip is-deep is-bordered">
   <div class="u-fixed-width">

--- a/templates/shared/_ubuntu_pro_on_public_cloud.html
+++ b/templates/shared/_ubuntu_pro_on_public_cloud.html
@@ -2,14 +2,12 @@
   <div class="row u-equal-height">
     <div class="col-8 p-card">
       <h2>Ubuntu Pro on public cloud</h2>
-      <p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">10 years of package updates and security maintenance with Ubuntu Pro</li>
-          <li class="p-list__item is-ticked">Kernel <a href="/livepatch">Livepatch</a>, which allows for continuous security patching and higher uptime and availability by allowing kernel security updates to be applied without a reboot</li>
-          <li class="p-list__item is-ticked">Customised FIPS and Common Criteria EAL-compliant components for use in environments under compliance regimes such as FedRAMP, PCI, HIPAA and ISO</li>
-          <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
-        </ul>
-      </p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">10 years of package updates and security maintenance with Ubuntu Pro</li>
+        <li class="p-list__item is-ticked">Kernel <a href="/livepatch">Livepatch</a>, which allows for continuous security patching and higher uptime and availability by allowing kernel security updates to be applied without a reboot</li>
+        <li class="p-list__item is-ticked">Customised FIPS and Common Criteria EAL-compliant components for use in environments under compliance regimes such as FedRAMP, PCI, HIPAA and ISO</li>
+        <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
+      </ul>
       <div class="row">
         <div class="col-4">
           <p>
@@ -26,7 +24,7 @@
       </div>
     </div>
     <div class="col-4 p-card">
-      <h2>Ubuntu Server</h2>
+      <h3>Ubuntu Server</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Maintenance and security updates guaranteed for five years with Ubuntu LTS</li>
         <li class="p-list__item is-ticked">Enterprise-grade support and management tools available direct from Canonical</li>
@@ -36,8 +34,5 @@
       <a class="p-button p-link--external" href="https://aws.amazon.com/marketplace/pp/B087QQNGF1?qid=1591613411512&sr=0-2&ref_=srh_res_product_title">Ubuntu Server on AWS</a>
       <a class="p-button p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview">Ubuntu Server on Azure</a>
     </div>
-  </div>
-  <div class="u-fixed-width">
-    <p class="p-heading--six"><em>18.04 LTS certifications are in-progress and will be available Q2 2020. Certified components and kernel live patches are not available for Ubuntu 14.04 LTS.</em></p>
   </div>
 </section>

--- a/templates/shared/_ubuntu_pro_on_public_cloud.html
+++ b/templates/shared/_ubuntu_pro_on_public_cloud.html
@@ -1,0 +1,43 @@
+<section class="p-strip--light is-deep is-bordered">
+  <div class="row u-equal-height">
+    <div class="col-8 p-card">
+      <h2>Ubuntu Pro on public cloud</h2>
+      <p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">10 years of package updates and security maintenance with Ubuntu Pro</li>
+          <li class="p-list__item is-ticked">Kernel <a href="/livepatch">Livepatch</a>, which allows for continuous security patching and higher uptime and availability by allowing kernel security updates to be applied without a reboot</li>
+          <li class="p-list__item is-ticked">Customised FIPS and Common Criteria EAL-compliant components for use in environments under compliance regimes such as FedRAMP, PCI, HIPAA and ISO</li>
+          <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
+        </ul>
+      </p>
+      <div class="row">
+        <div class="col-4">
+          <p>
+            <a class="p-link--external" href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf">Get the Ubuntu Pro for AWS datasheet</a>
+          </p>
+          <a class="p-button--positive" href="/aws/pro">Learn about Ubuntu Pro for AWS</a>
+        </div>
+        <div class="col-4">
+          <p>
+            <a class="p-link--external" href="https://assets.ubuntu.com/v1/27a386bc-Ubuntu_Pro_Azure_03.04.20.pdf">Get the Ubuntu Pro for Azure datasheet</a>
+          </p>
+          <a class="p-button--positive" href="/azure/pro">Learn about Ubuntu Pro for Azure</a>
+        </div>
+      </div>
+    </div>
+    <div class="col-4 p-card">
+      <h2>Ubuntu Server</h2>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Maintenance and security updates guaranteed for five years with Ubuntu LTS</li>
+        <li class="p-list__item is-ticked">Enterprise-grade support and management tools available direct from Canonical</li>
+        <li class="p-list__item is-ticked">Proven for enterprise-scale workloads on all leading public clouds</li>
+        <li class="p-list__item is-ticked">Free from licence fees, regardless of how many images you run</li>
+      </ul>
+      <a class="p-button p-link--external" href="https://aws.amazon.com/marketplace/pp/B087QQNGF1?qid=1591613411512&sr=0-2&ref_=srh_res_product_title">Ubuntu Server on AWS</a>
+      <a class="p-button p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview">Ubuntu Server on Azure</a>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <p class="p-heading--six"><em>18.04 LTS certifications are in-progress and will be available Q2 2020. Certified components and kernel live patches are not available for Ubuntu 14.04 LTS.</em></p>
+  </div>
+</section>


### PR DESCRIPTION
## Done

- Update /download/cloud copy
- Created an include from a strip on /public-cloud and used it on both pages
- Updated logos

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit?ts=5f6b774e#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3213


