### PR TITLE
Remove pre-commit hook requiring dotrun 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,7 @@
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}",
     "check-prettier": "prettier -c '**/*.{scss,js}'"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.scss": "dotrun exec yarn run lint-scss",
-    "*.py": "dotrun exec yarn run lint-python",
-    "*.js": [
-      "dotrun exec yarn run lint-js",
-      "prettier --write"
-    ]
-  },
+
   "keywords": [
     "website",
     "ubuntu"

--- a/package.json
+++ b/package.json
@@ -24,15 +24,13 @@
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}",
     "check-prettier": "prettier -c '**/*.{scss,js}'"
   },
-  "husky": {	
-    "hooks": {	
-      "pre-commit": "lint-staged"	
-    }	
-  },	
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
-    "*.js": [	
-      "prettier --write"	
-    ]	
+    "*.{js,json,scss}": "prettier --write"
   },
   "keywords": [
     "website",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,16 @@
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}",
     "check-prettier": "prettier -c '**/*.{scss,js}'"
   },
-
+  "husky": {	
+    "hooks": {	
+      "pre-commit": "lint-staged"	
+    }	
+  },	
+  "lint-staged": {
+    "*.js": [	
+      "prettier --write"	
+    ]	
+  },
   "keywords": [
     "website",
     "ubuntu"

--- a/static/js/src/appliance.js
+++ b/static/js/src/appliance.js
@@ -8,7 +8,6 @@ function initLightbox() {
   let images = lightboxElements.map(function (element) {
     return element.href;
   });
-  
 
   let lightboxClosure = function (event, currentElement, images) {
     event.preventDefault();

--- a/static/js/src/appliance.js
+++ b/static/js/src/appliance.js
@@ -8,6 +8,7 @@ function initLightbox() {
   let images = lightboxElements.map(function (element) {
     return element.href;
   });
+  
 
   let lightboxClosure = function (event, currentElement, images) {
     event.preventDefault();


### PR DESCRIPTION
## Done

- Remove pre-commit hook requiring `dotrun,` so changes to `scss,` `js` and `python` files can be committed if you're not using the `dotrun` script

## QA

- Check out this feature branch
- Run the site using the command `./run` ONLY 
- Make a change to a python, scss or js file, and try to commit
- There should be no failing pre-commit hook and the commit should be successful

## Issue / Card

Fixes #8733 

