### PR TITLE
advantage guest purchases: provide account/comany name

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -7,7 +7,7 @@ export async function getPurchase(purchaseID) {
   return data;
 }
 
-export async function getPurchaseAccount(email, paymentMethodID) {
+export async function ensurePurchaseAccount(email, name, paymentMethodID) {
   let response = await fetch(`/advantage/purchase-account`, {
     method: "POST",
     cache: "no-store",
@@ -18,6 +18,7 @@ export async function getPurchaseAccount(email, paymentMethodID) {
     },
     body: JSON.stringify({
       email: email,
+      name: name,
       payment_method_id: paymentMethodID,
     }),
   });

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -588,7 +588,11 @@ function handleGuestPaymentMethodResponse(data) {
   // purchases with and then continue
   const paymentMethod = data.paymentMethod;
 
-  ensurePurchaseAccount(customerInfo.email, customerInfo.name, paymentMethod.id).then((data) => {
+  ensurePurchaseAccount(
+    customerInfo.email,
+    customerInfo.name,
+    paymentMethod.id
+  ).then((data) => {
     if (data.code) {
       // an error was returned, most likely cause
       // is that the user is trying to make a purchase

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -110,10 +110,10 @@ function productSelector() {
         <button class="p-button--positive js-ua-shop-cta ${
           subtotal === 0 ? "u-disable" : ""
         }" data-cart='${JSON.stringify(cartData)}' data-account-id="${
-      window.accountId
-    }" data-subtotal='${subtotalUnits}' data-previous-purchase-id="${
-      window.previousPurchaseId
-    }">Buy now</button>
+          window.accountId
+        }" data-subtotal='${subtotalUnits}' data-previous-purchase-id="${
+          window.previousPurchaseId
+        }">Buy now</button>
       </div>
     </div>
     `;
@@ -166,7 +166,7 @@ function productSelector() {
             <div class="col-2 col-small-2">
               ${quantity !== null ? quantityHTML : ""}
             </div>
-            
+
             <div class="col-2 u-align--right ${
               action === "add" ? "col-small-2" : "u-hide--small"
             }">
@@ -176,7 +176,7 @@ function productSelector() {
             </div>
           </div>
         </div>
-    
+
         <div class="col-2 u-align--right ${
           action === "add" ? "p-shop-cart__block" : "col-small-2"
         }">

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -110,10 +110,10 @@ function productSelector() {
         <button class="p-button--positive js-ua-shop-cta ${
           subtotal === 0 ? "u-disable" : ""
         }" data-cart='${JSON.stringify(cartData)}' data-account-id="${
-          window.accountId
-        }" data-subtotal='${subtotalUnits}' data-previous-purchase-id="${
-          window.previousPurchaseId
-        }">Buy now</button>
+      window.accountId
+    }" data-subtotal='${subtotalUnits}' data-previous-purchase-id="${
+      window.previousPurchaseId
+    }">Buy now</button>
       </div>
     </div>
     `;

--- a/static/sass/_pattern_renewal-modal.scss
+++ b/static/sass/_pattern_renewal-modal.scss
@@ -71,6 +71,7 @@
 
     .p-modal__footer {
       box-shadow: 0 -1px 1px rgba($color-dark, 0.2);
+      position: relative;
     }
 
     .p-modal__progress {

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -48,7 +48,7 @@
           {% if account is defined %}
             <div class="p-form__group p-form-validation row u-no-padding u-vertically-center">
               <div class="col-3">
-                <label class="u-no-padding--top" for="name">Account name:</label>
+                <label class="u-no-padding--top" for="name">{% if account %}Account name{% else %}Choose account name{% endif %}:</label>
               </div>
 
               <div class="col-9">
@@ -57,7 +57,7 @@
 
               {% if not account %}
                 <div class="col-9 col-start-large-4">
-                  <small>For example, your organization ot team name</small>
+                  <small>Your name, or the name of your organisation.</small>
                 </div>
               {% endif %}
 

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -16,19 +16,6 @@
         </div>
 
         <form class="p-form p-form--stacked u-sv3" id="details-form">
-          <div class="p-form__group p-form-validation row u-no-padding u-vertically-center">
-            <div class="col-3">
-              <label class="u-no-padding--top" for="email">Email my receipt to:</label>
-            </div>
-
-            <div class="col-9">
-              <input class="p-form-validation__input" name="email" type="email" required value="{{ user_info.email }}" />
-            </div>
-
-            <div class="col-9 col-start-large-4">
-              <span class="p-form-validation__message u-hide"></span>
-            </div>
-          </div>
 
           <div class="p-form__group row u-no-padding u-vertically-center">
             <div class="col-3">
@@ -46,17 +33,39 @@
 
           <div class="p-form__group p-form-validation row u-no-padding u-vertically-center">
             <div class="col-3">
-              <label class="u-no-padding--top" for="name">Name on card:</label>
+              <label class="u-no-padding--top" for="email">Email my receipt to:</label>
             </div>
 
             <div class="col-9">
-              <input class="p-form-validation__input" name="name" type="text" required value="{{ user_info.fullname }}" />
+              <input class="p-form-validation__input" name="email" type="email" required value="{{ user_info.email }}" />
             </div>
 
             <div class="col-9 col-start-large-4">
               <span class="p-form-validation__message u-hide"></span>
             </div>
           </div>
+
+          {% if account is defined %}
+            <div class="p-form__group p-form-validation row u-no-padding u-vertically-center">
+              <div class="col-3">
+                <label class="u-no-padding--top" for="name">Account name:</label>
+              </div>
+
+              <div class="col-9">
+                <input class="p-form-validation__input" name="name" type="text" required value="{{ account.name }}"{% if account %}disabled{% endif %} />
+              </div>
+
+              {% if not account %}
+                <div class="col-9 col-start-large-4">
+                  <small>For example, your organization ot team name</small>
+                </div>
+              {% endif %}
+
+              <div class="col-9 col-start-large-4">
+                <span class="p-form-validation__message u-hide"></span>
+              </div>
+            </div>
+          {% endif %}
 
           <div class="p-form__group p-form-validation row u-no-padding">
             <div class="col-3">
@@ -109,6 +118,7 @@
               <small>e.g. GB101111, CY99999999L</small>
             </div>
           </div>
+
         </form>
 
         <div id="order-totals" class="u-hide u-sv1">
@@ -172,7 +182,7 @@
         <i class="p-icon--spinner u-animation--spin"></i>
       </div>
     </div>
-    
+
     <footer class="p-modal__footer u-align--right">
       <span id="js-progress-indicator" class="p-modal__progress u-hide">
         <i class="p-icon--success u-hide"></i>

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -12,8 +12,8 @@
   <section class="p-strip--suru-topped js-shop-hero u-no-padding--bottom">
     <div class="row">
       <div class="col-12 u-sv3">
-        {% if not user_info and not account %}  
-          <h1>Subscribe to Ubuntu Advantage</h1>        
+        {% if not user_info %}
+          <h1>Subscribe to Ubuntu Advantage</h1>
           <p>If you have existing subscriptions or sales offers, <a href="/login" onclick="dataLayer.push({ 'event' : 'GAEvent', 'eventCategory' : 'Advantage subscribe', 'eventAction' : 'Authentication', 'eventLabel' : 'Sign in', 'eventValue' : undefined });">sign in</a> to see them.
         {% else %}
           <h1>Add machines to your subscription</h1>
@@ -26,7 +26,7 @@
     <section class="p-strip is-shallow js-shop-step--type">
       <div class="row">
         <div class="col-12">
-          <h2 class="p-heading--three u-no-margin--bottom u-sv2 js-shop--form-heading">What are you setting up?</h2>          
+          <h2 class="p-heading--three u-no-margin--bottom u-sv2 js-shop--form-heading">What are you setting up?</h2>
         </div>
 
         <div class="col-12 row--5-col">
@@ -63,7 +63,7 @@
             <label for="type_aws">
               AWS instances
             </label>
-            
+
           </div>
 
           <div class="p-card--radio">
@@ -127,7 +127,7 @@
         <div id="aws" class="col-12 u-hide js-public-cloud-info" style="background-color: #f7f7f7; padding: 1.5rem;">
           <span>You can buy <a href="https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro" class="p-link--external">Ubuntu Pro on the AWS Marketplace</a> at an hourly, per-machine rate, with all UA software features included.</span>
         </div>
-  
+
         <div id="azure" class="col-12 u-hide js-public-cloud-info" style="background-color: #f7f7f7; padding: 1.5rem;">
           <span>You can buy <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1" class="p-link--external">Ubuntu Pro on the Azure Marketplace</a> at an hourly, per-machine rate, with all UA software features included.</span>
         </div>
@@ -139,7 +139,7 @@
         <div class="col-12">
           <h2 class="p-heading--three u-no-margin--bottom u-sv2 js-type-name">How many?</h2>
         </div>
-        
+
         <div class="col-2">
         <input autocomplete="off" class="js-product-input" type="number" name="quantity" placeholder="0" min="1" max="1000" step="1" data-stage="form" onwheel="this.blur()" pattern="\d+" />
         </div>
@@ -202,8 +202,8 @@
   <script defer>
     var productList = {
       {% for listing in product_listings %}
-      "{{ listing.id }}": { 
-        name: "{{ listing.product.name }}", 
+      "{{ listing.id }}": {
+        name: "{{ listing.product.name }}",
         price: {{ listing.price|tojson }},
         productID: "{{ listing.product.id}}",
         private: "{{ listing.privateForAccount }}"
@@ -211,8 +211,9 @@
       {% endfor %}
     };
 
-    var accountId = "{% if purchase_account_id %}{{ purchase_account_id }}{% endif %}";
-    var previousPurchaseId = "{% if previous_purchase_id%}{{ previous_purchase_id }}{% endif %}"
+    var accountId = "{{ account.id }}";
+    var accountName = "{{ account.name }}";
+    var previousPurchaseId = "{{ previous_purchase_id or ''}}"
   </script>
-  
+
 {% endblock %}

--- a/tests/test_advantage.py
+++ b/tests/test_advantage.py
@@ -1,0 +1,173 @@
+import unittest
+
+from requests.exceptions import HTTPError
+
+from webapp import advantage
+
+
+class Response:
+    """An HTTP response for testing."""
+
+    def __init__(self, status_code, content):
+        self.status_code = status_code
+        self._content = content
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise (HTTPError(response=self))
+
+    def json(self):
+        return self._content
+
+
+class Session:
+    """A request session for testing."""
+
+    def __init__(self, resp: Response):
+        self._resp = resp
+        self.request_kwargs = None
+
+    def request(self, **kwargs):
+        self.request_kwargs = kwargs
+        return self._resp
+
+
+def make_client(session: Session):
+    """Create and return a ua-contracts client for tests."""
+    return advantage.AdvantageContracts(
+        session,
+        "secret-token",
+        token_type="Bearer",
+        api_url="https://1.2.3.4/contracts/",
+    )
+
+
+class TestEnsurePurchaseAccount(unittest.TestCase):
+    def test_guest(self):
+        """The JSON decoded response is returned for guest requests."""
+        session = Session(Response(200, {"ok": True}))
+        client = make_client(session)
+        resp = client.ensure_purchase_account(
+            email="picard@enterprise",
+            name="jeanluc",
+            payment_method_id="pmid",
+        )
+        self.assertEqual(resp, {"ok": True})
+        self.assertEqual(
+            session.request_kwargs,
+            {
+                "headers": {"Authorization": "Bearer secret-token"},
+                "json": {
+                    "defaultPaymentMethod": {"Id": "pmid"},
+                    "email": "picard@enterprise",
+                    "name": "jeanluc",
+                },
+                "method": "post",
+                "url": "https://1.2.3.4/contracts/v1/purchase-account",
+            },
+        )
+
+    def test_authenticated(self):
+        """The JSON decoded response is returned for authenticated requests."""
+        session = Session(Response(200, {"ok": True}))
+        client = make_client(session)
+        resp = client.ensure_purchase_account()
+        self.assertEqual(resp, {"ok": True})
+        self.assertEqual(
+            session.request_kwargs,
+            {
+                "headers": {"Authorization": "Bearer secret-token"},
+                "json": {
+                    "defaultPaymentMethod": {"Id": ""},
+                    "email": "",
+                    "name": "",
+                },
+                "method": "post",
+                "url": "https://1.2.3.4/contracts/v1/purchase-account",
+            },
+        )
+
+    def test_unauthorized(self):
+        """The JSON decoded unauthorized error response is returned."""
+        session = Session(
+            Response(
+                401,
+                {
+                    "code": "bad wolf",
+                    "message": "end of the universe",
+                },
+            )
+        )
+        client = make_client(session)
+        with self.assertRaises(advantage.UnauthorizedError) as ctx:
+            client.ensure_purchase_account(
+                email="picard@enterprise",
+                name="jeanluc",
+                payment_method_id="pmid",
+            )
+        self.assertEqual(
+            ctx.exception.asdict(),
+            {
+                "code": "bad wolf",
+                "message": "end of the universe",
+            },
+        )
+
+    def test_error(self):
+        """An error is raised for non-unauthorized HTTP errors."""
+        session = Session(Response(500, {"error": "bad wolf"}))
+        client = make_client(session)
+        with self.assertRaises(HTTPError) as ctx:
+            client.ensure_purchase_account()
+        resp = ctx.exception.response
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json(), {"error": "bad wolf"})
+
+
+class TestGetPurchaseAccount(unittest.TestCase):
+    def test_success(self):
+        """The JSON decoded response is returned."""
+        session = Session(Response(200, {"ok": True}))
+        client = make_client(session)
+        resp = client.get_purchase_account()
+        self.assertEqual(resp, {"ok": True})
+        self.assertEqual(
+            session.request_kwargs,
+            {
+                "headers": {"Authorization": "Bearer secret-token"},
+                "method": "get",
+                "json": None,
+                "url": "https://1.2.3.4/contracts/v1/purchase-account",
+            },
+        )
+
+    def test_error(self):
+        """An error is raised for any HTTP errors."""
+        session = Session(Response(500, {"error": "bad wolf"}))
+        client = make_client(session)
+        with self.assertRaises(HTTPError) as ctx:
+            client.get_purchase_account()
+        resp = ctx.exception.response
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json(), {"error": "bad wolf"})
+
+
+class TestUnauthorizedError(unittest.TestCase):
+
+    err = advantage.UnauthorizedError("bad wolf", "end of the universe")
+
+    def test_str(self):
+        """The error is well represented as a string."""
+        self.assertEqual(
+            str(self.err), "unauthorized error: bad wolf: end of the universe"
+        )
+
+    def test_asdict(self):
+        """The error is well represented as a dict."""
+        self.assertEqual(
+            self.err.asdict(),
+            {
+                "code": "bad wolf",
+                "message": "end of the universe",
+            },
+        )

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -122,7 +122,7 @@ class AdvantageContracts:
                 method="post", path=f"v1/renewals/{renewal_id}/acceptance"
             )
         except HTTPError as http_error:
-            if http_error.code == 500:
+            if http_error.response.status_code == 500:
                 return response.json()
             else:
                 raise http_error

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,8 +46,8 @@ from webapp.views import (
     download_thank_you,
     appliance_install,
     appliance_portfolio,
+    ensure_purchase_account,
     get_purchase,
-    get_purchase_account,
     get_renewal,
     post_advantage_subscriptions,
     post_anonymised_customer_info,
@@ -201,7 +201,7 @@ app.add_url_rule(
 )
 app.add_url_rule(
     "/advantage/purchase-account",
-    view_func=get_purchase_account,
+    view_func=ensure_purchase_account,
     methods=["POST"],
 )
 app.add_url_rule(


### PR DESCRIPTION
## Done
- When purchasing without an account, allow specifying an account/company name.
- When already having an account, prevent the user from providing a different one.
- Implemented an API client method for getting an account for purchasing if it exists, without creating it.
- Improved test coverage around UA API client.

## QA
- Purchase as a guest, as a new user (with no UA accounts) and as an existing UA user.
- When not having an account, you should be able to set an account name.
- When returning later, the account name should be there.
- Now try a renewal, just to check that the stripe form is still working for that use case as well.
- Bonus: when purchasing again in the same day, the price is not prorated by the second anymore (not a fix in this branch, but nice to double check that's working).

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8522
