### PR TITLE
Remove LTS from the latest server download button

### DIFF
--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -101,7 +101,7 @@
         <input type="hidden" name="version" value="{{ releases.latest.full_version }}">
         <input type="hidden" name="architecture" value="amd64">
         <input type="hidden" name="next-step" value="download">
-        <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install - latest', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.latest.full_version }} LTS</button>
+        <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install - latest', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.latest.full_version }}</button>
       </form>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center">


### PR DESCRIPTION
## Done
Remove LTS from the latest server download button

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- Check the button "Download Ubuntu Server 20.10" does not have LTS in it

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/97311714-8dccd000-185c-11eb-9c7c-d0d8f9aa53f6.png)

