### PR TITLE
Security series updates

### DIFF
--- a/templates/security-series/index.html
+++ b/templates/security-series/index.html
@@ -417,7 +417,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Best practices for securing open source</p>
       <p>In this webinar learn about the common security and compliance issues with open source, five best practices the Ubuntu Security Team implements and how you can ensure the security integrity of your Ubuntu systems.</p>
-      <a class="p-link--external" https://www.brighttalk.com/webcast/6793/445555">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Register for the webinar</a>
     </div>
   </div>
 </section>

--- a/templates/security-series/index.html
+++ b/templates/security-series/index.html
@@ -51,7 +51,7 @@ Security and compliance for the full stack{% endblock %}
       <p class ="p-heading--4"><a href="#engineering-series">Team based webinars</a></p>
       <hr />
       <ul class="p-inline-list--middot">
-        <li class="p-inline-list__item"><a href="#management-series">CISO|CTO</a></li>
+        <li class="p-inline-list__item"><a href="#management-series">CISO, CTO</a></li>
         <li class="p-inline-list__item"><a href="#engineering-series">DevSecOps</a></li>
         <li class="p-inline-list__item"><a href="#management-series">IT Security Manager, Director</a></li>
         <li class="p-inline-list__item"><a href="#engineering-series">Security, Systems Engineer</a></li>
@@ -112,7 +112,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Best practices for securing open source</p>
       <p>In this webinar learn about the common security and compliance issues with open source, five best practices the Ubuntu Security Team implements and how you can ensure the security integrity of your Ubuntu systems.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440071">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Register for the webinar</a>
     </div>
     <div class="col-4">
       <p>
@@ -328,10 +328,10 @@ Security and compliance for the full stack{% endblock %}
       <p>
         {{
         image(
-          url="https://assets.ubuntu.com/v1/bf810a68-AppArmor_logo.svg",
+          url="https://assets.ubuntu.com/v1/81201fd0-Secure+cloud.svg",
           alt="",
           height="80",
-          width="90",
+          width="140",
           hi_def=True,
           loading="auto",
         ) | safe
@@ -417,7 +417,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Best practices for securing open source</p>
       <p>In this webinar learn about the common security and compliance issues with open source, five best practices the Ubuntu Security Team implements and how you can ensure the security integrity of your Ubuntu systems.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440071">Register for the webinar</a>
+      <a class="p-link--external" https://www.brighttalk.com/webcast/6793/445555">Register for the webinar</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated the BrightTalk webinar link for the Best practices for securing open source webinar to this link: https://www.brighttalk.com/webcast/6793/445555

- Removed the '|' and add a comma and a space between CISO, CTO in the 'Team based webinars' section

- Replaced the AppArmor icon with the multi-cloud security icon for the 'Securing open source across multi-cloud environments' webinar in the 'IoT & Device security' section

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the changes against the copy doc


## Issue / Card #8431 

