### PR TITLE
Build /aws/outposts page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -115,6 +115,8 @@ aws:
       path: /aws
     - title: Pro
       path: /aws/pro
+    - title: Outposts
+      path: /aws/outposts
     - title: Contact us
       path: /aws/contact-us
       hidden: True

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -183,7 +183,7 @@
               height="170",
               hi_def=True,
               loading="auto",
-              attrs={"class": "u-hide--small;"}
+              attrs={"class": "u-hide--small"}
             ) | safe
           }}
         </div>

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -1,0 +1,201 @@
+{% extends "aws/base_aws.html" %}
+
+{% block title %}Ubuntu Pro & Ubuntu on AWS Outposts{% endblock %}
+{% block meta_description %}The most popular Operating System in the public cloud, running on your premises with a consistent AWS experience. {% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1aXtrGHw7AcZ_qrov3kJahRtgsmbNx7eH5aWFlIySpfE/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-topped">
+    <div class="row u-equal-height">
+      <div class="col-7 col-medium-4">
+        <h1>Ubuntu on AWS Outposts</h1>
+        <p>The most popular operating system in the public cloud, running on your premises with a consistent AWS experience.</p>
+        <p>Security, compliance and support available for all enterprise scenarios.</p>
+        <a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on AWS Outposts</a>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center u-hide--small">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+            alt="",
+            width="200",
+            height="119",
+            hi_def=True,
+            loading="auto",
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h2>Choose the right Ubuntu for you</h2>
+      <p>Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and AWS integration:</p>
+    </div>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title">Ubuntu</h3>
+      <p class="p-heading--two">Free to use</p>
+      <hr class="u-sv1">
+      <div class="p-card__content">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">AWS service ready solution for AWS Outposts</li>
+          <li class="p-list__item is-ticked">AWS-optimised kernel and userspace components built from the latest releases</li>
+          <li class="p-list__item is-ticked">Broad set of open source application components available for development</li>
+          <li class="p-list__item is-ticked">Security patches for the kernel and key infrastructure components</li>
+          <li class="p-list__item is-ticked">Updates mirrored and images published in all AWS regions worldwide</li>
+          <li class="p-list__item is-ticked">5-year lifetime</li>
+        </ul>
+        <p><a href="https://aws.amazon.com/marketplace/pp/B087QQNGF1" class="p-link--external">Run Ubuntu Server 20.04 LTS</a></p>
+      </div>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title">Ubuntu Pro for AWS</h3>
+      <p class="p-heading--two">Starting at 0.1c/hour</p>
+      <hr class="u-sv1">
+      <div class="p-card__content">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">AWS service ready solution for AWS Outposts</li>
+          <li class="p-list__item is-ticked">Includes all Ubuntu optimisations and updates of the free version</li>
+          <li class="p-list__item is-ticked">Expanded security covering application components delivered with Ubuntu, including  Apache Kafka, NGINX, MongoDB, Redis and PostgreSQL</li>
+          <li class="p-list__item is-ticked">Kernel live patching for instant security and longer uptimes</li>
+          <li class="p-list__item is-ticked">FIPS 140-2 and CC-EAL certified components</li>
+          <li class="p-list__item is-ticked">10-year lifetime</li>
+        </ul>
+        <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 20.04 LTS</span></a></p>
+        <p><a href="/aws/pro">More about Ubuntu Pro for AWS&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2>Features</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">Optimised</h3>
+      <p>Ubuntu on AWS Outposts runs on an AWS-optimised kernel, which includes improved device drivers, like <a class="p-link--external" href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html">ENA</a>, and out of the box support for accelerators like GPUs. This means faster instance starts and better runtime performance for your workloads.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">Security built in</h3>
+      <p>Our security teams track alerts 24x7 and release- patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.</p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--four">Compliance ready</h3>
+      <p>Ubuntu Pro for AWS offers  long term maintenance, compliance (FIPS, CIS), expanded security coverage and optional 24x7 support;  covering any extra requirements you have for your on-premises workloads.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-sv2">
+    <div class="col-12">
+      <h2>Get Ubuntu on AWS Outposts now:</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-link--external">20.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-link--external">18.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-link--external">16.04 LTS</a></h3>
+    </div>
+  </div>
+  <div class="row u-sv2">
+    <div class="col-12">
+      <h2>Get Ubuntu Pro on AWS Outposts now:</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-link--external">20.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-link--external">18.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-link--external">18.04 FIPS LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-link--external">16.04 LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-link--external">16.04 FIPS LTS</a></h3>
+    </div>
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B0821V7QJP" class="p-link--external">14.04 LTS</a></h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p class="u-no-margin--bottom"><strong>Read more about</strong> <a href="/aws/pro">Ubuntu Pro&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="u-sv2">Launching Ubuntu on AWS Outposts</h2>
+    <ol class="p-stepped-list">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          Select the region your AWS Outpost is attached
+        </h3>
+        <div class="p-stepped-list__content">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/78ea4b05-aws-outposts-regions.png",
+              alt="",
+              width="300",
+              height="150",
+              hi_def=True,
+              loading="auto",
+            ) | safe
+          }}
+        </div>
+      </li>
+    
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          Select the Ubuntu version you want to launch
+        </h3>
+        <div class="p-stepped-list__content">
+        <p>Launch an EC2 instance and select Ubuntu from the instance launch quickstart, or visit the marketplace for more Ubuntu options.</p>
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/03238ea8-aws-outputs-ubuntu-image.png",
+              alt="",
+              width="940",
+              height="170",
+              hi_def=True,
+              loading="auto",
+            ) | safe
+          }}
+        </div>
+      </li>
+    
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">
+          Select the VPC your AWS Outposts resides
+        </h3>
+      <p class="p-stepped-list__content">When configuring the instance launch, make sure to select the network for your Outpost, and your instance will automatically be launched.</p>
+      </li>
+    </ol>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -183,6 +183,7 @@
               height="170",
               hi_def=True,
               loading="auto",
+              attrs={"class": "u-hide--small;"}
             ) | safe
           }}
         </div>

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -17,10 +17,10 @@
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+            url="https://assets.ubuntu.com/v1/6c8b8dd4-AWS-outposts.svg",
             alt="",
             width="200",
-            height="119",
+            height="220",
             hi_def=True,
             loading="auto",
           ) | safe


### PR DESCRIPTION
## Done

- Build `aws/outposts`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/outposts
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page matches [copy doc](https://docs.google.com/document/d/1aXtrGHw7AcZ_qrov3kJahRtgsmbNx7eH5aWFlIySpfE/edit#), and follows the design of [ubuntu.com/aws](https://ubuntu.com/aws)
- Banner image design [here](https://github.com/canonical-web-and-design/ubuntu.com/issues/8704#issuecomment-724621254)


## Issue / Card

Fixes #8705 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/98681612-d4d9bb80-235a-11eb-9d0c-3c0f01343572.png)

