### PR TITLE
Add rasp-pi to /download/desktop

### DIFF
--- a/templates/download/shared/_everywhere.html
+++ b/templates/download/shared/_everywhere.html
@@ -33,7 +33,7 @@
         </div>
 
         {# MircoK8s #}
-        <div class="col-4 js-everywhere js-macos js-linux">
+        <div class="col-4 u-hide">
           <h4>
             <a href="https://microk8s.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download everywhere', 'eventAction' : 'MicroK8s', 'eventLabel' : '{{ request.path }}', 'eventValue' : undefined });">
               {{
@@ -56,6 +56,34 @@
           <p class="u-align--right">
             <a class="p-button p-link--external" href="https://microk8s.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download everywhere', 'eventAction' : 'MicroK8s', 'eventLabel' : '{{ request.path }}', 'eventValue' : undefined });">
               Get MicroK8s
+            </a>
+          </p>
+        </div>
+
+        {# Raspberry pi #}
+        <div class="col-4 js-everywhere js-macos js-linux">
+          <h4>
+            <a href="https://microk8s.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download everywhere', 'eventAction' : 'Raspberry pi', 'eventLabel' : '{{ request.path }}', 'eventValue' : undefined });">
+              {{
+                image(
+                url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
+                alt="Raspberry pi",
+                width="41",
+                height="50",
+                hi_def=True,
+                loading="lazy",
+                attrs={ "class": "p-matrix__img", "style": "float: left;"  },
+                ) | safe
+              }}
+              Ubuntu on Raspberry Pi
+            </a>
+          </h4>
+          <p>
+            Running Ubuntu Desktop or Server on your Raspberry Pi is easy.
+          </p>
+          <p class="u-align--right">
+            <a class="p-button" href="/raspberry-pi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download everywhere', 'eventAction' : 'Raspberry pi', 'eventLabel' : '{{ request.path }}', 'eventValue' : undefined });">
+              Get Ubuntu on your Raspberry Pi
             </a>
           </p>
         </div>

--- a/templates/download/shared/_everywhere.html
+++ b/templates/download/shared/_everywhere.html
@@ -63,7 +63,7 @@
         {# Raspberry pi #}
         <div class="col-4 js-everywhere js-macos js-linux">
           <h4>
-            <a href="https://microk8s.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download everywhere', 'eventAction' : 'Raspberry pi', 'eventLabel' : '{{ request.path }}', 'eventValue' : undefined });">
+            <a href="/raspberry-pi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download everywhere', 'eventAction' : 'Raspberry pi', 'eventLabel' : '{{ request.path }}', 'eventValue' : undefined });">
               {{
                 image(
                 url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",


### PR DESCRIPTION
## Done

- Add rasp-pi to _everywhere partial only seen currently on /download/desktop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
-See that the text matches [this sheet](https://docs.google.com/spreadsheets/d/18mzFvEOSHr_2lluz14lbmEr-if6b4mrEUz1oI75qfOY/edit#gid=2034135081)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/96743613-1a3e4500-13bc-11eb-8f43-3131cf88f9cc.png)
