### PR TITLE
Reverse order of release

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -483,9 +483,7 @@ def cve_index():
         .all()
     )
 
-    releases_query = db_session.query(Release).order_by(
-        desc(Release.release_date)
-    )
+    releases_query = db_session.query(Release).order_by(Release.release_date)
 
     if versions and not any(a in ["", "current"] for a in versions):
         releases_query = releases_query.filter(Release.codename.in_(versions))


### PR DESCRIPTION
## Done

- Make cve table releases be ordered in ascending order.

## QA
- have the data imported in the databse
- fetch changes
- go to `/security/cve`
- look at the table head. The releases will be ordered in ascending order.

## Issue / Card

Fixes #8424
