### PR TITLE
Ubuntu Core on KVM guide: tweaks to make it clear we're installing UC18

### DIFF
--- a/templates/download/kvm.html
+++ b/templates/download/kvm.html
@@ -15,7 +15,7 @@
       <div class="u-equal-height row p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
-          <p>We will walk you through the steps of installing Ubuntu Core on your Linux desktop in a virtual machine.</p>
+          <p>We will walk you through the steps of installing Ubuntu Core 18 on your Linux desktop in a virtual machine.</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
@@ -41,7 +41,7 @@
         </h3>
         <div class="p-stepped-list__content">
           <ul class="u-no-margin--left">
-            <li>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core image for amd64</a></li>
+		  <li>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core 18 image for amd64</a>.</li>
             <li>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
             <li>
               <p>Uncompress the image with the following command:</p>


### PR DESCRIPTION
The Install Ubuntu Core on KVM guide does not work with UC20 (it's a more process complex). This is a small fix to make it explicit that these instructions will install UC18, rather than _any_ Ubuntu Core release, which still works and is still obviously supported.

## Done

- updated intro sentence
- updated image download step
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


