### PR TITLE
K8sDocs: Remove todo, which has been done

### DIFF
--- a/templates/kubernetes/docs/1.19/release-notes.md
+++ b/templates/kubernetes/docs/1.19/release-notes.md
@@ -89,7 +89,7 @@ For a full list of the changes introduced in Kubernetes 1.19, please see the
 
 - addon-resizer 1.8.9
 - ceph-csi 2.1.2
-- cloud-provider-openstack (TODO https://bugs.launchpad.net/cdk-addons/+bug/1889433)
+- cloud-provider-openstack
 - coredns 1.6.7
 - kube-state-metrics 1.9.7
 - kubernetes-dashboard 2.0.1

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -89,7 +89,7 @@ For a full list of the changes introduced in Kubernetes 1.19, please see the
 
 - addon-resizer 1.8.9
 - ceph-csi 2.1.2
-- cloud-provider-openstack (TODO https://bugs.launchpad.net/cdk-addons/+bug/1889433)
+- cloud-provider-openstack
 - coredns 1.6.7
 - kube-state-metrics 1.9.7
 - kubernetes-dashboard 2.0.1


### PR DESCRIPTION
## Done

- removed TODO from release notes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
