### PR TITLE
Added the Rapsberry Pi livestream blog product card

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,6 +1,9 @@
 <div id="product-card">
   {# Kubeflow tag cards #}
-  {% if article.tags and 2609 in article.tags %}
+  {% if article.tags and 1672 in article.tags %}
+    {% include "blog/product-cards/_raspberry-pi_2010-livestream.html" %}
+  {# Kubeflow tag cards #}
+  {% elif article.tags and 2609 in article.tags %}
     {% include "blog/product-cards/_kubeflow_jaas-bundle.html" %}
     {% include "blog/product-cards/_kubeflow_what-is-kubeflow.html" %}
     {% include "blog/product-cards/_kubeflow_deploy-tutorial.html" %}

--- a/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
+++ b/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
@@ -1,0 +1,10 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/77642675-partner-logo-raspberry-pi.png" alt="rapsberry pi logo">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/engage/raspberry-pi-livestream">Ubuntu Desktop for Raspberry Pi</a>
+  </h3>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/i-RofTKJXRc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <p>Join our live event on the 23rd of October, 5pm BST, and find out all the news about the new Ubuntu Desktop image for Raspberry Pi.</p>
+  <p><a href="/engage/raspberry-pi-livestream">Discover more&nbsp;&rsaquo;</a></p>
+</div>


### PR DESCRIPTION
## Done

- Added the Rapsberry Pi livestream blog product card

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

