### PR TITLE
Update GPU enablement link on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -690,7 +690,7 @@
           Cloud-native workload migration services
         </li>
         <li class="p-list__item is-ticked">
-          GPU enablement for <a href="/ai">AI/ML</a> workloads
+          GPU enablement for <a class="p-link--external" href="https://charmed-kubeflow.io">AI/ML workloads on K8s</a>
         </li>
         <li class="p-list__item is-ticked">
           <a href="https://maas.io/" class="p-link--external">Bare metal</a>, <a href="/openstack">OpenStack</a> and VMware


### PR DESCRIPTION
## Done

- Update GPU enablement link on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit?ts=5fa543b9#)


## Issue / Card

Fixes #8689

## Screenshots

![image](https://user-images.githubusercontent.com/441217/98371535-3a186e80-2034-11eb-91a2-adb137e7d0be.png)

