### PR TITLE
Change CTA on takeover

### DIFF
--- a/templates/takeovers/_security-cloud-computing.html
+++ b/templates/takeovers/_security-cloud-computing.html
@@ -6,7 +6,7 @@ image_width=180,
 image_height=180,
 image_hide_small=true,
 primary_url="https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001G3QyAAK",
-primary_cta="Register for the webinar",
+primary_cta="Watch the webinar",
 primary_cta_class="",
 secondary_url="",
 secondary_cta="" %}


### PR DESCRIPTION
## Done

- Change CTA from 'Register for the webinar" to "Watch the webinar" on security cloud computing takeover as requested in this [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/8579)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check 'Security, cloud native & confidential computing' takeover has correct CTA 


## Issue / Card

Requested in this [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/8579#issuecomment-719477746)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/97851076-cc470c80-1cec-11eb-9e9a-1277627dec5b.png)

