### PR TITLE
Create authenticated session for authenticated endpoints

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -100,13 +100,14 @@ app.config["CANONICAL_LOGIN_URL"] = os.getenv(
 ).rstrip("/")
 
 session = talisker.requests.get_session()
+authenticated_session = talisker.requests.get_session()
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/", session=session
 )
 
 authenticated_discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
-    session=session,
+    session=authenticated_session,
     api_key=os.getenv("DISCOURSE_API_KEY"),
     api_username=os.getenv("DISCOURSE_API_USERNAME"),
 )


### PR DESCRIPTION
## Done

Create authenticated session for authenticated endpoints (to avoid sharing pre set headers in the session)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- visit some pages (engage pages, blog)