### PR TITLE
Change the secondary CTA on 20.10 takeover

### DIFF
--- a/templates/takeovers/_2010-takeover.html
+++ b/templates/takeovers/_2010-takeover.html
@@ -10,8 +10,8 @@ equal_cols=true,
 primary_url="/download",
 primary_cta="Get Ubuntu 20.10",
 primary_cta_class="",
-secondary_url="/engage/raspberry-pi-livestream",
-secondary_cta="Watch the Raspberry Pi Ubuntu Desktop intro video",
+secondary_url="/raspberry-pi",
+secondary_cta="Learn more about Ubuntu Desktop on Raspberry Pi",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}

--- a/templates/takeovers/_2010-takeover.html
+++ b/templates/takeovers/_2010-takeover.html
@@ -11,7 +11,7 @@ primary_url="/download",
 primary_cta="Get Ubuntu 20.10",
 primary_cta_class="",
 secondary_url="/raspberry-pi",
-secondary_cta="Learn more about Ubuntu Desktop on Raspberry Pi",
+secondary_cta="Learn more about Ubuntu on the Raspberry Pi",
 lang="",
 locale="" %}
 {% include "takeovers/_template.html" %}


### PR DESCRIPTION

## Done

- Changed the secondary CTA to Learn more about Ubuntu Desktop on Raspberry Pi and linking to /raspberry-pi

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
