### PR TITLE
Copy update on digital signage

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -6,13 +6,13 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip is-deep is-bordered u-no-padding--top u-no-padding--bottom">
+<div class="p-strip is-deep u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-image">
     <div class="row u-equal-height">
       <div class="col-7">
         <h1>Digital signage and smart <br class="u-hide--large u-hide--medium">displays on Ubuntu</h1>
         <div class="row">
-          <ul class="p-list col-5">
+          <ul class="p-list col-7">
             <li class="p-list__item is-ticked">Easy out-of-the-box standard kiosk solution on Ubuntu</li>
             <li class="p-list__item is-ticked">Secure, reliable and remotely upgradable</li>
             <li class="p-list__item is-ticked">Rich ecosystem of hardware and software solutions</li>
@@ -37,7 +37,7 @@
   </div>
 </div>
 
-<div class="p-strip--light is-deep is-bordered">
+<div class="p-strip--light is-deep">
   <div class="u-fixed-width">
     <h2>Learn more about digital signage on Ubuntu</h2>
   </div>
@@ -239,7 +239,7 @@
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Innovation in digital signage</h2>
@@ -327,8 +327,8 @@
 
     <div class="col-8 u-vertically-center">
       <div>
-        <h2>Let&rsquo;s work together</h2>
-        <p>Talk to us if you are thinking about using Ubuntu Core for your next Internet of Things project.</p>
+        <h2>Build your own digital signage solution</h2>
+        <p>Ubuntu Core is entirely open source and supports a range of digital signage players. Just install it on a Raspberry Pi or NUC, download the app of your choice, create an account and you’re ready to go.</p>
         <p><a class="p-button--positive js-invoke-modal" href="/internet-of-things/contact-us?product=digital-signage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Digital Signage Page - Build your own', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Get in touch</a></p>
       </div>
     </div>

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -328,7 +328,7 @@
     <div class="col-8 u-vertically-center">
       <div>
         <h2>Build your own digital signage solution</h2>
-        <p>Ubuntu Core is entirely open source and supports a range of digital signage players. Just install it on a Raspberry Pi or NUC, download the app of your choice, create an account and you’re ready to go.</p>
+        <p>Ubuntu Core is entirely open source and supports a range of digital signage players. Just install it on a Raspberry Pi or Intel NUC, download the app of your choice, create an account and you’re ready to go.</p>
         <p><a class="p-button--positive js-invoke-modal" href="/internet-of-things/contact-us?product=digital-signage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Digital Signage Page - Build your own', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Get in touch</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Copy update on `/internet-of-things/digital-signage`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/digital-signage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit?ts=5fa2a0a6#)

## Issue / Card

Fixes [#3423](https://github.com/canonical-web-and-design/web-squad/issues/3423)

