### PR TITLE
Fix the engage page thank you pages

### DIFF
--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -53,7 +53,7 @@
   </div>
 </section>
 
-{% if related | length > 0% }
+{% if related | length > 0 %}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">

--- a/templates/engage/shared/_fr_thank-you.html
+++ b/templates/engage/shared/_fr_thank-you.html
@@ -53,7 +53,7 @@
   </div>
 </section>
 
-{% if related | length > 0% }
+{% if related | length > 0 %}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">

--- a/templates/engage/shared/_pt_thank-you.html
+++ b/templates/engage/shared/_pt_thank-you.html
@@ -53,7 +53,7 @@
   </div>
 </section>
 
-{% if related | length > 0% }
+{% if related | length > 0 %}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">


### PR DESCRIPTION
## Done
Fix the engage page thank you pages

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/de/openstack-made-easy/thank-you
- See that page does not 500
- Go to https://ubuntu.com/engage/de/openstack-made-easy/thank-you and see it returns a 500

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8456