### PR TITLE
Add education discount on /support

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "webpack-cli": "4.1.0"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.0.5",
+    "@canonical/cookie-policy": "3.0.6",
     "@canonical/global-nav": "2.4.5",
     "@canonical/latest-news": "1.0.4",
     "url-polyfill": "1.1.11",

--- a/templates/shared/_thank_you.html
+++ b/templates/shared/_thank_you.html
@@ -18,6 +18,6 @@
     </div>
   </div>
 </div>
-{% if level_1 == "cloud" or level_1 == "server" or level_1 == "containers" or level_1 == "support" %}
+{% if level_1 == "openstack" or level_1 == "kubernetes" or level_1 == "server" or level_1 == "pricing" or level_1 == "support" %}
 {% include "shared/_thank_you_footer.html" %}
 {% endif %}

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -1,27 +1,26 @@
-<div class="p-strip--light">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-10">
       <h2>More about our enterprise services</h2>
     </div>
   </div>
-
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Ubuntu Advantage</h3>
-      <p>Purchase our desktop support and access Ubuntu experts whenever you need.</p>
-      <p><a class="p-link--external" href="https://buy.ubuntu.com">Buy Ubuntu Advantage</a></p>
+      <h3 class="p-heading--four">Fully managed infrastructure</h3>
+      <p>Canonical offers fully managed infrastructure, including Kubernetes, OpenStack, Ceph and SWIFT storage and the recommended LMA stack.</p>
+      <p><a href="/pricing/infra#managed">Managed open infrastructure&nbsp;&rsaquo;</a></p>
     </div>
-
     <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Ubuntu OpenStack</h3>
-      <p>Learn about Canonical&rsquo;s industry leading, private cloud infrastructure platform based on Openstack.</p>
-      <p><a href="/openstack">Learn about Ubuntu OpenStack&nbsp;&rsaquo;</a></p>
+      <h3 class="p-heading--four">Consulting and deployment</h3>
+      <p>Open infrastructure consulting and training is also provided by Canonical, with optimal and custom architecture design and deployment.</p>
+      <p><a href="/pricing/consulting">Consulting, deployment from Canonical&nbsp;&rsaquo;</a></p>
+      <p><a href="/training">OpenStack, K8s, Kubeflow consulting &amp; training&nbsp;&rsaquo;</a></p>
     </div>
-    
     <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Landscape</h3>
-      <p>Manage Ubuntu in the enterprise with our private cloud infrastructure platform based on OpenStack.</p>
-      <p><a class="p-link--external" href="https://landscape.canonical.com/">Learn about Landscape</a></p>
+      <h3 class="p-heading--four">Infrastructure support &amp; security</h3>
+      <p>Access critical security fixes, legal assurance and phone and ticket support for OpenStack, K8s, Docker, Ceph and more through UA Infrastructure.</p>
+      <p><a href="/pricing/infra">Security maintenance and support&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--external" href="https://buy.ubuntu.com/">Purchase from our store</a></p>
     </div>
   </div>
-</div>
+</section>

--- a/templates/support/contact-us.html
+++ b/templates/support/contact-us.html
@@ -5,6 +5,18 @@
 
 {% block content %}
 
+{% if product == 'education-discount' %}
+
+{% with h1="Contact us about discounts for education and research",
+  intro_text="Considering Ubuntu for your school, research or academic organisation? Just fill in the form below and a member of our team will be in touch.",
+  formid="3762",
+  lpId="2065",
+  returnURL="https://www.ubuntu.com/support/thank-you?product=education-discount" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+{% else %}
+
 {% with h1="Contact Canonical about Ubuntu Advantage",
   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch.",
   formid="1240",
@@ -12,5 +24,10 @@
   returnURL="https://www.ubuntu.com/support/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
+
+{% endif %}
+
+
+
 
 {% endblock content %}

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -254,7 +254,7 @@
     <h2>Apps support</h2>
     <p>Full-stack support for open source apps with quick response time guaranteed through subscription SLAs. Quickly resolve technical support issues with your key applications wherever they are running.</p>
   </div>
-  
+
   <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
@@ -329,8 +329,8 @@
         </span>
       </div>
     </div>
-    
-    <div class="row">    
+
+    <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
           {{
@@ -404,7 +404,7 @@
         </span>
       </div>
     </div>
-    
+
     <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
@@ -479,7 +479,7 @@
         </span>
       </div>
     </div>
-    
+
     <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
@@ -546,8 +546,8 @@
         </span>
       </div>
     </div>
-    
-    <div class="row">      
+
+    <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
           {{
@@ -621,8 +621,8 @@
         </span>
       </div>
     </div>
-    
-    <div class="row">      
+
+    <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
           {{
@@ -696,7 +696,7 @@
         </span>
       </div>
     </div>
-    
+
     <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
@@ -771,7 +771,7 @@
         </span>
       </div>
     </div>
-    
+
     <div class="row">
       <div class="col-3 col-medium-3 p-media-object">
         <span class="p-media-object__image">
@@ -1159,7 +1159,29 @@
   </div>
 </section>
 
-<section class="p-strip is-deep">
+<section class="p-strip is-deep" id="education">
+  <div class="row u-equal-height">
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/a22613fc-train-with-ubuntu_AW.svg",
+            alt="",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>Education discounts</h2>
+      <p>To support those using Ubuntu in schools, research and academia, Canonical is pleased to offer a discount programme for approved institutions. Please mention your interest in this programme in your conversations with our team.</p>
+      <a class="p-button--neutral" href="/support/contact-us?product=education-discount">Contact us</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
   <div class= "row u-equal-height">
     <div class="col-8">
     <h3>ESM maintains Interana's system security while upgrading</h3>
@@ -1185,7 +1207,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-deep" id="stories">
+<section class="p-strip is-deep" id="stories">
   <div class="row u-equal-height">
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
       {{
@@ -1207,7 +1229,7 @@
   </div>
 </section>
 
-<section id="community-support" class="p-strip is-deep">
+<section id="community-support" class="p-strip--light is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Community support</h2>

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -7,54 +7,16 @@
 
 {% block content %}
 
-<section class="p-strip is-bordered is-deep">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h1>Thank you for contacting us about Ubuntu Advantage for Infrastructure</h1>
-      <p class="p-heading--four">A member of our team will be in touch within one working day or you can <a class="p-link--external" href="https://buy.ubuntu.com">visit our store</a> to purchase UA Infrastructure.</p>
-    </div>
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
-      {{
-        image(
-            url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
-            alt="smile",
-            width="200",
-            height="200",
-            hi_def=True,
-            loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
 
-<div class="p-strip--light">
-  <div class="row">
-    <div class="col-10">
-      <h2>More about our enterprise services</h2>
-    </div>
-  </div>
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Fully managed infrastructure</h3>
-      <p>Canonical offers fully managed infrastructure, including Kubernetes, OpenStack, Ceph and SWIFT storage and the recommended LMA stack.</p>
-      <p><a href="/pricing/infra#managed">Managed open infrastructure&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Consulting and deployment</h3>
-      <p>Open infrastructure consulting and training is also provided by Canonical, with optimal and custom architecture design and deployment.</p>
-      <p><a href="/pricing/consulting">Consulting, deployment from Canonical&nbsp;&rsaquo;</a></p>
-      <p><a href="/training">OpenStack, K8s, Kubeflow consulting &amp; training&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--four">Infrastructure support &amp; security</h3>
-      <p>Access critical security fixes, legal assurance and phone and ticket support for OpenStack, K8s, Docker, Ceph and more through UA Infrastructure.</p>
-      <p><a href="/pricing/infra">Security maintenance and support&nbsp;&rsaquo;</a></p>
-      <p><a class="p-link--external" href="https://buy.ubuntu.com/">Purchase from our store</a></p>
-    </div>
-  </div>
-</div>
+{% if product == 'education-discount' %}
 
+  {% with thanks_context="contacting us about discounts for education and research" %}{% include "shared/_thank_you.html" %}{% endwith %}
+
+{% else %}
+
+  {% with thanks_context="contacting us about Ubuntu Advantage for Infrastructure" %}{% include "shared/_thank_you.html" %}{% endwith %}
+
+{% endif %}
 
 {% endblock content %}
 {% block footer_extra %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.5.tgz#99e6d873832016c698534abda10f1ac17df65a3a"
-  integrity sha512-LLb4LnjPSdpR8fNywxpOLsmL5Fm7KbxmpTiJ8Syj+4LqHzB7WPAgR9UsmLebJ8G4BjFx92IHribWUFfOJAD20g==
+"@canonical/cookie-policy@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.6.tgz#2e55298f14b30b3759e1ffb63995dea298c0573b"
+  integrity sha512-UutegWhs6ecmuwUxo5x0MJiyM5hcMiKj6HZzaAg3aeHTr8Mcn3/y8mAgAwpMkBcTHCgJExczrOiGeMSaKHzuHQ==
 
 "@canonical/global-nav@2.4.5":
   version "2.4.5"


### PR DESCRIPTION
## Done

- Add education discount on /support
- Add education variation to the contact-us and thank-you pages
- Update thank-you footer
- Update cookie policy to 3.0.6

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/support#education
    - http://0.0.0.0:8001/support?product=education-discount
    - http://0.0.0.0:8001/support/thank-you?product=education-discount
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the copy docs - [support](https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit#), [contact-us](https://docs.google.com/document/d/1rWgWFGtal7ddDAkIOKtA6M3wXKd7gX-ABQtyhwbqjyk/edit?ts=5fabbd81#heading=h.j6qgadju3bae) and [thank-you](https://docs.google.com/document/d/1Vya-1Uq7bqJ7SFQ36j9-REp1iDT3rFENjYyCzuY02r4/edit?ts=5fabbdcc#heading=h.71jtwy38dsde)


## Issue / Card

Fixes #8718

## Screenshots

![image](https://user-images.githubusercontent.com/441217/98822021-2f8d1900-2428-11eb-95a6-1d658124d43d.png)
