### PR TITLE
WIP: Create /appliance/gitea page

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -92,7 +92,7 @@ appliances:
     appliance_name: "Gitea"
     url_name: "gitea"
     alias: "plexmedigiteaaserver"
-    port: 80
+    port: 3000
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
       pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"

--- a/appliances.yaml
+++ b/appliances.yaml
@@ -87,3 +87,17 @@ appliances:
       2: False
       3: False
       4: True
+  gitea:
+    name: "Gitea"
+    appliance_name: "Gitea"
+    url_name: "gitea"
+    alias: "plexmedigiteaaserver"
+    port: 80
+    iso_url:
+      raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
+      pc: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-amd64.img.xz"
+      pi2: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi-armhf.img.xz"
+    checksum:
+      raspberrypi: "ed9995235ca3b01d0e81eda7f9d5e215372f2d81d41c612c14f9ca9fde4e2cad *plexmediaserver-core18-pi.img.xz"
+      pc: "876c78512afbb783f9511653e82d3ac57b3c8e9e20a4ad65ed15a2edc41a9758 *plexmediaserver-core18-amd64.img.xz"
+      pi2: "0b22901990ddefcb8777e3eae0bd86c9f1738313abaf1b33ecb9cbec9fbdee37 *plexmediaserver-core18-pi-armhf.img.xz"

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -106,6 +106,18 @@ appliance:
           path: /appliance/mosquitto/intel-nuc
         - title: VM
           path: /appliance/mosquitto/vm
+    - title: Gitea
+      path: /appliance/gitea
+      hidden: True
+      children:
+        - title: Raspberry Pi 2
+          path: /appliance/gitea/raspberry-pi2
+        - title: Raspberry Pi 3 & 4
+          path: /appliance/gitea/raspberry-pi
+        - title: Intel NUC
+          path: /appliance/gitea/intel-nuc
+        - title: VM
+          path: /appliance/gitea/vm
 aws:
   title: AWS
   path: /aws
@@ -756,7 +768,7 @@ kubernetes:
             - title: 1.19 vSphere integrator
               path: /kubernetes/docs/1.19/charm-vsphere-integrator
               hidden: True
-              
+
     - title: Contact us
       path: /kubernetes/contact-us
       hidden: True

--- a/templates/appliance/gitea/_next-steps.html
+++ b/templates/appliance/gitea/_next-steps.html
@@ -1,0 +1,32 @@
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h2>
+        Start using your {{ appliance.name }} Ubuntu Appliance
+      </h2>
+      <p>
+        Now you can go ahead and set everything up.  It’s usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot. When you’re ready go to:
+      </p>
+      <pre><code>http://&lt;IP-of-your-appliance&gt;:{{ appliance.port }}</code></pre>
+      <p>
+        in another computer’s browser. Where you will find the initial configuration wizard. 
+      </p>
+      <p>
+        Follow the instructions to start using your new Gitea appliance.
+      </p>
+      <p>
+        Then just follow the instructions on the screen. For more information or more <a class="p-link--external" href="https://docs.gitea.io">documentation</a>, the <a class="p-link--external" href="https://gitea.io">{{ appliance.name }} website</a> is the best place to go next.
+      </p>
+    </div>
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
+      {{  image(
+        url="https://assets.ubuntu.com/v1/03c1ed84-gitea-3.png",
+        alt="Gitea screen",
+        width="879",
+        height="548",
+        hi_def=True,
+        loading="lazy",
+        ) | safe}}
+      </div>
+    </div>
+  </section>

--- a/templates/appliance/gitea/index.md
+++ b/templates/appliance/gitea/index.md
@@ -1,0 +1,51 @@
+---
+wrapper_template: "appliance/shared/_base_appliance_index.html"
+context:
+  name: "Gitea"
+  short_name: "gitea"
+  appliance_name: "Gitea"
+  company_name: "Gitea"
+  logo: "https://assets.ubuntu.com/v1/9f584e65-gitea.png"
+  category: "Developer"
+  meta_description: "Gitea, a painless self-hosted Git service."
+  downloads:
+    raspberrypi: True
+    pc: True
+    intelnuc: True
+  pi:
+    2: True
+    3: True
+    4: True
+  screenshots:
+    1: https://assets.ubuntu.com/v1/fa328332-gitea-1.png
+    2: https://assets.ubuntu.com/v1/a93620ee-gitea-2.png
+    3: https://assets.ubuntu.com/v1/03c1ed84-gitea-3.png
+  links:
+    1:
+      title: "License: MIT"
+      url: "https://github.com/go-gitea/gitea/blob/master/LICENSE"
+    2:
+      title: "Website"
+      url: "https://gitea.io"
+    3:
+      title: "Privacy Policy"
+      url: "https://discourse.gitea.io/privacy"
+  compliance:
+    1: EU GDPR
+  base: "core18"
+  published_date: "2020-09"
+  maintenance_date: "2030-09"
+  snaps:
+    1:
+      name: "gitea"
+      icon: "https://assets.ubuntu.com/v1/9f584e65-gitea.png"
+      link: "https://snapcraft.io/gitea"
+      publisher: "By Gitea"
+      channel: "latest/stable"
+      version: "1.12.4"
+      published_date: "4 September 2020"
+---
+
+#### Gitea - A painless self-hosted Git service
+
+The goal of this project is to make the easiest, fastest, and most painless way of setting up a self-hosted Git service. With Go, this can be done with an independent binary distribution across ALL platforms that Go supports, including Linux, Mac OS X, Windows and ARM.

--- a/templates/appliance/gitea/intel-nuc.html
+++ b/templates/appliance/gitea/intel-nuc.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1gb03YbX5ZQ_oO74M36b3ybCPwqq29d8Q17c6KaguW18/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_intel-nuc.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/gitea/raspberry-pi.html
+++ b/templates/appliance/gitea/raspberry-pi.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Raspberry Pi{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Raspberry Pi.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_raspberry-pi.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/gitea/raspberry-pi2.html
+++ b/templates/appliance/gitea/raspberry-pi2.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2 - Ubuntu Appliance{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi 2.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1H_4L-kqKx6HJ0_3krpzdDVZ24pdVm5jb0evLMT6mcuo/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_raspberry-pi2.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}

--- a/templates/appliance/gitea/vm.html
+++ b/templates/appliance/gitea/vm.html
@@ -1,0 +1,15 @@
+{% extends "appliance/_base-appliance.html" %}
+
+{% block title %}Try the {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine{% endblock title %}
+
+{% block meta_description %}Install and setup the {{ appliance.appliance_name }} Ubuntu Appliance on your Ubuntu desktop with KVM.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1G8IJoHrhd1RP3dHqyiasteMxPrxCwW5Sf0Vh3AY2SHQ/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% include 'appliance/shared/_vm.html' %}
+
+{% include 'appliance/' ~ appliance.url_name ~ '/_next-steps.html' %}
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Create /appliance/gitea page
- **Note: appliance images do not exist**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/appliance/gitea
    - http://0.0.0.0:8001/appliance/gitea/raspbery-pi2
    - http://0.0.0.0:8001/appliance/gitea/raspbery-pi
    - http://0.0.0.0:8001/appliance/gitea/intel-nuc
    - http://0.0.0.0:8001/appliance/gitea/vm
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [brief](https://docs.google.com/document/d/1gaAzXGPUCqUJE_pnmzqO02-ZOy3EP-t-SpIcsQfGp2g/edit)

## Issue / Card

Fixes #8357

