### PR TITLE
Replace work email with email on iot and /core modal contact us forms

### DIFF
--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -70,7 +70,7 @@
                 <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
+                <label for="Email" class="mktoLabel">Email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">


### PR DESCRIPTION
## Done

- Replace work email with email on iot and /core modal contact us forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core#get-in-touch and https://0.0.0.0:8001/internet-of-things#get-in-touch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it says 'Email' not 'Work email' on the second page and compare and accept the comment in the [copy doc](https://docs.google.com/document/d/1t8k61sE5AopyvsXuMoyNDAghdnrjH4TlRdDGT4tqAes/edit)

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3274