### PR TITLE
Change header image cassandra page

### DIFF
--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -19,23 +19,21 @@
         <a href="/managed/contact-us" class="p-button--positive">Get in touch</a>
         <a href="/managed/contact-us" class="p-button--neutral js-invoke-modal">Free deployment assessment</a>
       </p>
+      <p>We automate the mundane tasks so you can focus on building your core apps with Cassandra. Managed Apache Cassandra database service deployable on the cloud of your choice or on-prem.</p>
     </div>
     <div class="col-5 u-hide--small u-align--center">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/ce971717-Kafka-logo-badge-white.svg",
+        url="https://assets.ubuntu.com/v1/776d44a1-cassandra-eye.svg",
         alt="",
-        height="287",
-        width="178",
+        height="120",
+        width="220",
         hi_def=True,
         attrs={"class": ""},
         loading="auto",
         ) | safe
       }}
     </div>
-  </div>
-  <div class="row">
-    <p>We automate the mundane tasks so you can focus on building your core apps with Cassandra. Managed Apache Cassandra database service deployable on the cloud of your choice or on-prem.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Change header image on /managed/cassandra

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/cassandra
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check new header image is cassandra eye logo from issue


## Issue / Card

Fixes [#8260](https://github.com/canonical-web-and-design/ubuntu.com/issues/8620)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/97433926-28d5b080-1916-11eb-84df-4da00a827f87.png)

