### PR TITLE
Authentication clean-up

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,11 +27,8 @@ jobs:
         run: DOCKER_BUILDKIT=1 docker build --tag ubuntu-com .
 
       - name: Run image
-        env:
-          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
-          DISCOURSE_API_USERNAME: ${{ secrets.DISCOURSE_API_USERNAME }}
         run: |
-          docker run --detach --env DISCOURSE_API_KEY="$DISCOURSE_API_KEY" --env DISCOURSE_API_USERNAME="$DISCOURSE_API_USERNAME" --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres ubuntu-com
+          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres ubuntu-com
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 
@@ -66,11 +63,8 @@ jobs:
         run: /snap/bin/dotrun build
 
       - name: Run dotrun
-        env:
-          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
-          DISCOURSE_API_USERNAME: ${{ secrets.DISCOURSE_API_USERNAME }}
         run: |
-          /snap/bin/dotrun --env DISCOURSE_API_KEY="$DISCOURSE_API_KEY" --env DISCOURSE_API_USERNAME="$DISCOURSE_API_USERNAME" &
+          /snap/bin/dotrun &
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8001
 
   lint-scss:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -77,8 +77,6 @@ from webapp.security.views import (
 CAPTCHA_TESTING_API_KEY = os.getenv(
     "CAPTCHA_TESTING_API_KEY", "6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
 )
-DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
-DISCOURSE_API_USERNAME = os.getenv("DISCOURSE_API_USERNAME")
 
 # Set up application
 # ===
@@ -101,16 +99,8 @@ app.config["CANONICAL_LOGIN_URL"] = os.getenv(
 ).rstrip("/")
 
 session = talisker.requests.get_session()
-authenticated_session = talisker.requests.get_session()
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/", session=session
-)
-
-authenticated_discourse_api = DiscourseAPI(
-    base_url="https://discourse.ubuntu.com/",
-    session=authenticated_session,
-    api_key=os.getenv("DISCOURSE_API_KEY"),
-    api_username=os.getenv("DISCOURSE_API_USERNAME"),
 )
 
 
@@ -282,8 +272,6 @@ engage_pages = EngagePages(
         api=DiscourseAPI(
             base_url="https://discourse.ubuntu.com/",
             session=session,
-            api_key=DISCOURSE_API_KEY,
-            api_username=DISCOURSE_API_USERNAME,
         ),
         index_topic_id=17229,
         url_prefix=engage_path,


### PR DESCRIPTION
## Done

- Cleanup leftovers of authentication
- Remove unnecessary files that came from authentication

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that everything works e.g. `/engage`, `/takeovers`, `/advantage` anything that comes to your mind that may affect sessions


## Issue / Card

Fixes #8664
