### PR TITLE
Update blog to 6.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build stage: Install python dependencies
 # ===
 FROM ubuntu:focal AS python-dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools python3-wheel build-essential
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools python3-wheel build-essential git
 ADD requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 alembic==1.4.2
 canonicalwebteam.flask_base==0.6.4
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.2.4
+# canonicalwebteam.blog==6.2.4
+git+https://github.com/albertkol/canonicalwebteam.blog.git@fix-not-found-500s#egg=canonicalwebteam.blog
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.0


### PR DESCRIPTION
## Done

- Escape `NotFoundError` exceptions.

## QA

Browse to https://ubuntu.com/blog/topic/canonical-announcements/feed you get 500
Browse to https://ubuntu-com-8381.demos.haus/blog/topic/canonical-announcements/feed you get 404

Browse to https://ubuntu.com/blog/author/GET you get 500
Browse to https://ubuntu-com-8381.demos.haus/blog/author/GET you get 404

Browse to https://ubuntu.com/blog?category=1%27news you get 500
Browse to https://ubuntu-com-8381.demos.haus/blog?category=1%27news you get 404

Browse to https://ubuntu.com/blog/archives?group=design%3Fpage%3D2 you get 500
Browse to https://ubuntu-com-8381.demos.haus/blog/archives?group=design%3Fpage%3D2 you get 404

## Issue

Fixes #7837