### PR TITLE
Add smartstart link to digital-signage

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -18,6 +18,7 @@
             <li class="p-list__item is-ticked">Rich ecosystem of hardware and software solutions</li>
             <li class="p-list__item is-ticked">Hundreds of thousands of smart displays already deployed on Ubuntu</li>
           </ul>
+          <p><a href="/smartstart" class="p-button--positive">Build digital signage with SMART START</a></p>
         </div>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hide--small">


### PR DESCRIPTION
## Done
Add smartstart link to digital-signage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/digital-signage
- Check there is a button to smartstart in the intro as of the [copydoc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8667
