### PR TITLE
Copy update on /security-series

### DIFF
--- a/templates/security-series/index.html
+++ b/templates/security-series/index.html
@@ -95,7 +95,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">FIPS certification and CIS compliance with Ubuntu</p>
       <p>Learn about Ubuntu CIS and FIPS certified components to enable operating  under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered to ensure you and your team are, and remain, compliant.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/432536">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/432536">Watch on-demand</a>
     </div>
     <div class="col-4">
       <p>
@@ -112,7 +112,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Best practices for securing open source</p>
       <p>In this webinar learn about the common security and compliance issues with open source, five best practices the Ubuntu Security Team implements and how you can ensure the security integrity of your Ubuntu systems.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Watch on-demand</a>
     </div>
     <div class="col-4">
       <p>
@@ -198,7 +198,7 @@ Security and compliance for the full stack{% endblock %}
       <p class="p-heading--4">Security, Cloud Native & Confidential Computing on IBM Z & LinuxONE with 20.04</p>
       <p>With constant threats of cyber attacks and data breaches, now more than ever there is a need for workload isolation, data encryption, trusted execution environments and other security practices and tools to protect systems and containers. </p>
       <p>In this webinar, learn how Ubuntu enables Confidential Computing and IBM Z & LinuxONE capabilities to secure cloud service providers and public cloud consumers.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440529">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440529">Watch on-demand</a>
     </div>
     <div class="col-6">
       <p>
@@ -215,7 +215,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Ubuntu Core: A cybersecurity analysis</p>
       <p>We provide substantial documentation and content to share and support the Ubuntu Core architecture and approach, but we don’t want anyone to have to take our word for it when choosing Ubuntu: We brought in Rule4 for an independent, third-party review of Ubuntu Core’s security architecture controls.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/402503">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/402503">Watch on-demand</a>
     </div>
   </div>
 </section>
@@ -228,7 +228,7 @@ Security and compliance for the full stack{% endblock %}
       <p class="u-sv2">This webinar series is for those operating in heavily-regulated industries looking to meet FedRAMP, HIPAA, PCI and ISO compliance regimes. </p>
     </div>
   </div>
-  <div class="row u-equal-height">
+  <div class="row u-equal-height u-sv3">
     <div class="col-6">
       <p>
         {{
@@ -243,8 +243,8 @@ Security and compliance for the full stack{% endblock %}
       }}
       </p>
       <p class="p-heading--4">FIPS certification and CIS compliance with Ubuntu</p>
-      <p>Learn about Ubuntu CIS and FIPS certified components to enable operating  under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered to ensure you and your team are, and remain, compliant.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/432536">Register for the webinar</a>
+      <p>Learn about Ubuntu CIS and FIPS certified components to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered to ensure you and your team are, and remain, compliant.</p>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Watch on-demand</a>
     </div>
     <div class="col-6">
       <p>
@@ -264,6 +264,42 @@ Security and compliance for the full stack{% endblock %}
       <p>Furthermore, learn how Ubuntu helps organisations remain compliant with government and industry standards and regulations, including Common Criteria EAL2 with FIPS 140-2 Level 1 certified crypto modules.
       </p>
       <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440517">Register for the webinar</a>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <p>
+        {{
+        image(
+          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+          alt="aws",
+          height="80",
+          width="135",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
+      </p>
+      <p class="p-heading--4">Ubuntu Pro FIPS on AWS</p>
+      <p>This webinar introduces our <a class="/aws/pro">FIPS certified Ubuntu Pro images</a> available now on AWS to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Register to put your FIPS public cloud compliance concerns at ease.</p>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/449853">Watch on-demand</a>
+    </div>
+    <div class="col-6">
+      <p>
+        {{
+        image(
+          url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
+          alt="Microsoft Azure",
+          height="70",
+          width="230",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
+      </p>
+      <p class="p-heading--4">Ubuntu Pro FIPS on Azure</p>
+      <p>This webinar introduces our FIPS certified Ubuntu Pro images available now on Microsoft Azure to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Register to learn how you can get compliance made easy on Azure.</p>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/452063">Register for the webinar</a>
     </div>
   </div>
 </section>
@@ -309,7 +345,7 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Ubuntu Core: A cybersecurity analysis</p>
       <p>We provide substantial documentation and content to share and support the Ubuntu Core architecture and approach, but we don’t want anyone to have to take our word for it when choosing Ubuntu: We brought in Rule4 for an independent, third-party review of Ubuntu Core’s security architecture controls.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/402503">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/402503">Watch on-demand</a>
     </div>
   </div>
 </section>
@@ -358,7 +394,7 @@ Security and compliance for the full stack{% endblock %}
       <p class="p-heading--4">Security, Cloud Native & Confidential Computing on IBM Z & LinuxONE with 20.04</p>
       <p>With constant threats of cyber attacks and data breaches, now more than ever there is a need for workload isolation, data encryption, trusted execution environments and other security practices and tools to protect systems and containers. </p>
       <p>In this webinar, learn how Ubuntu enables Confidential Computing and IBM Z & LinuxONE capabilities to secure cloud service providers and public cloud consumers.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440529">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/440529">Watch on-demand</a>
     </div>
   </div>
 </section>
@@ -371,8 +407,44 @@ Security and compliance for the full stack{% endblock %}
       <p class="u-sv2">This webinar series is for those interested in compliance and security for their AWS and Azure public cloud instances.</p>
     </div>
   </div>
+  <div class="row u-equal-height u-sv3">
+    <div class="col-6">
+      <p>
+        {{
+        image(
+          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+          alt="aws",
+          height="80",
+          width="135",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
+      </p>
+      <p class="p-heading--4">Ubuntu Pro FIPS on AWS</p>
+      <p>This webinar introduces our <a class="/aws/pro">FIPS certified Ubuntu Pro images</a> available now on AWS to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Register to put your FIPS public cloud compliance concerns at ease.</p>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/449853">Watch on-demand</a>
+    </div>
+    <div class="col-6">
+      <p>
+        {{
+        image(
+          url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
+          alt="Microsoft Azure",
+          height="70",
+          width="230",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
+      </p>
+      <p class="p-heading--4">Ubuntu Pro FIPS on Azure</p>
+      <p>This webinar introduces our FIPS certified Ubuntu Pro images available now on Microsoft Azure to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Register to learn how you can get compliance made easy on Azure.</p>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/452063">Register for the webinar</a>
+    </div>
+  </div>
   <div class="row u-equal-height">
-    <div class="col-10">
+    <div class="col-6">
       <p>
         {{
         image(
@@ -402,7 +474,7 @@ Security and compliance for the full stack{% endblock %}
     </div>
   </div>
   <div class="row u-equal-height">
-    <div class="col-10">
+    <div class="col-6">
       <p>
         {{
         image(
@@ -417,7 +489,40 @@ Security and compliance for the full stack{% endblock %}
       </p>
       <p class="p-heading--4">Best practices for securing open source</p>
       <p>In this webinar learn about the common security and compliance issues with open source, five best practices the Ubuntu Security Team implements and how you can ensure the security integrity of your Ubuntu systems.</p>
-      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Register for the webinar</a>
+      <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/445555">Watch on-demand</a>
+    </div>
+    <div class="col-6">
+      <p>
+        {{
+        image(
+          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+          alt="aws",
+          height="70",
+          width="120",
+          hi_def=True,
+          loading="auto",
+          attrs={"style":"margin-right: 24px"}
+        ) | safe
+      }}
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
+          alt="Microsoft Azure",
+          height="70",
+          width="235",
+          hi_def=True,
+          loading="auto",
+        ) | safe
+      }}
+      </p>
+      <p class="p-heading--four">Securing public cloud instances</p>
+      <p>Tracking high and critical CVEs on the public cloud can be difficult, but Ubuntu Pro images on <a href="/aws/pro">AWS</a> and <a href="/azure/pro">Azure</a> include security coverage for all software packages shipped with Ubuntu. These premium images are ideal for teams that have embraced open source and need to remain compliant with government and industry standards and regulations. Register for our upcoming webinars and be confident when rolling out packages to production with Ubuntu Pro, and Ubuntu Pro FIPS images</p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/449853">Register for the Ubuntu Pro on AWS webinar</a>
+      </p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/452063">Register for the Ubuntu Pro on Azure webinar</a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Fix links for webinars in the past from "Register for the webinar" to "Watch on-demand"
- Add aws and azure sections

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security-series
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1A7JDBRZ_tuEvteE1pVA9_rV-oJUq1_DuT7GmO6zVCXM/edit#) 
- **Note** - some events have happened since copy doc was edited so check date of event, if event has happened link should say "Watch on-demand", if event is in the future link should say "Register for the webinar"


## Issue / Card

Fixes [#3424](https://github.com/canonical-web-and-design/web-squad/issues/3424)

