### PR TITLE
Pin vanilla to 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@canonical/latest-news": "1.0.4",
     "url-polyfill": "1.1.11",
     "url-search-params-polyfill": "8.1.0",
-    "vanilla-framework": "2.19.2"
+    "vanilla-framework": "2.18.0"
   },
   "resolutions": {
     "lodash": "4.17.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8296,15 +8296,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vanilla-framework@2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.18.0.tgz#75039937c6d53ec9b237b9cdc7ecad8046725ad5"
+  integrity sha512-hipKgpp7/kMQbln2NbX5qP6TotTNRhVmiHbgniGEqBsDXFz96vvZoetDp8fBBdgutaVKLQiaINth1yis7Q1jaQ==
+
 vanilla-framework@2.19.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
   integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
-
-vanilla-framework@2.19.2:
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.2.tgz#7a82d9f48c22e6fd805575140c70c011d5e6d54c"
-  integrity sha512-J4l4ug4MP0SPmbv5CY37aS/xLPxzh2pMO/Cex1fIH75pkrraj2a90oH2zD6hIQ8ri11IDLGaxI6s9BNDxBKVEg==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Pin vanilla to 2.18.0 to not have a navigation alignment regressoin

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the logo aligns with the global nav

## Screenshots

![image](https://user-images.githubusercontent.com/441217/97909635-7734e600-1d40-11eb-993d-103d5612cc55.png)

