### PR TITLE
Trilio webinar - takeover and engage page

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1057,5 +1057,14 @@
     {% endwith %}
   </div>
 
+    <div class="row u-equal-height u-clearfix">
+    {% with title="Extend your OpenStack cloud with native backup and recovery",
+    description="Learn how TrilioVault can be easily deployed in a Charmed OpenStack environment",
+    slug="trilio-backup-recovery",
+    type="webinar" %}
+    {% include "engage/_article-card.html" %}
+    {% endwith %}
+  </div>
+
 </section>
 {% endblock content %}

--- a/templates/engage/trilio-backup-recovery.md
+++ b/templates/engage/trilio-backup-recovery.md
@@ -1,0 +1,24 @@
+---
+wrapper_template: "engage/_base_engage_markdown.html"
+context:
+     title: "Extend your OpenStack cloud with native backup and recovery"
+     meta_description: "Learn how TrilioVault can be easily deployed in a Charmed OpenStack environment"
+     meta_image: https://assets.ubuntu.com/v1/8a7c58ea-Meta+data+img.jpg
+     meta_copydoc: https://docs.google.com/document/d/11iCopqnoLv_jBuOncrELAS7uo1DiKWggAEe-lCubbeM/edit?ts=5f55f52f
+     header_title: "Extend your OpenStack cloud with native backup and recovery"
+     header_subtitle: "Learn how TrilioVault can be easily deployed in a Charmed OpenStack environment"
+     header_image: "https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg"
+     header_image_width: "330"
+     header_image_height: "161"
+     header_url: '#register-section'
+     header_cta: Register for the webinar
+     header_cta_class: p-button--positive
+     header_class: p-engage-banner--dark
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 376727, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+---
+
+One of the biggest hurdles in the cloud is the management and data protection of your workloads. This is especially challenging in the context of OpenStack as it does not provide a built-in backup and recovery solution. In response, Canonical and Trilio have collaborated to introduce a new solution that expands Charmed OpenStack with the addition of the TrilioVault data protection platform.  These capabilities enable organisations to build resilient cloud architectures, meet service level agreements and adhere to compliance requirements. 
+
+Join our webinar to learn: 
+- How TrilioVault provides OpenStack users with a native backup and recovery solution
+- How TrilioVault can be easily deployed in a Charmed OpenStack environment

--- a/templates/engage/trilio-backup-recovery.md
+++ b/templates/engage/trilio-backup-recovery.md
@@ -3,7 +3,7 @@ wrapper_template: "engage/_base_engage_markdown.html"
 context:
      title: "Extend your OpenStack cloud with native backup and recovery"
      meta_description: "Learn how TrilioVault can be easily deployed in a Charmed OpenStack environment"
-     meta_image: https://assets.ubuntu.com/v1/8a7c58ea-Meta+data+img.jpg
+     meta_image: https://assets.ubuntu.com/v1/886396df-meta+image+trilio.jpg
      meta_copydoc: https://docs.google.com/document/d/11iCopqnoLv_jBuOncrELAS7uo1DiKWggAEe-lCubbeM/edit?ts=5f55f52f
      header_title: "Extend your OpenStack cloud with native backup and recovery"
      header_subtitle: "Learn how TrilioVault can be easily deployed in a Charmed OpenStack environment"

--- a/templates/engage/trilio-backup-recovery.md
+++ b/templates/engage/trilio-backup-recovery.md
@@ -14,7 +14,7 @@ context:
      header_cta: Register for the webinar
      header_cta_class: p-button--positive
      header_class: p-engage-banner--dark
-     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 376727, "displayMode" : "standalone", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
+     webinar_code: '<div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 430748, "displayMode" : "channelList", "height" : "2000" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>'
 ---
 
 One of the biggest hurdles in the cloud is the management and data protection of your workloads. This is especially challenging in the context of OpenStack as it does not provide a built-in backup and recovery solution. In response, Canonical and Trilio have collaborated to introduce a new solution that expands Charmed OpenStack with the addition of the TrilioVault data protection platform.  These capabilities enable organisations to build resilient cloud architectures, meet service level agreements and adhere to compliance requirements. 
@@ -22,3 +22,24 @@ One of the biggest hurdles in the cloud is the management and data protection of
 Join our webinar to learn: 
 - How TrilioVault provides OpenStack users with a native backup and recovery solution
 - How TrilioVault can be easily deployed in a Charmed OpenStack environment
+
+### Speakers
+
+<div class="row u-equal-height">
+  <div class="col-2">
+    <img src="https://assets.ubuntu.com/v1/f65ce9a7-speaker1.jpeg" alt="Speaker" style="width:150px;"/>
+  </div>
+  <div class="col-4 u-align--center u-vertically-center">
+    <p>Tytus Kurek, Product Manager at Canonical</p>
+  </div>
+</div>
+
+<div class="row u-equal-height">
+  <div class="col-2">
+    <img src="https://assets.ubuntu.com/v1/8a4c0187-speaker2.png" alt="Speaker" style="width:150px;"/>
+  </div>
+  <div class="col-4 u-align--center u-vertically-center">
+    <p>Robert Rother, Product Manager at Trilio</p>
+  </div>
+</div>
+

--- a/templates/engage/trilio-backup-recovery.md
+++ b/templates/engage/trilio-backup-recovery.md
@@ -23,7 +23,7 @@ Join our webinar to learn:
 - How TrilioVault provides OpenStack users with a native backup and recovery solution
 - How TrilioVault can be easily deployed in a Charmed OpenStack environment
 
-### Speakers
+### Speakers:
 
 <div class="row u-equal-height">
   <div class="col-2">

--- a/templates/engage/trilio-backup-recovery.md
+++ b/templates/engage/trilio-backup-recovery.md
@@ -29,7 +29,7 @@ Join our webinar to learn:
   <div class="col-2">
     <img src="https://assets.ubuntu.com/v1/f65ce9a7-speaker1.jpeg" alt="Speaker" style="width:150px;"/>
   </div>
-  <div class="col-4 u-align--center u-vertically-center">
+  <div class="col-4 u-vertically-center">
     <p>Tytus Kurek, Product Manager at Canonical</p>
   </div>
 </div>
@@ -38,7 +38,7 @@ Join our webinar to learn:
   <div class="col-2">
     <img src="https://assets.ubuntu.com/v1/8a4c0187-speaker2.png" alt="Speaker" style="width:150px;"/>
   </div>
-  <div class="col-4 u-align--center u-vertically-center">
+  <div class="col-4 u-vertically-center">
     <p>Robert Rother, Product Manager at Trilio</p>
   </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,11 +32,8 @@
   {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
   {% include "takeovers/_fips_certification_cis_compliance.html" %}
   {% include "takeovers/_cassandra-webinar-takeover.html" %}
-<<<<<<< HEAD
   {% include "takeovers/_security-webinar-series.html" %}
-=======
   {% include "takeovers/_trilio-backup-recovery.html" %}
->>>>>>> Build and add takeover
 
   {# FRENCH #}
   {% include "takeovers/fr/_cio-guide-to-multipass.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,11 @@
   {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
   {% include "takeovers/_fips_certification_cis_compliance.html" %}
   {% include "takeovers/_cassandra-webinar-takeover.html" %}
+<<<<<<< HEAD
   {% include "takeovers/_security-webinar-series.html" %}
+=======
+  {% include "takeovers/_trilio-backup-recovery.html" %}
+>>>>>>> Build and add takeover
 
   {# FRENCH #}
   {% include "takeovers/fr/_cio-guide-to-multipass.html" %}

--- a/templates/takeovers/_trilio-backup-recovery.html
+++ b/templates/takeovers/_trilio-backup-recovery.html
@@ -1,0 +1,15 @@
+{% with title="Extend your OpenStack cloud with native backup and recovery",
+subtitle="Learn how TrilioVault can be easily deployed in a Charmed OpenStack environment",
+class="p-takeover--dark",
+header_image="https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg",
+image_style="width: 350px;",
+image_hide_small="",
+equal_cols="true",
+primary_url="/engage/trilio-backup-recovery?utm_source=Takeover&utm_medium=Takeover&utm_campaign=CY20_DC_WBN_OpenStack_Trilio",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="",
+locale="en_GB" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -176,6 +176,11 @@
 {% include "takeovers/_fips_certification_cis_compliance.html" %}
 <p>22 September 2020</p>
 {% include "takeovers/_cassandra-webinar-takeover.html" %}
+<<<<<<< HEAD
 <p>23 September 2020</p>
 {% include "takeovers/_security-webinar-series.html" %}
+=======
+<p>29 September 2020</p>
+{% include "takeovers/_trilio-backup-recovery.html" %}
+>>>>>>> Build and add takeover
 {% endblock %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -176,11 +176,8 @@
 {% include "takeovers/_fips_certification_cis_compliance.html" %}
 <p>22 September 2020</p>
 {% include "takeovers/_cassandra-webinar-takeover.html" %}
-<<<<<<< HEAD
 <p>23 September 2020</p>
 {% include "takeovers/_security-webinar-series.html" %}
-=======
 <p>29 September 2020</p>
 {% include "takeovers/_trilio-backup-recovery.html" %}
->>>>>>> Build and add takeover
 {% endblock %}


### PR DESCRIPTION
## Done

- Build engage page and add to `/engage.index.html`
- Build takeover and add to `/index.html` and `/takeovers/index.html`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/trilio-backup-recovery and http://0.0.0.0:8001/takeovers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the pages match the [copy doc](https://docs.google.com/document/d/11iCopqnoLv_jBuOncrELAS7uo1DiKWggAEe-lCubbeM/edit?ts=5f55f52f), [brief](https://docs.google.com/spreadsheets/d/1e10lwtgEgvUZ7TeVaM8sYmqBtMwu1p5Y1iwRi3Ukz_g/edit#gid=1271849439) and [design](https://github.com/canonical-web-and-design/web-squad/issues/3225)
- Test the engage page on http://debug.iframely.com/ and https://cards-dev.twitter.com/validator


## Issue / Card

Fixes #8362 

