### PR TITLE
Use “For this period:” for subtotal when purchase is prorated

### DIFF
--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -225,7 +225,7 @@ export function setOrderInformation(listings, modal) {
 export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
   const currency = "USD";
   const totalsContainer = modal.querySelector("#order-totals");
-  const subtotalLabel = modal.querySelector(".js-subtotal u-text-light");
+  const subtotalLabel = modal.querySelector(".js-subtotal .u-text-light");
   const subtotalElement = modal.querySelector(".js-subtotal .js-info-value");
   const endDateElements = modal.querySelectorAll(".js-end-date .js-info-value");
   let proratedEndDate;

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -287,7 +287,7 @@ export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
       if (i === 0 && endDateEl.innerHTML !== proratedEndDate) {
         // if these are different, it means prorating
         // is in effect, so inform the user
-        subtotalLabel.innerHTML = "For this period:"
+        subtotalLabel.innerHTML = "For this period:";
         endDateEl.innerHTML = `${proratedEndDate}<br /><small>The same date as your existing annual subscription.</small>`;
       } else {
         endDateEl.innerHTML = proratedEndDate;

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -225,6 +225,7 @@ export function setOrderInformation(listings, modal) {
 export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
   const currency = "USD";
   const totalsContainer = modal.querySelector("#order-totals");
+  const subtotalLabel = modal.querySelector(".js-subtotal u-text-light");
   const subtotalElement = modal.querySelector(".js-subtotal .js-info-value");
   const endDateElements = modal.querySelectorAll(".js-end-date .js-info-value");
   let proratedEndDate;
@@ -286,6 +287,7 @@ export function setOrderTotals(country, vatApplicable, purchasePreview, modal) {
       if (i === 0 && endDateEl.innerHTML !== proratedEndDate) {
         // if these are different, it means prorating
         // is in effect, so inform the user
+        subtotalLabel.innerHTML = "For this period:"
         endDateEl.innerHTML = `${proratedEndDate}<br /><small>The same date as your existing annual subscription.</small>`;
       } else {
         endDateEl.innerHTML = proratedEndDate;

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -120,7 +120,7 @@ function attachCTAevents() {
       e.preventDefault();
       modal.classList.add("is-processing");
 
-      if (currentTransaction.accountId === "") {
+      if (!currentTransaction.accountId) {
         currentTransaction.accountId = data.accountId;
       }
     }
@@ -201,7 +201,6 @@ function attachFormEvents() {
 
     input.addEventListener("input", (e) => {
       if (guestPurchase && input.type === "email") {
-        console.log(guestPurchase);
         guestPurchase = false;
         currentTransaction.accountId = "";
       }


### PR DESCRIPTION
## Done

- Changed “Subtotal:” to “For this period:” when a purchase is prorated.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- With at least one existing subscription, select another and choose “Buy now”

## Disclaimer

- I have not tested this, and there are probably better ways to implement it.
- It seems brittle to me that the way to select the label is with the `u-text-light` class. I was expecting it to be something more semantic, like a `<th>`.

## Issue / Card

Addresses #8392