### PR TITLE
Updating the 20.10 takeover and adding notice

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -24,6 +24,17 @@
   </div>
 </section>
 
+<section class="p-strip is-shallow notice">
+  <div class="row">
+    <div class="p-heading-icon">
+      <div class="p-heading-icon__header">
+        <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what's new in Ubuntu 20.10 in our webinar</a></h4>
+      </div>
+    </div>
+  </div>
+</section>
+
 {% block notices_content %}
 {% endblock notices_content %}
 

--- a/templates/takeovers/_2010-takeover.html
+++ b/templates/takeovers/_2010-takeover.html
@@ -10,8 +10,8 @@ equal_cols=true,
 primary_url="/download",
 primary_cta="Get Ubuntu 20.10",
 primary_cta_class="",
-secondary_url="/raspberry-pi",
-secondary_cta="Learn more about the Raspberry Pi Desktop and livestream",
+secondary_url="/engage/raspberry-pi-livestream",
+secondary_cta="Join the Raspberry Pi livestream - 23 October 2020 4pm UTC",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}


### PR DESCRIPTION
## Done

- Updating the 20.10 takeover and adding notice
    - pi link goes to livestream engage page
    - notice added to 20.10 webinar

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the links work and looks ok (note engage page doesn't work locally)

![image](https://user-images.githubusercontent.com/441217/96885136-386a7a80-147a-11eb-9865-a88fe20a06f9.png)
