### PR TITLE
get first invoice in renewal invoice array, not the last

### DIFF
--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -367,7 +367,7 @@ function handleIncompleteRenewal(renewal) {
   let paymentIntentStatus;
   let subscriptionStatus;
 
-  if (renewal.stripeInvoices) {
+  if (renewal.stripeInvoices && renewal.stripeInvoices.length > 0) {
     invoice = renewal.stripeInvoices[0];
     paymentIntentStatus = invoice.pi_status;
     subscriptionStatus = invoice.subscription_status;

--- a/static/js/src/renewal-modal.js
+++ b/static/js/src/renewal-modal.js
@@ -368,7 +368,7 @@ function handleIncompleteRenewal(renewal) {
   let subscriptionStatus;
 
   if (renewal.stripeInvoices) {
-    invoice = renewal.stripeInvoices[renewal.stripeInvoices.length - 1];
+    invoice = renewal.stripeInvoices[0];
     paymentIntentStatus = invoice.pi_status;
     subscriptionStatus = invoice.subscription_status;
   }


### PR DESCRIPTION
## Done

Sentry flagged an [error](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/11588/events/477753/) that the CS team and I investigated, which revealed two small bugs, one for each team. 

In our case, on a payment attempt after a failed payment, we were retrieving the last invoice in an array of invoices attached to the renewal. In fact, the invoices are ordered by most recently updated, so we need to retrieve the first invoice in the array.

On the CS team side, the bug is that when one invoice is updated, all invoices are updated with the same date. It may take some time for the API to be updated with their fix, otherwise we could just loop over those dates and find the most recent, but they've [guaranteed](https://github.com/CanonicalLtd/ua-contracts/pull/1407/files#diff-4ce018d50024abc71e9a0b7e7526397943b3843d617f8074d581d9fef06a430dR1797) that the first invoice in the array is what we need.

This is tricky to QA, but it was confirmed by @alnvdl that this is the fix, so a code review should suffice:
> so, you should rely on the first invoice in the list, it's sorted by most recently updated to least recently updated. So the first will will always be the one of the last attempt at renewing.
