### PR TITLE
Update takeover cta text

### DIFF
--- a/templates/takeovers/_2010-takeover.html
+++ b/templates/takeovers/_2010-takeover.html
@@ -11,7 +11,7 @@ primary_url="/download",
 primary_cta="Get Ubuntu 20.10",
 primary_cta_class="",
 secondary_url="/engage/raspberry-pi-livestream",
-secondary_cta="Join the Raspberry Pi livestream - 23 October 2020 4pm UTC",
+secondary_cta="Watch the Raspberry Pi Ubuntu Desktop intro video",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}


### PR DESCRIPTION
## Done

- The live chat isn't live, changed the text to 'Watch the Raspberry Pi Ubuntu Desktop intro video ›'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [See that the homepage takevoer now reads 'Watch the Raspberry Pi Ubuntu Desktop intro video ›'


## Issue / Card

Fixes #8595

## Screenshots

![image](https://user-images.githubusercontent.com/441217/97169621-3e19d600-1782-11eb-8dd7-5a3119ddbb3c.png)
