### PR TITLE
Remove the double scroll bar on the purchase modal

### DIFF
--- a/static/sass/_pattern_renewal-modal.scss
+++ b/static/sass/_pattern_renewal-modal.scss
@@ -46,6 +46,8 @@
     }
 
     .p-modal__dialog {
+      display: flex;
+      flex-direction: column;
       max-width: 50rem;
       overflow: auto;
       padding: 0;
@@ -60,9 +62,7 @@
     }
 
     .p-modal__body {
-      max-height: 70vh;
       overflow-y: scroll;
-      position: relative;
     }
 
     .p-modal__header {
@@ -71,7 +71,6 @@
 
     .p-modal__footer {
       box-shadow: 0 -1px 1px rgba($color-dark, 0.2);
-      position: relative;
     }
 
     .p-modal__progress {


### PR DESCRIPTION
## Done
- Layed the three modal sections (header, main and footer) using flex and removed the percentage height of the viewport

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Make a selection and Add it to the basket
- Click Buy now
- Check the modal on all screen sizes works as expected and only has a single scrollbar in the main content.


## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8248

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/96604302-e0523d80-12ec-11eb-8a41-6ffc5c972dde.png)

