### PR TITLE
Maximum 1000 machines

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -141,7 +141,7 @@
         </div>
         
         <div class="col-2">
-        <input autocomplete="off" class="js-product-input" type="number" name="quantity" placeholder="0" min="1" step="1" data-stage="form" onwheel="this.blur()" pattern="\d+" />
+        <input autocomplete="off" class="js-product-input" type="number" name="quantity" placeholder="0" min="1" max="1000" step="1" data-stage="form" onwheel="this.blur()" pattern="\d+" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

- Set maximum UA purchase to 1000 machines.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Try to buy for more than 1000 machines

## Issue / Card

Fixes #8393.