### PR TITLE
Copy update Kubeflow training

### DIFF
--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -44,6 +44,16 @@
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
+{% elif product == 'kubeflow-training-onsite' %}
+
+{% with h1="Contact us about our Kubeflow training",
+intro_text="Fill in your details below and a member of our training team will be in touch.",
+formid="1448",
+lpId="2661",
+returnURL="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite" %}
+{% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
 {% elif product == 'maas-training-onsite' %}
 
 {% with h1="Contact us about our MAAS Deployment and Operations training",

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -11,19 +11,21 @@
 
 <section class="p-strip--suru-topped is-deep is-bordered">
   <div class="row u-equal-height">
+    <h1>Train with Ubuntu</h1>
+  </div>
+  <div class="row u-equal-height">
     <div class="col-6 u-vertically-center">
       <div>
-        <h1>Train with Ubuntu</h1>
         <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
       </div>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/a22613fc-train-with-ubuntu_AW.svg",
+        url="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg",
         alt="",
-        width="350",
-        height="350",
+        width="210",
+        height="125",
         hi_def=True,
         loading="auto",
         ) | safe
@@ -219,7 +221,40 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>Kubeflow</h2>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr />
+    <h3>Modelling and Operations training</h3>
+  </div>
+
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>A four-day workshop-like course at your premises for up to 15 people that guides you through all aspects of performing effective Machine Learning and Deep Learning automation on your Kubeflow cluster. A follow-up course to Kubernetes Explorer, it guides you through common tasks such as creating Pipelines, working with Notebooks, training models, visualizing results, model serving, and troubleshooting, as well as introducing MLOps practices for streamlined data science using containerized frameworks and infrastructure.</p>
+      <p><a href="https://assets.ubuntu.com/v1/4d0487aa-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">4 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">29,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/training/contact-us?product=kubeflow-training-onsite"  data-form-location="/shared/forms/interactive/kubeflow" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
   <div class="row">
     <div class="col-7">
       <h2>Metal as a Service (MAAS)</h2>
@@ -252,7 +287,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered u-no-padding--top">
+<section class="p-strip is-bordered u-no-padding--top">
   <div class="row">
     <div class="col-7">
       <h2>Ceph Operations</h2>
@@ -285,7 +320,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-7">
       <h2>Questions about training?</h2>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -15,8 +15,11 @@
   {% with thanks_context="enquiring about our on-site training courses" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% elif product == 'openstack-training-server-admin' %}
   {% with thanks_context="enquiring about our server admin training courses" %}{% include "shared/_thank_you.html" %}{% endwith %}
+  {% elif product == 'kubeflow-training-onsite' %}
+  {% with thanks_context="enquiring about our Kubeflow training course" %}{% include "shared/_thank_you.html" %}
+  {% endwith %}
 {% elif product == 'maas-training-onsite' %}
-  {% with thanks_context="enquiring about our MAAS Deployment and Operations training course" %}{% include "shared/_thank_you.html" %}{% endwith %}
+  {% with thanks_context="enquiring about our MAAS Deployment and Operations training course" %}{% include "shared/_thank_you.html" %} {% endwith %}
 {% else %}
   {% with thanks_context="enquiring about training" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
## Done

- Add Kubeflow section to `/training` with link to PDF
- Change 'Train with Ubuntu' illustration to match copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page matches [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?ts=5f6c7e7a#heading=h.7gh8c2ema0rv) and check PDF/contact us links. 


## Issue / Card

Fixes 
[#3220](https://github.com/canonical-web-and-design/web-squad/issues/3220)
[#3221](https://github.com/canonical-web-and-design/web-squad/issues/3221)
[#3222](https://github.com/canonical-web-and-design/web-squad/issues/3222)

