### PR TITLE
Update managed pricing on /pricing/infra

### DIFF
--- a/templates/shared/pricing/_openstack-kubernetes-lma.html
+++ b/templates/shared/pricing/_openstack-kubernetes-lma.html
@@ -17,7 +17,7 @@
         <tr>
           <td><a href="/openstack/managed">Managed OpenStack</a> on bare metal</td>
           <td class="u-align--center">&nbsp;</td>
-          <td class="u-align--center">$5,010</td>
+          <td class="u-align--center">$5,457</td>
         </tr>
         <tr>
           <td><a href="/kubernetes/managed">Managed Kubernetes</a> on bare metal</td>
@@ -32,7 +32,7 @@
         <tr>
           <td>Combined offering - managed on-demand K8s on fully managed OpenStack</td>
           <td class="u-align--center">&nbsp;</td>
-          <td class="u-align--center">$6,324</td>
+          <td class="u-align--center">$6,351</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Managed OpenStack on bare metal and Combination price changed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/infra#managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the managed pricing to the [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#)

