### PR TITLE
Update link on /raspberry-pi to livestream

### DIFF
--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -18,8 +18,8 @@
         A tiny machine with a giant impact. The Ubuntu community and Canonical are proud to enable desktop, server and production internet of things on the Raspberry Pi. In support of inventors, educators, entrepreneurs and eccentrics everywhere, we join the Raspberry Pi Foundation in striving to deliver the most open platform at the lowest price, powered by our communities.
       </p>
       <p>
-        <a class="p-link--external p-link--inverted" href="https://www.youtube.com/watch?v=i-RofTKJXRc&feature=youtu.be&ab_channel=celebrateubuntu">
-        Join the live stream - October 23rd 5:00PM (BST)
+        <a class="p-link--inverted" href="/engage/raspberry-pi-livestream">
+        Join the live stream - 23 October 2020 16:00 UTC
         </a>
       </p>
     </div>
@@ -52,7 +52,7 @@
           loading="auto",
           attrs={"class": "u-hide--small"},
         ) | safe
-      }} 
+      }}
     </div>
     <div class="col-7">
       <h2>Full Desktop experience</h2>
@@ -97,7 +97,7 @@
           loading="auto",
           attrs={"class": "u-hide--small"},
         ) | safe
-      }} 
+      }}
     </div>
   </div>
 </section>
@@ -115,12 +115,12 @@
           loading="auto",
           attrs={"class": "u-hide--small"},
         ) | safe
-      }} 
+      }}
     </div>
     <div class="col-7">
       <h2>All of open source</h2>
       <p class="p-heading--four">
-        Every aspect of modern compute at your fingertips 
+        Every aspect of modern compute at your fingertips
       </p>
       <p>
         Open source is the new normal for software innovation - from cloud to edge, containers to IoT, from AI/ML to robotics, from self-driving cars to nanosats, the biggest companies in the world are building on open source and making it better too.
@@ -157,11 +157,9 @@
           loading="auto",
           attrs={"class": "u-hide--small"},
         ) | safe
-      }}    
+      }}
     </div>
   </div>
 </section>
 
 {% endblock content %}
-
-

--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -18,8 +18,13 @@
         A tiny machine with a giant impact. The Ubuntu community and Canonical are proud to enable desktop, server and production internet of things on the Raspberry Pi. In support of inventors, educators, entrepreneurs and eccentrics everywhere, we join the Raspberry Pi Foundation in striving to deliver the most open platform at the lowest price, powered by our communities.
       </p>
       <p>
+      <a class="p-button--positive" href="/download/raspberry-pi">
+        Get Ubuntu for the Raspberry Pi
+      </a>
+    </p>
+      <p>
         <a class="p-link--inverted" href="/engage/raspberry-pi-livestream">
-        Join the live stream - 23 October 2020 16:00 UTC
+        Join the live stream - 23 October 2020 16:00 UTC&nbsp;&rsaquo;
         </a>
       </p>
     </div>

--- a/templates/takeovers/_2010-takeover.html
+++ b/templates/takeovers/_2010-takeover.html
@@ -11,7 +11,7 @@ primary_url="/download",
 primary_cta="Get Ubuntu 20.10",
 primary_cta_class="",
 secondary_url="/raspberry-pi",
-secondary_cta="Learn about the Raspberry Pi Desktop",
+secondary_cta="Learn more about the Raspberry Pi Desktop and livestream",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}


### PR DESCRIPTION
## Done

- Update link on /raspberry-pi to livestream
- Add the download button
- Update CTA on homepage takeover

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1XS8KyKQnQdgY9NJfxHMs_9ql4sPOTRj0yweunMPoOdM/edit#)


## Issue / Card

Fixes #8562

![image](https://user-images.githubusercontent.com/441217/96855540-c6cc0580-1454-11eb-9f6d-ea4a0072917c.png)

