### PR TITLE
Update blog to 6.3.1 and image-template to 1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 alembic==1.4.2
 canonicalwebteam.flask_base==0.6.4
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.2.4
+canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.image-template==1.3.0
+canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==2.0.1
 canonicalwebteam.launchpad==0.7.7
 python-dateutil==2.8.1


### PR DESCRIPTION
## Done

Fix blog article thumbnails and image pixelation.

## QA

https://ubuntu.com/blog
Check the thumbnails, they will have slightly different sizes.
https://ubuntu-com-8409.demos.haus/blog
Check the thumbnails, you will notice they all have the same size(330x185) and cover the whole width of the block.

https://ubuntu.com
Check Spotify logo. It should look good.


## Issue

Part of: https://github.com/canonical-web-and-design/canonicalwebteam.blog/pull/153