### PR TITLE
Replace subtotal with for this period to help explain pricing

### DIFF
--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -95,7 +95,7 @@ function setSummaryInfo(summaryObject, modal) {
   });
 
   infoContainer.innerHTML += buildInfoRow({
-    label: "Subtotal: ",
+    label: "For this period: ",
     value: "...",
     extraClasses: "js-subtotal",
   });


### PR DESCRIPTION
## Done
- Replace subtotal with for this period to help explain pricing

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Add something to the basket that you already have
- Click Pay now
- See that the model does not add up but instead of "Subtotal" you see "For this period" 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8392

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/96607019-d2ea8280-12ef-11eb-9793-ca1a2c280ae3.png)
