### PR TITLE
Add ceph and smartstart to footer

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -210,6 +210,8 @@ ceph:
       path: /ceph
     - title: What is Ceph
       path: /ceph/what-is-ceph
+    - title: Docs
+      path: /ceph/docs
 
 publiccloud:
   title: Public cloud

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -11,10 +11,10 @@
           {% with section=nav_sections.openstack %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
-          {% with section=nav_sections.pricing %}
+          {% with section=nav_sections.ceph %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
-          {% with section=nav_sections.raspberrypi %}
+          {% with section=nav_sections.managedapps %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
@@ -31,26 +31,26 @@
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
-          {% with section=nav_sections.desktop %}
+          {% with section=nav_sections.iot %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
-          {% with section=nav_sections.iot %}
+          {% with section=nav_sections.raspberrypi %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
+          {% with section=nav_sections.smartstart %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom">
         <ul class="p-footer__links">
+          {% with section=nav_sections.desktop %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
           {% with section=nav_sections.server %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
-          {% with section=nav_sections.support %}
-          {% include 'templates/_footer_item.html' %}
-          {% endwith %}
           {% with section=nav_sections.security %}
-          {% include 'templates/_footer_item.html' %}
-          {% endwith %}
-          {% with section=nav_sections.managedapps %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
         </ul>
@@ -67,6 +67,12 @@
       </div>
       <div class="p-footer__nav-col col-2 u-no-margin--bottom last-col">
         <ul class="p-footer__links">
+          {% with section=nav_sections.support %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
+          {% with section=nav_sections.pricing %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
           <li class="p-footer__item p-footer__item--spaced">
             <h2 class="p-footer__title p-footer__title-text">
               <span>Sectors</span>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -115,6 +115,8 @@
             <li class="p-list__item"><a href="https://landscape.canonical.com/">Landscape remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>
+            <li class="p-list__item"><a href="/aws">Get Ubuntu Pro on AWS</a></li>
+            <li class="p-list__item"><a href="/azure">Get Ubuntu Pro on Azure</a></li>
           </ul>
         </div>
       </div>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -115,6 +115,8 @@
             <li class="p-list__item"><a href="https://landscape.canonical.com/">Landscape remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>
+            <li class="p-list__item"><a href="/security">Security</a></li>
+            <li class="p-list__item"><a href="https://certification.ubuntu.com">Hardware certification</a></li>
             <li class="p-list__item"><a href="/aws">Get Ubuntu Pro on AWS</a></li>
             <li class="p-list__item"><a href="/azure">Get Ubuntu Pro on Azure</a></li>
           </ul>


### PR DESCRIPTION
## Done

- Add ceph and smartstart to footer
- Add ceph/docs to secondary
- Added ubuntu pro, security and hardware certification to the #enterprise menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph/docs
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that ceph and smartstart are in the footer
- See that 'Docs' is in the ceph secondary nav


## Issue / Card

Fixes #8669

## Screenshots
[secondary nav]
![image](https://user-images.githubusercontent.com/441217/98349887-78049b00-2012-11eb-89ea-b6b97864b823.png)

[footer]
![image](https://user-images.githubusercontent.com/441217/98349861-6c18d900-2012-11eb-8552-5e1af40497c9.png)

[enterprise menu]
![image](https://user-images.githubusercontent.com/441217/98350789-b8184d80-2013-11eb-8eb1-f53521f78447.png)

