### PR TITLE
Increase logo size on /what-is-kubeflow

### DIFF
--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -108,10 +108,10 @@
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
+            url="https://assets.ubuntu.com/v1/e0ef0377-intel-logo-2-1.png",
             alt="intel",
-            height="65",
-            width="100",
+            height="35",
+            width="90",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",

--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -43,35 +43,9 @@
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/403148e0-2018-logo-canonical.svg",
-            alt="Canonical",
-            height="120",
-            width="120",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-      </li> 
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/7cc3bee4-IBM_logo.svg",
-            alt="IBM",
-            height="90",
-            width="90",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-      </li>   
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/2d54fa27-logo-google--snapcraft-homepage.svg",
+            url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
             alt="Google",
-            height="130",
+            height="42",
             width="130",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
@@ -82,36 +56,62 @@
       <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/d8293409-intel_logo.svg",
-            alt="Intel",
-            height="120",
-            width="120",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/8a4d26de-2018-logo-cisco.svg",
-            alt="Cisco",
-            height="110",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/c15698ab-logo-microsoft.svg",
+            url="https://assets.ubuntu.com/v1/b179abab-microsoft-logo+copy.svg",
             alt="Microsoft",
-            height="110",
+            height="33",
+            width="145",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
+            alt="Canonical",
+            height="20",
+            width="140",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
+      </li> 
+      <li class="p-inline-images__item">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/16aec8e3-cisco-logo-transparent.png",
+            alt="Cisco",
+            height="53",
             width="110",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/67db21e0-logo-ibm.png",
+            alt="IBM",
+            height="40",
+            width="90",
+            hi_def=True,
+            attrs={"class": "p-inline-images__logos"},
+            loading="lazy",
+          ) | safe
+        }}
+      </li>   
+      <li class="p-inline-images__item">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
+            alt="intel",
+            height="65",
+            width="100",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -123,11 +123,11 @@
 </section>
 
 <section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="u-sv3">What's inside Kubeflow?</h2>
+  </div>
   <div class="row">
     <div class="col-7">
-      <div class="u-fixed-width u-sv4">
-        <h2>What's inside Kubeflow?</h2>
-      </div>
       <p class="p-heading--4">Kubeflow dashboard</p>
       <p><a class="p-link--external" href="https://www.kubeflow.org/docs/components/central-dash/overview/">Multi-user dashboard</a> with role-based access control (RBAC) allows data scientists to focus on creating great models, while the ops team takes care of the backend.</p>
 
@@ -161,10 +161,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/9ea16fa1-jupiter_logo.svg",
-            alt="Jupiter",
-            height="120",
-            width="120",
+            url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
+            alt="Jupyter",
+            height="90",
+            width="80",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -174,10 +174,10 @@
         <li class="p-inline-images__item ">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/57dd2115-TensorFlow-logo.svg",
+            url="https://assets.ubuntu.com/v1/c4da5b86-Tensor-flow-logo.png",
             alt="TensorFlow",
-            height="120",
-            width="120",
+            height="90",
+            width="90",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -187,10 +187,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/86dc5036-Seldon_logo.svg",
+            url="https://assets.ubuntu.com/v1/6d6b4148-seldon-logo.png",
             alt="Seldon",
-            height="120",
-            width="120",
+            height="90",
+            width="100",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -200,10 +200,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/9b1d457f-PyTorch_logo.svg",
+            url="https://assets.ubuntu.com/v1/a774cbbb-py-torch-logo.png",
             alt="PyTorch",
-            height="120",
-            width="120",
+            height="90",
+            width="100",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -213,10 +213,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/338c2b34-Istio_logo.svg",
+            url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
             alt="Istio",
-            height="120",
-            width="120",
+            height="60",
+            width="100",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -226,10 +226,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/2e52a8c6-mxnet_logo.svg",
+            url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
             alt="MXNet",
-            height="120",
-            width="120",
+            height="40",
+            width="110",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -239,10 +239,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/d89128ff-Katib_logo.svg",
+            url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
             alt="Katib",
-            height="120",
-            width="120",
+            height="90",
+            width="75",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -252,10 +252,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/6ee7c707-Prometheus_logo.svg",
+            url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
             alt="Prometheus",
-            height="120",
-            width="120",
+            height="80",
+            width="80",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -265,10 +265,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/afd47009-Ambassador_logo.svg",
+            url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
             alt="Ambassador",
-            height="120",
-            width="120",
+            height="100",
+            width="80",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -278,10 +278,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ec6a2cfa-ONNX_logo.svg",
+            url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
             alt="ONNX",
-            height="120",
-            width="120",
+            height="30",
+            width="110",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -291,10 +291,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/aa7f0e45-XGBoost-logo.svg",
+            url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
             alt="XGBoost",
-            height="120",
-            width="120",
+            height="37",
+            width="110",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -304,10 +304,10 @@
         <li class="p-inline-images__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/0428a1ce-scikit-learn_logo.svg",
+            url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
             alt="Scikit",
-            height="120",
-            width="120",
+            height="60",
+            width="110",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
@@ -317,10 +317,10 @@
         <li class="p-inline-images__item ">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/614f1f45-Pachyderm_logo.svg",
+            url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
             alt="Pachyderm",
-            height="120",
-            width="130",
+            height="100",
+            width="110",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",

--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -46,7 +46,7 @@
             url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
             alt="Google",
             height="42",
-            width="130",
+            width="128",
             hi_def=True,
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",


### PR DESCRIPTION
## Done

- Increase logo size on `/kubeflow/what-is-kubeflow`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/what-is-kubeflow
- Check logo sizes in 'contributors to kubeflow' section and 'What's inside Kubeflow?' section fix comment in [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit#)


## Issue / Card

Fixes [#3390](https://github.com/canonical-web-and-design/web-squad/issues/3390)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/97985629-6af86980-1dd0-11eb-983a-a56635d12ada.png)
![image](https://user-images.githubusercontent.com/58959073/97985641-6f248700-1dd0-11eb-9ecd-d6a2260233aa.png)
