### PR TITLE
Remove TCO calculator from /kubernetes secondary nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -283,8 +283,6 @@ kubernetes:
       path: /kubernetes/features
     - title: Managed
       path: /kubernetes/managed
-    - title: TCO calculator
-      path: /tco-calculator
     - title: Install
       path: /kubernetes/install
     - title: Docs


### PR DESCRIPTION
## Done

- Remove TCO calculator from /kubernetes secondary nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes
- Compare against [live site](https://ubuntu.com/kubernetes) and check TCO calculator is no longer visible on secondary nav

## Issue / Card

Fixes [#3439](https://github.com/canonical-web-and-design/web-squad/issues/3439)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/98697402-cdbba900-236c-11eb-8068-ce1c9ce1a859.png)

