### PR TITLE
Update meta description on /uasd page

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -2,7 +2,7 @@
 wrapper_template: "legal/ubuntu-advantage-service-description/_base_legal_markdown.html"
 context:
      title: "Ubuntu Advantage service description"
-     description: How to get Ceph deployed and related to Kubernetes in order to have a default storage class. This allows for easy storage allocation.
+     description: "Detailed description and explanation of the benefits and services you receive as an Ubuntu Advantage customer."
 markdown_includes:
      pricing_table: "shared/pricing/_ua-for-infrastructure.html"
 ---


### PR DESCRIPTION
## Done

- Update meta description on /uasd page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/uasd
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Look at the source of the page to see the description now reads "Detailed description and explanation of the benefits and services you receive as an Ubuntu Advantage customer."


## Issue / Card

Fixes #8355


