### PR TITLE
Add Kubernetes enterprise takeover - es

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,7 @@
 
   {# SPANISH #}
   {% include "takeovers/es/_redhat-openstack-comparacion-manual.html" %}
+  {% include "takeovers/es/_kubernetes-despliegue-empresa-manual.html" %}
 {% endblock takeover_content %}
 
 {#

--- a/templates/takeovers/es/_kubernetes-despliegue-empresa-manual.html
+++ b/templates/takeovers/es/_kubernetes-despliegue-empresa-manual.html
@@ -1,0 +1,19 @@
+{% with
+  title="Cinco estrategias para acelerar a los Kubernetes en la empresa",
+  subtitle="Cómo elegir el mejor enfoque de Kubernetes <br /> para su negocio",
+  class="p-takeover--dark",
+  header_image="https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg",
+  image_width="240",
+  image_height="234",
+  image_hide_small="true",
+  equal_cols="true",
+  primary_url="/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover&utm_medium=Takeover&utm_campaign=7013z000001WkLAAA0",
+  primary_cta="Descargar el manual",
+  primary_cta_class="",
+  secondary_url="",
+  secondary_cta="",
+  stacked_image="true", 
+  lang="es"
+%}
+  {% include "takeovers/_template.html" %}
+{% endwith %}

--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -186,4 +186,6 @@
 {% include "takeovers/_manage-risk-service-providers.html" %}
 <p>02 November 2020</p>
 {% include "takeovers/es/_redhat-openstack-comparacion-manual.html" %}
+<p>04 November 2020</p>
+{% include "takeovers/es/_kubernetes-despliegue-empresa-manual.html" %}
 {% endblock %}


### PR DESCRIPTION
## Done

- Build takeover and add to `/index.html` and `/takeovers/index.html`
- Add takeover to takeovers table on discourse
- Add [engage page](https://ubuntu.com/engage/es/kubernetes-despliegue-empresa-manual) to [discourse](https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check takeover isn't visible when browser language is English - change language to Spanish and check takeover is visible on refresh
- Check takeover and engage page against [brief](https://docs.google.com/spreadsheets/d/12lR8xs_-sk9rqGVdppdqzjWaBMHMLpjJUQWxdMXF-z8/edit#gid=2113339190)


## Issue / Card

Fixes [#8585](https://github.com/canonical-web-and-design/ubuntu.com/issues/8585)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/98120513-f1cb4600-1ea5-11eb-88d4-3021a2e82709.png)

