### PR TITLE
More prominent “Buy a subscription”

### DIFF
--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -94,7 +94,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="/advantage/subscribe">Buy a subscription</a></p>
+      <p><a class="p-button--neutral" href="/advantage/subscribe">Buy a subscription</a></p>
     </div>
   </div>
 </div>

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -94,7 +94,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p class="u-no-margin--bottom"><a href="/advantage/subscribe" class="p-button--positive u-no-margin--bottom">Purchase a subscription</a></p>
+      <p><a href="/advantage/subscribe">Buy a subscription</a></p>
     </div>
   </div>
 </div>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -298,7 +298,7 @@
             });">
             Sign in
           </a>
-          <a href="/advantage/subscribe" class="p-button--neutral">Buy a subscription</a></p>
+          <a href="/advantage/subscribe" class="p-button--neutral">Buy a subscription</a>
         </p>
       </div>
     </div>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -287,8 +287,8 @@
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
         <p>Sign in to access your personal or paid subscriptions.</p>
-        <p class="u-no-margin--bottom">
-          <a href="/login" class="p-button--neutral u-no-margin--bottom"
+        <p>
+          <a href="/login" class="p-button--neutral"
             onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage',
@@ -298,6 +298,7 @@
             });">
             Sign in
           </a>
+          <a href="/advantage/subscribe" class="p-button--neutral">Buy a subscription</a></p>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Changed positive “Purchase a subscription”, at the bottom of /advantage, to neutral “Buy a subscription”.
- Added another “Buy a subscription” button alongside “Sign in”, fixing #8634.
- Removed unnecessary margin fiddling.

[Copy doc updated](https://docs.google.com/document/d/1K65n3NpZCh7EWDXKLhG31seGJ2jKbW6lqw3BwV2mlnU/edit#heading=h.nleu1cdig11l).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage while signed out

## Issue / Card

Fixes #8634.

## Screenshot

![image](https://user-images.githubusercontent.com/19801137/97706764-1b532e80-1aae-11eb-9f37-0cdb95581536.png)