### PR TITLE
Add Snap Store terms of service

### DIFF
--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -137,7 +137,7 @@
 <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3>Snap Store Terms of Service</h3>
-      <p>The terms for use of our Snap Store and services delivered via Snapcraft.io.</p>
+      <p>The terms for use of our Snap Store and services delivered via snapcraft.io.</p>
       <p><a href="/legal/terms-and-policies/snap-store-terms">View Snap Store terms&nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -133,6 +133,14 @@
       <p><a href="/legal/motd">View MOTD information notice&nbsp;&rsaquo;</a></p>
     </div>
   </div>
+
+<div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3>Snap Store Terms of Service</h3>
+      <p>The terms for use of our Snap Store and services delivered via Snapcraft.io.</p>
+      <p><a href="/legal/terms-and-policies/snap-store-terms">View Snap Store terms&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
 </div>
 
 {% endblock content %}

--- a/templates/legal/terms-and-policies/snap-store-terms.html
+++ b/templates/legal/terms-and-policies/snap-store-terms.html
@@ -1,0 +1,130 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Snap Store Terms of Service{% endblock %}
+
+{% block meta_description %}Ubuntu and Canonical Legal - Snap Store Terms of Service {% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1liRDdiO4JIIV43hqNckIk0ONGYW5MeaLuW-4U2HZky4/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+<div class="p-strip row">
+   <h1>Snap Store Terms of Service</h1>
+   <p class="p-heading--three">
+     Valid since October 2020
+   </p>
+   <p>
+     These Terms of Service cover your use of the Snap Store as provided by Canonical Group Limited registered in England, company number 6870835 ("<b>Canonical</b>", "<b>us</b>", "<b>we</b>" or "<b>our</b>").
+   </p>
+   <p>
+     Please read these terms carefully before you use the Snap Store or create a Snap Store account. By using the Snap Store or registering for an account, you agree to be bound by these terms. 
+   </p>
+   <p>
+     If you register for a Snap Store account on behalf of an entity, you represent that you have authority to bind such entity to these terms. 
+   </p>
+   <p>
+     You must be at least 13 years old to use the Snap Store. If you are aged between 13 and 18, we require your parent's or legal guardian's consent to create a Snap Store account or use the Snap Store. Please contact us at legal@canonical.com. 
+   </p>
+   <h2>1. Definitions</h2>
+   <p>
+     <b>Snap</b>: a single file to transport a software payload, which may include binary code, data, configuration, policies, metadata and other content. Snaps may be used to distribute an application, kernel, or other software.
+   </p>
+   <p>
+     <b>Snap Store</b>: the Canonical-hosted infrastructure for publishing and distributing Snaps. 
+   </p>
+   <h2>2. Use of the Snap Store</h2>
+   <p>
+     You may use the Snap Store to browse, locate, or download Snaps. Snaps may be published by Canonical or by third parties. Snaps may be updated from time to time; you agree to receive such updates for Snaps that you have downloaded. You may also create a Snap Store account, as described below, to publish your own Snaps.
+   </p>
+   <h2>3. Account</h2>
+   <p>
+     A Snap Store account is accessed through an Ubuntu single sign-on account or other specified account mechanism. If you don’t already have an Ubuntu single sign-on account, you will be prompted to create one. You are responsible for the security and confidentiality of your account and for keeping your account details up to date. 
+   </p>
+   <p>
+    You will notify us immediately if your account information is lost, stolen, or otherwise compromised. Any activity completed through your account will be deemed to have been completed by you.
+   </p>
+   <h2>4. Your Snaps</h2>
+   <div class="row">
+     <ul class="p-list col-9">
+       <li class="p-list__item">4.1  Once you have accepted these terms and created an account, you may publish Snaps to the Snap Store.</li>
+       <li class="p-list__item">4.2 You represent that the Snaps you publish to the Snap Store do not infringe any intellectual property right of any third party or any applicable law or regulation.</li>
+       <li class="p-list__item">4.3 Canonical may remove your Snap from the Snap Store at any time in its sole discretion.</li>
+       <li class="p-list__item">4.4 You may remove your Snap from the Snap Store at any time. Removing a Snap from will prevent new discovery and installation, but will not remove the Snap from those users who have previously installed it.</li>
+     </ul>
+   </div>
+   <h2>5. Prohibited use of Snap Store</h2>
+   <p>
+     You agree to use the Snap Store only for purposes that are legal and in accordance with these terms and any applicable policies or guidelines. By way of example, and not as a limitation, you will not provide any content or use the Snap Store in a way that:
+   </p>
+   <div class="row">
+     <ul class="p-list col-9">
+       <li class="p-list__item">5.1 infringes, misappropriates or violates any third party intellectual property rights;</li>
+       <li class="p-list__item">5.2 is defamatory, harmful to minors, or pornographic;</li>
+       <li class="p-list__item">5.3 contains hate-related or violent content;</li>
+       <li class="p-list__item">5.4 might be libellous or defamatory;</li>
+       <li class="p-list__item">5.5 contains threats or incites violence towards individuals or entities;</li>
+       <li class="p-list__item">5.6 violates the privacy or publicity rights of any third party;</li>
+       <li class="p-list__item">5.7 contains or distributes any viruses or programming routines intended to damage, surreptitiously intercept or expropriate any system, data or information or otherwise affect the ability of Canonical to provide the Snap Store; </li>
+       <li class="p-list__item">5.8 attempts to reverse engineer or otherwise access the Snap Store infrastructure; </li>
+       <p>or</p>
+       <li class="p-list__item">5.9 violates or encourages conduct that would violate any criminal laws, any other applicable laws, or any third-party rights.</li>
+     </ul>
+   </div>
+   <h2>6. Content and licences</h2>
+    <div class="row">
+     <ul class="p-list col-9">
+       <li class="p-list__item">6.1 You grant Canonical (and its affiliated entities): (i) a worldwide, non-exclusive licence to install, deploy, reproduce, and run your Snaps for the purposes of testing and evaluation and to reproduce and distribute your Snaps to end users through the Snap Store; and (ii) a licence to use any trademarks and branding you provide as part of the Snap in the Snap Store and in associated uses (such as use in marketing materials and advertising relating to the Snap).</li>
+       <li class="p-list__item">6.2 You will include the applicable licence for your Snap to end users of your Snap and identify the licence in the Snap information. If you require an agreement to be displayed to the end user, you will configure your Snap to display it upon the user’s first run of the Snap. </li>
+       <li class="p-list__item">6.3 If your Snap includes open source software, you will comply with all applicable open source software licence requirements. Nothing in these terms limits or grants rights that override any open source software licence terms. </li>
+       <li class="p-list__item">6.4 Canonical may make logos or phrases available to you to publicise the availability of your Snap through the Snap Store. Canonical hereby grants you a worldwide, non-exclusive licence during the Term to use such logos or phrases for the purpose of marketing your Snap in connection with its availability through the Snap Store, subject to Canonical's Intellectual Property Rights policy, which Canonical may update from time to time at <a href="/legal/IP">www.ubuntu.com/legal/IP</a>.</li>
+       <li class="p-list__item">6.5 You may access and download Snaps and content provided by third parties in your use of the Snap Store. Such Snaps are licensed under the terms identified for that Snap. Canonical is not responsible for any Snaps or content provided by any third party. All Snaps and content are accessed at your sole discretion and risk. Should you reasonably believe that any third party content you access through the Snap Store is in breach of any law, regulation or third party's rights, please notify Canonical at legal@canonical.com. </li>
+     </ul>
+   </div>
+   <h2>7. Availability and support</h2>
+   <p>
+     Snap Store availability is subject to Snap Store maintenance and other outages, which are or will be reported on Canonical’s status page <a class="p-link--external" href="https://status.snapcraft.io/">status.snapcraft.io</a>. Canonical will not provide any end user support for your Snaps unless otherwise expressly agreed.
+   </p>
+   <h2>8. Ratings, reviews and popularity information</h2>
+   <p>
+     We may allow third parties to publish ratings and reviews of your Snap. Canonical may use these ratings and information about the popularity of your Snap, including the number of times your Snap has been downloaded in publicity for Ubuntu or the Snap Store, in publicising the Snaps or as Canonical otherwise sees fit.
+   </p>
+   <h2>9. Account term </h2>
+   <p>
+     These terms begin when you use the Snap Store or create an account and will continue until: (i) you cease using the Snap Store , (ii) you close your account; (ii) we suspend your account, due to a breach of these terms; or (iii) we otherwise suspend your account with 30 days notice.  Upon termination for any reason, we may remove your Snaps from the Snap Store.
+   </p>
+   <h2>10. Changes to the Snap Store </h2>
+   <p>
+     We aim to continually improve the delivery and content of the Snap Store and, as a result, may change the Snap Store from time to time. New features may be added, but we also may modify or discontinue (temporarily or permanently) a feature in part or in whole.  
+   </p>
+   <h2>11. Changes to these terms </h2>
+   <p>
+     If Canonical changes these terms, all changes will go into effect at the time we post the updated terms and on your continued use of the Snap Store.
+   </p>
+   <h2>12. Additional services and payment </h2>
+   <p>
+     Additional Snap Store services may require payment of fees, such as access to a customer-dedicated and managed Snap Store and associated services. Such services are governed by these terms. Any associated fees will be governed by the terms applicable such fees.
+   </p>
+   <h2>13. Personal data </h2>
+   <p>
+     Our Privacy Notice and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a> explain how we treat your personal data and protect your privacy.
+   </p>
+   <h2>14. Limitation of liability</h2>
+   <div class="row">
+     <ul class="p-list col-9">
+       <li class="p-list__item">14.1 Your use of the Snap Store is at your sole risk. The Snap Store is provided without warranty of any kind, including as to access, availability or content. All warranties (whether express, implied, statutory or otherwise) are expressly excluded to the maximum extent permitted by law in respect of the Snap Store. </li>
+       <li class="p-list__item">14.2 Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical’s total liability in contract, tort or otherwise for any claims is limited to £10.</li>
+       <li class="p-list__item">14.3 Nothing in these terms will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.</li>
+       <li class="p-list__item">14.4 You will defend, indemnify and hold harmless Canonical from and against any and all damages, costs, losses and expenses (including reasonable attorney fees) incurred as a result of any claim, suit or proceeding brought against Canonical in relation to your Snaps or as a result of any use or misuse of the Snap Store(s) by you.</li>
+     </ul>
+   </div>
+   <h2>15. General</h2>
+   <div class="row">
+     <ul class="p-list col-9">
+       <li class="p-list__item">15.1 These terms constitute the entire agreement between Canonical and you in relation to use of the Snap Store. </li>
+       <li class="p-list__item">15.2 Failure by Canonical to enforce any right or provision of these terms shall not constitute a waiver of such right or provision. </li>
+       <li class="p-list__item">15.3 If any part of these terms is held invalid or unenforceable, that part will be construed to reflect the parties' original intent, and the remaining portions will remain in full force and effect. </li>
+       <li class="p-list__item">15.4 Any notices should be sent by email to legal@canonical.com or by registered post to Canonical Group Limited, 5th Floor, Blue Fin Building, 110 Southwark Street, London, England, SE1 0SU.</li>
+       <li class="p-list__item">15.5 These terms are governed by the laws of England and any dispute will be heard by the courts of England. </li>
+     </ul>
+   </div>
+</div>
+{% endblock %}

--- a/templates/legal/terms-and-policies/snap-store-terms.html
+++ b/templates/legal/terms-and-policies/snap-store-terms.html
@@ -22,7 +22,7 @@
      If you register for a Snap Store account on behalf of an entity, you represent that you have authority to bind such entity to these terms. 
    </p>
    <p>
-     You must be at least 13 years old to use the Snap Store. If you are aged between 13 and 18, we require your parent's or legal guardian's consent to create a Snap Store account or use the Snap Store. Please contact us at legal@canonical.com. 
+     You must be at least 13 years old to use the Snap Store. If you are aged between 13 and 18, we require your parent's or legal guardian's consent to create a Snap Store account or use the Snap Store. Please contact us at <a href="mailto:legal@canonical.com">legal@canonical.com</a>. 
    </p>
    <h2>1. Definitions</h2>
    <p>
@@ -122,7 +122,7 @@
        <li class="p-list__item">15.1 These terms constitute the entire agreement between Canonical and you in relation to use of the Snap Store. </li>
        <li class="p-list__item">15.2 Failure by Canonical to enforce any right or provision of these terms shall not constitute a waiver of such right or provision. </li>
        <li class="p-list__item">15.3 If any part of these terms is held invalid or unenforceable, that part will be construed to reflect the parties' original intent, and the remaining portions will remain in full force and effect. </li>
-       <li class="p-list__item">15.4 Any notices should be sent by email to legal@canonical.com or by registered post to Canonical Group Limited, 5th Floor, Blue Fin Building, 110 Southwark Street, London, England, SE1 0SU.</li>
+       <li class="p-list__item">15.4 Any notices should be sent by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> or by registered post to Canonical Group Limited, 5th Floor, Blue Fin Building, 110 Southwark Street, London, England, SE1 0SU.</li>
        <li class="p-list__item">15.5 These terms are governed by the laws of England and any dispute will be heard by the courts of England. </li>
      </ul>
    </div>

--- a/templates/legal/terms-and-policies/snap-store-terms.html
+++ b/templates/legal/terms-and-policies/snap-store-terms.html
@@ -105,7 +105,7 @@
    </p>
    <h2>13. Personal data </h2>
    <p>
-     Our Privacy Notice and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a> explain how we treat your personal data and protect your privacy.
+     Our <a href="/legal/data-privacy/snap-store">Privacy Notice</a> and <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a> explain how we treat your personal data and protect your privacy.
    </p>
    <h2>14. Limitation of liability</h2>
    <div class="row">


### PR DESCRIPTION
## Done

- Add Snap Store terms of service to `legal/terms-and-policies/snap-store-terms`
- Add blurb box on `/legal/terms-and-policies` 

**Known difference**:
- Privacy notice link in _13. Personal data_ links to privacy page which has not yet been updated.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/terms-and-policies/snap-store-terms and check against [copy doc](https://docs.google.com/document/d/1liRDdiO4JIIV43hqNckIk0ONGYW5MeaLuW-4U2HZky4/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check new Snap Store blurb box on http://0.0.0.0:8001/legal/terms-and-policies 


## Issue / Card

Fixes [#8443](https://github.com/canonical-web-and-design/ubuntu.com/issues/8443)

