### PR TITLE
Create IoT app store product card  for blog posts with IoT tag

### DIFF
--- a/templates/blog/product-cards/_IoT_appstore.html
+++ b/templates/blog/product-cards/_IoT_appstore.html
@@ -1,0 +1,10 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/431b4ca2-ubuntu+core+18+circular+.svg" alt="smart start logo">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/internet-of-things/appstore">IoT app store</a>
+  </h3>
+  <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation.
+  Get a secure, hosted and managed multi-tenant app store for your IoT devices.</p>
+  <p><a href="/internet-of-things/appstore">Build your IoT app ecosystem</a></p>
+</div>


### PR DESCRIPTION
## Done

- Add dynamic blog product cards in place of Marketo RTPs.
  Eg. on blog post tagged `kubeflow`, a list of relevant cards is added to the blog post right column and one is made visible at random. This PR comes with instrumentation to assess CTR on cards.

- This PR comes with cards for the following blog post:
  - [IoT](https://ubuntu.com/blog/tag/IoT)

- The list of cards is maintained by PMs and Mktg and ongoing card code maintenance will be on Mktg.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the CTA works well& the website linked is correct
-Ensure that the ration between the image& text is correct