### PR TITLE
Add embed youtube link as the other form has a x-origin error

### DIFF
--- a/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
+++ b/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
@@ -4,7 +4,7 @@
   <h3>
     <a href="/engage/raspberry-pi-livestream">Ubuntu Desktop for Raspberry Pi</a>
   </h3>
-  <iframe width="560" height="315" src="https://youtu.be/0pT4-RcTERU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/0pT4-RcTERU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   <p>Join our live event on the 23rd of October, 5pm BST, and find out all the news about the new Ubuntu Desktop image for Raspberry Pi.</p>
   <p><a href="/engage/raspberry-pi-livestream">Discover more&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

- The youtu.be url doesn't seem to work, reverting the embed form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/build-a-raspberry-pi-desktop-with-an-ubuntu-heart
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the video in the side bar works

