### PR TITLE
CVE search by description update

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -533,7 +533,12 @@ def cve_index():
         cves_query = cves_query.filter(CVE.priority == priority)
 
     if query:
-        cves_query = cves_query.filter(CVE.description.ilike(f"%{query}%"))
+        cves_query = cves_query.filter(
+            or_(
+                CVE.description.ilike(f"%{query}%"),
+                CVE.ubuntu_description.ilike(f"%{query}%"),
+            )
+        )
 
     parameters = []
     if package:


### PR DESCRIPTION
## Done

- Make search by description check for both `CVE.description` and `CVE.ubuntu_description`.

## QA

- Go to https://ubuntu.com/security/cve?q=was+discovered+that+jsoup+improperly&package=&priority=&version=&status=
You will see no CVE listed

- Check out this feature branch

- Have CVEs imported

- `dotrun` and go to http://0.0.0.0:8001/security/cve?q=was+discovered+that+jsoup+improperly&package=&priority=&version=&status=
You will see one CVE listed: CVE-2015-6748 


## Issue / Card

Fixes #8419
