### PR TITLE
Redhat takeover and engage page 

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,9 @@
   {# ALL #}
   {% include "takeovers/_2010-takeover.html" %}
   {% include "takeovers/_security-cloud-computing.html" %}
+
+  {# SPANISH #}
+  {% include "takeovers/es/_redhat-openstack-comparacion-manual.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/es/_redhat-openstack-comparacion-manual.html
+++ b/templates/takeovers/es/_redhat-openstack-comparacion-manual.html
@@ -12,8 +12,7 @@
   secondary_url="",
   secondary_cta="",
   stacked_image="true",
-  lang="es",
-  locale="en_ES"
+  lang="es"
 %}
   {% include "takeovers/_template.html" %}
 {% endwith %}

--- a/templates/takeovers/es/_redhat-openstack-comparacion-manual.html
+++ b/templates/takeovers/es/_redhat-openstack-comparacion-manual.html
@@ -1,0 +1,19 @@
+{% with
+  title="Comparando la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical",
+  subtitle="Reducir significativamente el coste total de propiedad con Charmed OpenStack",
+  class="p-takeover--dark",
+  header_image="https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg",
+  image_style="width: 300px;",
+  image_hide_small="",
+  equal_cols="true",
+  primary_url="/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001WkRmAAK",
+  primary_cta="Descargar el manual",
+  primary_cta_class="",
+  secondary_url="",
+  secondary_cta="",
+  stacked_image="true",
+  lang="es",
+  locale="en_ES"
+%}
+  {% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -184,4 +184,6 @@
 {% include "takeovers/_security-cloud-computing.html" %}
 <p>30 October 2020</p>
 {% include "takeovers/_manage-risk-service-providers.html" %}
+<p>02 November 2020</p>
+{% include "takeovers/es/_redhat-openstack-comparacion-manual.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Build takeover and add to `/index.html` and `/takeovers/index.html`
- Build [engage page](https://ubuntu.com/engage/es/redhat-openstack-comparacion-manual) on discourse
- Add engage page to index

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check first Spanish takeover is not visible when language is English. Change browser language to Spanish and check takeover is visible. 
- Check [engage page](https://ubuntu.com/engage/es/redhat-openstack-comparacion-manual) and takeover against [brief](https://docs.google.com/spreadsheets/d/1oswntN5H7Xf9vOAzHcX1waxwSxTzeHhWQUXOcqkivdg/edit#gid=1271849439)
- Test the engage page on http://debug.iframely.com/ and https://cards-dev.twitter.com/validator

## Issue / Card

Fixes [#8584](https://github.com/canonical-web-and-design/ubuntu.com/issues/8584)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/98009878-f6342800-1ded-11eb-86a6-a85b6a3e7c58.png)

