### PR TITLE
K8sDocs: fix rendering of image list

### DIFF
--- a/templates/kubernetes/docs/1.19/components.md
+++ b/templates/kubernetes/docs/1.19/components.md
@@ -330,6 +330,7 @@ These charms are frequently used with Charmed Kubernetes.
 These are the container images used by this release:
 
 <!-- GENERATED CONTAINER IMAGES -->
+
 -   cdk/addon-resizer-amd64:1.8.9
 -   cdk/addon-resizer-arm64:1.8.9
 -   cdk/addon-resizer-ppc64le:1.8.9


### PR DESCRIPTION
## Done

Added a single blank line (the markdown processor is very particular)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check images  on 1.19/components are rendered as a list

## Issue / Card

Fixes #8450 

