### PR TITLE
WIP: Add rocket chat appliance

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -4,6 +4,7 @@ appliances:
     appliance_name: "Plex Media Server"
     url_name: "plex"
     alias: "plexmediaserver"
+    logo: "https://assets.ubuntu.com/v1/402069bd-plex-media-server.png"
     port: 32400
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
@@ -18,6 +19,7 @@ appliances:
     appliance_name: "AdGuard"
     url_name: "adguard"
     alias: "adguard-home"
+    logo: "https://assets.ubuntu.com/v1/1ec45573-AdGuard.png"
     port: 3000
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi.img.xz"
@@ -32,6 +34,7 @@ appliances:
     appliance_name: "OpenHAB"
     url_name: "openhab"
     alias: "openhab"
+    logo: "https://assets.ubuntu.com/v1/f4632e06-openhab-logo.png"
     port: 8080
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi.img.xz"
@@ -46,6 +49,7 @@ appliances:
     appliance_name: "Mosquitto"
     url_name: "mosquitto"
     alias: "mosquitto"
+    logo: "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/mosquitto-logo-only.svg.png"
     port: 1883
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi.img.xz"
@@ -60,6 +64,7 @@ appliances:
     appliance_name: "Nextcloud"
     url_name: "nextcloud"
     alias: "nextcloud"
+    logo: "https://dashboard.snapcraft.io/site_media/appmedia/2016/06/icon.svg_1.png"
     port: 80
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi.img.xz"
@@ -74,6 +79,7 @@ appliances:
     appliance_name: "LXD"
     url_name: "lxd"
     alias: "lxd"
+    logo: "https://assets.ubuntu.com/v1/3a24a2f9-lxd.png"
     port: 80
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/lxd-core18-pi.img.xz"
@@ -87,3 +93,18 @@ appliances:
       2: False
       3: False
       4: True
+  rocket-chat:
+    name: "Rocket.Chat"
+    appliance_name: "Rocket.Chat Server"
+    url_name: "rocket-chat"
+    alias: "rocket-chat"
+    logo: "https://assets.ubuntu.com/v1/0abeb03e-rocket.chat.svg"
+    port: 3000
+    iso_url:
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi-armhf.img.xz"
+    checksum:
+      raspberrypi: "ed9995235ca3b01d0e81eda7f9d5e215372f2d81d41c612c14f9ca9fde4e2cad *plexmediaserver-core18-pi.img.xz"
+      pc: "876c78512afbb783f9511653e82d3ac57b3c8e9e20a4ad65ed15a2edc41a9758 *plexmediaserver-core18-amd64.img.xz"
+      pi2: "0b22901990ddefcb8777e3eae0bd86c9f1738313abaf1b33ecb9cbec9fbdee37 *plexmediaserver-core18-pi-armhf.img.xz"

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -106,6 +106,18 @@ appliance:
           path: /appliance/mosquitto/intel-nuc
         - title: VM
           path: /appliance/mosquitto/vm
+    - title: Rocket Chat
+      path: /appliance/rocket-chat
+      hidden: True
+      children:
+        - title: Raspberry Pi 2
+          path: /appliance/rocket-chat/raspberry-pi2
+        - title: Raspberry Pi 3 & 4
+          path: /appliance/rocket-chat/raspberry-pi
+        - title: Intel NUC
+          path: /appliance/rocket-chat/intel-nuc
+        - title: VM
+          path: /appliance/rocket-chat/vm
 aws:
   title: AWS
   path: /aws
@@ -756,7 +768,7 @@ kubernetes:
             - title: 1.19 vSphere integrator
               path: /kubernetes/docs/1.19/charm-vsphere-integrator
               hidden: True
-              
+
     - title: Contact us
       path: /kubernetes/contact-us
       hidden: True

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -14,9 +14,27 @@
   </div>
 </section>
 
+{% if appliances %}
 <section class="p-strip--light is-bordered">
-  {% with heading="Featured today" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
+  <div class="row">
+  {% for app in appliances|sort %}
+  {%- if loop.index == 7 %}
+  </div>
+  <div class="row">
+  {% endif %}
+  <div class="col-2 u-sv3">
+    <a href="/appliance/{{ appliances[app].url_name}}" class="p-link--soft">
+      <h3 class="p-heading--five u-no-padding--top">{{ appliances[app].name }}</h3>
+      <hr />
+      <div class="u-align--center">
+        <img src="{{ appliances[app].logo }}?h=72" alt="{{ appliances[app].name }} logo" style="max-height:72px;">
+      </div>
+    </a>
+  </div>
+  {% endfor %}
+  </div>
 </section>
+{% endif %}
 
 <section class="p-strip is-deep">
   <div class="row u-equal-height">

--- a/templates/appliance/rocket-chat/_next-steps.html
+++ b/templates/appliance/rocket-chat/_next-steps.html
@@ -7,12 +7,12 @@
       <p>
         Now you can go ahead and set everything up.  It’s usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot. When you’re ready go to:
       </p>
-      <pre><code>http://&lt;IP-of-your-appliance&gt;:3000/web</code></pre>
+      <pre><code>http://&lt;IP-of-your-appliance&gt;:{{ appliance.port }}</code></pre>
       <p>
         in another computer’s browser. Where you will find the initial configuration wizard.
       </p>
       <p>
-        Follow the instructions to start using your new Rocket.chat appliance.
+        Follow the instructions to start using your new {{ appliance.name }} appliance.
       </p>
       <p>
         For more information or more documentation on what to do now, the <a class="p-link--external" href="https://docs.rocket.chat/">Rocket.Chat website</a> is the best place to go next.

--- a/templates/appliance/rocket-chat/_next-steps.html
+++ b/templates/appliance/rocket-chat/_next-steps.html
@@ -1,0 +1,32 @@
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h2>
+        Start using your {{ appliance.name }} Ubuntu Appliance
+      </h2>
+      <p>
+        Now you can go ahead and set everything up.  It’s usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot. When you’re ready go to:
+      </p>
+      <pre><code>http://&lt;IP-of-your-appliance&gt;:3000/web</code></pre>
+      <p>
+        in another computer’s browser. Where you will find the initial configuration wizard.
+      </p>
+      <p>
+        Follow the instructions to start using your new Rocket.chat appliance.
+      </p>
+      <p>
+        For more information or more documentation on what to do now, the <a class="p-link--external" href="https://docs.rocket.chat/">Rocket.Chat website</a> is the best place to go next.
+      </p>
+    </div>
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
+      {{  image(
+        url="https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.00.png",
+        alt="Rocket.chat welcome screen",
+        width="879",
+        height="549",
+        hi_def=True,
+        loading="lazy",
+        ) | safe}}
+      </div>
+    </div>
+  </section>

--- a/templates/appliance/rocket-chat/index.md
+++ b/templates/appliance/rocket-chat/index.md
@@ -1,0 +1,59 @@
+---
+wrapper_template: "appliance/shared/_base_appliance_index.html"
+context:
+  name: "Rocket.Chat Server"
+  short_name: "rocket-chat"
+  appliance_name: "Rocket Chat"
+  company_name: "Rocket.Chat"
+  logo: "https://assets.ubuntu.com/v1/0abeb03e-rocket.chat.svg"
+  category: "Server"
+  meta_description: "Slack-like online chat server for your office, group or family. Up and running in seconds."
+  downloads:
+    raspberrypi: True
+    pc: True
+    intelnuc: True
+  pi:
+    2: True
+    3: True
+    4: True
+  screenshots:
+    1: https://www.youtube.com/embed/MW_qsbgt1KQ
+    2: https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.44.26.png
+    3: https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.00.png
+    4: https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.45.35.png
+    5: https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.47.10.png
+    6: https://dashboard.snapcraft.io/site_media/appmedia/2016/08/Screen_Shot_2016-02-22_at_21.48.31.png
+  links:
+    1:
+      title: "Website"
+      url: "https://rocket.chat/"
+    2:
+      title: "Privacy Policy"
+      url: "https://docs.rocket.chat/legal/privacy"
+    3:
+      title: "License: MIT"
+      url: "https://github.com/RocketChat/Rocket.Chat/blob/develop/LICENSE"
+  compliance:
+    1: "EU GDPR"
+  base: "core18"
+  published_date: "2020-09"
+  maintenance_date: "2030-09"
+  snaps:
+    1:
+      name: "Rocket.chat server"
+      icon: "https://assets.ubuntu.com/v1/0abeb03e-rocket.chat.svg"
+      link: "https://snapcraft.io/rocketchat-server"
+      publisher: "Rocket.Chat (rocketchat)"
+      channel: "latest/stable"
+      version: "3.5.2"
+      published_date: "13 August 2020"
+
+---
+
+#### Group chat server for 100s, installed in seconds.
+
+Slack-like online chat server for your office, group or family. Up and running in seconds. Supports file sharing, video conference, geolocation, and much more. Web and mobile client. MIT licensed Open Source project.
+
+- [Developer website](https://rocket.chat/)
+- [MIT licensed source code](https://github.com/RocketChat/Rocket.Chat)
+- [24 x 7 community support and community server](https://open.rocket.chat/)

--- a/templates/appliance/rocket-chat/index.md
+++ b/templates/appliance/rocket-chat/index.md
@@ -40,14 +40,13 @@ context:
   maintenance_date: "2030-09"
   snaps:
     1:
-      name: "Rocket.chat server"
+      name: "Rocket.Chat Server"
       icon: "https://assets.ubuntu.com/v1/0abeb03e-rocket.chat.svg"
       link: "https://snapcraft.io/rocketchat-server"
       publisher: "Rocket.Chat (rocketchat)"
       channel: "latest/stable"
       version: "3.5.2"
       published_date: "13 August 2020"
-
 ---
 
 #### Group chat server for 100s, installed in seconds.

--- a/templates/appliance/rocket-chat/intel-nuc.html
+++ b/templates/appliance/rocket-chat/intel-nuc.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_intel-nuc.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/rocket-chat/raspberry-pi.html
+++ b/templates/appliance/rocket-chat/raspberry-pi.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Raspberry Pi{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Raspberry Pi.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_raspberry-pi.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/rocket-chat/raspberry-pi2.html
+++ b/templates/appliance/rocket-chat/raspberry-pi2.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2 - Ubuntu Appliance{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi 2.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_raspberry-pi2.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/rocket-chat/vm.html
+++ b/templates/appliance/rocket-chat/vm.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Try the {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.appliance_name }} Ubuntu Appliance on your Ubuntu desktop with KVM.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_vm.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -81,15 +81,15 @@
     </a>
   </div>
   <div class="col-2">
-    <a href="/appliance/mosquitto" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Mosquitto</h3>
+    <a href="/appliance/rocket-chat" class="p-link--soft">
+      <h3 class="p-heading--five u-no-padding--top">Rocket Chat</h3>
       <hr />
       <div class="u-align--center">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
+            url="https://assets.ubuntu.com/v1/1ad274f9-rocket-chat.svg",
             alt="",
-            height="72",
+            height="62",
             width="72",
             hi_def=True,
             loading="lazy",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -37,6 +37,7 @@ from webapp.views import (
     download_harness,
     download_thank_you,
     appliance_install,
+    appliance_portfolio,
     get_renewal,
     post_customer_info,
     post_stripe_invoice_id,
@@ -181,6 +182,9 @@ app.add_url_rule(
     "/appliance/<regex('.+'):app>/<regex('.+'):device>",
     view_func=appliance_install,
 )
+app.add_url_rule(
+    "/appliance/portfolio", view_func=appliance_portfolio,
+)
 # blog section
 
 blog_views = BlogViews(
@@ -204,12 +208,10 @@ app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 
 # usn section
 app.add_url_rule(
-    "/security/api/notices/<notice_id>",
-    view_func=read_notice,
+    "/security/api/notices/<notice_id>", view_func=read_notice,
 )
 app.add_url_rule(
-    "/security/api/notices",
-    view_func=read_notices,
+    "/security/api/notices", view_func=read_notices,
 )
 app.add_url_rule("/security/notices", view_func=notices)
 app.add_url_rule(
@@ -300,9 +302,7 @@ tutorials_docs.init_app(app)
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api,
-        index_topic_id=17250,
-        url_prefix="/ceph/docs",
+        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
     ),
     document_template="/ceph/document.html",
     url_prefix="/ceph/docs",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -183,7 +183,8 @@ app.add_url_rule(
     view_func=appliance_install,
 )
 app.add_url_rule(
-    "/appliance/portfolio", view_func=appliance_portfolio,
+    "/appliance/portfolio",
+    view_func=appliance_portfolio,
 )
 # blog section
 
@@ -208,10 +209,12 @@ app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 
 # usn section
 app.add_url_rule(
-    "/security/api/notices/<notice_id>", view_func=read_notice,
+    "/security/api/notices/<notice_id>",
+    view_func=read_notice,
 )
 app.add_url_rule(
-    "/security/api/notices", view_func=read_notices,
+    "/security/api/notices",
+    view_func=read_notices,
 )
 app.add_url_rule("/security/notices", view_func=notices)
 app.add_url_rule(
@@ -302,7 +305,9 @@ tutorials_docs.init_app(app)
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs",
+        api=discourse_api,
+        index_topic_id=17250,
+        url_prefix="/ceph/docs",
     ),
     document_template="/ceph/document.html",
     url_prefix="/ceph/docs",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -124,6 +124,17 @@ def appliance_install(app, device):
     )
 
 
+def appliance_portfolio():
+    with open("appliances.yaml") as appliances:
+        appliances = yaml.load(appliances, Loader=yaml.FullLoader)
+
+    return flask.render_template(
+        "appliance/portfolio.html",
+        http_host=flask.request.host,
+        appliances=appliances["appliances"],
+    )
+
+
 def releasenotes_redirect():
     """
     View to redirect to https://wiki.ubuntu.com/ URLs for release notes.
@@ -556,8 +567,7 @@ def make_renewal(advantage, contract_info):
         return None
 
     sorted_renewals = sorted(
-        renewals,
-        key=lambda renewal: dateutil.parser.parse(renewal["start"]),
+        renewals, key=lambda renewal: dateutil.parser.parse(renewal["start"]),
     )
 
     renewal = sorted_renewals[0]

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -567,7 +567,8 @@ def make_renewal(advantage, contract_info):
         return None
 
     sorted_renewals = sorted(
-        renewals, key=lambda renewal: dateutil.parser.parse(renewal["start"]),
+        renewals,
+        key=lambda renewal: dateutil.parser.parse(renewal["start"]),
     )
 
     renewal = sorted_renewals[0]


### PR DESCRIPTION
## Done

- Add rocket chat appliance
- Update portfolio page to build dynamically
- Update /appliance featured appliances
- **Note - actual downloads and checksums are missing**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/appliance
    - http://0.0.0.0:8001/appliance/portfolio
    - http://0.0.0.0:8001/appliance/rocket-chat
    - http://0.0.0.0:8001/appliance/rocket-chat/raspberry-pi2
    - http://0.0.0.0:8001/appliance/rocket-chat/raspberry-pi
    - http://0.0.0.0:8001/appliance/rocket-chat/pc
    - http://0.0.0.0:8001/appliance/rocket-chat/intel-nuc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it matches the [brief](https://docs.google.com/document/d/1cp8qGmKwpoLUmenlOHc6j6MILkiVLh9mEaqIv_VLZSU/edit?ts=5f50ca4b)

## Issue / Card

Fixes #8358