### PR TITLE
Show information about active takeovers on the takeover index page

### DIFF
--- a/templates/takeovers/_template.html
+++ b/templates/takeovers/_template.html
@@ -1,4 +1,4 @@
-<section {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover" {% if lang_skip %}lang-skip="{{ lang_skip }}"{% endif %} >
+<section {% if lang %}lang="{{ lang }}"{% endif %} data-lang="{% if locale %}{{ locale }}{% else %}en_GB{% endif %}" class="{% if active == 'true' %}is-active {% endif %}{% if class %}{{ class }}{% else %}p-takeover--grad{% endif %} js-takeover" {% if lang_skip %}lang-skip="{{ lang_skip }}"{% endif %} >
   <div class="row u-equal-height">
     <div class="{% if equal_cols %}col-6{% else %}col-7{% endif %} u-vertically-center">
       {% if stacked_image %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -6,24 +6,49 @@
 
 {% block content %}
 
+<section class="p-strip is-shallow">
+  <div class="row">
+    <ul class="p-inline-list u-no-margin--bottom">
+      <li class="p-inline-list__item">
+        Active takeovers: <strong>{{ active_count }}</strong>
+      </li>
+      <li class="p-inline-list__item">
+        Hidden takeovers: <strong>{{ hidden_count }}</strong>
+      </li>
+    </ul>
+  </div>
+</section>
+
 {% for takeover in takeovers %}
-    {% with 
-      title=takeover['title'],
-      subtitle=takeover['subtitle'],
-      class="p-takeover--" + takeover['class'],
-      header_image=takeover['image'],
-      image_style="width: " + takeover['image_width'] + "px; height: " + takeover['image_height'] + "px; ",
-      image_hide_small="true",
-      primary_url=takeover['primary_url'],
-      primary_cta=takeover['primary_cta'],
-      primary_cta_class="",
-      secondary_cta=takeover['secondary_cta'],
-      secondary_url=takeover['secondary_url'],
-      lang=takeover['language'],
-      lang_skip=takeover['lang_skip']
+  {% with
+    title=takeover['title'],
+    subtitle=takeover['subtitle'],
+    class="p-takeover--" + takeover['class'],
+    header_image=takeover['image'],
+    image_style="width: " + takeover['image_width'] + "px; height: " + takeover['image_height'] + "px; ",
+    image_hide_small="true",
+    primary_url=takeover['primary_url'],
+    primary_cta=takeover['primary_cta'],
+    primary_cta_class="",
+    secondary_cta=takeover['secondary_cta'],
+    secondary_url=takeover['secondary_url'],
+    lang=takeover['language'],
+    lang_skip=takeover['lang_skip'],
+    active=takeover['active']
     %}
     {% include "takeovers/_template.html" %}
-    {% endwith %}
-  {% endfor %}  
+  {% endwith %}
+{% endfor %}
+
+<style>
+  .is-active::after {
+    background: rgba(249, 155, 17, 0.5);
+    content: "Active";
+    padding: .5rem 1rem;
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+  }
+</style>
 
 {% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -319,8 +319,18 @@ def build_takeovers_index(engage_pages):
             key=lambda takeover: takeover["publish_date"],
             reverse=True,
         )
+        active_takeovers = [
+            takeover
+            for takeover in engage_pages.parser.takeovers
+            if takeover["active"] == "true"
+        ]
+        active_count = len(active_takeovers)
+        hidden_count = len(sorted_takeovers) - active_count
         return flask.render_template(
-            "takeovers/index.html", takeovers=sorted_takeovers
+            "takeovers/index.html",
+            active_count=active_count,
+            hidden_count=hidden_count,
+            takeovers=sorted_takeovers,
         )
 
     return takeover_index


### PR DESCRIPTION
## Done
Show information about active takeovers on the takeover index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers
- See that you see the active counts at the top and an active indicator on the takeovers

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/97864365-63698f80-1d00-11eb-9689-43710c15cf7c.png)

