### PR TITLE
WIP: Support git+ protocol in requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 FROM ubuntu:focal AS python-dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools python3-wheel build-essential
 ADD requirements.txt /tmp/requirements.txt
+RUN if grep -q git+ /tmp/requirements.txt; then apt-get install --yes --no-install-recommends git; fi
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
 
 


### PR DESCRIPTION
We often want to demo a change from a module branch, and the simplest
way to do it is to include a line in requirements.txt like
`git+git://github.com/owner/repo@branch#module`

This was failing in demos because the docker image doesn't install git,
which is needed.

This will optionally install git if it notices that the requirements.txt
includes a git+ line.

## QA

Put the following line in requirements.txt, to replace the `canonicalwebteam.discourse` line:

```
git+https://github.com/canonical-web-and-design/canonicalwebteam.discourse@master#egg=canonicalwebteam.discourse
```

Then do `docker build .`. See that it succeeds, after installing Git.
