### PR TITLE
Validate VAT number on input change for logged in users

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -209,7 +209,9 @@ function attachFormEvents() {
     });
 
     input.addEventListener("blur", (e) => {
-      validateFormInput(e.target, true);
+      if (input.name !== "tax") {
+        validateFormInput(e.target, true);
+      }
     });
   }
 
@@ -353,6 +355,8 @@ function applyLoggedInPurchaseTotals() {
         // preview data
         const errorObject = parseForErrorObject(data);
         presentError(errorObject);
+      } else {
+        validateFormInput(form.tax, true);
       }
 
       if (currentTransaction.type === "purchase") {

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -345,7 +345,16 @@ function applyLoggedInPurchaseTotals() {
     addressObject,
     taxObject
   )
-    .then(() => {
+    .then((data) => {
+      if (data.code) {
+        // an error was returned, most likely
+        // regarding an invalid VAT number.
+        // We don't need it to block posting the
+        // preview data
+        const errorObject = parseForErrorObject(data);
+        presentError(errorObject);
+      }
+
       if (currentTransaction.type === "purchase") {
         postPurchasePreviewData(
           currentTransaction.accountId,

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -106,7 +106,7 @@
             </div>
 
             <div class="col-9 col-start-large-4">
-              <small>e.g. GB101111, CY99999999L</small>
+              <small>e.g. GB 123 1234 12 123 or GB 123 4567 89 1234</small>
             </div>
           </div>
         </form>


### PR DESCRIPTION
## Done

For logged in users, we can validate any VAT number they input at the same time we make the call to get their VAT total (for guest users, this validation can only occur when they've clicked "Continue" and their account has been created).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure you're logged in
- Select a product, add it to your cart, and click "Buy" to launch the payment modal
- Fill out the card and address details, and select United Kingdom as your country
- Type some nonsense into the VAT number field
- See that, after a short delay, the field displays an error
