### PR TITLE
Update UTM on webinar notice on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -29,7 +29,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what&rsquo;s new in Ubuntu 20.10 in our webinar</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what&rsquo;s new in Ubuntu 20.10 in our webinar</a></h4>
       </div>
     </div>
   </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -29,7 +29,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what&rsquo;s new in Ubuntu 20.10 in our webinar</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=Takeover&amp;utm_medium=Takeover&amp;utm_campaign=7013z000001WldOAAS" class="p-link--external">Find out what&rsquo;s new in Ubuntu 20.10 in our webinar</a></h4>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update UTM on webinar notice on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the UTM is now `?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001WldOAAS`

