### PR TITLE
Update text on /openstack/install

### DIFF
--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -106,7 +106,7 @@
       <p class="u-sv3">These instructions use <a href="https://snapcraft.io/microstack" class="p-link--external">MicroStack</a>, an upstream single-node OpenStack deployment which can run directly on your workstation. MicroStack is OpenStack in a <a href="https://snapcraft.io/" class="p-link--external">snap</a> which means that all services and supporting libraries are together in a single package that can be easily installed, upgraded or removed. MicroStack includes all key OpenStack components: Keystone, Nova, Neutron, Glance, and is evolving extremely fast. You can use it for development, prototyping and testing, but it is also perfectly suitable for the network edge, IoT and appliances.</p>
       <div class="p-notification">
         <p class="p-notification__response">
-          <span class="p-notification__status">NOTE:</span> MicroStack is in a technical preview state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>, but we do not recommend using it in production environments. For information on installing a production-grade OpenStack cluster, refer to the <a href="#cluster-deployment">cluster deployment instructions</a>.
+          <span class="p-notification__status">NOTE:</span> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.
         </p>
       </div>
     </div>
@@ -329,13 +329,13 @@ You can also visit the openstack dashboard at 'http://10.20.20.1/</code></pre>
   <div class="row">
     <div class="col-8">
       <p>These instructions use <a href="https://snapcraft.io/microstack" class="p-link--external">MicroStack</a> too. However, in this case a clustering feature is used.</p>
-      <div class="p-notification--information u-sv3">
+      <div class="p-notification">
         <p class="p-notification__response">
-          <span class="p-notification__status">
-            <span class="p-muted-heading">Note:</span> MicroStack clustering is in a technical preview state. We encourage you to test it give us your <a href="https://bugs.launchpad.net/microstack" class="p-link--external">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask question</a>, but we do not recommend using it in production environments. For information on installing a production-grade OpenStack cluster, refer to the <a href="#cluster-deployment">cluster deployment instructions</a>.</span>
-          </div>
-        </div>
+          <span class="p-notification__status">NOTE:</span> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.
+        </p>
       </div>
+    </div>
+  </div>
 
       <div class="row">
         <div class="col-8">

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -161,7 +161,7 @@
 Marked microstack as initialized!
 </code></pre>
 
-          <p>Your local OpenStack cloud is now running and is ready for being used!</p>
+          <p>Your local OpenStack cloud is now running and is ready for use!</p>
         </div>
       </li>
 
@@ -208,7 +208,7 @@ password: keystone</code></pre>
 
           <p>You can start playing with your local private cloud (i.e. create additional users, launch instances, etc.).</p>
           <p><strong>CLI:</strong></p>
-          <p>You can also interact withOpenStack via the CLI by using the <code>microstack.openstack</code> command. The MicroStack CLI syntax is identical to the client delivered by the <a href="https://docs.openstack.org/python-openstackclient/latest/cli/command-list.html" class="p-link--external">python-openstackclient</a> package.</p>
+          <p>You can also interact with OpenStack via the CLI by using the <code>microstack.openstack</code> command. The MicroStack CLI syntax is identical to the client delivered by the <a href="https://docs.openstack.org/python-openstackclient/latest/cli/command-list.html" class="p-link--external">python-openstackclient</a> package.</p>
           <p>For example, to list available OpenStack endpoints run:</p>
 
           <div class="p-code-copyable">
@@ -221,11 +221,11 @@ password: keystone</code></pre>
 <pre><code>+-----------+-----------+-----------------------------------------+
 | Name      | Type      | Endpoints                               |
 +-----------+-----------+-----------------------------------------+
-| keystone  |  identity | &lt;none&gt;                            |
+| keystone  |  identity | &lt;none&gt;                                  |
 |           |           | public: http://10.20.20.1:5000/v3/      |
-|           |           | &lt;none&gt;                            |
+|           |           | &lt;none&gt;                                  |
 |           |           | internal: http://10.20.20.1:5000/v3/    |
-|           |           | &lt;none&gt;                            |
+|           |           | &lt;none&gt;                                  |
 |           |           | admin: http://10.20.20.1:5000/v3/       |
 |           |           |                                         |
 | glance    | image     | microstack                              |
@@ -464,7 +464,7 @@ password: keystone</code></pre>
 
               <p>You can start playing with your local private cloud (i.e. create additional users, launch instances, etc.).</p>
               <p><strong>CLI:</strong></p>
-              <p>You can also interact withOpenStack via the CLI by using the <code>microstack.openstack</code> command. The MicroStack CLI syntax is identical to the client delivered by the <a href="https://docs.openstack.org/python-openstackclient/latest/cli/command-list.html" class="p-link--external">python-openstackclient</a> package.</p>
+              <p>You can also interact with OpenStack via the CLI by using the <code>microstack.openstack</code> command. The MicroStack CLI syntax is identical to the client delivered by the <a href="https://docs.openstack.org/python-openstackclient/latest/cli/command-list.html" class="p-link--external">python-openstackclient</a> package.</p>
               <p>For example, to list available OpenStack endpoints run:</p>
 
               <div class="p-code-copyable">


### PR DESCRIPTION
## Done

- Update text on /openstack/install

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit)


## Issue / Card

Fixes #8479
