### PR TITLE
Change "What is Kubeflow" blog product card link to /kubeflow/what-is-kubeflow

### DIFF
--- a/templates/blog/product-cards/_kubeflow_what-is-kubeflow.html
+++ b/templates/blog/product-cards/_kubeflow_what-is-kubeflow.html
@@ -2,12 +2,12 @@
   <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg" alt="kubeflow logo" style="width: 137px;height: 32px;">
   <hr class="u-sv1">
   <h3>
-    <a href="/kubeflow">What is Kubeflow?</a>
+    <a href="/kubeflow/what-is-kubeflow">What is Kubeflow?</a>
   </h3>
   <p>Kubeflow makes deployments of Machine Learning workflows on Kubernetes simple, portable and scalable.
     <br /><br />
     Kubeflow is the machine learning toolkit for Kubernetes. It extends Kubernetes ability to run independent and
     configurable steps, with machine learning specific frameworks and libraries.
   </p>
-  <p><a href="/kubeflow">Learn more about Kubeflow&nbsp;&rsaquo;</a></p>
+  <p><a href="/kubeflow/what-is-kubeflow">Learn more about Kubeflow&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

- Update the What is Kubeflow product card link, now that the /what-is-kubeflow page has been refreshed.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to any Kubeflow blog post, ensure the "What is Kubeflow" card on the right pane is pointing at the expected page