### PR TITLE
Update meta title and add meta image

### DIFF
--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -1,8 +1,10 @@
 {% extends "managed/_base_managed-apps.html" %}
 
-{% block title %}Canonical's Managed Apache Cassandra | Fully managed Cassandra for your mission-critical data needs{% endblock %}
+{% block title %}Managed Cassandra on Ubuntu | Multi-Cloud and On-Premise{% endblock %}
 
 {% block meta_description %}Canonical and Ubuntu provide fully managed Apache Cassandra on Ubuntu hosted on any cloud architecture, including Kubernetes, public cloud, on-premise or bare-metal.{% endblock meta_description %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/f35b0722-twitter_wide_banner+%289%29.jpeg{% endblock meta_image%}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1iYMH1ISY4uDtr3ZzH0f_hnEzvqaeufO43z__cMxs0vQ/edit?ts=5f71f2cb#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

- Update meta title and added meta image on `/managed/cassandra`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/cassandra
- Check the source, meta title should be "Managed Cassandra on Ubuntu | Multi-Cloud and On-Premise"


## Issue / Card

Fixes [#3450](https://github.com/canonical-web-and-design/web-squad/issues/3450)

