### PR TITLE
Add covid notice to /training page

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -9,7 +9,7 @@
 {% block outer_content %}
 {% block content %}
 
-<section class="p-strip--suru-topped is-deep is-bordered">
+<section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
     <h1>Train with Ubuntu</h1>
   </div>
@@ -30,6 +30,13 @@
         loading="auto",
         ) | safe
       }}
+    </div>
+  </div>
+  <div class="row">
+    <div class="p-notification--caution col-6">
+      <p class="p-notification__response" role="status">
+        <span class="p-notification__status">PLEASE NOTE:</span> Due to current circumstances linked to the COVID-19 pandemic, all training programmes mentioned in this page are performed remotely. All training content and labs will remain the same. We aim to return to an on-site delivery model as soon as the circumstances permit.
+      </p>
     </div>
   </div>
 </section>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -9,31 +9,32 @@
 {% block outer_content %}
 {% block content %}
 
-<section class="p-strip--suru-topped is-bordered">
-  <div class="row u-equal-height">
+<section class="p-strip--suru-bottomed u-image-position">
+  <div class="row">
     <h1>Train with Ubuntu</h1>
   </div>
   <div class="row u-equal-height">
-    <div class="col-6 u-vertically-center">
+    <div class="col-7">
       <div>
         <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
       </div>
     </div>
-    <div class="col-6 u-align--center u-hide--small">
+    <div class="col-5 u-hide--small">
       {{
         image(
         url="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg",
         alt="",
-        width="210",
-        height="125",
+        width="400",
+        height="237",
         hi_def=True,
         loading="auto",
+        attrs={"class": "u-image-position--top"}
         ) | safe
       }}
     </div>
   </div>
   <div class="row">
-    <div class="p-notification--caution col-6">
+    <div class="p-notification--caution col-6" style="position: relative;">
       <p class="p-notification__response" role="status">
         <span class="p-notification__status">PLEASE NOTE:</span> Due to current circumstances linked to the COVID-19 pandemic, all training programmes mentioned in this page are performed remotely. All training content and labs will remain the same. We aim to return to an on-site delivery model as soon as the circumstances permit.
       </p>


### PR DESCRIPTION
## Done

- Add covid notice to /training page
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?ts=5f7ffa38#)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/95559895-5d89d280-0a10-11eb-94d0-6877570831ac.png)
