### PR TITLE
Update USN search by details

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -111,7 +111,11 @@ def notices():
 
     if details:
         notices_query = notices_query.filter(
-            Notice.details.ilike(f"%{details}%")
+            or_(
+                Notice.id.like(f"%{details}%"),
+                Notice.details.like(f"%{details}%"),
+                Notice.cves.any(CVE.id.like(f"%{details}%")),
+            )
         )
 
     # Snapshot total results for search


### PR DESCRIPTION
Change USN search by detail to also find results if `notice.id` or `notice.cves.id` matches the search criteria.

## QA

- have cves and notices imported
- fetch changes
- launch website `dotrun`
- browse to `/security/notices` try to search by cve.id, notice.id; It will work.


## Issue / Card

Fixes #7947 