### PR TITLE
“invoice” > “receipt”

### DIFF
--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -18,7 +18,7 @@
         <form class="p-form p-form--stacked u-sv3" id="details-form">
           <div class="p-form__group p-form-validation row u-no-padding u-vertically-center">
             <div class="col-3">
-              <label class="u-no-padding--top" for="email">Email my invoice to:</label>
+              <label class="u-no-padding--top" for="email">Email my receipt to:</label>
             </div>
 
             <div class="col-9">


### PR DESCRIPTION
## Done

- Changed the reference to “invoice” to “receipt” in the payment dialog.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Buy or renew a subscription
- Check that the payment dialog says “Email my receipt to:”

## Issue / Card

Fixes #8507.