### PR TITLE
Add charmed-kubeflow links

### DIFF
--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -17,7 +17,7 @@
           <a class="p-button--positive" href="/kubeflow/install">
           Try Kubeflow
           </a>
-          <a class="p-link--external" href="http://charmed-kubeflow.io">Kubeflow operators</a>
+          <a class="p-link--external" href="https://charmed-kubeflow.io">Kubeflow operators</a>
         </p>
       </div>
       <div class="col-4 col-start-large-8 u-vertically-center u-align--center u-hide--small">
@@ -339,7 +339,7 @@
         <h2>Kubeflow, well packaged</h2>
         <p>Charmed Kubeflow integrates the <a href="https://jaas.ai/u/kubeflow-charmers#charms" class="p-link--external p-link--inverted">30+ apps</a> that make up Kubeflow with ops code to provide the best Kubeflow experience, from deployment to day-2 operations.</p>
         <br />
-          <a class="p-link--external p-link--inverted" href="http://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
+          <a class="p-link--external p-link--inverted" href="https://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
       </div>
     </div>
     <div class="col-5 u-align--center">

--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -17,7 +17,7 @@
           <a class="p-button--positive" href="/kubeflow/install">
           Try Kubeflow
           </a>
-          <a class="p-link--external" href="https://jaas.ai/kubeflow">Kubeflow operators</a>
+          <a class="p-link--external" href="http://charmed-kubeflow.io">Kubeflow operators</a>
         </p>
       </div>
       <div class="col-4 col-start-large-8 u-vertically-center u-align--center u-hide--small">
@@ -339,7 +339,7 @@
         <h2>Kubeflow, well packaged</h2>
         <p>Charmed Kubeflow integrates the <a href="https://jaas.ai/u/kubeflow-charmers#charms" class="p-link--external p-link--inverted">30+ apps</a> that make up Kubeflow with ops code to provide the best Kubeflow experience, from deployment to day-2 operations.</p>
         <br />
-          <a class="p-link--external p-link--inverted" href="https://jaas.ai/kubeflow">Visit Charmed-Kubeflow</a>
+          <a class="p-link--external p-link--inverted" href="http://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
       </div>
     </div>
     <div class="col-5 u-align--center">


### PR DESCRIPTION
## Done

- Added links from `/kubeflow/what-is-kubeflow` to live http://charmed-kubeflow.io

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/what-is-kubeflow
- Check _Kubeflow operators_ and _Visit Charmed-kubeflow.io_ links redirect to  http://charmed-kubeflow.io as seen in [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit#)

## Issue

[#8262 ](https://github.com/canonical-web-and-design/ubuntu.com/issues/8262)
