### PR TITLE
Add ecom analytics to UA shop

### DIFF
--- a/static/js/src/advantage/ecom-analytics-events.js
+++ b/static/js/src/advantage/ecom-analytics-events.js
@@ -3,13 +3,7 @@ export function addToCartEvent(product) {
     event: "addToCart",
     ecommerce: {
       add: {
-        products: [
-          {
-            name: product.name,
-            id: product.id,
-            quantity: product.quantity,
-          },
-        ],
+        products: [product],
       },
     },
   });
@@ -20,13 +14,44 @@ export function removeFromCartEvent(product) {
     event: "removeFromCart",
     ecommerce: {
       remove: {
-        products: [
-          {
-            name: product.name,
-            id: product.id,
-            quantity: product.quantity,
-          },
-        ],
+        products: [product],
+      },
+    },
+  });
+}
+
+/**
+ *
+ * @param {Array} cartItems
+ * @param {String} step
+ *
+ * There are three steps to the checkout:
+ * proceededToCheckout, addedPaymentDetails and
+ * confirmedPurchase
+ */
+export function checkoutEvent(products, step) {
+  dataLayer.push({
+    event: "checkout",
+    ecommerce: {
+      checkout: {
+        actionField: { step: step },
+        products: products,
+      },
+    },
+  });
+}
+
+export function purchaseEvent(purchaseInfo, products) {
+  dataLayer.push({
+    ecommerce: {
+      purchase: {
+        actionField: {
+          id: purchaseInfo.id, // Transaction ID. Required for purchases and refunds.
+          affiliation: purchaseInfo.origin,
+          revenue: purchaseInfo.total, // Total transaction value (incl. tax and shipping)
+          tax: purchaseInfo.tax,
+        },
+        products: products,
       },
     },
   });

--- a/static/js/src/advantage/ecom-analytics-events.js
+++ b/static/js/src/advantage/ecom-analytics-events.js
@@ -1,23 +1,27 @@
 export function addToCartEvent(product) {
-  dataLayer.push({
-    event: "addToCart",
-    ecommerce: {
-      add: {
-        products: [product],
+  if (dataLayer) {
+    dataLayer.push({
+      event: "addToCart",
+      ecommerce: {
+        add: {
+          products: [product],
+        },
       },
-    },
-  });
+    });
+  }
 }
 
 export function removeFromCartEvent(product) {
-  dataLayer.push({
-    event: "removeFromCart",
-    ecommerce: {
-      remove: {
-        products: [product],
+  if (dataLayer) {
+    dataLayer.push({
+      event: "removeFromCart",
+      ecommerce: {
+        remove: {
+          products: [product],
+        },
       },
-    },
-  });
+    });
+  }
 }
 
 /**
@@ -30,29 +34,33 @@ export function removeFromCartEvent(product) {
  * confirmedPurchase
  */
 export function checkoutEvent(products, step) {
-  dataLayer.push({
-    event: "checkout",
-    ecommerce: {
-      checkout: {
-        actionField: { step: step },
-        products: products,
+  if (dataLayer) {
+    dataLayer.push({
+      event: "checkout",
+      ecommerce: {
+        checkout: {
+          actionField: { step: step },
+          products: products,
+        },
       },
-    },
-  });
+    });
+  }
 }
 
 export function purchaseEvent(purchaseInfo, products) {
-  dataLayer.push({
-    ecommerce: {
-      purchase: {
-        actionField: {
-          id: purchaseInfo.id, // Transaction ID. Required for purchases and refunds.
-          affiliation: purchaseInfo.origin,
-          revenue: purchaseInfo.total, // Total transaction value (incl. tax and shipping)
-          tax: purchaseInfo.tax,
+  if (dataLayer) {
+    dataLayer.push({
+      ecommerce: {
+        purchase: {
+          actionField: {
+            id: purchaseInfo.id, // Transaction ID. Required for purchases and refunds.
+            affiliation: purchaseInfo.origin,
+            revenue: purchaseInfo.total, // Total transaction value (incl. tax and shipping)
+            tax: purchaseInfo.tax,
+          },
+          products: products,
         },
-        products: products,
       },
-    },
-  });
+    });
+  }
 }

--- a/static/js/src/advantage/ecom-analytics-events.js
+++ b/static/js/src/advantage/ecom-analytics-events.js
@@ -1,0 +1,33 @@
+export function addToCartEvent(product) {
+  dataLayer.push({
+    event: "addToCart",
+    ecommerce: {
+      add: {
+        products: [
+          {
+            name: product.name,
+            id: product.id,
+            quantity: product.quantity,
+          },
+        ],
+      },
+    },
+  });
+}
+
+export function removeFromCartEvent(product) {
+  dataLayer.push({
+    event: "removeFromCart",
+    ecommerce: {
+      remove: {
+        products: [
+          {
+            name: product.name,
+            id: product.id,
+            quantity: product.quantity,
+          },
+        ],
+      },
+    },
+  });
+}

--- a/static/js/src/advantage/ecom-analytics-events.js
+++ b/static/js/src/advantage/ecom-analytics-events.js
@@ -50,6 +50,7 @@ export function checkoutEvent(products, step) {
 export function purchaseEvent(purchaseInfo, products) {
   if (dataLayer) {
     dataLayer.push({
+      event: "purchase",
       ecommerce: {
         purchase: {
           actionField: {

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -22,6 +22,10 @@ import {
   setPaymentInformation,
   setRenewalInformation,
 } from "./advantage/set-modal-info.js";
+import {
+  checkoutEvent,
+  purchaseEvent,
+} from "./advantage/ecom-analytics-events.js";
 
 const modal = document.getElementById("ua-payment-modal");
 
@@ -147,10 +151,14 @@ function attachCTAevents() {
       currentTransaction.previousPurchaseId = data.previousPurchaseId;
       cartItems.forEach((item) => {
         currentTransaction.products.push({
+          name: item.product.name,
+          price: item.product.price.value,
           product_listing_id: item.listingID,
           quantity: parseInt(item.quantity),
         });
       });
+
+      checkoutEvent(analyticsFriendlyProducts(), "Proceeded to checkout");
 
       setOrderInformation(cartItems, modal);
     }
@@ -364,15 +372,15 @@ function applyLoggedInPurchaseTotals() {
           currentTransaction.accountId,
           currentTransaction.products,
           currentTransaction.previousPurchaseId
-        ).then((data) => {
-          purchasePreview = data;
+        ).then((purchasePreview) => {
+          currentTransaction.total = purchasePreview.total;
+          currentTransaction.tax = purchasePreview.taxAmount;
           modal.classList.remove("is-processing");
           setOrderTotals(country, vatApplicable, purchasePreview, modal);
         });
       } else if (currentTransaction.type === "renewal") {
         postRenewalPreviewData(currentTransaction.transactionId).then(
-          (data) => {
-            purchasePreview = data;
+          (purchasePreview) => {
             modal.classList.remove("is-processing");
             setOrderTotals(country, vatApplicable, purchasePreview, modal);
           }
@@ -494,6 +502,21 @@ function enableProcessingState(mode) {
   }, 2000);
 }
 
+function analyticsFriendlyProducts() {
+  let products = [];
+
+  currentTransaction.products.forEach((product) => {
+    products.push({
+      id: product.product_listing_id,
+      name: product.name,
+      price: product.price / 100,
+      quantity: product.quantity,
+    });
+  });
+
+  return products;
+}
+
 function handleIncompletePayment(invoice) {
   if (invoice.pi_status === "requires_payment_method") {
     // the user's original payment method failed,
@@ -589,10 +612,12 @@ function handlePaymentMethodResponse(data) {
     presentError(errorObject);
     return;
   }
+
   if (currentTransaction.accountId) {
     attachCustomerInfoToStripeAccount(data.paymentMethod);
     return;
   }
+
   handleGuestPaymentMethodResponse(data);
 }
 
@@ -644,6 +669,11 @@ function handleCustomerInfoResponse(paymentMethod, data) {
   } else if (data.createdAt) {
     // payment method was successfully attached,
     // ask user to click "Pay"
+
+    if (currentTransaction.type == "purchase") {
+      checkoutEvent(analyticsFriendlyProducts(), "Added payment details");
+    }
+
     setPaymentInformation(paymentMethod, modal);
     showPayMode();
   } else {
@@ -667,8 +697,22 @@ function handlePaymentAttemptResponse(data) {
   }
 }
 
-function handleSuccessfulPayment() {
+function handleSuccessfulPayment(transaction) {
   sendGAEvent("payment succeeded");
+
+  if (currentTransaction.type == "purchase") {
+    const purchaseInfo = {
+      id: transaction.id,
+      origin: "UA Shop",
+      total: currentTransaction.total / 100,
+      tax: currentTransaction.tax,
+    };
+
+    const products = analyticsFriendlyProducts();
+
+    purchaseEvent(purchaseInfo, products);
+  }
+
   disableProcessingState();
   progressIndicator.querySelector(".p-icon--spinner").classList.add("u-hide");
   progressIndicator
@@ -703,7 +747,7 @@ function pollTransactionStatus() {
         if (transaction.status !== "done") {
           incompleteHandler(transaction);
         } else {
-          handleSuccessfulPayment();
+          handleSuccessfulPayment(transaction);
         }
       })
       .catch((error) => {
@@ -762,6 +806,8 @@ function processStripePayment() {
         presentError();
       });
   } else if (currentTransaction.type === "purchase") {
+    checkoutEvent(analyticsFriendlyProducts(), "Confirmed purchase");
+
     postPurchaseData(
       currentTransaction.accountId,
       currentTransaction.products,

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -158,7 +158,7 @@ function attachCTAevents() {
         });
       });
 
-      checkoutEvent(analyticsFriendlyProducts(), "Proceeded to checkout");
+      checkoutEvent(analyticsFriendlyProducts(), 1);
 
       setOrderInformation(cartItems, modal);
     }
@@ -671,7 +671,7 @@ function handleCustomerInfoResponse(paymentMethod, data) {
     // ask user to click "Pay"
 
     if (currentTransaction.type == "purchase") {
-      checkoutEvent(analyticsFriendlyProducts(), "Added payment details");
+      checkoutEvent(analyticsFriendlyProducts(), 2);
     }
 
     setPaymentInformation(paymentMethod, modal);
@@ -705,7 +705,7 @@ function handleSuccessfulPayment(transaction) {
       id: transaction.id,
       origin: "UA Shop",
       total: currentTransaction.total / 100,
-      tax: currentTransaction.tax,
+      tax: currentTransaction.tax / 100,
     };
 
     const products = analyticsFriendlyProducts();
@@ -806,7 +806,7 @@ function processStripePayment() {
         presentError();
       });
   } else if (currentTransaction.type === "purchase") {
-    checkoutEvent(analyticsFriendlyProducts(), "Confirmed purchase");
+    checkoutEvent(analyticsFriendlyProducts(), 3);
 
     postPurchaseData(
       currentTransaction.accountId,

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -300,11 +300,20 @@ function productSelector() {
 
         products.forEach((product) => {
           if (product.get("productId")[0] === data.productId) {
+            const productId = product.get("productId")[0];
+            const originalQuantity = product.get("quantity")[0];
+            let updatedQuantity = input.value;
+
             if (input.value < 0) {
-              product.set("quantity", ["0"]);
-            } else {
-              product.set("quantity", [input.value]);
+              updatedQuantity = "0";
             }
+
+            updateEcomAnalyticsQuantity(
+              productId,
+              originalQuantity,
+              updatedQuantity
+            );
+            product.set("quantity", [updatedQuantity]);
           }
         });
       }
@@ -507,6 +516,37 @@ function productSelector() {
       product.set("quantity", [`${quantity}`]);
       product.set("imageURL", [imageURL]);
       state.push("cart", product);
+    }
+  }
+
+  function updateEcomAnalyticsQuantity(
+    productId,
+    originalQuantity,
+    updatedQuantity
+  ) {
+    const product = products[productId];
+    const name = product.name;
+    const unitPrice = product.price.value / 100;
+    let quantityDelta;
+
+    if (updatedQuantity > originalQuantity) {
+      quantityDelta = updatedQuantity - originalQuantity;
+
+      addToCartEvent({
+        id: productId,
+        name: name,
+        price: unitPrice,
+        quantity: quantityDelta,
+      });
+    } else if (updatedQuantity < originalQuantity) {
+      quantityDelta = originalQuantity - updatedQuantity;
+
+      removeFromCartEvent({
+        id: productId,
+        name: name,
+        price: unitPrice,
+        quantity: quantityDelta,
+      });
     }
   }
 

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -1,5 +1,9 @@
 import { StateManager } from "./utils/state.js";
 import { debounce } from "./utils/debounce.js";
+import {
+  addToCartEvent,
+  removeFromCartEvent,
+} from "./advantage/ecom-analytics-events.js";
 
 function productSelector() {
   const form = document.querySelector(".js-shop-form");
@@ -240,9 +244,11 @@ function productSelector() {
     const productId = data.productId;
     const imageURL = data.imageUrl;
     const quantity = data.quantity;
+    const productName = products[productId].name;
 
     if (action === "add") {
       updateCartState(productId, quantity, imageURL);
+      addToCartEvent({ id: productId, name: productName, quantity: quantity });
       cartStep.scrollIntoView();
       resetForm();
     } else if (action === "remove") {
@@ -250,6 +256,12 @@ function productSelector() {
         productId: productId,
         quantity: quantity,
         imageURL: imageURL,
+      });
+
+      removeFromCartEvent({
+        id: productId,
+        name: productName,
+        quantity: quantity,
       });
     }
   }

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -244,11 +244,18 @@ function productSelector() {
     const productId = data.productId;
     const imageURL = data.imageUrl;
     const quantity = data.quantity;
-    const productName = products[productId].name;
+    const product = products[productId];
+    const name = product.name;
+    const unitPrice = product.price.value / 100;
 
     if (action === "add") {
       updateCartState(productId, quantity, imageURL);
-      addToCartEvent({ id: productId, name: productName, quantity: quantity });
+      addToCartEvent({
+        id: productId,
+        name: name,
+        price: unitPrice,
+        quantity: quantity,
+      });
       cartStep.scrollIntoView();
       resetForm();
     } else if (action === "remove") {
@@ -260,7 +267,8 @@ function productSelector() {
 
       removeFromCartEvent({
         id: productId,
-        name: productName,
+        name: name,
+        price: unitPrice,
         quantity: quantity,
       });
     }


### PR DESCRIPTION
## Done

Added ecom analytics events for:
- Adding/removing items from the cart
- Proceeding to checkout
- Adding payment details
- Confirming purchase
- A successful purchase

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Trigger the events by:
  - Adding a product
  - Removing a product
  - Adding another product
  - Proceeding to checkout
  - Filling out payment details and clicking "Continue"
    - card info: 4242 4242 4242 4242, 04/24, 242, 42424
  - Clicking "Pay" on the second screen of the payment modal
- Verify that the events were sent to GA/GTM


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3385
