### PR TITLE
Update product-cards.html

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,22 +1,22 @@
 <div id="product-card">
    {# Telco tag cards #}
   {% if article.tags and 1377 in article.tags %}
-    {% include "blog/product-cards/_smartstart.html" %}} 
-    {% include "blog/product-cards/_IoT_appstore.html" %}} 
-  
+    {% include "blog/product-cards/_smartstart.html" %}
+    {% include "blog/product-cards/_IoT_appstore.html" %}
+
    {# IoT tag cards #}
-  {% if article.tags and 1665 in article.tags %}
-    {% include "blog/product-cards/_smartstart.html" %}} 
-    {% include "blog/product-cards/_IoT_appstore.html" %}} 
+  {% elif article.tags and 1665 in article.tags %}
+    {% include "blog/product-cards/_smartstart.html" %}
+    {% include "blog/product-cards/_IoT_appstore.html" %} 
   
   {# Finance tag cards #}
-  {% if article.tags and 1419 in article.tags %}
-    {% include "blog/product-cards/_financialservices-awerness.html" %}}
-  
+  {% elif article.tags and 1419 in article.tags %}
+    {% include "blog/product-cards/_financialservices-awerness.html" %}
+
   {# Rapsberry Pi tag cards #}
-  {% if article.tags and 1672 in article.tags %}
+  {% elif article.tags and 1672 in article.tags %}
     {% include "blog/product-cards/_raspberry-pi_2010-livestream.html" %}
-  
+
   {# Kubeflow tag cards #}
   {% elif article.tags and 2609 in article.tags %}
     {% include "blog/product-cards/_kubeflow_jaas-bundle.html" %}

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,7 +1,22 @@
 <div id="product-card">
-  {# Kubeflow tag cards #}
+   {# Telco tag cards #}
+  {% if article.tags and 1377 in article.tags %}
+    {% include "blog/product-cards/_smartstart.html" %}} 
+    {% include "blog/product-cards/_IoT_appstore.html" %}} 
+  
+   {# IoT tag cards #}
+  {% if article.tags and 1665 in article.tags %}
+    {% include "blog/product-cards/_smartstart.html" %}} 
+    {% include "blog/product-cards/_IoT_appstore.html" %}} 
+  
+  {# Finance tag cards #}
+  {% if article.tags and 1419 in article.tags %}
+    {% include "blog/product-cards/_financialservices-awerness.html" %}}
+  
+  {# Rapsberry Pi tag cards #}
   {% if article.tags and 1672 in article.tags %}
     {% include "blog/product-cards/_raspberry-pi_2010-livestream.html" %}
+  
   {# Kubeflow tag cards #}
   {% elif article.tags and 2609 in article.tags %}
     {% include "blog/product-cards/_kubeflow_jaas-bundle.html" %}

--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,8 +1,7 @@
 <div id="product-card">
    {# Telco tag cards #}
   {% if article.tags and 1377 in article.tags %}
-    {% include "blog/product-cards/_smartstart.html" %}
-    {% include "blog/product-cards/_IoT_appstore.html" %}
+    {% include "blog/product-cards/_telco.html" %}
 
    {# IoT tag cards #}
   {% elif article.tags and 1665 in article.tags %}

--- a/templates/blog/product-cards/_IoT_appstore.html
+++ b/templates/blog/product-cards/_IoT_appstore.html
@@ -1,0 +1,10 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/431b4ca2-ubuntu+core+18+circular+.svg" alt="smart start logo">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/internet-of-things/appstore">IoT app store</a>
+  </h3>
+  <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation.
+  Get a secure, hosted and managed multi-tenant app store for your IoT devices.</p>
+  <p><a href="/internet-of-things/appstore">Build your IoT app ecosystem</a></p>
+</div>

--- a/templates/blog/product-cards/_IoT_appstore.html
+++ b/templates/blog/product-cards/_IoT_appstore.html
@@ -6,5 +6,5 @@
   </h3>
   <p>Build a platform ecosystem for connected devices to unlock new avenues for revenue generation.
   Get a secure, hosted and managed multi-tenant app store for your IoT devices.</p>
-  <p><a href="/internet-of-things/appstore">Build your IoT app ecosystem</a></p>
+  <p><a href="/internet-of-things/appstore">Build your IoT app ecosystem&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/blog/product-cards/_financialservices-awerness.html
+++ b/templates/blog/product-cards/_financialservices-awerness.html
@@ -1,5 +1,5 @@
 <div class="p-card js-product-card u-hide">
-  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dcbd63b9-9outof10.JPG" alt="9outof10financialinstitutions">
+  <img src="https://assets.ubuntu.com/v1/dcbd63b9-9outof10.JPG" alt="9outof10financialinstitutions">
   <hr class="u-sv1">
   <h3>
     <a href="/engage/finance">Why is Ubuntu popular with top financial institutions?</a>

--- a/templates/blog/product-cards/_financialservices-awerness.html
+++ b/templates/blog/product-cards/_financialservices-awerness.html
@@ -1,0 +1,13 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dcbd63b9-9outof10.JPG" alt="9outof10financialinstitutions">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/engage/finance">Why is Ubuntu popular with top financial institutions?</a>
+  </h3>
+
+  <p>
+  Financial institutions are increasingly pressed for agility and velocity to adapt to changing market conditions, increased customer expectations while satisfying regulatory and compliance requirements.
+   
+  </p>
+  <p><a href="/engage/finance">Learn more about Ubuntu</a></p>
+</div>

--- a/templates/blog/product-cards/_financialservices-awerness.html
+++ b/templates/blog/product-cards/_financialservices-awerness.html
@@ -9,5 +9,5 @@
   Financial institutions are increasingly pressed for agility and velocity to adapt to changing market conditions, increased customer expectations while satisfying regulatory and compliance requirements.
    
   </p>
-  <p><a href="/engage/finance">Learn more about Ubuntu</a></p>
+  <p><a href="/engage/finance">Learn more about Ubuntu&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/blog/product-cards/_smartstart.html
+++ b/templates/blog/product-cards/_smartstart.html
@@ -7,5 +7,5 @@
   <p>Bring an IoT device to market fast. Focus on your apps, we handle the rest. Canonical offers hardware bring up, 
     app integration, knowledge transfer and engineering support to get your first device to market. App store and 
     security updates guaranteed.</p>
-  <p><a href="/smartstart">Get your IoT device to market fast</a></p>
+  <p><a href="/smartstart">Get your IoT device to market fast&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/blog/product-cards/_smartstart.html
+++ b/templates/blog/product-cards/_smartstart.html
@@ -1,0 +1,11 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/51aec8b1-Networking+equipment.svg" alt="smart start">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/smartstart">IoT as a service</a>
+  </h3>
+  <p>Bring an IoT device to market fast. Focus on your apps, we handle the rest. Canonical offers hardware bring up, 
+    app integration, knowledge transfer and engineering support to get your first device to market. App store and 
+    security updates guaranteed.</p>
+  <p><a href="/smartstart">Get your IoT device to market fast</a></p>
+</div>

--- a/templates/blog/product-cards/_telco.html
+++ b/templates/blog/product-cards/_telco.html
@@ -10,5 +10,5 @@
     Save costs by operating your infrastructure and applications the smart way, ensuring full automation from day 0 
     to day N.
     </p>
-  <p><a href="/telco">Learn more about Ubuntu for telco</a></p>
+  <p><a href="/telco">Learn more about Ubuntu for telco&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/blog/product-cards/_telco.html
+++ b/templates/blog/product-cards/_telco.html
@@ -1,0 +1,14 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg" alt="kubernetes logo">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/telco">What is Kubernetes?</a>
+  </h3>
+  <p>Designed with economics in mind, Canonical’s solutions for telecommunications ensure ROI, providing first class 
+  quality at the same time.
+    <br>
+    Save costs by operating your infrastructure and applications the smart way, ensuring full automation from day 0 
+    to day N.
+    </p>
+  <p><a href="/telco">Learn more about Ubuntu for telco</a></p>
+</div>


### PR DESCRIPTION
## Done

Add dynamic blog product cards in place of Marketo RTPs.
Eg. on blog post tagged kubeflow, a list of relevant cards is added to the blog post right column and one is made visible at random. This PR comes with instrumentation to assess CTR on cards.

This PR comes with cards for the following blog posts:
  - [IoT](https://ubuntu.com/blog/tag/IoT)
  - [Event](https://ubuntu.com/blog/tag/Event)
  - [telco](https://ubuntu.com/blog/tag/telco)

- The list of cards is maintained by PMs and Mktg and ongoing card code maintenance will be on Mktg.

## QA

- Ensure blog posts listed under:
  - [IoT](https://ubuntu-com-8731.demos.haus/blog/tag/IoT)
  - [Event](https://ubuntu-com-8731.demos.haus/blog/tag/Event) - is there any way this image can be bigger? (so the user can read the text within it)
  - [telco](https://ubuntu-com-8731.demos.haus/blog/tag/telco)


Examples of blog posts:
https://ubuntu-com-8731.demos.haus/blog/open-operators-training-day-hosted-by-canonical-a-co-located-kubecon-event
https://ubuntu-com-8731.demos.haus/blog/malawis-tnm-selects-canonicals-charmed-openstack-to-help-lead-virtualisation-charge