### PR TITLE
Gclid in forms

### DIFF
--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -47,6 +47,7 @@
             .replace(/%% lpurl %%/g, formData.lpUrl);
           setProductContext(contactButton);
           setUTMs();
+          setGclid();
           initialiseForm();
           window.CaptchaCallback();
         })
@@ -118,6 +119,15 @@
       var utm_medium = document.getElementById("utm_medium");
       if (utm_medium) {
         utm_medium.value = params.get("utm_medium");
+      }
+    }
+
+    function setGclid() {
+      var gclid_field = document.getElementById("gclid");
+      var gclid = JSON.parse(localStorage.getItem('gclid'));
+      var isGclidValid = new Date().getTime() < gclid.expiryDate;
+      if (gclid && isGclidValid && gclid_field) {
+        gclid_field.value = gclid.value;
       }
     }
 

--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -124,11 +124,11 @@
 
     function setGclid() {
       if (localStorage.getItem("gclid")) {
-        var gclid_field = document.getElementById("gclid");
+        var gclidField = document.getElementById("gclid");
         var gclid = JSON.parse(localStorage.getItem("gclid"));
         var isGclidValid = new Date().getTime() < gclid.expiryDate;
-        if (gclid && isGclidValid && gclid_field) {
-          gclid_field.value = gclid.value;
+        if (gclid && isGclidValid && gclidField) {
+          gclidField.value = gclid.value;
         }
       }
     }

--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -123,9 +123,9 @@
     }
 
     function setGclid() {
-      if (localStorage.getItem('gclid')) {
+      if (localStorage.getItem("gclid")) {
         var gclid_field = document.getElementById("gclid");
-        var gclid = JSON.parse(localStorage.getItem('gclid'));
+        var gclid = JSON.parse(localStorage.getItem("gclid"));
         var isGclidValid = new Date().getTime() < gclid.expiryDate;
         if (gclid && isGclidValid && gclid_field) {
           gclid_field.value = gclid.value;

--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -123,11 +123,13 @@
     }
 
     function setGclid() {
-      var gclid_field = document.getElementById("gclid");
-      var gclid = JSON.parse(localStorage.getItem('gclid'));
-      var isGclidValid = new Date().getTime() < gclid.expiryDate;
-      if (gclid && isGclidValid && gclid_field) {
-        gclid_field.value = gclid.value;
+      if (localStorage.getItem('gclid')) {
+        var gclid_field = document.getElementById("gclid");
+        var gclid = JSON.parse(localStorage.getItem('gclid'));
+        var isGclidValid = new Date().getTime() < gclid.expiryDate;
+        if (gclid && isGclidValid && gclid_field) {
+          gclid_field.value = gclid.value;
+        }
       }
     }
 

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -76,6 +76,7 @@
         <input name="cr" value="" type="hidden">
         <input name="searchstr" value="" type="hidden">
         <input name="_mkt_disp" value="return" type="hidden">
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
         <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
         <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
       </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -228,6 +228,7 @@
               <input name="searchstr" value="" type="hidden">
               <input name="_mkt_disp" value="return" type="hidden">
               <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
               <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
             </div>
           </div>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -111,6 +111,7 @@
               <input type="hidden" aria-hidden="true"
               name="subId" class="mktoField " value="30">
               <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField " value="066-EOV-335">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
               <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
               <input
               type="hidden" aria-hidden="true" name="cr" class="mktoField " value=""><input type="hidden" aria-hidden="true" name="kw" class="mktoField " value=""><input type="hidden" aria-hidden="true" name="q" class="mktoField " value="">

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -76,6 +76,7 @@
               <input type="hidden" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" name="download_asset_url" value="https://assets.ubuntu.com/v1/fe2cb442-IoTSecurityWhitepaper-FinalReport.zip" aria-label="">
               <input type="hidden" name="thankyoumessage" value="Thank you<br />Enjoy the ebook!" aria-lable="">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>
           </ul>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -85,6 +85,7 @@
               <input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/LP-MAAS_eBook.html" aria-label="">
               <input type="hidden" name="download_asset_url" value="https://assets.ubuntu.com/v1/05f610df-eBook_MAAS.pdf.zip" aria-label="">
               <input type="hidden" name="thankyoumessage" value="Thank you<br />Enjoy the ebook!" aria-lable="">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>
           </ul>

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -32,6 +32,7 @@
       <input type="hidden" name="formVid" class="mktoField" value="3485">
       <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
       <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       <input type="hidden" name="return_url" value="https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf" />
     </form>
   </div>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -58,6 +58,7 @@
         <input type="hidden" name="retURL" value="{{ returnURL }}" aria-label="retURL">
         <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="return_url">
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -65,6 +65,7 @@
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
         <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -64,6 +64,7 @@
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
         <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -54,5 +54,6 @@
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{ returnURL }}" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
   </fieldset>
 </form>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -64,6 +64,7 @@
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
         <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -64,6 +64,7 @@
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
         <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/gov/form.html
+++ b/templates/gov/form.html
@@ -220,6 +220,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/internet-of-things/edgex.html
+++ b/templates/internet-of-things/edgex.html
@@ -142,6 +142,7 @@
           <input type="hidden" name="lpurl" value="">
           <input type="hidden" name="ret" value="https://ubuntu.com/internet-of-things/edgex#subscribed">
           <input type="hidden" name="return_url" value="https://ubuntu.com/internet-of-things/edgex#subscribed">
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
           <input type="hidden" name="cr" value="">
           <input type="hidden" name="kw" value="">
           <input type="hidden" name="q" value="">

--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -76,6 +76,7 @@
         <input type="hidden" name="retURL" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
         <input type="hidden" name="return_url" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" aria-label="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </form>
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -108,6 +108,7 @@
         <input type="hidden" name="searchstr" value=""/>
         <input type="hidden" name="_mkt_disp" value="return"/>
         <input type="hidden" name="_mkt_trk" value=""/>
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </form>
 
     <!-- /MARKETO FORM -->

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -79,6 +79,7 @@
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -85,6 +85,7 @@
           <input type="hidden" aria-hidden="true" name="retURL" value="{{returnURL}}" aria-label="retURL" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" aria-label="Consent_to_Processing__c" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -90,6 +90,7 @@
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -25,6 +25,7 @@
         <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
         <input type="hidden" name="ret" value="https://ubuntu.com/openstack/newsletter-thank-you" />
         <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
         <input type="hidden" name="kw" value="" />
         <input type="hidden" name="cr" value="" />
         <input type="hidden" name="searchstr" value="" />

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -31,6 +31,7 @@
         <input type="hidden" name="retURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
         <input type="hidden" name="return_url" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>
     </ul>
   </form>

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -169,6 +169,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -157,6 +157,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -163,6 +163,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -347,6 +347,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -200,6 +200,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -232,6 +232,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -112,6 +112,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -182,6 +182,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -263,6 +263,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -226,6 +226,7 @@
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
           </div>
 
           <div class="pagination">

--- a/templates/shared/forms/interactive/managed-cassandra.html
+++ b/templates/shared/forms/interactive/managed-cassandra.html
@@ -261,6 +261,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -219,6 +219,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -49,6 +49,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -349,6 +349,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -248,6 +248,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -203,6 +203,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -216,6 +216,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -232,6 +232,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -191,6 +191,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -705,6 +705,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -202,6 +202,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/telco.html
+++ b/templates/shared/forms/interactive/telco.html
@@ -296,6 +296,7 @@
               <input type="hidden" aria-hidden="true" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/whitepapers/beta/shared/form.html
+++ b/templates/whitepapers/beta/shared/form.html
@@ -58,6 +58,7 @@
       <input type="hidden" name="formid" aria-label="formid" class="mktoField " value="3261">
       <input type="hidden" name="formVid" aria-label="formVid" class="mktoField " value="3261">
       <input type="hidden" name="munchkinId" aria-label="munchkinId" class="mktoField" value="066-EOV-335">
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
     </li>
   </ul>
 </fieldset>

--- a/templates/whitepapers/shared/form.html
+++ b/templates/whitepapers/shared/form.html
@@ -58,6 +58,7 @@
       <input type="hidden" name="formid" aria-label="formid" class="mktoField " value="3261">
       <input type="hidden" name="formVid" aria-label="formVid" class="mktoField " value="3261">
       <input type="hidden" name="munchkinId" aria-label="munchkinId" class="mktoField" value="066-EOV-335">
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
     </li>
   </ul>
 </fieldset>


### PR DESCRIPTION
## Done

`gclid` is a URL parameter used by Google Ads to follow the conversion status of people who arrived through ads for optimisation purposes. GTM captures it if present in URLs and stores it in localstorage, only if the cookie policy has been accepted at the maximum level.

- Added support in forms for gclid, injected by GTM if today < `expiryDate` 
- Added gclid capture from localstorage in modal forms (no event GTM can use to inject gclid when the form loads) if today < `expiryDate` 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- **Use [this demo link](https://ubuntu-com-8672.demos.haus/openstack/consulting?utm_source=google_ad&utm_campaign=7013z000001GHPGAA4&cmp_id=10427889240&adg_id=104519439518&kwd=ubuntu%20support&device=c&gclid=foobar) to pretend you are coming from an ad seen on Google.**
1. Open the first contact form you encounter on the page, navigate to the end and ensure the form contains a `gclid` hidden field with the value "foobar"
2. Navigate to any blog post. Ensure the newsletter form contains the same hidden field with the same value.
3. Test on /download/server/ -> Option 3 -> CLI cheatsheet download form
4. Test on /engage/es/guia-para-la-implementacion-de-openstack
5. Test on https://ubuntu-com-8672.demos.haus/contact-us/form?product=generic-contact-us
6. Inspect the locally stored `gclid` value, it should be a bit of JSON with two keys: `value: foobar` and `expiryDate: <timestamp +90 days>`. 

