### PR TITLE
add /advantage link to /support subnav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -930,6 +930,7 @@ support:
       path: /support/plans-and-pricing
     - title: Your subscriptions
       path: /advantage
+      persist: True
     - title: Community support
       path: /support/community-support
     - title: Contact us

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -928,6 +928,8 @@ support:
       path: /support
     - title: Pricing
       path: /support/plans-and-pricing
+    - title: Your subscriptions
+      path: /advantage
     - title: Community support
       path: /support/community-support
     - title: Contact us

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@canonical/cookie-policy": "2.1.0",
-    "@canonical/global-nav": "2.4.3",
+    "@canonical/global-nav": "2.4.5",
     "@canonical/latest-news": "1.0.3",
     "url-polyfill": "1.1.11",
     "date-fns": "2.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,12 +1238,12 @@
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-2.1.0.tgz#77b96e3f2e29ba2d6e9d654bdb4729dc21e93612"
   integrity sha512-Z26080BBDjE2YkQSaP1iDenBwhsiU3jrmvIkZQcE5EgCf+4uqtka3LDZKxwRg7liZQATVxZqDwPV9IYtV8G9XQ==
 
-"@canonical/global-nav@2.4.3":
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"
-  integrity sha512-8ttxoViIlE16dKBIcuVsvBF2GhsJbC/c7fxLf93EXmn5DKoUYf+rjyhXvEDaRGCtTAnS4finwBwMMo7nQFOSEA==
+"@canonical/global-nav@2.4.5":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.5.tgz#e300d2995aaccf9b35c83cdf8c37b1c9b9d2559a"
+  integrity sha512-OoSfKtD86QDbj9zcOrRg1je3CDQQRPm8Erq+yfDuR5jnN0eB8NfsT7JjAEDcANkzyJues3gMDDmv+cjN3Tu5KQ==
   dependencies:
-    vanilla-framework "2.13.0"
+    vanilla-framework "2.19.1"
 
 "@canonical/latest-news@1.0.3":
   version "1.0.3"
@@ -9224,15 +9224,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.13.0.tgz#ac73e745150bcef183eb35e3ee47f3fd079ddd3e"
-  integrity sha512-EuxlGxO4SmCGL4GVzcye5aas2HGVqRhPxlTHg84Lfw1e1E4F/Coxs78i3xxkPGw3LOcfea0KU096ar1PnLNuXQ==
-
 vanilla-framework@2.15.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.15.0.tgz#be22c92cda0a22108daa35eb76d096add0cebbe7"
   integrity sha512-PrNwDwAHUCVnJQz0hIufFm5GHpeDds+uiK9GHtXD/mgyDoFeQLrARSqIb9cA0FtYqoCOw3vJPmk1HD08eKTNnA==
+
+vanilla-framework@2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
+  integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Added "Your subscriptions", linking to /advantage, to /support subnav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
-See that there is a link to "Your subscriptions" in the subnav
- Follow the link and check you arrive at /advantage, and the subnav is still present
- On any page, see that "Your subscriptions" is present in the "Support" section of the footer navigation


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8600
