### PR TITLE
Hide "Survey" in secondary nav from /legal/data-privacy

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -756,7 +756,7 @@ kubernetes:
             - title: 1.19 vSphere integrator
               path: /kubernetes/docs/1.19/charm-vsphere-integrator
               hidden: True
-              
+
     - title: Contact us
       path: /kubernetes/contact-us
       hidden: True
@@ -1130,6 +1130,7 @@ legal:
           hidden: True
         - title: Survey
           path: /legal/data-privacy/survey
+          hidden: True
         - title: Events
           path: /legal/data-privacy/events
           hidden: True


### PR DESCRIPTION
## Done

- The legal team asked that we hide "Survey" in secondary nav from /legal/data-privacy

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/data-privacy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that 'Survey' has been hidden

## Screenshots

[before]
![image](https://user-images.githubusercontent.com/441217/94900613-315cd780-048d-11eb-9524-784ca0c1e742.png)

[after]
![image](https://user-images.githubusercontent.com/441217/94900659-446fa780-048d-11eb-967b-73ed9ffb3f65.png)
