### PR TITLE
K8sdocs 1.19 fixes

### DIFF
--- a/templates/kubernetes/docs/1.19/components.md
+++ b/templates/kubernetes/docs/1.19/components.md
@@ -31,7 +31,7 @@ reference page, detailing very specifically what this release of
 Other information about this release can be found on the following pages:
 
 <a class='p-button--brand' href='/kubernetes/docs/1.19/release-notes'>Release notes </a>
-<a class='p-button--brand' href='/kubernetes/docs/1.19/upgrade'>Upgrading </a>
+<a class='p-button--brand' href='/kubernetes/docs/1.19/upgrading'>Upgrading </a>
 <a class='p-button--brand' href='https://bugs.launchpad.net/charmed-kubernetes'>Bugs </a>
 <a class='p-button--brand' href='https://github.com/charmed-kubernetes/bundle'>Source </a>
 <a class='p-button--brand' href='https://launchpad.net/charmed-kubernetes/+milestone/1.19'>Milestone </a>

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -57,7 +57,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.19.x         | [charmed-kubernetes-509](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-509/archive/bundle.yaml) |
+| 1.19.x         | [charmed-kubernetes-519](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-509/archive/bundle.yaml) |
 | 1.18.x         | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |
 | 1.17.x         | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |
 | 1.16.x         | [charmed-kubernetes-316](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-316/archive/bundle.yaml) |


### PR DESCRIPTION
## Done

- Fix broken link
- update bundle rev number

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
