### PR TITLE
UA shop: add marketo form

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -514,6 +514,23 @@ function analyticsFriendlyProducts() {
   return products;
 }
 
+function getSessionData(key) {
+  const keyValue = localStorage.getItem(key);
+
+  if (keyValue) {
+    if (key === "gclid") {
+      const gclid = JSON.parse(keyValue);
+      const isGclidValid = new Date().getTime() < gclid.expiryDate;
+      if (gclid && isGclidValid) {
+        return gclid.value;
+      }
+    } else {
+      return keyValue;
+    }
+  }
+  return;
+}
+
 function handleIncompletePayment(invoice) {
   if (invoice.pi_status === "requires_payment_method") {
     // the user's original payment method failed,
@@ -719,7 +736,7 @@ function handleSuccessfulPayment(transaction) {
     "Payment complete. One moment...";
   progressIndicator.classList.remove("u-hide");
 
-  reloadPage();
+  submitMarketoForm();
 }
 
 function hideErrors() {
@@ -923,6 +940,33 @@ function showPayMode() {
   addPaymentMethodButton.disabled = true;
   processPaymentButton.disabled = true;
   termsCheckbox.checked = false;
+}
+
+function submitMarketoForm() {
+  let request = new XMLHttpRequest();
+  let formData = new FormData();
+
+  formData.append("munchkinId", "066-EOV-335");
+  formData.append("formid", 3756);
+  formData.append("formVid", 3756);
+  formData.append("Email", customerInfo.email);
+  formData.append("Consent_to_Processing__c", "yes");
+  formData.append("GCLID__c", getSessionData("gclid"));
+  formData.append("utm_campaign", getSessionData("utm_campaign"));
+  formData.append("utm_source", getSessionData("utm_source"));
+  formData.append("utm_medium", getSessionData("utm_medium"));
+
+  request.open(
+    "POST",
+    "https://app-sjg.marketo.com/index.php/leadCapture/save2"
+  );
+  request.send(formData);
+
+  request.onreadystatechange = () => {
+    if (request.readyState === 4) {
+      reloadPage();
+    }
+  };
 }
 
 function toggleModal() {

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -16,7 +16,6 @@
         </div>
 
         <form class="p-form p-form--stacked u-sv3" id="details-form">
-
           <div class="p-form__group row u-no-padding u-vertically-center">
             <div class="col-3">
               <label class="u-no-padding--top">Payment card:</label>
@@ -124,7 +123,6 @@
               <small>e.g. GB 123 1234 12 123 or GB 123 4567 89 1234</small>
             </div>
           </div>
-
         </form>
 
         <div id="order-totals" class="u-hide u-sv1">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -744,7 +744,7 @@ def advantage_shop_view():
                     "advantage/subscribe/index.html",
                     account=account,
                     previous_purchase_id=previous_purchase_id,
-                    product_listings=None,
+                    product_listings=[],
                     stripe_publishable_key=stripe_publishable_key,
                 )
             if code != 404:


### PR DESCRIPTION
## Done

Added a marketo form to the payment modal, that triggers on successful payment.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select a product, add it to cart, checkout and use these card details with any address:
  - 4242 4242 4242 4242, expiry: 04/24, CVC: 242, ZIP: 42424
- Open the network tab in dev tools
- Click "Continue", then check the Ts & Cs box, then click "Pay"
- In the network tab, you should see a post request to "https://app-sjg.marketo.com/index.php/leadCapture/save2"
- for Marketo gurus: verify that the form is sending the necessary data
