### PR TITLE
UA shop: maintenance mode

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_API_URL=https://contracts.staging.canonical.com/
 STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
-STORE_MAINTENANCE=true
+STORE_MAINTENANCE=false
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.env
+++ b/.env
@@ -5,6 +5,7 @@ DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_API_URL=https://contracts.staging.canonical.com/
 STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
+STORE_MAINTENANCE=true
 
 # This is a test api key https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 CAPTCHA_TESTING_API_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,7 @@ name: PR checks
 on: pull_request
 env:
   SECRET_KEY: insecure_test_key
+  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
 
 jobs:
   run-image:
@@ -154,18 +155,23 @@ jobs:
           sudo apt-get update && sudo apt-get install --yes python3-setuptools
           sudo pip3 install -r requirements.txt
 
+      - name: Install dotrun
+        run: |
+          sudo snap install dotrun
+          sudo chown root:root /
+
       - name: Install dependencies
         run: sudo pip3 install coverage
 
       - name: Install node dependencies
-        run: yarn install --immutable
+        run: /snap/bin/dotrun install
 
       - name: Build resources
-        run: yarn build
+        run: /snap/bin/dotrun build
 
       - name: Run tests with coverage
         run: |
-          DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres coverage run  --source=. -m unittest discover tests
+          /snap/bin/dotrun exec coverage run --source=. -m unittest discover tests
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-js:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -3,6 +3,11 @@ domain: ubuntu.com
 image: prod-comms.docker-registry.canonical.com/ubuntu.com
 
 env:
+  - name: STORE_MAINTENANCE
+    configMapKeyRef:
+      key: maintenance
+      name: ubuntu-com
+
   - name: DATABASE_URL
     secretKeyRef:
       key: database_url

--- a/templates/advantage/maintenance.html
+++ b/templates/advantage/maintenance.html
@@ -12,7 +12,7 @@
             <img src="https://assets.ubuntu.com/v1/05dad221-info.svg" alt="" style="width: 70px;">
           </div>
           <div class="u-vertically-center">
-            <h1 class="p-heading--three">Shop is unavilable</h1>
+            <h1 class="p-heading--three">Shop is unavailable</h1>
             <p class="p-heading--four">The shop is undergoing maintenance, we'll be back soon.</p>
           </div>
         </div>

--- a/templates/advantage/maintenance.html
+++ b/templates/advantage/maintenance.html
@@ -1,0 +1,23 @@
+{% extends "templates/one-column.html" %}
+{% block title %}Ubuntu Advantage for Infrastructure: maintenance{% endblock %}
+
+
+{% block content %}
+<div class="p-strip">
+  <div class="row">
+    <div class="col-6 col-start-large-4">
+      <div class="p-card--outline">
+        <div class="row u-equal-height">
+          <div class="u-vertically-center">
+            <img src="https://assets.ubuntu.com/v1/05dad221-info.svg" alt="" style="width: 70px;">
+          </div>
+          <div class="u-vertically-center">
+            <h1 class="p-heading--three">Shop is unavilable</h1>
+            <p class="p-heading--four">The shop is undergoing maintenance, we'll be back soon.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -112,7 +112,7 @@ class TestRoutes(VCRTestCase):
         When logged in, we should still get a 200 status code
         """
         with support.EnvironmentVarGuard() as env:
-            env['STORE_MAINTENANCE'] = "false"
+            env["STORE_MAINTENANCE"] = "false"
 
         self.assertEqual(self.client.get("/advantage").status_code, 200)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,6 @@
 # Standard library
 import unittest
+from test import support
 
 # Packages
 from vcr_unittest import VCRTestCase
@@ -110,6 +111,9 @@ class TestRoutes(VCRTestCase):
 
         When logged in, we should still get a 200 status code
         """
+        with support.EnvironmentVarGuard() as env:
+            env['STORE_MAINTENANCE'] = "false"
+
         self.assertEqual(self.client.get("/advantage").status_code, 200)
 
         with self.client.session_transaction() as s:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,5 @@
 # Standard library
 import unittest
-from test import support
 
 # Packages
 from vcr_unittest import VCRTestCase
@@ -111,8 +110,6 @@ class TestRoutes(VCRTestCase):
 
         When logged in, we should still get a 200 status code
         """
-        with support.EnvironmentVarGuard() as env:
-            env["STORE_MAINTENANCE"] = "false"
 
         self.assertEqual(self.client.get("/advantage").status_code, 200)
 

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -1,0 +1,22 @@
+# Core packages
+import os
+import functools
+from distutils.util import strtobool
+
+# Third party packages
+import flask
+
+
+def store_maintenance(func):
+    """
+    Decorator that checks if the maintence mode is enabled
+    """
+
+    @functools.wraps(func)
+    def is_store_in_maintenance(*args, **kwargs):
+        if strtobool(os.getenv("STORE_MAINTENANCE")):
+            return flask.render_template("advantage/maintenance.html")
+
+        return func(*args, **kwargs)
+
+    return is_store_in_maintenance

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -25,6 +25,7 @@ from requests.exceptions import HTTPError
 # Local
 from webapp.login import empty_session, user_info
 from webapp.advantage import AdvantageContracts, UnauthorizedError
+from webapp.decorators import store_maintenance
 
 
 # Define the metric name for the number of active machines.
@@ -394,6 +395,7 @@ def search_snaps():
     )
 
 
+@store_maintenance
 def advantage_view():
     accounts = None
     personal_account = None
@@ -703,6 +705,7 @@ def post_renewal_preview(renewal_id):
     return flask.jsonify(preview), 200
 
 
+@store_maintenance
 def advantage_shop_view():
     account = previous_purchase_id = None
     stripe_publishable_key = os.getenv(
@@ -789,6 +792,7 @@ def advantage_shop_view():
     )
 
 
+@store_maintenance
 def advantage_thanks_view():
     email = flask.request.args.get("email")
 


### PR DESCRIPTION
## Done

Adds a maintenance mode for /advantage and /advantage/subscribe; enabled if the `STORE_MAINTENANCE` env variable is set to `true`.

(The sequel to [Charmhub's maintenance mode](https://github.com/canonical-web-and-design/charmhub.io/pull/594))

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- See that the page informs you that maintenance is happening
- Visit /advantage/subscribe and see that the same thing happens


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8710

![Screenshot from 2020-11-12 15-03-40](https://user-images.githubusercontent.com/2376968/98956738-4ac75980-24f8-11eb-9522-46369f4f0b6a.png)

