### PR TITLE
Create _smartstart.html product card  for blog posts with IoT tag

### DIFF
--- a/templates/blog/product-cards/_smartstart.html
+++ b/templates/blog/product-cards/_smartstart.html
@@ -1,0 +1,11 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src=https://assets.ubuntu.com/v1/51aec8b1-Networking+equipment.svg" alt="smart start ">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/smartstart">IoT as a service</a>
+  </h3>
+  <p>Bring an IoT device to market fast. Focus on your apps, we handle the rest. Canonical offers hardware bring up, 
+    app integration, knowledge transfer and engineering support to get your first device to market. App store and 
+    security updates guaranteed.</p>
+  <p><a href="/smartstart">Get your IoT device to market fast</a></p>
+</div>


### PR DESCRIPTION
## Done

- Add dynamic blog product cards in place of Marketo RTPs.

- This PR comes with cards for the following blog post:
  - [IoT](https://ubuntu.com/blog/tag/IoT)



- The list of cards is maintained by PMs and Mktg and ongoing card code maintenance will be on Mktg.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the CTA works well& the website linked is correct
-Ensure that the ration between the image& text is correct