### PR TITLE
Update checksums for 20.10

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -28,14 +28,16 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "20.10": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.10-desktop-amd64.iso"
+    "20.10": "3ef833828009fb69d5c584f3701d6946f89fa304757b7947e792f9491caa270e *ubuntu-20.10-desktop-amd64.iso"
     "20.04.1": "b45165ed3cd437b9ffad02a2aad22a4ddc69162470e2622982889ce5826f6e3d *ubuntu-20.04.1-desktop-amd64.iso"
   live-server:
-    "20.10": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.10-live-server-amd64.iso"
+    "20.10": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45 *ubuntu-20.10-live-server-amd64.iso"
     "20.04.1": "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93 *ubuntu-20.04.1-live-server-amd64.iso"
-  arm64+raspi:
-    "20.10": "aadc64a1d069c842e56a4289fe1a6b4b5a0af4efcf95bcce78eb2a80fe5270f4 *ubuntu-20.10-preinstalled-server-arm64+raspi.img.xz"
+  desktop-arm64+raspi:
+    "20.10": "2fa19fb53fe0144549ff722d9cd755d9c12fb508bb890926bfe7940c0b3555e8 *ubuntu-20.10-preinstalled-desktop-arm64+raspi.img.xz"
+  server-arm64+raspi:
+    "20.10": "73a98e83fbb6398f86902c7a83c826536f1afbd0be2d80cb0d7faa94ede33137 *ubuntu-20.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.1": "aadc64a1d069c842e56a4289fe1a6b4b5a0af4efcf95bcce78eb2a80fe5270f4 *ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz"
-  armhf+raspi:
-    "20.10": "bfd1eee56f7e346e1645666fc184af854c536b3ab4e1ce49d06c266f21b1ee46 *ubuntu-20.10-preinstalled-server-armhf+raspi.img.xz"
+  server-armhf+raspi:
+    "20.10": "941752f93313ba765069b48f38af18bbf961bebefcc9c4296a953cf1260f0fe1 *ubuntu-20.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.1": "bfd1eee56f7e346e1645666fc184af854c536b3ab4e1ce49d06c266f21b1ee46 *ubuntu-20.04.1-preinstalled-server-armhf+raspi.img.xz"


### PR DESCRIPTION
## Done

- Update checksums for 20.10

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that they appear in the verify boxes of the download thank you pages (test desktop 20.10, server 20.10, raspberry-pi desktop  20.10, raspberry-pi server  20.10 pi 2 and pi 4)

## Issue / Card

Fixes #8535

