### PR TITLE
Add education discount and webinar to /sercurity

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -48,7 +48,35 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h2>
+        FIPS certification and CIS compliance with Ubuntu
+      </h2>
+      <p>
+        Learn about Ubuntu CIS and FIPS certified components to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered in our upcoming webinar to ensure you and your team are, and remain, compliant.
+      </p>
+      <p>
+        <a class="p-button p-link--external" href="https://www.brighttalk.com/webcast/6793/432536">Watch the webinar</a>
+      </p>
+    </div>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
+          alt="",
+          height="143",
+          width="250",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>Find out more</h2>
   </div>
@@ -317,8 +345,8 @@
         image(
           url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
           alt="",
-          height="300",
-          width="250",
+          height="240",
+          width="200",
           hi_def=True,
           loading="lazy",
           attrs={"class": "u-hide--small u-hide--medium"}
@@ -456,7 +484,9 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+{% with strip="p-strip--light" %}{% include "shared/_education-discount.html" %}{% endwith %}
+
+<section class="p-strip">
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Talk to a member of our team</h2>
@@ -483,7 +513,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep">
+<section class="p-strip--light is-deep">
   <div class="row u-equal-height">
     <div class="col-4 u-hide--small u-align--center u-vertically-center">
       {{
@@ -500,7 +530,7 @@
     <div class="col-8">
       <h2>Ubuntu security disclosure policy</h2>
       <p>
-        Canonical and the Ubuntu Security Team participate in responsible disclosure and collaborate with the wider community on security issues. 
+        Canonical and the Ubuntu Security Team participate in responsible disclosure and collaborate with the wider community on security issues.
         For more information on how to contact the Ubuntu Security Team and expectations, please refer to our <a href="/security/disclosure-policy">Ubuntu Security disclosure and embargo policy</a>.
       </p>
     </div>

--- a/templates/shared/_education-discount.html
+++ b/templates/shared/_education-discount.html
@@ -1,0 +1,27 @@
+<section class="{% if strip %}{{ strip }}{% else %}p-strip{% endif %} is-deep" id="education">
+  <div class="row u-equal-height">
+    <div class="col-4 u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/a22613fc-train-with-ubuntu_AW.svg",
+            alt="",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </div>
+    <div class="col-8">
+      <h2>
+        Education discounts
+      </h2>
+      <p>
+        To support those using Ubuntu in schools, research and academia, Canonical is pleased to offer a discount programme for approved institutions. Please mention your interest in this programme in your conversations with our team.
+      </p>
+      <p>
+        <a class="p-button--neutral" href="/support/contact-us?product=education-discount">Contact us</a>
+      </p>
+    </div>
+  </div>
+</section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1159,27 +1159,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep" id="education">
-  <div class="row u-equal-height">
-    <div class="col-5 u-hide--small u-align--center u-vertically-center">
-      {{
-        image(
-            url="https://assets.ubuntu.com/v1/a22613fc-train-with-ubuntu_AW.svg",
-            alt="",
-            width="200",
-            height="200",
-            hi_def=True,
-            loading="auto",
-        ) | safe
-      }}
-    </div>
-    <div class="col-7">
-      <h2>Education discounts</h2>
-      <p>To support those using Ubuntu in schools, research and academia, Canonical is pleased to offer a discount programme for approved institutions. Please mention your interest in this programme in your conversations with our team.</p>
-      <a class="p-button--neutral" href="/support/contact-us?product=education-discount">Contact us</a>
-    </div>
-  </div>
-</section>
+{% include "shared/_education-discount.html" %}
 
 <section class="p-strip--light is-deep">
   <div class= "row u-equal-height">


### PR DESCRIPTION
## Done

- Made partial out of eduction strip on support
- Add education discount strip to /security
- Add webinar strip to /sercurity

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security#education and http://0.0.0.0:8001/support#education
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and approve comments in the [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit?ts=5fabbf60#)


## Issue / Card

Fixes #8721

## Screenshots

webinar
![image](https://user-images.githubusercontent.com/441217/98936001-412ff880-24dc-11eb-8c47-674489a80ee1.png)


education
![image](https://user-images.githubusercontent.com/441217/98935939-2f4e5580-24dc-11eb-9e5d-932dca627943.png)

