### PR TITLE
Add LXD to appliance homepage and portfolio

### DIFF
--- a/appliances.yaml
+++ b/appliances.yaml
@@ -4,6 +4,7 @@ appliances:
     appliance_name: "Plex Media Server"
     url_name: "plex"
     alias: "plexmediaserver"
+    logo: "https://assets.ubuntu.com/v1/402069bd-plex-media-server.png"
     port: 32400
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/plexmediaserver-core18-pi.img.xz"
@@ -18,6 +19,7 @@ appliances:
     appliance_name: "AdGuard"
     url_name: "adguard"
     alias: "adguard-home"
+    logo: "https://assets.ubuntu.com/v1/1ec45573-AdGuard.png"
     port: 3000
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/adguard-home-core18-pi.img.xz"
@@ -32,6 +34,7 @@ appliances:
     appliance_name: "OpenHAB"
     url_name: "openhab"
     alias: "openhab"
+    logo: "https://assets.ubuntu.com/v1/f4632e06-openhab-logo.png"
     port: 8080
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/openhab-core18-pi.img.xz"
@@ -46,6 +49,7 @@ appliances:
     appliance_name: "Mosquitto"
     url_name: "mosquitto"
     alias: "mosquitto"
+    logo: "https://dashboard.snapcraft.io/site_media/appmedia/2018/08/mosquitto-logo-only.svg.png"
     port: 1883
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/mosquitto-core18-pi.img.xz"
@@ -60,6 +64,7 @@ appliances:
     appliance_name: "Nextcloud"
     url_name: "nextcloud"
     alias: "nextcloud"
+    logo: "https://dashboard.snapcraft.io/site_media/appmedia/2016/06/icon.svg_1.png"
     port: 80
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/nextcloud-core18-pi.img.xz"
@@ -74,6 +79,7 @@ appliances:
     appliance_name: "LXD"
     url_name: "lxd"
     alias: "lxd"
+    logo: "https://assets.ubuntu.com/v1/3a24a2f9-lxd.png"
     port: 80
     iso_url:
       raspberrypi: "https://cdimage.ubuntu.com/ubuntu-core/appliances/lxd-core18-pi.img.xz"

--- a/templates/appliance/lxd/_next-steps.html
+++ b/templates/appliance/lxd/_next-steps.html
@@ -6,7 +6,7 @@
           Start using your {{ appliance.name }} Ubuntu Appliance
         </h2>
         <p>
-          Now you can go ahead and set everything up.  It’s usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot. 
+          Now you can go ahead and set everything up.  It’s usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot.
         </p>
         <p>
           When you’re ready ssh into your appliance as described in step 6 and run:
@@ -19,7 +19,7 @@
           <li>
             <code>snap install lxd</code> on Linux
           </li>
-         <li> 
+         <li>
            <code>brew install lxc</code> on macOS
           </li>
           <li>
@@ -27,12 +27,12 @@
           </li>
         </ul>
         <p>
-          And connect to the appliance with: 
+          And connect to the appliance with:
         </p>
         <pre>lxc remote add appliance IP-ADDRESS
 lxc list appliance:</pre>
         <p>
-          And you’re away. For more information or more documentation on what to do now, the <a class="p-link--external" href="https://linuxcontainers.org">LXD website</a> is the best place to go next.
+          And you’re away. For more information check out the <a class="p-link--external" href="https://linuxcontainers.org">LXD website</a> or read our <a class="p-link--external" href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076">tutorial on turning the LXD Ubuntu Appliance into your own homelab</a>.
         </p>
         <div class="p-notification" id="notification">
           <div class="p-notification__response">
@@ -40,7 +40,7 @@ lxc list appliance:</pre>
               Note:
             </span>
             <p>
-              If there is a core update, the appliance will automatically update, then reboot. Typically this isn’t an issue but some use cases should take note. 
+              If there is a core update, the appliance will automatically update, then reboot. Typically this isn’t an issue but some use cases should take note.
             </p>
           </div>
         </div>

--- a/templates/appliance/portfolio.html
+++ b/templates/appliance/portfolio.html
@@ -14,9 +14,27 @@
   </div>
 </section>
 
+{% if appliances %}
 <section class="p-strip--light is-bordered">
-  {% with heading="Featured today" %}{% include "/appliance/shared/_featured_appliances.html" %}{% endwith %}
+  <div class="row">
+  {% for app in appliances|sort %}
+  {%- if loop.index == 7 %}
+  </div>
+  <div class="row">
+  {% endif %}
+  <div class="col-2 u-sv3">
+    <a href="/appliance/{{ appliances[app].url_name}}" class="p-link--soft">
+      <h3 class="p-heading--five u-no-padding--top">{{ appliances[app].name }}</h3>
+      <hr />
+      <div class="u-align--center">
+        <img src="{{ appliances[app].logo }}?h=72" alt="{{ appliances[app].name }} logo" style="max-height:72px;">
+      </div>
+    </a>
+  </div>
+  {% endfor %}
+  </div>
 </section>
+{% endif %}
 
 <section class="p-strip is-deep">
   <div class="row u-equal-height">

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -80,6 +80,27 @@
       </div>
     </a>
   </div>
+  {% if request.path == "/appliance/vm" %}
+  <div class="col-2">
+    <a href="/appliance/mosquitto" class="p-link--soft">
+      <h3 class="p-heading--five u-no-padding--top">Mosquitto</h3>
+      <hr />
+      <div class="u-align--center">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
+            alt="",
+            height="72",
+            width="72",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-top: 1rem;"}
+          ) | safe
+        }}
+      </div>
+    </a>
+  </div>
+  {% else %}
   <div class="col-2">
     <a href="/appliance/lxd" class="p-link--soft">
       <h3 class="p-heading--five u-no-padding--top">LXD</h3>
@@ -99,4 +120,5 @@
       </div>
     </a>
   </div>
+  {% endif %}
 </div>

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -81,13 +81,13 @@
     </a>
   </div>
   <div class="col-2">
-    <a href="/appliance/mosquitto" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Mosquitto</h3>
+    <a href="/appliance/lxd" class="p-link--soft">
+      <h3 class="p-heading--five u-no-padding--top">LXD</h3>
       <hr />
       <div class="u-align--center">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
+            url="https://assets.ubuntu.com/v1/3a24a2f9-lxd.png",
             alt="",
             height="72",
             width="72",

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -40,8 +40,7 @@
         url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
         alt="",
         height="250",
-        width="250",
-        hi_def=True,
+        width="320",
         loading="auto"
         ) | safe
       }}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -37,6 +37,7 @@ from webapp.views import (
     download_harness,
     download_thank_you,
     appliance_install,
+    appliance_portfolio,
     get_renewal,
     post_customer_info,
     post_stripe_invoice_id,
@@ -181,6 +182,11 @@ app.add_url_rule(
     "/appliance/<regex('.+'):app>/<regex('.+'):device>",
     view_func=appliance_install,
 )
+app.add_url_rule(
+    "/appliance/portfolio",
+    view_func=appliance_portfolio,
+)
+
 # blog section
 
 blog_views = BlogViews(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -124,6 +124,17 @@ def appliance_install(app, device):
     )
 
 
+def appliance_portfolio():
+    with open("appliances.yaml") as appliances:
+        appliances = yaml.load(appliances, Loader=yaml.FullLoader)
+
+    return flask.render_template(
+        "appliance/portfolio.html",
+        http_host=flask.request.host,
+        appliances=appliances["appliances"],
+    )
+
+
 def releasenotes_redirect():
     """
     View to redirect to https://wiki.ubuntu.com/ URLs for release notes.


### PR DESCRIPTION
## Done

- Add LXD to appliance homepage and portfolio
- Add a tutorial to next setup
- Made the portfolio page build from the application.yaml
- Fixed side of the mascot on /download

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance, http://0.0.0.0:8001/appliance/lxd/intel-nuc and http://0.0.0.0:8001/appliance/portfolio 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that LXD replaces Mosquitto on the /appliance page
- See that LXD is on the /appliance/portfolio page
- See that the 'Getting started' section text is updated per the [copy doc](https://docs.google.com/document/d/1B39LSVUaj9DY_W-v2v76DyNFKyzXZn6ppCUeNuZXfNc/edit?ts=5f7f59c4)
- See that LXD isn't on the /appliance/vm page as it doesn't have a VM

## Screenshots

[If relevant, please include a screenshot.]
![image](https://user-images.githubusercontent.com/441217/95503669-90e24800-09a3-11eb-90e3-4b6e1ae05b5e.png)

