### PR TITLE
Fix engage thank-you pages and <space>&nbsp;

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -90,7 +90,7 @@
                     <tr class="p-table__row">
                       <td class="u-no-padding{% if open_subscription == contract['contractInfo']['id'] %} p-table--open"{% endif %}">
                         <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                          {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
+                          {{ contract['contractInfo']['name'] }}&nbsp;<i class="p-icon--contextual-menu">Open</i>
                           {% if contract["renewal"] %}
                             {% if contract["renewal"]["renewable"] or contract["renewal"]["actionable"] == false %}
                               <div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}warning{% endif %}"></i>&nbsp;&nbsp;
@@ -111,7 +111,7 @@
                       <td style="text-transform: capitalize;"><span class="u-truncate" style="padding-top: 0.35rem;">{{ contract['supportLevel'] }}</span></td>
                       <td class="u-align--center {% if default_open_cell %}p-table--open{% endif %}">
                         <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if default_cell_open %}true{% else %}false{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
-                          {{ contract['machineCount'] }} &nbsp;<i class="p-icon--contextual-menu {% if default_open_cell %}u-rotate{% endif %}">Open</i>
+                          {{ contract['machineCount'] }}&nbsp;<i class="p-icon--contextual-menu {% if default_open_cell %}u-rotate{% endif %}">Open</i>
                         </button>
                       </td>
 
@@ -128,7 +128,7 @@
                         {% if contract['entitlements']['livepatch'] == True %}
                         <button class="u-toggle" aria-controls="#expanded-row-livepatch-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
                           <span class="u-truncate">
-                            <i class="p-icon--{% if expired_renewable %}error u-disable{% else %}success{% endif %}"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
+                            <i class="p-icon--{% if expired_renewable %}error u-disable{% else %}success{% endif %}"></i>&nbsp;<i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
                         <span style="padding-top: 0.35rem;">N/A</span>
@@ -137,7 +137,7 @@
                       <td class="u-align--center">
                         {% if contract['entitlements']['fips']  == True or contract['entitlements']['cc-eal']  == True %}
                         <button class="u-toggle" aria-controls="#expanded-row-certifications-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-                          <span class="u-truncate"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}success{% endif %}"></i> &nbsp;<i class="p-icon--contextual-menu">Open</i></span>
+                          <span class="u-truncate"><i class="p-icon--{% if expired_renewable %}error u-disable{% else %}success{% endif %}"></i>&nbsp;<i class="p-icon--contextual-menu">Open</i></span>
                         </button>
                         {% else %}
                         <span style="padding-top: 0.35rem;">N/A</span>
@@ -165,7 +165,7 @@
                                       <td class="u-align--left">
                                         <strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>
                                         {% if contract["contractInfo"]["daysTillExpiry"] >= 0 %}
-                                          &nbsp;&mdash;&nbsp;
+                                         &nbsp;&mdash;&nbsp;
                                           {% if contract["contractInfo"]["daysTillExpiry"] == 0 %}
                                             today
                                           {% elif contract["contractInfo"]["daysTillExpiry"] == 1 %}

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -225,7 +225,7 @@
 
   <div class="u-fixed-width">
     <p class="u-sv3">
-      &nbsp;
+     &nbsp;
     </p>
   </div>
 
@@ -282,7 +282,7 @@
 
   <div class="u-fixed-width">
     <p class="u-sv3">
-      &nbsp;
+     &nbsp;
 
     </p>
   </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -162,7 +162,7 @@
       <ul class="p-inline-list">
         <li class="p-inline-list__item">
           <a href="/contact-us" class="js-invoke-modal">
-            Let’s talk open source &nbsp;&rsaquo;
+            Let’s talk open source&nbsp;&rsaquo;
           </a>
         </li>
         <li class="p-inline-list__item">

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -139,7 +139,7 @@
 
         <div class="row">
           <div class="col-4">
-            <p>Your contribution &nbsp;<span class="p-card" style="padding: .5rem;">&#36;<span class="js-total-amount">16</span></span></p>
+            <p>Your contribution&nbsp;<span class="p-card" style="padding: .5rem;">&#36;<span class="js-total-amount">16</span></span></p>
           </div>
           <div class="u-align--right">
             <input type="hidden" name="cmd" value="_cart">

--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -66,7 +66,7 @@
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>
       <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">Mehr sehen &nbsp;&rsaquo;</a></p>
+      <p><a href="{{page['path']}}">Mehr sehen&nbsp;&rsaquo;</a></p>
     </div>
     {% endfor %}
   </div>

--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -46,7 +46,7 @@
       </p>
       {% else %}
         <p>
-          Discuple, no hemos entendido la petici&oacute; de descarga.  Por favor, inf&oacute;rmanos rellenando <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">este formulario en GitHub</a>. Y dinos qu&eacute; esperabas descargarte.
+          Disculpa, no hemos entendido la petici&oacute; de descarga.  Por favor, inf&oacute;rmanos rellenando <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">este formulario en GitHub</a>. Y dinos qu&eacute; esperabas descargarte.
         </p>
       {% endif %}
     </div>

--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -57,7 +57,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2 class="p-heading--three">Tambi&eacute; te puede interesar &hellip;</h2>
+      <h2 class="p-heading--three">Tambi&eacute;n te puede interesar &hellip;</h2>
     </div>
   </div>
   <div class="row p-divider">

--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -66,7 +66,7 @@
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>
       <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">Ver m&acute;s &nbsp;&rsaquo;</a></p>
+      <p><a href="{{page['path']}}">Ver m&aacute;s&nbsp;&rsaquo;</a></p>
     </div>
     {% endfor %}
   </div>

--- a/templates/engage/shared/_fr_thank-you.html
+++ b/templates/engage/shared/_fr_thank-you.html
@@ -66,7 +66,7 @@
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>
       <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">En savoir plus &nbsp;&rsaquo;</a></p>
+      <p><a href="{{page['path']}}">En savoir plus&nbsp;&rsaquo;</a></p>
     </div>
     {% endfor %}
   </div>

--- a/templates/engage/shared/_it_thank-you.html
+++ b/templates/engage/shared/_it_thank-you.html
@@ -66,7 +66,7 @@
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>
       <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">Vedi altro &nbsp;&rsaquo;</a></p>
+      <p><a href="{{page['path']}}">Vedi altro&nbsp;&rsaquo;</a></p>
     </div>
     {% endfor %}
   </div>

--- a/templates/engage/shared/_pt_thank-you.html
+++ b/templates/engage/shared/_pt_thank-you.html
@@ -39,7 +39,7 @@
     <div class="col-8">
       {% if 'pages.ubuntu.com' in resource_url %}
       <p>
-        {{ resource_name }} est&acute; pronto para download.
+        {{ resource_name | capitalize }} est&aacute; pronto para download.
       </p>
       <p>
         <a class="p-button--positive" href="{{ resource_url }}">Download</a>
@@ -66,7 +66,7 @@
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>
       <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">Ver mais &nbsp;&rsaquo;</a></p>
+      <p><a href="{{page['path']}}">Ver mais&nbsp;&rsaquo;</a></p>
     </div>
     {% endfor %}
   </div>

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -66,7 +66,7 @@
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>
       <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">See more &nbsp;&rsaquo;</a></p>
+      <p><a href="{{page['path']}}">See more&nbsp;&rsaquo;</a></p>
     </div>
     {% endfor %}
   </div>

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -12,7 +12,7 @@
       <h1>Ubuntu leads in hyperscale</h1>
       <p>Ubuntu is the hyperscale OS, natively powering scale-out workloads on a new wave of low-cost, ultra-dense hardware based on x86 and Arm processors.</p>
       <p><a class="p-button--positive" href="/download/server">Download Ubuntu Server</a></p>
-      <p><a href="/download/arm">Download Ubuntu for ARM &nbsp;&rsaquo;</a></p>
+      <p><a href="/download/arm">Download Ubuntu for ARM&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/tests/cassettes/TestRoutes.test_blog.yaml
+++ b/tests/cassettes/TestRoutes.test_blog.yaml
@@ -1216,9 +1216,9 @@ interactions:
         neon<\/a> extension, which makes the latest Qt5 and KDE Frameworks libraries
         available to KBlocks at runtime. The necessary code block [sic] is as follows:<\/p>\n\n\n\n<pre
         class=\"wp-block-preformatted\">\u2026<br>adopt-info: kblocks<br>apps:<br>&nbsp;&nbsp;&nbsp;
-        kblocks:<br>&nbsp; &nbsp; &nbsp;&nbsp;&nbsp; <strong>extensions:<\/strong><strong><br><\/strong><strong>&nbsp;
-        &nbsp; <\/strong><strong>&nbsp;&nbsp;&nbsp; <\/strong><strong>- kde-neon<\/strong><br>&nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; common-id: org.kde.kblocks.desktop<br>...<\/pre>\n\n\n\n<p>But
+        kblocks:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <strong>extensions:<\/strong><strong><br><\/strong><strong>&nbsp;
+       &nbsp; <\/strong><strong>&nbsp;&nbsp;&nbsp; <\/strong><strong>- kde-neon<\/strong><br>&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; common-id: org.kde.kblocks.desktop<br>...<\/pre>\n\n\n\n<p>But
         we need to see what happens behind the scenes.<\/p>\n\n\n\n<p>You can expand
         an extension declaration in any snapcraft.yaml file by running:<\/p>\n\n\n\n<pre
         class=\"wp-block-preformatted\">snapcraft expand-extensions<\/pre>\n\n\n\n<p>This
@@ -1524,22 +1524,22 @@ interactions:
         the connected plugs for the home interface. Similarly, you can also see the
         list of all the interfaces that have at least one plug on your system.<\/p>\n\n\n\n<pre
         class=\"wp-block-preformatted\">snap interface<br>...<br>desktop-legacy&nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows privileged access to desktop legacy
-        methods<br>gsettings &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows privileged access to desktop legacy
+        methods<br>gsettings&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
         allows access to any gsettings item of current user<br>hardware-observe&nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; allows reading information about system hardware<br>home&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows
+       &nbsp;&nbsp;&nbsp;&nbsp; allows reading information about system hardware<br>home&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows
         access to non-hidden files in the home directory<br>kernel-module-control
-        &nbsp; allows insertion, removal and querying of kernel modules<br>log-observe
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows read access to system
-        logs<br>lxd-support &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows
-        operating as the LXD service<br>network &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; allows access to the network<br>network-bind&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows operating as a network service<br>network-control
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows configuring networking and network
-        namespaces<br>network-manager &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows operating
-        as the NetworkManager service<br>opengl&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; allows access to OpenGL stack<br>...<\/pre>\n\n\n\n<p>From
+       &nbsp; allows insertion, removal and querying of kernel modules<br>log-observe
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows read access to system
+        logs<br>lxd-support&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows
+        operating as the LXD service<br>network&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; allows access to the network<br>network-bind&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows operating as a network service<br>network-control
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows configuring networking and network
+        namespaces<br>network-manager&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows operating
+        as the NetworkManager service<br>opengl&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; allows access to OpenGL stack<br>...<\/pre>\n\n\n\n<p>From
         a security and\/or privacy perspective, you can quickly inspect your system
         and determine whether there are any potential gaps in your baseline, or whether
         there are applications that have the ability to utilise resources that you
@@ -1551,134 +1551,134 @@ interactions:
         you can obtain by running <em>snap connections<\/em>. This one-liner allows
         you to see all the connected snaps for each interface, or all the interfaces
         defined for each snap (whether they are connected or not).<\/p>\n\n\n\n<pre
-        class=\"wp-block-preformatted\">snap connections<br>Interface &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; Plug &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; Slot&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; Notes<br>audio-playback&nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; cncra2yr:audio-playback&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :audio-playback &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; -<br>audio-playback&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        libreoffice:audio-playback &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        :audio-playback &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>audio-playback&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; obs-studio:audio-playback&nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :audio-playback &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; -<br>audio-playback&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        vlc:audio-playback &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :audio-playback &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        -<br>audio-record&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; obs-studio:audio-record&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :audio-record
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>browser-support &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; obs-studio:browser-support &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :browser-support&nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; -<br>browser-support &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        spotify:browser-support&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; :browser-support&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        -<br>camera&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        obs-studio:camera&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :camera &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[gtk-3-themes] &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        cncra2yr:gtk-3-themes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-3-themes&nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[icon-themes]&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        cncra2yr:icon-themes &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; gtk-common-themes:icon-themes &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[wine-3-stable]&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        cncra2yr:wine-3-stable &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; wine-platform-3-stable:wine-3-stable&nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[wine-runtime] &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; cncra2yr:wine-runtime&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        wine-platform-runtime:wine-runtime&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        -<br>content[gtk-3-themes] &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; cncra:gtk-3-themes &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-3-themes&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[icon-themes]&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        cncra:icon-themes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; gtk-common-themes:icon-themes &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[wine-3-stable]&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        cncra:wine-3-stable&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; wine-platform-3-stable:wine-3-stable&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[wine-runtime] &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        cncra:wine-runtime &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; wine-platform-runtime:wine-runtime&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[gnome-3-28-1804]&nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        gimp:gnome-3-28-1804 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; gnome-3-28-1804:gnome-3-28-1804 &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>content[gtk-3-themes] &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        gimp:gtk-3-themes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-3-themes&nbsp;<\/pre>\n\n\n\n<p>For
+        class=\"wp-block-preformatted\">snap connections<br>Interface&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Plug&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; Slot&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Notes<br>audio-playback&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; cncra2yr:audio-playback&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :audio-playback&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; -<br>audio-playback&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        libreoffice:audio-playback&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        :audio-playback&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>audio-playback&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; obs-studio:audio-playback&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :audio-playback&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; -<br>audio-playback&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        vlc:audio-playback&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :audio-playback&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        -<br>audio-record&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; obs-studio:audio-record&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :audio-record
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>browser-support&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; obs-studio:browser-support&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :browser-support&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; -<br>browser-support&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        spotify:browser-support&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; :browser-support&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        -<br>camera&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        obs-studio:camera&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :camera&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[gtk-3-themes]&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        cncra2yr:gtk-3-themes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-3-themes&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[icon-themes]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        cncra2yr:icon-themes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; gtk-common-themes:icon-themes&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[wine-3-stable]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        cncra2yr:wine-3-stable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; wine-platform-3-stable:wine-3-stable&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; -<br>content[wine-runtime]&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; cncra2yr:wine-runtime&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        wine-platform-runtime:wine-runtime&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        -<br>content[gtk-3-themes]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; cncra:gtk-3-themes&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-3-themes&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[icon-themes]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        cncra:icon-themes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; gtk-common-themes:icon-themes&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[wine-3-stable]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        cncra:wine-3-stable&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; wine-platform-3-stable:wine-3-stable&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[wine-runtime]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        cncra:wine-runtime&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; wine-platform-runtime:wine-runtime&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[gnome-3-28-1804]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        gimp:gnome-3-28-1804&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; gnome-3-28-1804:gnome-3-28-1804&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>content[gtk-3-themes]&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        gimp:gtk-3-themes&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-3-themes&nbsp;<\/pre>\n\n\n\n<p>For
         instance, you may want to know what the kompoZer snaps requires:<\/p>\n\n\n\n<pre
-        class=\"wp-block-preformatted\">snap connections kompozer<br>Interface &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; Plug&nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; Slot&nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
+        class=\"wp-block-preformatted\">snap connections kompozer<br>Interface&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Plug&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Slot&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
         Notes<br>content[gtk-2-engines]&nbsp; kompozer:gtk-2-engines&nbsp;&nbsp;&nbsp;
-        gtk2-common-themes:gtk-2-engines&nbsp; -<br>content[gtk-2-themes] &nbsp; kompozer:gtk-2-themes
-        &nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-2-themes&nbsp;&nbsp;&nbsp; -<br>content[icon-themes]&nbsp;&nbsp;&nbsp;
-        kompozer:icon-themes&nbsp; &nbsp;&nbsp;&nbsp; gtk-common-themes:icon-themes
-        &nbsp;&nbsp;&nbsp; -<br>desktop &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; kompozer:desktop&nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        :desktop&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; -<br>desktop-legacy&nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        kompozer:desktop-legacy &nbsp; :desktop-legacy &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>home&nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; kompozer:home &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; :home &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<br>removable-media
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; kompozer:removable-media&nbsp; - &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; -<br>unity7&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; kompozer:unity7 &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp;
-        :unity7 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp;&nbsp;&nbsp; -<br>x11 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; kompozer:x11&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp;&nbsp;&nbsp; :x11&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-        &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;&nbsp; -<\/pre>\n\n\n\n<p>When
+        gtk2-common-themes:gtk-2-engines&nbsp; -<br>content[gtk-2-themes]&nbsp; kompozer:gtk-2-themes
+       &nbsp;&nbsp;&nbsp; gtk-common-themes:gtk-2-themes&nbsp;&nbsp;&nbsp; -<br>content[icon-themes]&nbsp;&nbsp;&nbsp;
+        kompozer:icon-themes&nbsp;&nbsp;&nbsp;&nbsp; gtk-common-themes:icon-themes
+       &nbsp;&nbsp;&nbsp; -<br>desktop&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; kompozer:desktop&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        :desktop&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; -<br>desktop-legacy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        kompozer:desktop-legacy&nbsp; :desktop-legacy&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>home&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; kompozer:home&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; :home&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<br>removable-media
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; kompozer:removable-media&nbsp; -&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; -<br>unity7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; kompozer:unity7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        :unity7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp; -<br>x11&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; kompozer:x11&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp; :x11&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -<\/pre>\n\n\n\n<p>When
         it comes to system configuration and inspection, the output provided by this
         command allows you to focus on specific snaps rather than specific resources.
         It can also help you troubleshoot any potential problems with snaps at runtime.<\/p>\n\n\n\n<p>A
@@ -6006,14 +6006,14 @@ interactions:
         patches.<\/p>\n\n\n\n<p>Then, occasionally, you may want to check which snaps
         will update on next refresh. This will give you an indication of the pending
         list of new snap revisions your system will receive:<\/p>\n\n\n\n<pre class=\"wp-block-preformatted\">snap
-        refresh --list<br>Name &nbsp; &nbsp;&nbsp;&nbsp; Version&nbsp; Rev&nbsp;&nbsp;&nbsp;
-        Publisher &nbsp; Notes<br>lxd&nbsp; &nbsp; &nbsp;&nbsp;&nbsp; 4.3&nbsp; &nbsp;&nbsp;&nbsp;
+        refresh --list<br>Name&nbsp;&nbsp;&nbsp;&nbsp; Version&nbsp; Rev&nbsp;&nbsp;&nbsp;
+        Publisher&nbsp; Notes<br>lxd&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 4.3&nbsp;&nbsp;&nbsp;&nbsp;
         16044&nbsp; canonical\u2713&nbsp; -<br>snapcraft&nbsp; 4.1.1&nbsp;&nbsp;&nbsp;
-        5143 &nbsp; canonical\u2713&nbsp; classic<\/pre>\n\n\n\n<p>Now, the full list
+        5143&nbsp; canonical\u2713&nbsp; classic<\/pre>\n\n\n\n<p>Now, the full list
         of installed snaps is longer. For example, the system currently has lxd version
         4.2 installed:<\/p>\n\n\n\n<pre class=\"wp-block-preformatted\">snap list
-        lxd<br>Name&nbsp; Version&nbsp; Rev&nbsp;&nbsp;&nbsp; Tracking &nbsp; &nbsp;&nbsp;&nbsp;
-        Publisher &nbsp; Notes<br>lxd &nbsp; 4.2&nbsp; &nbsp;&nbsp;&nbsp; 15878&nbsp;
+        lxd<br>Name&nbsp; Version&nbsp; Rev&nbsp;&nbsp;&nbsp; Tracking&nbsp;&nbsp;&nbsp;&nbsp;
+        Publisher&nbsp; Notes<br>lxd&nbsp; 4.2&nbsp;&nbsp;&nbsp;&nbsp; 15878&nbsp;
         latest\/stable&nbsp; canonical\u2713&nbsp; -<\/pre>\n\n\n\n<h1>Refresh awareness<\/h1>\n\n\n\n<p>This
         is <a href=\"https:\/\/snapcraft.io\/blog\/experimental-feature-snap-refresh-awareness-and-update-inhibition\">another
         feature<\/a> that you can use to control the updates. In some cases, you may
@@ -6251,7 +6251,7 @@ interactions:
         the environment<\/h3>\n\n\n\n<p>The following line sets the DISPLAY environment
         variable required by X. The display within the container is always mapped
         to &#8221;&#8217;:0&#8221;&#8217;.<br><\/p>\n\n\n\n<pre class=\"wp-block-preformatted\">
-        &nbsp;environment.DISPLAY: :0<br><\/pre>\n\n\n\n<p>Our linux containers will
+       &nbsp;environment.DISPLAY: :0<br><\/pre>\n\n\n\n<p>Our linux containers will
         run under the security context of the current user, but all work within the
         Ubuntu containers will be done under the default <code>ubuntu<\/code> user
         account. The <code>raw.imap<\/code> setting maps our workstation&#8217;s user
@@ -6277,8 +6277,8 @@ interactions:
         \/tmp\/.X11-unix\/X0\n    source: \/tmp\/.X11-unix\/<span style=\"background-color:yellow\">X0<\/span>\n    type:
         disk\n<\/code><\/pre>\n\n\n\n<p>If you have a separate graphics card with
         a discrete GPU, you may also find it necessary to add the GPU as a device:<\/p>\n\n\n\n<pre
-        class=\"wp-block-preformatted\"> &nbsp;mygpu:<br>&nbsp;&nbsp;&nbsp;&nbsp;type:
-        gpu<br> &nbsp;&nbsp;&nbsp;name: gui<br><\/pre>\n\n\n\n<p>To learn more about
+        class=\"wp-block-preformatted\">&nbsp;mygpu:<br>&nbsp;&nbsp;&nbsp;&nbsp;type:
+        gpu<br>&nbsp;&nbsp;&nbsp;name: gui<br><\/pre>\n\n\n\n<p>To learn more about
         running graphical apps in LXD containers, including some caveats when working
         with an NVidia GPU, take a look at <a rel=\"noreferrer noopener\" aria-label=\"
         (opens in a new tab)\" href=\"https:\/\/blog.simos.info\/running-x11-software-in-lxd-containers\/\"
@@ -6291,9 +6291,9 @@ interactions:
         forwarding) is required for either ROS 1 or ROS 2.<br><\/p>\n\n\n\n<p>The
         network interface (nic) device configured here uses macvlan to connect the
         parent network adapter <code>enx001a98a552d4<\/code> to the container&#8217;s
-        eth0 interface:<br><\/p>\n\n\n\n<pre class=\"wp-block-preformatted\"> &nbsp;eth0:<br>&nbsp;&nbsp;&nbsp;&nbsp;name:
+        eth0 interface:<br><\/p>\n\n\n\n<pre class=\"wp-block-preformatted\">&nbsp;eth0:<br>&nbsp;&nbsp;&nbsp;&nbsp;name:
         eth0<br>&nbsp;&nbsp;&nbsp;&nbsp;nictype: macvlan<br>&nbsp;&nbsp;&nbsp;&nbsp;parent:
-        <span style=\"background-color:yellow\">enx001a98a552d4<\/span><br> &nbsp;&nbsp;&nbsp;type:
+        <span style=\"background-color:yellow\">enx001a98a552d4<\/span><br>&nbsp;&nbsp;&nbsp;type:
         nic<br><\/pre>\n\n\n\n<p>Take a look at <a href=\"https:\/\/blog.simos.info\/how-to-make-your-lxd-container-get-ip-addresses-from-your-lan\/\">this
         post<\/a> if you need more information about LXD networking with macvlan.<\/p>\n\n\n\n<p>A
         disk image must be connected to the container. This disk device simply uses
@@ -7079,7 +7079,7 @@ interactions:
         the environment<\/h3>\n\n\n\n<p>The following line sets the DISPLAY environment
         variable required by X. The display within the container is always mapped
         to &#8221;&#8217;:0&#8221;&#8217;.<br><\/p>\n\n\n\n<pre class=\"wp-block-preformatted\">
-        &nbsp;environment.DISPLAY: :0<br><\/pre>\n\n\n\n<p>Our linux containers will
+       &nbsp;environment.DISPLAY: :0<br><\/pre>\n\n\n\n<p>Our linux containers will
         run under the security context of the current user, but all work within the
         Ubuntu containers will be done under the default <code>ubuntu<\/code> user
         account. The <code>raw.imap<\/code> setting maps our workstation&#8217;s user
@@ -7105,8 +7105,8 @@ interactions:
         \/tmp\/.X11-unix\/X0\n    source: \/tmp\/.X11-unix\/<span style=\"background-color:yellow\">X0<\/span>\n    type:
         disk\n<\/code><\/pre>\n\n\n\n<p>If you have a separate graphics card with
         a discrete GPU, you may also find it necessary to add the GPU as a device:<\/p>\n\n\n\n<pre
-        class=\"wp-block-preformatted\"> &nbsp;mygpu:<br>&nbsp;&nbsp;&nbsp;&nbsp;type:
-        gpu<br> &nbsp;&nbsp;&nbsp;name: gui<br><\/pre>\n\n\n\n<p>To learn more about
+        class=\"wp-block-preformatted\">&nbsp;mygpu:<br>&nbsp;&nbsp;&nbsp;&nbsp;type:
+        gpu<br>&nbsp;&nbsp;&nbsp;name: gui<br><\/pre>\n\n\n\n<p>To learn more about
         running graphical apps in LXD containers, including some caveats when working
         with an NVidia GPU, take a look at <a rel=\"noreferrer noopener\" aria-label=\"
         (opens in a new tab)\" href=\"https:\/\/blog.simos.info\/running-x11-software-in-lxd-containers\/\"
@@ -7119,9 +7119,9 @@ interactions:
         forwarding) is required for either ROS 1 or ROS 2.<br><\/p>\n\n\n\n<p>The
         network interface (nic) device configured here uses macvlan to connect the
         parent network adapter <code>enx001a98a552d4<\/code> to the container&#8217;s
-        eth0 interface:<br><\/p>\n\n\n\n<pre class=\"wp-block-preformatted\"> &nbsp;eth0:<br>&nbsp;&nbsp;&nbsp;&nbsp;name:
+        eth0 interface:<br><\/p>\n\n\n\n<pre class=\"wp-block-preformatted\">&nbsp;eth0:<br>&nbsp;&nbsp;&nbsp;&nbsp;name:
         eth0<br>&nbsp;&nbsp;&nbsp;&nbsp;nictype: macvlan<br>&nbsp;&nbsp;&nbsp;&nbsp;parent:
-        <span style=\"background-color:yellow\">enx001a98a552d4<\/span><br> &nbsp;&nbsp;&nbsp;type:
+        <span style=\"background-color:yellow\">enx001a98a552d4<\/span><br>&nbsp;&nbsp;&nbsp;type:
         nic<br><\/pre>\n\n\n\n<p>Take a look at <a href=\"https:\/\/blog.simos.info\/how-to-make-your-lxd-container-get-ip-addresses-from-your-lan\/\">this
         post<\/a> if you need more information about LXD networking with macvlan.<\/p>\n\n\n\n<p>A
         disk image must be connected to the container. This disk device simply uses


### PR DESCRIPTION
## Done

- Fix engage thank-you pages and `<space>&nbsp;`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/es/kubernetes-despliegue-empresa-manual/thank-you and http://0.0.0.0:8001/engage/pt/vmware-para-o-openstack/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the a accute (á) works and 'Whitepaper' are capitalised


## Issue / Card

Fixes #8659

## Screenshots

see a acute
![image](https://user-images.githubusercontent.com/441217/98223667-5d66ef00-1f4a-11eb-8038-62dab7cd5b2c.png)

see capitalised whitepaper
![image](https://user-images.githubusercontent.com/441217/98223716-6a83de00-1f4a-11eb-8d53-2340fca3384f.png)

