### PR TITLE
Build Raspberry Pi page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -168,6 +168,14 @@ openstack:
           path: /openstack/thank-you
           hidden: True
 
+raspberry:
+  title: Raspberry Pi
+  path: /raspberry-pi
+
+  children:
+    - title: Overview
+      path: /raspberry-pi
+
 ceph:
   title: Ceph
   path: /ceph

--- a/templates/raspberry-pi/_base_raspberry-pi.html
+++ b/templates/raspberry-pi/_base_raspberry-pi.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1PIA5jw0bHKQgTP3_Tpbj07FWr4u7aQ_H{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -44,7 +44,19 @@
 
 <section class="p-strip is-deep">
   <div class="row u-equal-height">
-    <div class="col-5"></div>
+    <div class="col-5 u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/ac0294f7-Ubuntu-Screens-for-Raspberry-Pi.png",
+          alt="Ubuntu screens for Raspberry Pi",
+          height="168",
+          width="300",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }} 
+    </div>
     <div class="col-7">
       <h2>Full Desktop Experience</h2>
       <p class="p-heading--four">
@@ -146,34 +158,6 @@
           attrs={"class": "u-hide--small"},
         ) | safe
       }}    
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-deep">
-  <div class="row u-equal-height">
-    <div class="col-4 u-vertically-center u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-          alt="Download and install Ubuntu Server",
-          height="150",
-          width="200",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "u-hide--small"},
-        ) | safe
-      }}    
-    </div>
-    <div class="col-8">
-      <h2>Need help?</h2>
-      <p>
-        Get in touch with one of our engineers.
-      </p>
-      <p>
-        <a class="p-button--positive" href="tutorials/how-to-kubernetes-cluster-on-raspberry-pi#1-overview">Contact us</a>
-      </p>
-      </p>
     </div>
   </div>
 </section>

--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -10,23 +10,20 @@
 <section class="p-strip--suru is-dark">
   <div class="row u-equal-height">
     <div class="col-7">
-    <h1>Ubuntu for Raspberry Pi</h1>
-    <p class="p-heading--four">
-      Your gateway to open source invention
-    </p>
-    <p>
-      A tiny machine with a giant impact. The Ubuntu community and Canonical are proud to enable desktop, server and production internet of things on the Raspberry Pi. In support of inventors, educators, entrepreneurs and eccentrics everywhere, we join the Raspberry Pi Foundation in striving to deliver the most open platform at the lowest price, powered by our communities.
-    </p>
-    <p>
-      <a class="p-button--positive">Download</a>
-    </p>
-    <p>
-      <a class="p-link--external p-link--inverted" href="https://www.youtube.com/watch?v=i-RofTKJXRc&feature=youtu.be&ab_channel=celebrateubuntu">
-      Join the live stream - October 23rd 5:00PM (BST)
-      </a>
-    </p>
-  </div>
-      <div class="col-5 u-vertically-center u-align--center">
+      <h1>Ubuntu for Raspberry Pi</h1>
+      <p class="p-heading--four">
+        Your gateway to open source invention
+      </p>
+      <p>
+        A tiny machine with a giant impact. The Ubuntu community and Canonical are proud to enable desktop, server and production internet of things on the Raspberry Pi. In support of inventors, educators, entrepreneurs and eccentrics everywhere, we join the Raspberry Pi Foundation in striving to deliver the most open platform at the lowest price, powered by our communities.
+      </p>
+      <p>
+        <a class="p-link--external p-link--inverted" href="https://www.youtube.com/watch?v=i-RofTKJXRc&feature=youtu.be&ab_channel=celebrateubuntu">
+        Join the live stream - October 23rd 5:00PM (BST)
+        </a>
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/8fdc8250-Ubuntu+and+Raspberry+Pi.svg",
@@ -58,12 +55,15 @@
       }} 
     </div>
     <div class="col-7">
-      <h2>Full Desktop Experience</h2>
+      <h2>Full Desktop experience</h2>
       <p class="p-heading--four">
         Work, web and software development, done
       </p>
       <p>
         Raspberry Pi 4 brings the graphics, RAM and connectivity needed for a Linux workstation.
+      </p>
+      <p>
+        <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">Follow the tutorial&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>

--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -1,0 +1,183 @@
+{% extends "raspberry-pi/_base_raspberry-pi.html" %}
+
+{% block title %}Ubuntu for Raspberry Pi{% endblock %}
+
+{% block meta_description %}The Raspberry Pi is an ARM computer for everybody. Perfect for teaching, coding, surfing the web or simply as a desktop for anyone, anywhere. The Raspberry Pi with Ubuntu is a gateway to the world of open source invention.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1XS8KyKQnQdgY9NJfxHMs_9ql4sPOTRj0yweunMPoOdM/edit#heading=h.alvyav8qzr5r{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--suru is-dark">
+  <div class="row u-equal-height">
+    <div class="col-7">
+    <h1>Ubuntu for Raspberry Pi</h1>
+    <p class="p-heading--four">
+      Your gateway to open source invention
+    </p>
+    <p>
+      A tiny machine with a giant impact. The Ubuntu community and Canonical are proud to enable desktop, server and production internet of things on the Raspberry Pi. In support of inventors, educators, entrepreneurs and eccentrics everywhere, we join the Raspberry Pi Foundation in striving to deliver the most open platform at the lowest price, powered by our communities.
+    </p>
+    <p>
+      <a class="p-button--positive">Download</a>
+    </p>
+    <p>
+      <a class="p-link--external p-link--inverted" href="https://www.youtube.com/watch?v=i-RofTKJXRc&feature=youtu.be&ab_channel=celebrateubuntu">
+      Join the live stream - October 23rd 5:00PM (BST)
+      </a>
+    </p>
+  </div>
+      <div class="col-5 u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/8fdc8250-Ubuntu+and+Raspberry+Pi.svg",
+          alt="Canonical OpenStack",
+          height="130",
+          width="280",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-5"></div>
+    <div class="col-7">
+      <h2>Full Desktop Experience</h2>
+      <p class="p-heading--four">
+        Work, web and software development, done
+      </p>
+      <p>
+        Raspberry Pi 4 brings the graphics, RAM and connectivity needed for a Linux workstation.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>Mission-critical platform for industrial-grade Pi</h2>
+      <p class="p-heading--four">
+        The RPi Compute Module is built for production
+      </p>
+      <p>
+        When your invention turns into a product, the Raspberry Pi compute module is a hardened, industrial grade system-on-module that provides the brain for a range of hardware from robots to racks.
+      </p>
+      <p>
+        Take the Pi to production with <a href="/server/">Ubuntu Server LTS</a> and <a href="/core">Ubuntu Core</a> with a decade of security updates.
+      </p>
+      <p>
+        <a target="blank" href="https://assets.ubuntu.com/v1/66fcd858-ubuntu-core-security-whitepaper.pdf?_ga=2.222811483.1572924598.1601997796-1689254820.1578926620" class="p-link--external">Read the Ubuntu Core security whitepaper</a>
+      </p>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/aec863e2-Off+the+shelf.svg",
+          alt="Leverage snaps",
+          height="168",
+          width="300",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }} 
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-5 u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a46ea917-3+-+Leverage+snaps+to+build+a+lean+custom+production+image.svg",
+          alt="Leverage snaps",
+          height="220",
+          width="350",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }} 
+    </div>
+    <div class="col-7">
+      <h2>All of open source</h2>
+      <p class="p-heading--four">
+        Every aspect of modern compute at your fingertips 
+      </p>
+      <p>
+        Open source is the new normal for software innovation - from cloud to edge, containers to IoT, from AI/ML to robotics, from self-driving cars to nanosats, the biggest companies in the world are building on open source and making it better too.
+      </p>
+      <p>
+        <a href="tutorials/how-to-kubernetes-cluster-on-raspberry-pi#1-overview">MicroK8s for Kubernetes on Raspberry Pi Tutorial</a>
+      </p>
+      <p>
+        <a href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076" class="p-link--external">Build a Raspberry Pi homelab with LXD</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>Your ARM exploration starts here</h2>
+      <p class="p-heading--four">
+        Same OS, whole new world
+      </p>
+      <p>
+        The Raspberry Pi is an ARM instruction set computer, just like your Android or iOS phone, and the next generation Mac. This feels just like Ubuntu on a PC, but under the hood you have a whole new approach to architecture and devices.
+      </p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg",
+          alt="Download and install Ubuntu Server",
+          height="184",
+          width="300",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }}    
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-4 u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="Download and install Ubuntu Server",
+          height="150",
+          width="200",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "u-hide--small"},
+        ) | safe
+      }}    
+    </div>
+    <div class="col-8">
+      <h2>Need help?</h2>
+      <p>
+        Get in touch with one of our engineers.
+      </p>
+      <p>
+        <a class="p-button--positive" href="tutorials/how-to-kubernetes-cluster-on-raspberry-pi#1-overview">Contact us</a>
+      </p>
+      </p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}
+
+


### PR DESCRIPTION
## Done

- Build `/raspberry-pi` page

**Known difference**:
- Waiting on link for "Follow the tutorial"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1XS8KyKQnQdgY9NJfxHMs_9ql4sPOTRj0yweunMPoOdM/edit#heading=h.alvyav8qzr5r)


## Issue / Card

Fixes #8472 
