### PR TITLE
20.10 takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,26 +28,7 @@
 
 {% block takeover_content %}
   {# ALL #}
-  {% include "takeovers/_redhat-openstack.html" %}
-  {% include "takeovers/_kubernetes-enterprise-whitepaper-takeover.html" %}
-  {% include "takeovers/_fips_certification_cis_compliance.html" %}
-  {% include "takeovers/_cassandra-webinar-takeover.html" %}
-  {% include "takeovers/_security-webinar-series.html" %}
-  {% include "takeovers/_trilio-backup-recovery.html" %}
-
-  {# FRENCH #}
-  {% include "takeovers/fr/_cio-guide-to-multipass.html" %}
-  {% include "takeovers/fr/_french_vmware-to-os.html" %}
-
-  {# PORTUGUESE #}
-  {% include "takeovers/pt/_vmware-para-o-openstack.html" %}
-
-  {# ITALIAN #}
-  {% include "takeovers/it/_da-vmware-a-openstack.html" %}
-  {% include "takeovers/it/_da-vmware-a-charmed-openstack.html" %}
-
-  {# SPANISH #}
-  {% include "takeovers/es/guia-implementacion-openstack.html" %}
+  {% include "takeovers/_2010-takeover.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_2010-takeover.html
+++ b/templates/takeovers/_2010-takeover.html
@@ -1,0 +1,18 @@
+{% with title="What&rsquo;s new in Ubuntu&nbsp;20.10?",
+subtitle="Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds. ",
+class="",
+header_image="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",
+image_style="",
+image_height="388",
+image_width="250",
+image_hide_small=true,
+equal_cols=true,
+primary_url="/download",
+primary_cta="Get Ubuntu 20.10",
+primary_cta_class="",
+secondary_url="/raspberry-pi",
+secondary_cta="Learn about the Raspberry Pi Desktop",
+lang="",
+locale="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}


### PR DESCRIPTION
## Done

- The 20.10 takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- You can look at the [brief, but it is messy](https://docs.google.com/spreadsheets/d/1ad28yxJA7Mfc83kynYPC--Uo8WcJ5peN63D2F2Yntv0/edit?ts=5f85c02a#gid=2113339190)


## Issue / Card

Fixes #8471

## Screenshots

![image](https://user-images.githubusercontent.com/441217/96726893-5e284e80-13aa-11eb-8f50-57f00462c2c4.png)

