### PR TITLE
Change copy on AWS page

### DIFF
--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -12,7 +12,7 @@
         <h1>Ubuntu on AWS</h1>
         <p>Whether you are moving to Amazon Web Services or are already running cloud-native, Ubuntu is the platform of choice for AWS.</p>
         <p>Canonical continuously tracks and delivers updates to Ubuntu images to ensure security and stability are built-in from the moment your machines and containers launch.</p>
-        <p>Today, Ubuntu powers billions of compute hours yearly of innovative and mission-critical workloads.</p>
+        <p>Today, Ubuntu powers billions of mission-critical workloads.</p>
         <a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on AWS</a>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -97,7 +97,7 @@
   <div class="row">
     <div class="col-6">
       <h2>Choose the right Ubuntu for you</h2>
-      <p>Select between standard Ubuntu Server and the Pro edition, which includes expanded security and AWS integration:</p>
+      <p>Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and AWS integration:</p>
     </div>
   </div>
 
@@ -150,7 +150,7 @@
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">Security built in</h3>
-      <p>Our security teams tracks alerts 24x7 and releases patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.</p>
+      <p>Our security teams track alerts 24x7 and release patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.</p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--four">All the bits you need</h3>


### PR DESCRIPTION
## Done

- Changed the copy on the AWS page according to the comments on the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #8695

My first PR 🥳