### PR TITLE
Update releases.yaml and /download/server to include 20.10

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,11 +1,11 @@
 latest:
-  slug: EoanErmine
-  name: "Eoan Ermine"
-  short_version: "19.10"
-  full_version: "19.10"
-  release_date: "October 2019"
-  eol: "July 2020"
-  past_eol_date: true
+  slug: GroovyGorilla
+  name: "Groovy Gorilla"
+  short_version: "20.10"
+  full_version: "20.10"
+  release_date: "October 2020"
+  eol: "July 2021"
+  past_eol_date: false
 lts:
   slug: FocalFossa
   name: "Focal Fossa"
@@ -19,6 +19,8 @@ previous_lts:
   name: "Bionic Beaver"
   short_version: "18.04"
   full_version: "18.04.5"
+  release_date: "April 2018"
+  eol: "April 2023"
 previous_previous_lts:
   name: "Xenial Xerus"
   short_version: "16.04"
@@ -26,10 +28,14 @@ previous_previous_lts:
 
 checksums:
   desktop:
+    "20.10": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso"
     "20.04.1": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso"
   live-server:
+    "20.10": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.10-live-server-amd64.iso"
     "20.04.1": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso"
   arm64+raspi:
+    "20.10": "aadc64a1d069c842e56a4289fe1a6b4b5a0af4efcf95bcce78eb2a80fe5270f4 *ubuntu-20.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.1": "aadc64a1d069c842e56a4289fe1a6b4b5a0af4efcf95bcce78eb2a80fe5270f4 *ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz"
   armhf+raspi:
+    "20.10": "bfd1eee56f7e346e1645666fc184af854c536b3ab4e1ce49d06c266f21b1ee46 *ubuntu-20.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.1": "bfd1eee56f7e346e1645666fc184af854c536b3ab4e1ce49d06c266f21b1ee46 *ubuntu-20.04.1-preinstalled-server-armhf+raspi.img.xz"

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -43,7 +43,7 @@
       <h3 class="p-heading--four"><span>Ubuntu {{ releases.latest.full_version }}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.latest.full_version }} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Ubuntu {{ releases.latest.full_version }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Ubuntu Server {{ releases.latest.full_version }}</a></li>
       </ul>
     </div>
     {% endif %}
@@ -51,14 +51,14 @@
       <h3 class="p-heading--four"><span>Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.lts.full_version }} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu {{ releases.lts.full_version }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu Server {{ releases.lts.full_version }} LTS</a></li>
       </ul>
     </div>
     <div class="col-4">
       <h3 class="p-heading--four"><span>Ubuntu {{ releases.previous_lts.full_version }} <abbr title="Long-term support">LTS</abbr></span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item"><a class="download-lts" href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.previous_lts.full_version }} Desktop (64-bit)</a></li>
-        <li class="p-list__item"><a class="download-lts" href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu {{ releases.previous_lts.full_version }} Server (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-lts" href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu Server {{ releases.previous_lts.full_version }} LTS</a></li>
       </ul>
     </div>
   </div>

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -87,7 +87,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h3>
-        Ubuntu Server {{ releases.latest.full_version }}
+        Get Ubuntu Server {{ releases.latest.full_version }}
       </h3>
       <p>
         The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{ releases.latest.eol }}.

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -7,14 +7,17 @@
 {% block content %}
 
 <section class="p-strip--suru-topped">
+  <div class="row">
+    <p class="p-muted-heading">Get Ubuntu server</p>
+    <h1 class="js-download-option">Option 3: Manual install</h1>
+  </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <p class="p-muted-heading">Get Ubuntu server</p>
-      <h1 class="js-download-option">Option 3: Manual install</h1>
+      <h2>Ubuntu Server {{ releases.lts.full_version }}</h2>
       <p class="p-heading--four">Download and install Ubuntu Server {{ releases.lts.short_version }} LTS using a USB stick or a DVD burner</p>
       <p>The long-term support version of Ubuntu Server, including the {{ releases.openstack_lts.slug }} release of OpenStack and support guaranteed until {{ releases.lts.eol }}.</p>
       <p>
-        <a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a>
+        <a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ releases.lts.short_version }} LTS release notes</a>
       </p>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center" style="min-height: 328px">
@@ -50,7 +53,7 @@
         <input type="hidden" name="version" value="{{ releases.lts.full_version }}">
         <input type="hidden" name="architecture" value="amd64">
         <input type="hidden" name="next-step" value="download">
-        <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install', 'eventValue' : undefined });">Download Ubuntu {{ releases.lts.full_version }} LTS</button>
+        <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.lts.full_version }} LTS</button>
       </form>
       <p>
         <a href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server" class="p-link--external">Watch the webinar &ndash; "Ubuntu 20.04 LTS: What’s new in server?"</a>
@@ -69,6 +72,40 @@
       </ul>
     </div>
   </div>
+  {% if releases.latest.short_version > releases.lts.short_version %}
+  <div class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-divider__block">
+      <h2>Ubuntu Server {{ releases.latest.full_version }}</h2>
+      <p class="u-no-padding--top">The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{ releases.latest.eol }}.</p>
+      <p><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ releases.latest.short_version }} release notes</a></p>
+      <form action="/download/server" method="post" style="display: inline">
+        <input type="hidden" name="version" value="{{ releases.latest.full_version }}">
+        <input type="hidden" name="architecture" value="amd64">
+        <input type="hidden" name="next-step" value="download">
+        <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install - latest', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.latest.full_version }} LTS</button>
+      </form>
+    </div>
+    <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center">
+      <div class="u-align--center">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",
+            alt="",
+            height="237",
+            width="153",
+            hi_def=True,
+            loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
 </section>
 
 <section class="p-strip--light u-no-padding--bottom">
@@ -79,14 +116,30 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu Server for ARM</h3>
-      <p>The next version of Ubuntu Server, to be officially released in October 2020.</p>
-      <p><a href="http://cdimage.ubuntu.com/ubuntu-server/daily-live/current/" class="p-link--external">Get Ubuntu Server 20.10</a></p>
+      <h3 class="p-card__title">BitTorrents</h3>
+      <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">
+          Ubuntu Server {{ releases.lts.full_version }} LTS&nbsp;&rsaquo;
+        </a>
+        </li>
+        <li class="p-list__item">
+          <a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">
+          Ubuntu Server {{ releases.latest.full_version }}&nbsp;&rsaquo;
+        </a>
+        </li>
+    </ul>
     </div>
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu Server 18.04 LTS</h3>
-      <p>Ubuntu is available on the IBM POWER platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER.</p>
-      <p><a href="http://cdimage.ubuntu.com/ubuntu/releases/18.04/release/" class="p-link--external">Get Ubuntu Server 18.04 LTS</a></p>
+      <h3 class="p-card__title">Ubuntu&nbsp;Server&nbsp;{{ releases.previous_lts.short_version }}&nbsp;LTS</h3>
+      <p>The previous long-term support version of Ubuntu Server, including support guaranteed until {{ releases.previous_lts.eol }}.</p>
+      <form action="/download/server" method="post" style="display: inline">
+        <input type="hidden" name="version" value="{{ releases.previous_lts.full_version }}">
+        <input type="hidden" name="architecture" value="amd64">
+        <input type="hidden" name="next-step" value="download">
+        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install - previous_lts', 'eventValue' : undefined });">Get Ubuntu Server {{ releases.previous_lts.short_version }} LTS</button>
+      </form>
     </div>
     <div class="col-4 p-card">
       <h3 class="p-card__title">Other versions</h3>

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -7,36 +7,28 @@
 {% block content %}
 
 <section class="p-strip--suru-topped">
-  <div class="row">
-    <p class="p-muted-heading">Get Ubuntu server</p>
-    <h1 class="js-download-option">Option 3: Manual install</h1>
-  </div>
   <div class="row u-equal-height">
-    <div class="col-6">
-      <h2>Ubuntu Server {{ releases.lts.full_version }}</h2>
-      <p class="p-heading--four">Download and install Ubuntu Server {{ releases.lts.short_version }} LTS using a USB stick or a DVD burner</p>
-      <p>The long-term support version of Ubuntu Server, including the {{ releases.openstack_lts.slug }} release of OpenStack and support guaranteed until {{ releases.lts.eol }}.</p>
-      <p>
-        <a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ releases.lts.short_version }} LTS release notes</a>
+    <div class="col-7">
+      <p class="p-muted-heading">
+        Get Ubuntu server
       </p>
-    </div>
-    <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center" style="min-height: 328px">
-      <div class="u-hide--small u-align--center">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
-            alt="",
-            height="1500",
-            width="1922",
-            hi_def=True,
-            loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
+      <h1 class="js-download-option">
+        Option 3: Manual install
+      </h1>
+      <h2 class="p-heading--three">
+        Get Ubuntu Server {{ releases.lts.full_version }} LTS
+      </h2>
+      <p>
+        Download and install Ubuntu Server using a USB stick or a DVD burner.
+      </p>
+      <p>
+        The long-term support version of Ubuntu Server, including the {{ releases.openstack_lts.slug }} release of OpenStack and support guaranteed until {{ releases.lts.eol }}.
+      </p>
+      <p class="u-sv3">
+        <a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">
+          Ubuntu {{ releases.lts.short_version }} LTS release notes
+        </a>
+      </p>
       <form action="/download/server" method="post" class="p-inline-list__item" style="display: inline">
         <input type="hidden" name="next-step" value="step1">
         <button type="submit" class="p-button--neutral" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Previous option', 'eventLabel' : 'Option 1', 'eventValue' : undefined });">
@@ -71,6 +63,20 @@
         </li>
       </ul>
     </div>
+    <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center" style="min-height: 328px">
+      <div class="u-hide--small u-align--center">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
+            alt="",
+            height="1500",
+            width="1922",
+            hi_def=True,
+            loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
   </div>
   {% if releases.latest.short_version > releases.lts.short_version %}
   <div class="p-strip is-shallow">
@@ -79,10 +85,18 @@
     </div>
   </div>
   <div class="row u-equal-height">
-    <div class="col-6 p-divider__block">
-      <h2>Ubuntu Server {{ releases.latest.full_version }}</h2>
-      <p class="u-no-padding--top">The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{ releases.latest.eol }}.</p>
-      <p><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu Server {{ releases.latest.short_version }} release notes</a></p>
+    <div class="col-6">
+      <h3>
+        Ubuntu Server {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{ releases.latest.eol }}.
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">
+          Ubuntu {{ releases.latest.short_version }} release notes
+        </a>
+      </p>
       <form action="/download/server" method="post" style="display: inline">
         <input type="hidden" name="version" value="{{ releases.latest.full_version }}">
         <input type="hidden" name="architecture" value="amd64">
@@ -91,18 +105,16 @@
       </form>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center">
-      <div class="u-align--center">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",
-            alt="",
-            height="237",
-            width="153",
-            hi_def=True,
-            loading="lazy"
-          ) | safe
-        }}
-      </div>
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",
+          alt="",
+          height="237",
+          width="153",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
   {% endif %}
@@ -132,8 +144,12 @@
     </ul>
     </div>
     <div class="col-4 p-card">
-      <h3 class="p-card__title">Ubuntu&nbsp;Server&nbsp;{{ releases.previous_lts.short_version }}&nbsp;LTS</h3>
-      <p>The previous long-term support version of Ubuntu Server, including support guaranteed until {{ releases.previous_lts.eol }}.</p>
+      <h3 class="p-card__title">
+        Get the previous LTS
+      </h3>
+      <p>
+        The previous long-term support version of Ubuntu Server, including support guaranteed until {{ releases.previous_lts.eol }}.
+      </p>
       <form action="/download/server" method="post" style="display: inline">
         <input type="hidden" name="version" value="{{ releases.previous_lts.full_version }}">
         <input type="hidden" name="architecture" value="amd64">

--- a/templates/shared/contextual_footers/_download_helping_hands.html
+++ b/templates/shared/contextual_footers/_download_helping_hands.html
@@ -4,6 +4,6 @@
   <ul class="p-list">
       <li><a class="p-link--external" href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu.com', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ask Ubuntu</a></li>
       <li><a class="p-link--external" href="https://ubuntuforums.org/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntuforums', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ubuntu Forums</a></li>
-      <li><a class="p-link--external" href="https://wiki.ubuntu.com/IRC/ChannelList" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'wiki.u.c IRC channel list', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">IRC-based support</a></li>
+      <li><a class="p-link--external" href="https://discourse.ubuntu.com" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu discourse', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ubuntu Discourse</a></li>
   </ul>
 </div>

--- a/templates/shared/contextual_footers/_download_server_guide.html
+++ b/templates/shared/contextual_footers/_download_server_guide.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Ubuntu Server docs</h3>
   <p>Read the official Ubuntu Server documentation.</p>
-  <p><a href="/server/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu {{ releases.lts.short_version }} LTS documentation&nbsp;&rsaquo;</a></p>
+  <p><a href="/server/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu Server {{ releases.lts.short_version }} LTS documentation&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_server_guide.html
+++ b/templates/shared/contextual_footers/_download_server_guide.html
@@ -1,5 +1,13 @@
 <div class="col-4 p-divider__block">
-  <h3 class="p-heading--four">Ubuntu Server docs</h3>
-  <p>Read the official Ubuntu Server documentation.</p>
-  <p><a href="/server/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">Ubuntu Server {{ releases.lts.short_version }} LTS documentation&nbsp;&rsaquo;</a></p>
+  <h3 class="p-heading--four">
+    Ubuntu Server guide
+  </h3>
+  <p>
+    Read the official Ubuntu Server {{ releases.lts.short_version }} LTS documentation.
+  </p>
+  <p>
+    <a href="/server/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server docs', 'eventLabel' : 'Server guide', 'eventValue' : undefined });">
+      Ubuntu Server Guide&nbsp;&rsaquo;
+    </a>
+  </p>
 </div>

--- a/templates/shared/contextual_footers/_download_server_installation.html
+++ b/templates/shared/contextual_footers/_download_server_installation.html
@@ -2,7 +2,10 @@
   <h3 class="p-heading--four">Installation guides</h3>
   <p>If you need some help installing Ubuntu, please check out our step-by-step guides.</p>
   <ul class="p-list">
-      <li><a class="p-link--external" href="/tutorials/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu Server</a></li><li>
-      </li><li><a href="/download/cloud" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'cloud instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">Installation instructions for Ubuntu OpenStack&nbsp;&rsaquo;</a></li>
+    <li>
+      <a class="p-link--external" href="/tutorials/tutorial-install-ubuntu-server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server instructions', 'eventLabel' : 'Installation guides', 'eventValue' : undefined });">
+        Installation instructions for Ubuntu Server
+      </a>
+    </li>
   </ul>
 </div>


### PR DESCRIPTION
## Done

- Update releases.yaml to include 20.10
- Added latest release block to /download/server
- Updated the Alternate blocks to make sense
- Updated the contextual footer text

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [server copy doc](https://docs.google.com/document/d/12kr3JvN3ALMdr5IPOheMwOaf-ygvEulFo5D7x-0ag0k/edit)


## Issue / Card

Fixes #8503

