### PR TITLE
Use px instead of pct for icon sizes

### DIFF
--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -38,7 +38,7 @@
             </h3>
             <hr>
             <div class="u-align--center">
-              <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=100" alt="" style="width: 50%;">
+              <img src="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png?h=100" alt="" style="width: 68px; height: 44px;">
             </div>
           </a>
         </div>
@@ -51,7 +51,7 @@
             </h3>
             <hr>
             <div class="u-align--center">
-              <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=100" style="width: 50%;">
+              <img src="https://assets.ubuntu.com/v1/78b65554-1920px-Intel_NUC8.jpg?h=100" style="width: 68px; height: 45px;">
             </div>
           </a>
         </div>
@@ -64,7 +64,7 @@
             </h3>
             <hr>
             <div class="u-align--center">
-              <img src="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg" style="width: 30%;">
+              <img src="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg" style="width:40px; height: 40px;">
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Done

- Using pixels instead of percents seems to fix the icons from being clipped on /applaince/<app> pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliance/adguard
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the multipass, nuc and pi icons look ok

## Issue / Card

Fixes #8461 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/96022344-a1ce0600-0e48-11eb-90a2-e6273d14b56d.png)
