### PR TITLE
Add mascots to /download

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -37,10 +37,10 @@
     <div class="col-6 u-align--center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
+        url="https://assets.ubuntu.com/v1/817b07bd-GG-FF-download-mascots.svg",
         alt="",
-        height="250",
-        width="320",
+        height="600",
+        width="1382",
         hi_def=True,
         loading="auto"
         ) | safe


### PR DESCRIPTION
## Done

- Add mascots to /download

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the mascot


## Issue / Card

Fixes #8505 

## Screenshots
![image](https://user-images.githubusercontent.com/441217/96768988-68f8d880-13d6-11eb-9c10-4c4ebba64a6e.png)

