### PR TITLE
Remove secrets for discourse

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -36,16 +36,6 @@ env:
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-  - name: DISCOURSE_API_KEY
-    secretKeyRef:
-      key: api-key
-      name: discourse-api
-
-  - name: DISCOURSE_API_USERNAME
-    secretKeyRef:
-      key:  api-username
-      name: discourse-api
-
 memoryLimit: 512Mi
 
 extraHosts:


### PR DESCRIPTION
## Done

We keep making authenticated API calls even if the endpoints are public
This might cause an outage due to the limit of requests from discourse

## QA

- Make sure site deploys well to demo
