### PR TITLE
Unstack the purchase button on small screens

### DIFF
--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -189,7 +189,7 @@
           Continue
         </button>
 
-        <button class="js-process-payment col-small-2 col-medium-3 col-3 p-button--positive u-no-margin--right" style="text-align: center;" disabled type="submit">
+        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive" style="text-align: center;" disabled type="submit">
           Pay
         </button>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -193,7 +193,7 @@
           Pay
         </button>
 
-        <button class="js-close-modal col-small-2 col-medium-3 col-3 p-button" style="text-align: center;">OK</button>
+        <button class="js-close-modal col-small-2 col-medium-2 col-3 p-button" style="text-align: center;">OK</button>
       </div>
     </footer>
   </div>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -185,7 +185,7 @@
           Cancel
         </button>
 
-        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive" style="text-align: center;" disabled type="submit">
+        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive u-no-margin" style="text-align: center;" disabled type="submit">
           Continue
         </button>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -181,7 +181,7 @@
       </span>
 
       <div class="row u-no-padding">
-        <button class="js-cancel-modal col-small-2 col-medium-3 col-3" style="text-align: center;">
+        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin--right" style="text-align: center;">
           Cancel
         </button>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -172,27 +172,29 @@
         <i class="p-icon--spinner u-animation--spin"></i>
       </div>
     </div>
-    
-    <footer class="p-modal__footer u-align--right">
+
+    <footer class="p-modal__footer">
       <span id="js-progress-indicator" class="p-modal__progress u-hide">
         <i class="p-icon--success u-hide"></i>
         <i class="p-icon--spinner u-animation--spin"></i>&nbsp;&nbsp;
         <span></span>
       </span>
 
-      <button class="js-cancel-modal" style="min-width: 5.5rem;">
-        Cancel
-      </button>
+      <div class="row u-no-padding">
+        <button class="js-cancel-modal col-small-2 col-medium-3 col-3" style="text-align: center;">
+          Cancel
+        </button>
 
-      <button class="js-payment-method p-button--positive u-no-margin--right" disabled type="submit" style="min-width: 5.5rem;">
-        Continue
-      </button>
+        <button class="js-payment-method col-small-2 col-medium-3 col-3 p-button--positive u-no-margin--right" style="text-align: center;" disabled type="submit">
+          Continue
+        </button>
 
-      <button class="js-process-payment p-button--positive u-no-margin--right" disabled type="submit" style="min-width: 5.5rem;">
-        Pay
-      </button>
+        <button class="js-process-payment col-small-2 col-medium-3 col-3 p-button--positive u-no-margin--right" style="text-align: center;" disabled type="submit">
+          Pay
+        </button>
 
-      <button class="js-close-modal p-button">OK</button>
+        <button class="js-close-modal col-small-2 col-medium-3 col-3 p-button" style="text-align: center;">OK</button>
+      </div>
     </footer>
   </div>
 </div>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -189,7 +189,7 @@
           Continue
         </button>
 
-        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive" style="text-align: center;" disabled type="submit">
+        <button class="js-process-payment col-small-2 col-medium-2 col-3 p-button--positive u-no-margin" style="text-align: center;" disabled type="submit">
           Pay
         </button>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -185,7 +185,7 @@
           Cancel
         </button>
 
-        <button class="js-payment-method col-small-2 col-medium-3 col-3 p-button--positive u-no-margin--right" style="text-align: center;" disabled type="submit">
+        <button class="js-payment-method col-small-2 col-medium-2 col-3 p-button--positive" style="text-align: center;" disabled type="submit">
           Continue
         </button>
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -181,7 +181,7 @@
       </span>
 
       <div class="row u-no-padding">
-        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin--right" style="text-align: center;">
+        <button class="js-cancel-modal col-small-2 col-medium-2 col-start-medium-3 col-start-large-7 col-3 u-no-margin" style="text-align: center;">
           Cancel
         </button>
 


### PR DESCRIPTION
## Done
Unstack the purchase button on small screens

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
= Login
- Add a product to the cart
- Click the Buy now button
- Check the Cancel and Continue buttons in the modal footer look ok
- Shrink the screen and check grid alignment works
- Continue through the process and see it all works

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8516

