### PR TITLE
UA shop: account check

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -214,8 +214,8 @@
       {% endfor %}
     };
 
-    var accountId = "{{ account.id }}";
-    var accountName = "{{ account.name }}";
+    var accountId = "{% if account %}{{ account.id }}{% endif %}";
+    var accountName = "{% if account %}{{ account.name }}{% endif %}";
     var previousPurchaseId = "{{ previous_purchase_id or ''}}"
   </script>
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -740,7 +740,13 @@ def advantage_shop_view():
 
                 empty_session(flask.session)
 
-                return flask.render_template("advantage/subscribe/index.html")
+                return flask.render_template(
+                    "advantage/subscribe/index.html",
+                    account=account,
+                    previous_purchase_id=previous_purchase_id,
+                    product_listings=None,
+                    stripe_publishable_key=stripe_publishable_key,
+                )
             if code != 404:
                 raise
             # There is no purchase account yet for this user.

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -737,7 +737,9 @@ def advantage_shop_view():
                         "response_message": err.response.json()["message"],
                     }
                 )
+
                 empty_session(flask.session)
+
                 return flask.render_template("advantage/subscribe/index.html")
             if code != 404:
                 raise


### PR DESCRIPTION
## Done

Noticed while doing some QA after a while of not having looked at the demo for a period of time, in which my macaroon auth seemed to have expired.

In /subscribe/index.html, we write the value of `account.id` and `account.name` to variables we can use in js. If a user is not logged in, we set `account` to `None`, so `id` and `name` return false/an empty string. 

If a user _is_ logged in, those values can be set as expected, unless their macaroon has expired. Line [724](https://github.com/canonical-web-and-design/ubuntu.com/blob/advantage-shop/webapp/views.py#L724) of views.py catches the error that this raises, and renders the /subscribe/index.html template, but in this instance `account` is never set (even as `None`), so trying to access `id` and `name` raises [an UndefinedError](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/12776/?query=is%3Aunresolved). The session is emptied during this catch block, so reloading the page will load the page without 500ing.

~I've chosen to add a check for the account variable in the template, I thought it was more robust, but I could see the argument for passing `account=None` to the return on line [743](https://github.com/canonical-web-and-design/ubuntu.com/blob/advantage-shop/webapp/views.py#L743), so would appreciate a second opinion on which is best.~

@frankban suggested also passing the expected variables to the return on line [743](https://github.com/canonical-web-and-design/ubuntu.com/blob/advantage-shop/webapp/views.py#L743) - which I've done.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Expire your macaroon authentication somehow
- Reload the page, see that it doesn't 500 (compare to https://ubuntu-com-8294.demos.haus/advantage/subscribe)
