### PR TITLE
Add &rsquo; to homepage and /download

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -29,7 +29,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what's new in Ubuntu 20.10 in our webinar</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what&rsquo;s new in Ubuntu 20.10 in our webinar</a></h4>
       </div>
     </div>
   </div>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -51,7 +51,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what's new in Ubuntu 20.10 in our webinar</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what&rsquo;s new in Ubuntu 20.10 in our webinar</a></h4>
       </div>
     </div>
   </div>

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -48,7 +48,7 @@
         <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.lts.full_version }} LTS</button>
       </form>
       <p>
-        <a href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server" class="p-link--external">Watch the webinar &ndash; "Ubuntu 20.04 LTS: What’s new in server?"</a>
+        <a href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server" class="p-link--external">Watch the webinar &ndash; &ldquo;Ubuntu 20.04 LTS: What’s new in server?&rdquo;</a>
       </p>
       <h4 class="p-muted-heading">Explore:</h4>
       <ul class="p-inline-list">


### PR DESCRIPTION
## Done

- Add &rsquo; to homepage and /download on the notice

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- and http://0.0.0.0:8001/download
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see that `s/'/&rsquo;/`

