### PR TITLE
Remove typos from the base index template

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1348,7 +1348,7 @@
     </div>
   </div>
 
-    <div clas="row">
+    <div class="row">
       <ul class="p-inline-images--small u-no-margin--bottom">
         <li class="p-inline-images__item">
           {{
@@ -1404,7 +1404,6 @@
         </li>
       </ul>
     </div>
-  </div>
 </section>
 
 {% block footer_content %}


### PR DESCRIPTION
When randomly browsing the [W3C validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fubuntu.com%2F), I noticed there were a few typos on the Ubuntu website. This PR fixes the most obvious `clas` typo, and based on other image rows, I removed the redundant div.

WDYT? 