### PR TITLE
UA: inform the user how they'll receive setup instructions

### DIFF
--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -43,6 +43,12 @@
             <div class="col-9 col-start-large-4">
               <span class="p-form-validation__message u-hide"></span>
             </div>
+            
+            {% if type == "purchase" %}
+            <div class="col-9 col-start-large-4">
+              <small>We’ll also send setup instructions to this address.</small>
+            </div>
+            {% endif %}
           </div>
 
           {% if account is defined %}

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -276,7 +276,10 @@
     </section>
   {% endif %}
 
-  {% include 'advantage/_stripe-modal.html' %}
+  {% with type="renewal" %}
+    {% include 'advantage/_stripe-modal.html' %}
+  {% endwith %}
+  
 {% else %}
   <section class="p-strip--suru-topped is-shallow" style="padding-top: 6rem;"></section>
     <div class="row">

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -196,7 +196,10 @@
       </div>
     </section>
   </form>
-  {% include 'advantage/_stripe-modal.html' %}
+
+  {% with type="purchase" %}
+    {% include 'advantage/_stripe-modal.html' %}
+  {% endwith %}
 
   <script src="{{ versioned_static('js/src/ua-product-selector.js') }}" type="module" defer></script>
   <script defer>


### PR DESCRIPTION
## Done

Add "We’ll also send setup instructions to this address." below the email field when making a purchase (but not when making a renewal).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select a product, add it to cart and click "Buy Now"
- You should see the line of text below the email field.


## Issue / Card

Fixes #8536 

## Screenshots
![Screenshot from 2020-10-27 12-26-00](https://user-images.githubusercontent.com/2376968/97301380-9bc82400-184f-11eb-82cd-5fe4794a81ad.png)

