### PR TITLE
Don't 500 on invalid renewal

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -531,9 +531,15 @@ def advantage_view():
                             "daysTillExpiry"
                         ] = date_difference.days
 
-                    contract["renewal"] = make_renewal(
-                        advantage, contract["contractInfo"]
-                    )
+                    try:
+                        contract["renewal"] = make_renewal(
+                            advantage, contract["contractInfo"]
+                        )
+                    except KeyError:
+                        flask.current_app.extensions[
+                            "sentry"
+                        ].captureException()
+                        contract["renewal"] = None
 
                     enterprise_contract = enterprise_contracts.setdefault(
                         contract["accountInfo"]["name"], []


### PR DESCRIPTION
See #8626 

This will handle invalid renewal state (or invalid parsing) gracefully and send an exception sentry instead of displaying a 500 page on `/advantage` in this case.