### PR TITLE
Add webinar notice on /download

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -48,6 +48,14 @@
     </div>
   </div>
   <div class="row">
+    <div class="p-heading-icon">
+      <div class="p-heading-icon__header">
+        <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what's new in Ubuntu 20.10 in our webinar</a></h4>
+      </div>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-12">
       <hr style="margin: 0 0 3rem 0;">
     </div>


### PR DESCRIPTION
## Done

- Add webinar notice on /download

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See and test the link in the webinar

## Screenshots

![image](https://user-images.githubusercontent.com/441217/96866735-a3f51d80-1463-11eb-8128-dc10c1bf6536.png)
