### PR TITLE
Fix expiry date/new label bug on /advantage

### DIFF
--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -1,7 +1,9 @@
 <td class="u-no-padding{% if open_subscription == contract['contractInfo']['id'] %} p-table--open{% endif %}">
   <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-    {% if contract["contractInfo"]["id"] == new_subscription_id and contract["contractInfo"]["daysTillExpiry"] > 0%}
-      <div class="p-label--new">New</div>
+    {% if contract["contractInfo"]["id"] == new_subscription_id %}
+      {% if "daysTillExpiry" in contract["contractInfo"] and contract["contractInfo"]["daysTillExpiry"] > 0 %}
+        <div class="p-label--new">New</div>
+      {% endif %}
     {% endif %}
     
     {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>


### PR DESCRIPTION
## Done

- Added a check to make sure the `daysTillExpiry` property exists on a contract before deciding whether to apply a "new" label.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Visit /advantage, login with SSO, and see that you can see a list of contracts, rather than a template error


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8380
