### PR TITLE
Copy update on IoT page

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -29,99 +29,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered u-no-padding--bottom">
-  <div class="u-fixed-width">
-    <h4 class="p-muted-heading u-align--center">Leading brands choose Ubuntu Core for security, apps and updates</h4>
-    <ul class="p-inline-images u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
-            alt="Dell",
-            width="88",
-            height="88",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/ee23142d-logo-ibm-large.png",
-            alt="IBM",
-            width="110",
-            height="50",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/3cf238fd-Qualcomm-Logo.svg",
-            alt="Qualcomm",
-            width="110",
-            height="25",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/e71bd588-logo-samsung.svg",
-            alt="Samsung",
-            width="110",
-            height="37",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
-            alt="Intel",
-            width="110",
-            height="73",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg",
-            alt="Arm",
-            width="110",
-            height="34",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/45fd87b5-2018-logo-rigado.svg",
-            alt="Rigado",
-            width="140",
-            height="140",
-            hi_def=True,
-            attrs={"class": "p-inline-images__logo", "style": "max-width: 140px; max-height: 140px;"},
-          ) | safe
-        }}
-      </li>
-    </ul>
-  </div>
-</section>
-
-<section class="p-strip--light is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-6 p-tile">
       <div class="row p-tile__row">
@@ -139,7 +47,7 @@
           </div>
         </div>
         <div class="col-3 col-medium-3">
-          <h3>Digital signage</h3>
+          <h3>Signage</h3>
           <p>A small footprint and full OpenGL make Ubuntu Core the perfect platform for secure digital signs.</p>
           <p><a href="/internet-of-things/digital-signage">Learn more&nbsp;&rsaquo;</a></p>
         </div>
@@ -167,7 +75,7 @@
         </div>
       </div>
     </div>
-    <div class="col-6 p-tile">
+    <div class="col-6 p-tile" style="margin-bottom: 64px;">
       <div class="row p-tile__row">
         <div class="col-3 col-medium-3">
           <div class="u-align--center">
@@ -211,10 +119,32 @@
         </div>
       </div>
     </div>
+    <div class="col-6 p-tile">
+      <div class="row p-tile__row">
+        <div class="col-3 col-medium-3">
+          <div class="u-align--center">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/51aec8b1-Networking+equipment.svg",
+                alt="Networking",
+                width="180",
+                height="165",
+                hi_def=True,
+              ) | safe
+            }}
+          </div>
+        </div>
+        <div class="col-3 col-medium-3">
+          <h3>Networking</h3>
+          <p>Build secure SmartNICs and operate them at scale on Ubuntu.</p>
+          <p><a href="/internet-of-things/networking">Learn more&nbsp;&rsaquo;</a></p>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
       <h2>Private App Store included</h2>
@@ -224,23 +154,68 @@
   <div class="u-fixed-width u-hide--small">
     {{
       image(
-        url="https://assets.ubuntu.com/v1/6a4925fa-limenet-appstore.png",
+        url="https://assets.ubuntu.com/v1/43b992df-private-app-store.png",
         alt="Snap store screenshot",
         width="1040",
-        height="641",
+        height="510",
         hi_def=True,
-        attrs={"style": "border-color: #cdcdcd; border-style: solid; border-width: 1px;"},
+        attrs={"class":"p-image--shadowed"},
       ) | safe
     }}
     <p><a href="http://snapcraft.io/store" class="p-link--external">Visit the Snap Store</a></p>
   </div>
 </section>
 
-{% with custom_class="is-bordered" %}
+{% with class="p-strip" %}
   {% include "shared/pricing/_smart-start-prices.html" %}
 {% endwith %}
 
-<section class="p-strip is-bordered">
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Ready&ndash;to&ndash;go gateway solutions</h2>
+    <p>For industrial and enterprise solutions, just add your apps and they&rsquo;ll handle the rest.</p>
+  </div>
+  <ul class="p-inline-images u-no-margin--bottom">
+    <li class="p-inline-images__item">
+      {{
+      image(
+        url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
+        alt="Dell",
+        width="88",
+        height="88",
+        hi_def=True,
+        attrs={"class": "p-inline-images__logo"},
+      ) | safe
+      }}
+    </li>
+    <li class="p-inline-images__item">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c95e6028-rigado-logo.png",
+          alt="Rigado",
+          width="130",
+          height="80",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo", "style": "max-width: 140px; max-height: 140px;"},
+        ) | safe
+      }}
+    </li>
+    <li class="p-inline-images__item">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/582bee22-avantech-logo.png",
+          alt="Avantech",
+          width="170",
+          height="48",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+        ) | safe
+      }}
+    </li>
+  </ul>
+</section>
+
+<section class="p-strip--light">
   <div class="row">
     <div class="col-6">
       <h2>Update Control</h2>
@@ -261,7 +236,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip">
   <div class="row u-equal-height">
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{
@@ -289,7 +264,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-8">
       <h2>Look who&rsquo;s leading</h2>
@@ -321,7 +296,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>From prototype to production on all major platforms</h2>
@@ -342,7 +317,7 @@
       </header>
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Intel NUC, Up2 and TANK</h3>
-      <p class="p-card__content">Intel’s dedicated IoT kits bring 64-bit multi-core processing to the connected device market, for rapid developer engagement and industry-standard code.</p>
+      <p class="p-card__content">Intel&rsquo;s dedicated IoT kits bring 64-bit multi-core processing to the connected device market, for rapid developer engagement and industry-standard code.</p>
       <p class="p-card__content"><a href="https://software.intel.com/en-us/iot/hardware/all" class="p-link--external">Learn more on intel.com</a></p>
     </div>
     <div class="col-6 p-card">
@@ -384,7 +359,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-7">
       <h2>Best for developers</h2>
@@ -405,7 +380,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row u-equal-height">
     <div class="col-4 u-align--left u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Copy update `/internet-of-things`

**Known difference** - SMART START price guide was updated 8 days ago but the screen shot on the [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit?ts=5fa29fb1#heading=h.anmejk5zc0mp) is the old version. Confirmed the updated version is to be used. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit?ts=5fa29fb1#heading=h.anmejk5zc0mp)


## Issue / Card

Fixes [#3422](https://github.com/canonical-web-and-design/web-squad/issues/3422)

