### PR TITLE
Build takeover for manage risk with service providers

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
   {# ALL #}
   {% include "takeovers/_2010-takeover.html" %}
   {% include "takeovers/_security-cloud-computing.html" %}
+  {% include "takeovers/_manage-risk-service-providers.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/_manage-risk-service-providers.html
+++ b/templates/takeovers/_manage-risk-service-providers.html
@@ -1,0 +1,14 @@
+{% with title="How to manage risk with secure managed service providers",
+subtitle="Learn the standards and control objects that should be met through a certified MSP provider",
+class="p-takeover--grad",
+header_image="https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg",
+image_width=220,
+image_height=220,
+image_hide_small=true,
+primary_url="https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001G3QyAAK",
+primary_cta="Register for the webinar",
+primary_cta_class="",
+secondary_url="",
+secondary_cta="" %}
+{% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -182,4 +182,6 @@
 {% include "takeovers/_trilio-backup-recovery.html" %}
 <p>23 October 2020</p>
 {% include "takeovers/_security-cloud-computing.html" %}
+<p>30 October 2020</p>
+{% include "takeovers/_manage-risk-service-providers.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Build takeover
- Add to `index.html`
- Add to `takeovers/index.html`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check takeover and CTA link 


## Issue / Card

Fixes [#3364](https://github.com/canonical-web-and-design/web-squad/issues/3364)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/97174571-2e9e8b00-178a-11eb-8e93-7ce79878c0a7.png)

