### PR TITLE
Advantage shop free token menu

### DIFF
--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,5 +1,4 @@
 function toggleMenu(element, show) {
-  console.log(element);
   const dropdown = document.querySelector(
     element.getAttribute("aria-controls")
   );
@@ -48,13 +47,11 @@ function attachHoverEvent(toggle) {
     }, 50);
   });
 
-  document.onkeydown = (e) => {
-    e = e || window.event;
-
-    if (e.keyCode === 27) {
+  document.addEventListener("keydown", (e) => {
+    if (e.code === "Escape") {
       toggleMenu(toggle, false);
     }
-  };
+  });
 }
 
 function setupContextualMenuListeners(contextualMenuToggleSelector) {

--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -83,15 +83,13 @@ function setupContextualMenuListeners(contextualMenuToggleSelector) {
     });
   });
 
-  document.onkeydown = (e) => {
-    e = e || window.event;
-
-    if (e.keyCode === 27) {
+  document.addEventListener("keydown", (e) => {
+    if (e.code === "Escape") {
       toggles.forEach((toggle) => {
         toggleMenu(toggle, false);
       });
     }
-  };
+  });
 }
 
 setupContextualMenuListeners(".p-contextual-menu__toggle");

--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -9,7 +9,7 @@ function toggleMenu(element, show) {
 
 function attachClickEvent(toggle) {
   toggle.addEventListener("click", (e) => {
-    const menuAlreadyOpen = e.target.getAttribute("aria-expanded") === "true";
+    const menuAlreadyOpen = toggle.getAttribute("aria-expanded") === "true";
 
     e.preventDefault();
     toggleMenu(toggle, !menuAlreadyOpen);

--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,4 +1,5 @@
 function toggleMenu(element, show) {
+  console.log(element);
   const dropdown = document.querySelector(
     element.getAttribute("aria-controls")
   );
@@ -12,7 +13,7 @@ function attachClickEvent(toggle) {
     const menuAlreadyOpen = e.target.getAttribute("aria-expanded") === "true";
 
     e.preventDefault();
-    toggleMenu(e.target, !menuAlreadyOpen);
+    toggleMenu(toggle, !menuAlreadyOpen);
   });
 }
 

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -99,7 +99,7 @@ const tooltipIconList = document.querySelectorAll(".cve-tooltip-icon");
 tooltipIconList.forEach(function (tooltipIcon) {
   tooltipIcon.addEventListener(
     "mouseover",
-    function (event) {
+    function () {
       if (tooltipIcon.parentElement.querySelector(".cve-tooltip") == null) {
         const priority = this.dataset.priority;
         const status = this.dataset.status;
@@ -129,7 +129,7 @@ tooltipIconList.forEach(function (tooltipIcon) {
   );
   tooltipIcon.addEventListener(
     "mouseout",
-    function (event) {
+    function () {
       const tooltip = tooltipIcon.parentElement.querySelector(".cve-tooltip");
 
       if (tooltip != null) {


### PR DESCRIPTION
## Done
- Pass listened to element instead of target for contextual menu interaction
- Upgrade the keyboard event handling to the modern approach
- Lint the `cve.js` file

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Login and scroll to the "Your free personal subscription" strip
- Click the "Get your free token" contextual menu button and see it works as expected.
- Now click directly on the chevron icon (which on live errors) and see it works the same
- Check other chevrons across the table continue to work as expected

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8524
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8383
