### PR TITLE
Add charmed-kubeflow links throughout the Kubeflow journey

### DIFF
--- a/templates/blog/product-cards/_kubeflow_jaas-bundle.html
+++ b/templates/blog/product-cards/_kubeflow_jaas-bundle.html
@@ -2,7 +2,7 @@
   <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg" alt="kubeflow logo" style="width: 137px;height: 32px;">
   <hr class="u-sv1">
   <h3>
-    <a href="https://jaas.ai/kubeflow/bundle/185">Run Kubeflow anywhere, easily</a>
+    <a href="https://charmed-kubeflow.io">Run Kubeflow anywhere, easily</a>
   </h3>
   <p>With Charmed Kubeflow, deployment and operations of Kubeflow are easy for any scenario.
     <br /><br />
@@ -10,5 +10,5 @@
     katib or pipelines-ui.
     <br /><br />
     Use Kubeflow on-prem, desktop, edge, public cloud and multi-cloud.
-    <p><a href="https://jaas.ai/kubeflow/bundle/185">Learn more about Charmed Kubeflow&nbsp;&rsaquo;</a></p>
+    <p><a href="https://charmed-kubeflow.io">Learn more about Charmed Kubeflow&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/kubeflow/index.html
+++ b/templates/kubeflow/index.html
@@ -15,7 +15,7 @@
       <p>Canonical&rsquo;s Kubeflow supports the most popular tools for machine learning &mdash; starting with JupyterHub and Tensorflow &mdash; in a standardised workflow running on Kubernetes.</p>
       <p>
         <a class="p-button--positive" href="/kubeflow/install">Try Kubeflow</a>
-        <a class="p-button--neutral" href="/kubeflow/consulting">Enterprise training</a>
+        <a class="p-button--neutral p-link--external" href="https://charmed-kubeflow.io">Kubeflow operators</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Changed secondary CTA on /kubeflow
- Changed a blog product card

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to any ["kubefllow" tagged blog post](https://ubuntu-com-8446.demos.haus/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-2), refresh until you see the "Run Kubeflow anywhere, easily" product card next to the post
- Ensure the [/kubeflow](https://ubuntu-com-8446.demos.haus/kubeflow) page matches the copy doc