### PR TITLE
Add updated tutorials to /download/raspberry-pi page

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -15,7 +15,9 @@
       <h1>Install Ubuntu on a Raspberry Pi 2, 3 or 4</h1>
       <p>Running Ubuntu on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your Pi and away you go.</p>
       <p>First time installing Ubuntu on Raspberry Pi?</p>
-      <p><a class="p-button--positive" href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">Follow our tutorial</a></p>
+      <p>
+        Follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">desktop</a> or <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">server</a> tutorials.
+      </p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Add updated tutorials to /download/raspberry-pi page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit?ts=5f9941c0)


## Issue / Card

Fixes #8617

