### PR TITLE
Make contributions GAevent

### DIFF
--- a/static/js/src/contributions.js
+++ b/static/js/src/contributions.js
@@ -161,24 +161,22 @@ function sendContributionFormAnalytics() {
     let value = amountElement.value || 0;
 
     if (value > 0) {
-      transactionProducts.push({
-        sku: name,
-        name: name,
-        category: "",
-        price: value,
-        quantity: 1,
+      dataLayer.push({
+        event: "GAEvent",
+        eventCategory: "Contributions",
+        eventAction: "Item",
+        eventLabel: name,
+        eventValue: value,
       });
     }
   });
 
   dataLayer.push({
-    transactionId: orderId,
-    transactionAffiliation: "Ubuntu contributions",
-    transactionTotal: total,
-    transactionTax: 0,
-    transactionShipping: 0,
-    transactionProducts: transactionProducts,
-    event: "transactionComplete",
+    event: "GAEvent",
+    eventCategory: "Contributions",
+    eventAction: "Paid",
+    eventLabel: "Total",
+    eventValue: total,
   });
 }
 


### PR DESCRIPTION
## Done

- Make contributions GAevent
- To clean up the e-commerce space for the Ubuntu Advantage shop, I am moving the contribution data to normal ga events

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it pushes GA events instead of e-commerce events

## Screenshots

![image](https://user-images.githubusercontent.com/441217/97708359-974e7600-1ab0-11eb-9dee-6453731e74be.png)
