### PR TITLE
Add 20.10 what's new on /desktop/developers

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,11 +1,11 @@
 latest:
-  slug: EoanErmine
-  name: "Eoan Ermine"
-  short_version: "19.10"
-  full_version: "19.10"
-  release_date: "October 2019"
-  eol: "July 2020"
-  past_eol_date: true
+  slug: GroovyGorilla
+  name: "Groovy Gorilla"
+  short_version: "20.10"
+  full_version: "20.10"
+  release_date: "October 2020"
+  eol: "July 2021"
+  past_eol_date: false
 lts:
   slug: FocalFossa
   name: "Focal Fossa"

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -71,6 +71,27 @@
   <section class="p-strip--light">
     <div class="row">
       <div class="col-8">
+        <h2>What&rsquo;s new in Ubuntu {{ releases.latest.short_version }}?</h2>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Support for the Raspberry Pi 4 with 4GB and 8GB RAM</li>
+        <li class="p-list__item is-ticked">Linux 5.8 kernel</li>
+        <li class="p-list__item is-ticked">GNOME Desktop 3.38 with all the latest features</li>
+        <li class="p-list__item is-ticked">Uniquely generated QR codes for sharing private WiFi hotspots</li>
+        <li class="p-list__item is-ticked">LibreOffice 7.0</li>
+        <li class="p-list__item is-ticked">Thunderbird email client integrated calendar and user friendly PGP encryption</li>
+        <li class="p-list__item is-ticked">Improved settings for battery percentage and microphone mute status</li>
+        <li class="p-list__item is-ticked">New photographic and Raspberry Pi themed wallpapers</li>
+      </ul>
+      <p><a class="p-link--external" href="https://discourse.ubuntu.com/t/groovy-gorilla-release-notes/15533">Read the full release notes</a></p>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-8">
         <h2>What&rsquo;s new in Ubuntu {{ releases.lts.short_version }} LTS?</h2>
         <p>Ubuntu {{ releases.lts.short_version }} is the latest LTS release. Alongside support for the very latest hardware, this release includes new versions of many core apps and developer technologies.</p>
       </div>
@@ -91,7 +112,7 @@
     </div>
   </section>
 
-  <section class="p-strip">
+  <section class="p-strip--light">
     <div class="row u-vertically-center">
       <div class="col-6">
         <h2>All the tools developers need</h2>


### PR DESCRIPTION
## Done

- Add what's new in 20.10

## QA

- Please double check the Groovy Gorilla in the ymal file
- Browse to: https://ubuntu-com-8544.demos.haus/desktop/developers
- You will see the new "What's new in 20.10" section
- Please confirm the url at the bottom of the section is correct

## Issue / Card

Fixes #8502

## Screenshots

![image](https://user-images.githubusercontent.com/6387619/96709702-fb778880-1392-11eb-8614-7232744aeb2a.png)
