### PR TITLE
K8sdocs-1.19 version updates

### DIFF
--- a/templates/kubernetes/docs/1.19/components.md
+++ b/templates/kubernetes/docs/1.19/components.md
@@ -128,7 +128,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> Delivers EasyRSA to create a Certificate Authority (CA). </td>
   <td> <a href="/kubernetes/docs/1.19/charm-easyrsa">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/easyrsa/330">330</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/easyrsa/333">333</a> </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -136,7 +136,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> Deploy a TLS terminated ETCD Cluster </td>
   <td> <a href="/kubernetes/docs/1.19/charm-etcd">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/etcd/539">539</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/etcd/540">540</a> </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -184,7 +184,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> The Kubernetes control plane. </td>
   <td> <a href="/kubernetes/docs/1.19/charm-kubernetes-master">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/886">886</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/891">891</a> </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -192,7 +192,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> The workload bearing units of a kubernetes cluster </td>
   <td> <a href="/kubernetes/docs/1.19/charm-kubernetes-worker">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/700">700</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/704">704</a> </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -330,7 +330,6 @@ These charms are frequently used with Charmed Kubernetes.
 These are the container images used by this release:
 
 <!-- GENERATED CONTAINER IMAGES -->
-
 -   cdk/addon-resizer-amd64:1.8.9
 -   cdk/addon-resizer-arm64:1.8.9
 -   cdk/addon-resizer-ppc64le:1.8.9

--- a/templates/kubernetes/docs/1.19/release-notes.md
+++ b/templates/kubernetes/docs/1.19/release-notes.md
@@ -89,7 +89,7 @@ For a full list of the changes introduced in Kubernetes 1.19, please see the
 
 - addon-resizer 1.8.9
 - ceph-csi 2.1.2
-- cloud-provider-openstack
+- cloud-provider-openstack 1.18.0
 - coredns 1.6.7
 - kube-state-metrics 1.9.7
 - kubernetes-dashboard 2.0.1
@@ -114,12 +114,6 @@ cluster now requires an explicit `--kubeconfig <file>` option:
 
 - The webhook authentication service included in this release runs on port 5000 of each
 kubernetes-master unit. Ensure this port is available prior to upgrading.
-
-- Due to a bug in the pacemaker package on Ubuntu, Charmed Kubernetes does not
-work with HAcluster on Ubuntu 20.04 (Focal). If you intend to use HAcluster,
-we recommend deploying to Ubuntu 18.04 (Bionic) instead. Details
-about this bug can be found at
-[https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762](https://bugs.launchpad.net/ubuntu/+source/pacemaker/+bug/1881762).
 
 - Additional known issues scheduled for the first 1.19 bugfix release can be found at [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1)
 


### PR DESCRIPTION
## Done

A few updates on versions of charms for 1.19

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
