### PR TITLE
Add video to hero on IoT/appstore

### DIFF
--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -9,7 +9,7 @@
 
 <section class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-half-and-half">
-    <div class="row u-equal-height u-align--center u-vertically-center">
+    <div class="row u-equal-height u-vertically-center">
       <div class="col-7 col-medium-4">
         <h1>White-label app stores <br class="u-hide--small" />for Linux and IoT</h1>
         <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation. We provide the infrastructure for secure management and seamless software updates for your fleet of devices. Whether you need a branded app store for your IoT devices or private application repository on premise, we can accommodate your requirements.</p>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -9,7 +9,7 @@
 
 <section class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-half-and-half">
-    <div class="row u-equal-height">
+    <div class="row u-equal-height u-align--center u-vertically-center">
       <div class="col-7 col-medium-4">
         <h1>White-label app stores <br class="u-hide--small" />for Linux and IoT</h1>
         <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation. We provide the infrastructure for secure management and seamless software updates for your fleet of devices. Whether you need a branded app store for your IoT devices or private application repository on premise, we can accommodate your requirements.</p>
@@ -22,17 +22,8 @@
           </li>
         </ul>
       </div>
-      <div class="col-5 u-align--center u-vertically-center u-hide--small">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/c3b8a9dd-Snap_Store_shopping_icon.svg",
-            alt="",
-            height="218",
-            width="250",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
+      <div class="col-5 u-embedded-media u-align--center u-hide--small">
+         <iframe title="Introduction to IoT app stores" class="u-embedded-media__element" src="https://player.vimeo.com/video/466105746" allowfullscreen=""></iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add video to hero on `/internet-of-things/appstore`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001//internet-of-things/appstore
- Check video added from [copy doc](https://docs.google.com/document/d/1CKwmPDDtXOIgw-jSZFwzP-qLMc_rS_dUACpHQXlg0fA/edit#heading=h.az7bmia5r3fh) and working correctly - hero section

## Issue / Card

Fixes [#3179](https://github.com/canonical-web-and-design/web-squad/issues/3179)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/95989566-5acd1a00-0e22-11eb-87d1-5ca5f2b292a5.png)

