### PR TITLE
Allow missing form-id in engage pages

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -82,7 +82,7 @@
       {{ text | safe }}
       {% endfor %}
     </div>
-    {% if document["metadata"]["form_id"] != "" %}
+    {% if "form_id" in document["metadata"] and document["metadata"]["form_id"] != "" %}
     <div class="col-5" id="the-form">
       {% if document["metadata"]["language"] != '' %}
         {% set form = "engage/shared/_" + document["metadata"]["language"] + "_engage_form.html" %}


### PR DESCRIPTION
## Done

- For engage pages, you had to have a blank form-id to not present a form. It would print a broken form if you skipped the value, so I added a check for the existence as well.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the form works for a webinar and for a whitepaper, see that the logic makes sense

Would have fixed #8607

