### PR TITLE
Fix path for download mirror list

### DIFF
--- a/scripts/create-usns.py
+++ b/scripts/create-usns.py
@@ -12,13 +12,13 @@ from macaroonbakery import httpbakery
 
 
 def guess_binary_links(binary, version, sources):
-    '''Guess links to the source package based on binary package and version.
+    """Guess links to the source package based on binary package and version.
 
     Keyword Arguments:
     binary -- the name of the binary
     version -- the version of the binary
     sources -- a dictionary of source package names to source package versions
-    '''
+    """
     match_first = False
     source_match = None
     version_match = None
@@ -40,19 +40,19 @@ def guess_binary_links(binary, version, sources):
         return (None, None)
 
     for source in sources:
-        source_version = sources[source].get('version')
+        source_version = sources[source].get("version")
         if match_first or version == source_version:
             source_match = source
             version_match = source_version
             break
 
     if source_match:
-        source_link = 'https://launchpad.net/ubuntu/+source/' + source_match
+        source_link = "https://launchpad.net/ubuntu/+source/" + source_match
         if version_match:
             # Be certain to use the source package version rather than the
             # binary package version here or the link will be broken for
             # certain packages
-            version_link = source_link + '/' + version_match
+            version_link = source_link + "/" + version_match
 
     return (source_link, version_link)
 
@@ -94,7 +94,7 @@ with open(args.file_path) as usn_json:
                         "name": name,
                         "version": info["version"],
                         "description": info["description"],
-                        "is_source": "true"
+                        "is_source": "true",
                     }
                 )
 

--- a/templates/list_endpoints.py
+++ b/templates/list_endpoints.py
@@ -1,11 +1,10 @@
-with open('endpoints.txt') as endpoints:
+with open("endpoints.txt") as endpoints:
     lines = endpoints.read()
 
 endpoints = [l[2:-5] for l in lines.split()]
 
 no_indecies = map(
-    lambda e: e[:-len("/index")] if e.endswith("/index") else e,
-    endpoints
+    lambda e: e[: -len("/index")] if e.endswith("/index") else e, endpoints
 )
 
 prefixed = ["https://www.ubuntu.com/" + str(e) for e in no_indecies]

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -41,7 +41,7 @@ def _build_mirror_list():
     mirror_list = []
 
     try:
-        with open(f"{os.getcwd()}etc/ubuntu-mirrors-rss.xml") as rss:
+        with open(f"{os.getcwd()}/etc/ubuntu-mirrors-rss.xml") as rss:
             mirrors = feedparser.parse(rss.read()).entries
     except IOError:
         pass


### PR DESCRIPTION
Download mirrors are broken because the path to the mirrors file is incorrect.

This bug was introduced in https://github.com/canonical-web-and-design/ubuntu.com/pull/8073, and brought to our attention in https://rt.ubuntu.com/Ticket/Display.html?id=34579.

## QA

On the demo, go to /download/desktop, download a version of Ubuntu, see that you download from a mirror rather than releases.ubuntu.com.

