### PR TITLE
Create _telco.html product card for blog posts with telco tag

### DIFF
--- a/templates/blog/product-cards/_telco.html
+++ b/templates/blog/product-cards/_telco.html
@@ -1,0 +1,14 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="kubernetes logo">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/telco">What is Kubernetes?</a>
+  </h3>
+  <p>Designed with economics in mind, Canonical’s solutions for telecommunications ensure ROI, providing first class 
+  quality at the same time.
+    <br>
+    Save costs by operating your infrastructure and applications the smart way, ensuring full automation from day 0 
+    to day N.
+    </p>
+  <p><a href="/telco">Learn more about Ubuntu for telco</a></p>
+</div>


### PR DESCRIPTION
## Done

- Add dynamic blog product cards in place of Marketo RTPs.
  Eg. on blog post tagged `kubeflow`, a list of relevant cards is added to the blog post right column and one is made visible at random. This PR comes with instrumentation to assess CTR on cards.

- This PR comes with cards for the following blog post:
  - [telco](https://ubuntu.com/blog/tag/telco)
  -[Telecommunications](https://ubuntu.com/blog/tag/Telecommunications)


- The list of cards is maintained by PMs and Mktg and ongoing card code maintenance will be on Mktg.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the CTA works well& the website linked is correct
-Ensure that the ration between the image& text is correct
