### PR TITLE
Add smartstart to the enterprise menu

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -79,6 +79,7 @@
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/internet-of-things">Build your IoT on Ubuntu</a></li>
+            <li class="p-list__item"><a href="/smartstart">Launch a product with SMART START</a></li>
             <li class="p-list__item"><a href="/core">Ubuntu Core - embedded &amp; secure</a></li>
             <li class="p-list__item"><a href="/appliance">Appliance images</a></li>
             <li class="p-list__item"><a href="/embedded">Embedded Linux with Ubuntu</a></li>


### PR DESCRIPTION
## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Click the enterprise menu and see the smartstart link is there.
- Matches the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8661

