### PR TITLE
Change the notice import

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -220,7 +220,7 @@ def _update_notice_object(notice, data):
     ]
 
     notice.cves.clear()
-    for cve_id in data["cves"]:
+    for cve_id in set(data["cves"]):
         notice.cves.append(db_session.query(CVE).get(cve_id) or CVE(id=cve_id))
 
     return notice


### PR DESCRIPTION
Change the notice import to only import unique cve ids.

This way if a notice has the same cve id duplicated it will only import
it one time.

## Issue / Card

Fixes #7946
