### PR TITLE
Build takeover - cloud native and computing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,7 @@
 {% block takeover_content %}
   {# ALL #}
   {% include "takeovers/_2010-takeover.html" %}
+  {% include "takeovers/_security-cloud-computing.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_security-cloud-computing.html
+++ b/templates/takeovers/_security-cloud-computing.html
@@ -1,0 +1,14 @@
+{% with title="Security, cloud native & confidential computing",
+subtitle="A deep dive into securing against the threats of cyber attacks and data breaches",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png",
+image_width=180,
+image_height=180,
+image_hide_small=true,
+primary_url="https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001G3QyAAK",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -180,4 +180,6 @@
 {% include "takeovers/_security-webinar-series.html" %}
 <p>29 September 2020</p>
 {% include "takeovers/_trilio-backup-recovery.html" %}
+<p>23 October 2020</p>
+{% include "takeovers/_security-cloud-computing.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Build takeover - Security, cloud native & confidential computing
- Add to `/index.html` and `/takeovers/index.html`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check takeover including CTA 


## Issue / Card

Fixes [#3362](https://github.com/canonical-web-and-design/web-squad/issues/3362)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/96999448-11b94c00-152d-11eb-88f1-df1ed35dbc61.png)

