### PR TITLE
Replace with transparent logos on /security/certifications

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -76,7 +76,7 @@
         loading="lazy",
         attrs={"class": ""}
         ) | safe
-      }}        
+      }}
     </div>
     <div class="col-6">
       <h3 class="p-card__title">FIPS certification and CIS compliance with Ubuntu</h3>
@@ -93,7 +93,7 @@
         FIPS 140-2 is a U.S. Government computer security standard. It defines security requirements related to the design and implementation of a cryptographic module. It is a requirement for U.S. Federal agencies to use FIPS 140-2 validated cryptography to protect sensitive information.
       </p>
       <p>
-        The standard puts stringent requirements on testing and ensuring that the cryptographic implementations meet the standards and work as expected. The testing and validation must be performed by a laboratory, which is accredited under the Cryptographic and Security Testing (CST) Laboratory Accreditation Program (LAP) and is part of NIST’s <a class="p-link--external" href="https://www.nist.gov/nvlap/">National Voluntary Laboratory Accreditation Program (NVLAP)</a> in the US and <a class="p-link--external" 
+        The standard puts stringent requirements on testing and ensuring that the cryptographic implementations meet the standards and work as expected. The testing and validation must be performed by a laboratory, which is accredited under the Cryptographic and Security Testing (CST) Laboratory Accreditation Program (LAP) and is part of NIST’s <a class="p-link--external" href="https://www.nist.gov/nvlap/">National Voluntary Laboratory Accreditation Program (NVLAP)</a> in the US and <a class="p-link--external"
  href="https://csrc.nist.gov/projects/cryptographic-module-validation-program">CCCS’s Cryptographic Module Validation Program (CMVP)</a> in Canada. The validation testing for Ubuntu 18.04 LTS and 16.04 LTS was performed by atsec Information Security, a U.S. Government and BSI accredited laboratory.
       </p>
       <p>
@@ -150,7 +150,7 @@
       <p>Ubuntu 18.04 has been submitted and is currently awaiting final certification from CSEC.  The evaluation was performed on Intel x86_64 and IBM Z hardware platforms.</p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg?w=150" width="150" alt="">
+      <img src="https://assets.ubuntu.com/v1/961a1ad1-csec-logo-removebg-preview.png?w=150" width="150" alt="">
     </div>
   </div>
 </section>
@@ -187,7 +187,7 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg?w=150" width="150" alt="">
+      <img src="https://assets.ubuntu.com/v1/f98af83d-cis-logo-removebg-preview.png?w=150" width="150" alt="">
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Replace with transparent logos

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the CSEC and CIS logos are now transparent


## Issue / Card

Fixes #8385

