### PR TITLE
Update cta on /raspberry-pi

### DIFF
--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -24,7 +24,7 @@
     </p>
       <p>
         <a class="p-link--inverted" href="/engage/raspberry-pi-livestream">
-        Join the live stream - 23 October 2020 16:00 UTC&nbsp;&rsaquo;
+          Watch the Raspberry Pi Ubuntu Desktop intro video&nbsp;&rsaquo;
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- Update cta on /raspberry-pi

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comment on the [copy doc](https://docs.google.com/document/d/1XS8KyKQnQdgY9NJfxHMs_9ql4sPOTRj0yweunMPoOdM/edit?ts=5f980681#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3384