### PR TITLE
Redirect buy.ubuntu.com to /advantage

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -54,6 +54,7 @@ extraHosts:
   - domain: webapps.ubuntu.com
   - domain: ubuntuserver.org
   - domain: developer.ubuntu.com
+  - domain: buy.ubuntu.com
 
 # Overrides for production
 production:
@@ -103,6 +104,9 @@ production:
   nginxConfigurationSnippet: |
     if ($host = 'apps.ubuntu.com' ) {
       rewrite ^ https://snapcraft.io/ permanent;
+    }
+    if ($host = 'buy.ubuntu.com' ) {
+      rewrite ^ https://ubuntu.com/advantage permanent;
     }
     if ($host = 'cloud.ubuntu.com' ) {
       rewrite ^ https://ubuntu.com/public-cloud$request_uri? permanent;


### PR DESCRIPTION
Set up the ubuntu.com ingress to listen for buy.ubuntu.com.

This domain will be pointed at the ubuntu.com cluster once
https://portal.admin.canonical.com/C128440
is completed, so this is ready for when that happens.

Visitors coming from buy.ubuntu.com will be redirected to
/advantage.

## QA

Not sure how to QA. You could do it using microk8s, but I can't remember exactly how the tooling for this works right now.
