### PR TITLE
Add smartstart link to internet-of-things

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -11,13 +11,14 @@
   <div class="row u-vertically-center">
     <div class="col-6">
       <h1>Ubuntu for the Internet&nbsp;of&nbsp;Things</h1>
-      <p>From smart homes to smart drones, robots, and industrial systems, Ubuntu is the <a class="p-link--inverted" href="/embedded" style="font-style: italic;">new standard for embedded Linux</a>. Get the world’s best security, a custom app store, a huge developer community and reliable updates.
+      <p>From smart homes to smart drones, robots, and industrial systems, Ubuntu is the <a class="p-link--inverted" href="/embedded">new standard for embedded Linux</a>. Get the world’s best security, a custom app store, a huge developer community and reliable updates.
       </p>
+      <p><a href="/smartstart" class="p-button--neutral">Launch a smart product with SMART START</a></p>
     </div>
     <div class="col-5 col-start-large-8 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg ",
+          url="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg",
           alt="",
           width="350",
           height="350",


### PR DESCRIPTION
## Done
Add smartstart link to internet-of-things

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things
- Check it matched the [copy docs](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8663
