### PR TITLE
Fix download text for desktop Raspberry Pi

### DIFF
--- a/templates/raspberry-pi/desktop.html
+++ b/templates/raspberry-pi/desktop.html
@@ -17,7 +17,7 @@
       </p>
       <p>
         <a href="/download/raspberry-pi">
-          Download Ubuntu Server for Raspberry Pi&nbsp;&rsaquo;</a>
+          Download Raspberry Pi Ubuntu Desktop&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-align--right">


### PR DESCRIPTION
## Done

- Fix text for download link on Raspberry Pi for Desktop page.

## QA

- Go to: https://ubuntu-com-8569.demos.haus/raspberry-pi/desktop
- Look at the text of the button. It should be: Download Raspberry Pi Ubuntu Desktop
- Just like it says in the doc: 
https://docs.google.com/document/d/14WEwUuwaKGMaR5FlsJJZttkAn0iCqUuXhRQLMWurpQ4/edit#

## Screenshots

![image](https://user-images.githubusercontent.com/6387619/96882327-19b6b480-1477-11eb-9f36-c6ce181e3fc0.png)

