### PR TITLE
Build /kubernetes/compare page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -297,6 +297,8 @@ kubernetes:
       path: /kubernetes/features
     - title: Managed
       path: /kubernetes/managed
+    - title: Compare
+      path: /kubernetes/compare
     - title: Install
       path: /kubernetes/install
     - title: Docs

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -303,8 +303,6 @@ kubernetes:
       path: /kubernetes/install
     - title: Docs
       path: /kubernetes/docs
-    - title: Apps
-      path: /managed
 
       children:
         - title: Home

--- a/static/sass/_pattern_ratings.scss
+++ b/static/sass/_pattern_ratings.scss
@@ -1,8 +1,26 @@
-.p-rating {
+@mixin p-rating {
   background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: -75px;
   background-position-y: center;
   background-repeat: no-repeat;
+}
+
+@mixin p-rating-before($positionX, $width) {
+  @include p-rating;
+
+  background-position-x: #{$positionX};
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: #{$width};
+}
+
+.p-rating {
+  @include p-rating;
+
+  background-position-x: -75px;
   display: inline-block;
   height: $sp-large;
   margin-left: $sp-xx-small;
@@ -10,86 +28,27 @@
   text-indent: -9999px;
   width: 74px;
 }
+
 .p-rating--1::before {
-  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: -60px;
-  background-position-y: center;
-  background-repeat: no-repeat;
-  bottom: 0;
-  content: "";
-  display: block;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 74px;
+  @include p-rating-before(-60px, 74px);
 }
 
 .p-rating--2::before {
-  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: -45px;
-  background-position-y: center;
-  background-repeat: no-repeat;
-  bottom: 0;
-  content: "";
-  display: block;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 74px;
+  @include p-rating-before(-45px, 74px);
 }
 
 .p-rating--3::before {
-  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: -30px;
-  background-position-y: center;
-  background-repeat: no-repeat;
-  bottom: 0;
-  content: "";
-  display: block;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 74px;
+  @include p-rating-before(-30px, 74px);
 }
 
 .p-rating--4::before {
-  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: -15px;
-  background-position-y: center;
-  background-repeat: no-repeat;
-  bottom: 0;
-  content: "";
-  display: block;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 74px;
+  @include p-rating-before(-15px, 74px);
 }
 
-.p-rating--4-half::before {
-  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: 0;
-  background-position-y: center;
-  background-repeat: no-repeat;
-  bottom: 0;
-  content: "";
-  display: block;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 66px;
+.p-rating--4.is-half::before {
+  @include p-rating-before(0, 66px);
 }
 
 .p-rating--5::before {
-  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
-  background-position-x: 0;
-  background-position-y: center;
-  background-repeat: no-repeat;
-  bottom: 0;
-  content: "";
-  display: block;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 74px;
+  @include p-rating-before(0, 74px);
 }

--- a/static/sass/_pattern_ratings.scss
+++ b/static/sass/_pattern_ratings.scss
@@ -1,0 +1,95 @@
+.p-rating {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: -75px;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  display: inline-block;
+  height: $sp-large;
+  margin-left: $sp-xx-small;
+  position: relative;
+  text-indent: -9999px;
+  width: 74px;
+}
+.p-rating--1::before {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: -60px;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 74px;
+}
+
+.p-rating--2::before {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: -45px;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 74px;
+}
+
+.p-rating--3::before {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: -30px;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 74px;
+}
+
+.p-rating--4::before {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: -15px;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 74px;
+}
+
+.p-rating--4-half::before {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: 0;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 66px;
+}
+
+.p-rating--5::before {
+  background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+  background-position-x: 0;
+  background-position-y: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 74px;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -56,6 +56,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_matrix";
 @import "pattern_navigation";
 @import "pattern_pie_chart";
+@import "pattern_ratings";
 @import "pattern_renewal-modal";
 @import "pattern_separator";
 @import "pattern_shop-cart";

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -1,0 +1,222 @@
+{% extends "kubernetes/base_kubernetes.html" %}
+
+{% block title %}Canonical Kubernetes vs Red Hat OpenShift vs Rancher{% endblock %}
+
+{% block meta_description %}Feature and price comparison of enterprise Kubernetes offerings from Canonical, Red Hat and Rancher.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1JngYmRhohPo62yU72V1xpzCCILI21SmHKKttBxHjPog/edit?ts=5faa80b7{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>Kubernetes distributions comparison</h1>
+      <p>The Kubernetes landscape is vast and saturated. If you are looking to compare different enterprise Kubernetes distributions, have a look at the table below. Kubernetes by Canonical focuses on multi-cloud operations, security and price-performance optimisation.</p>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/91154a9f-Managed+Kubernetes.svg",
+        alt="Kubernetes Certified Service Provider",
+        width="280",
+        height="200",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <table>
+      <thead>
+        <tr>
+          <th colspan="2">&nbsp;</th>
+          <th class="u-align--center">Canonical Kubernetes</th>
+          <th class="u-align--center">Red Hat Openshift</th>
+          <th class="u-align--center">Rancher</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td colspan="2">CNCF Conformant</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">High availability</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Enterprise update control</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center">&ndash;</td>
+          <td class="u-align--center">&ndash;</td>
+        </tr>
+        <tr>
+          <td colspan="2">Automated upgrades between versions</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center">&ndash;</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Edge support</td>
+          <td class="u-align--center">5*<p>MicroK8s</p></td>
+          <td class="u-align--center">3*<p>Openshift</p></td>
+          <td class="u-align--center">5*<p>K3s</p></td>
+        </tr>
+        <tr>
+          <td colspan="2">Single-node edition</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center">&ndash;</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Managed Kubernetes offering</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center">&ndash;</td>
+        </tr>
+        <tr>
+          <td colspan="2">Container runtime and registries</td>
+          <td class="u-align--center">5*<p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
+          <td class="u-align--center">3*<p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
+          <td class="u-align--center">3*<p>ContainerD, Docker</p><p>DockerHub, private registries, public cloud registries</p></td>
+        </tr>
+        <tr>
+          <td colspan="2">Networking</td>
+          <td class="u-align--center">5*<p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p></td>
+          <td class="u-align--center">4*<p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p></td>
+          <td class="u-align--center">3*<p>Canal, Calico, Flannel, Weave</p></td>
+        </tr>
+        <tr>
+          <td colspan="2">Storage</td>
+          <td class="u-align--center">5*<p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p></td>
+          <td class="u-align--center">4*<p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p></td>
+          <td class="u-align--center">4*<p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p></td>
+        </tr>
+        <tr>
+          <td colspan="2">Monitoring and Operations Management</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Multi cloud deployments</td>
+          <td class="u-align--center">5*<p>Juju</p></td>
+          <td class="u-align--center">3*<p>Ansible</p></td>
+          <td class="u-align--center">4*<p>Helm</p></td>
+        </tr>
+        <tr>
+          <td colspan="2">Native AWS/GCP/Azure integration</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Native Openstack/VMware integration</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">GPGPU support for accelerated workloads</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Bare metal deployment</td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+        </tr>
+        <tr>
+          <td colspan="2">Architectures supported</td>
+          <td class="u-align--center">X86, POWER, ARM, Z</td>
+          <td class="u-align--center">X86, POWER, Z</td>
+          <td class="u-align--center">X86</td>
+        </tr>
+        <tr>
+          <td colspan="2">Pricing</td>
+          <td class="u-align--center">$</td>
+          <td class="u-align--center">$$$$$</td>
+          <td class="u-align--center">$$$</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row u-equal-height">
+   <div class="col-8">
+     <h2>Canonical Kubernetes pricing</h2>
+     <p class="p-heading--4">Predictable pricing model. No license fees. Enterprise support.</p>
+     <p>Canonical’s support services for Kubernetes follow a per host pricing model to bring you the best price-performance. Just count the number of physical or virtual machines you want support for and get coverage through <a href="/advantage">Ubuntu Advantage</a>, without any additional license or support fees.</p>
+   </div>
+   <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
+        alt="Kubernetes Certified Service Provider",
+        width="280",
+        height="150",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}   
+   </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
+        alt="Kubernetes Certified Service Provider",
+        width="280",
+        height="150",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}   
+    </div>
+    <div class="col-7">
+     <h2>Multi-cloud deployments & operations</h2>
+     <p class="p-heading--4">Model-driven Kubernetes Operators. Supported or fully managed from public cloud to on-prem. </p>
+     <p><a class="p-link--external" href="https://charmhub.io/">Universal operators</a> streamline your Kubernetes deployments and operations across all clouds. Get started with our K8s architecture design workshop and our cloud-native migration services. Get peace of mind with Managed Kubernetes from Canonical.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row u-equal-height">
+   <div class="col-8">
+     <h2>Secure Kubernetes</h2>
+     <p class="p-heading--4">Hardened platform. Immutable containers. Security patching.</p>
+     <p>Canonical Kubernetes runs in immutable containers to provide for better security out of the box. Integration with K8s RBAC, Active Directory and LDAP, CIS hardening by default, encryption at rest and automatic security patching ensure you get the most secure Kbernetes in the market.</p>
+   </div>
+   <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
+        alt="Kubernetes Certified Service Provider",
+        width="280",
+        height="150",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}   
+   </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -14,7 +14,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Kubernetes distributions comparison</h1>
-      <p>The Kubernetes landscape is vast and saturated. If you are looking to compare different enterprise Kubernetes distributions, have a look at the table below. Kubernetes by Canonical focuses on multi-cloud operations, security and price-performance optimisation.</p>
+      <p>The Kubernetes landscape is vast and complex. If you are looking to compare different enterprise Kubernetes distributions, have a look at the table below. <a href="/kubernetes">Kubernetes by Canonical</a> stands out because it delivers multi-cloud operations, enterprise-grade security and optimal price-performance.</p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
@@ -96,19 +96,19 @@
           <td aria-label="Category">Edge support</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
+              <span class="p-rating p-rating--5">5 out of 5</span>
               <p>MicroK8s</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
+              <span class="p-rating p-rating--3">3 out of 5</span>
               <p>Openshift</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
+              <span class="p-rating p-rating--5">5 out of 5</span>
               <p>K3s</p>
             </div>
           </td>
@@ -141,23 +141,23 @@
           <td aria-label="Category">Container runtime and registries</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
+              <span class="p-rating p-rating--5">5 out of 5</span>
               <p>ContainerD, Docker, Kata</p>
               <p>Private registries, DockerHub, ROCKs, public cloud registries</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
+              <span class="p-rating p-rating--3">3 out of 5</span>
               <p>CRI-O, Kata</p>
-              <p>DockerHub Private registries, public cloud registries</p>
+              <p>Private registries, DockerHub, public cloud registries</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4" role="img" aria-label="4 out of 5"></span>
+              <span class="p-rating p-rating--4">4 out of 5</span>
               <p>ContainerD, Docker</p>
-              <p>DockerHub, Private registries, public cloud registries</p>
+              <p>Private registries, DockerHub, public cloud registries</p>
             </div>
           </td>
         </tr>
@@ -165,19 +165,19 @@
           <td aria-label="Category">Networking</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
+              <span class="p-rating p-rating--5">5 out of 5</span>
               <p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4-half" role="img" aria-label="4.5 out of 5"></span>
+              <span class="p-rating p-rating--4 is-half">4.5 out of 5</span>
               <p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
+              <span class="p-rating p-rating--3">3 out of 5</span>
               <p>Canal, Calico, Flannel, Weave</p>
             </div>
           </td>
@@ -186,19 +186,19 @@
           <td aria-label="Category">Storage</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
-              <p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p>
+              <span class="p-rating p-rating--5">5 out of 5</span>
+              <p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume, PureStorage</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4-half" role="img" aria-label="4.5 out of 5"></span>
+              <span class="p-rating p-rating--4 is-half">4.5 out of 5</span>
               <p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4-half" role="img" aria-label="4.5 out of 5"></span>
+              <span class="p-rating p-rating--4 is-half">4.5 out of 5</span>
               <p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p>
             </div>
           </td>
@@ -219,19 +219,19 @@
           <td aria-label="Category">Multi cloud deployments</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
+              <span class="p-rating p-rating--5">5 out of 5</span>
               <p>Juju</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
+              <span class="p-rating p-rating--3">3 out of 5</span>
               <p>Ansible</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4" role="img" aria-label="4 out of 5"></span>
+              <span class="p-rating p-rating--4">4 out of 5</span>
               <p>Helm</p>
             </div>
           </td>
@@ -300,28 +300,6 @@
 
 <section class="p-strip">
   <div class="row u-equal-height">
-   <div class="col-8">
-     <h2>Canonical Kubernetes pricing</h2>
-     <p class="p-heading--4">Predictable pricing model. No license fees. Enterprise support.</p>
-     <p>Canonical’s support services for Kubernetes follow a per host pricing model to bring you the best price-performance. Just count the number of physical or virtual machines you want support for and get coverage through <a href="/advantage">Ubuntu Advantage</a>, without any additional license or support fees.</p>
-   </div>
-   <div class="col-4 u-vertically-center u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/d399db60-save-money.svg",
-        alt="Pricing",
-        width="220",
-        height="220",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}   
-   </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-equal-height">
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{
         image(
@@ -337,12 +315,12 @@
     <div class="col-7">
      <h2>Multi-cloud deployments & operations</h2>
      <p class="p-heading--4">Model-driven Kubernetes Operators. Supported or fully managed from public cloud to on-prem. </p>
-     <p><a class="p-link--external" href="https://charmhub.io/">Universal operators</a> streamline your Kubernetes deployments and operations across all clouds. Get started with our K8s architecture design workshop and our cloud-native migration services. Get peace of mind with Managed Kubernetes from Canonical.</p>
+     <p><a class="p-link--external" href="https://charmhub.io/">Universal operators</a> streamline your Kubernetes deployments and operations across all clouds. Get started with our <a class="p-link--external" href="https://jaas.ai/canonical-kubernetes">K8s Architecture Design and Deployment Workshop</a> and our Cloud-native Migration Services. Enjoy peace of mind with Managed Kubernetes from Canonical.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row u-equal-height">
    <div class="col-8">
      <h2>Secure Kubernetes</h2>
@@ -364,7 +342,96 @@
   </div>
 </section>
 
-<section class="p-strip--light is-shallow">
+<section class="p-strip">
+  <div class="row u-equal-height">
+   <div class="col-4 u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/d399db60-save-money.svg",
+        alt="Pricing",
+        width="220",
+        height="220",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}   
+   </div>
+   <div class="col-8">
+     <h2>Canonical Kubernetes pricing</h2>
+     <p class="p-heading--4">Predictable pricing model. No license fees. Enterprise support.</p>
+     <p>Canonical’s support services for Kubernetes follow a per host pricing model to bring you the best price-performance. Just count the number of physical or virtual machines you want support for and get coverage through <a href="/advantage">Ubuntu Advantage</a>, without any additional license or support fees.</p>
+   </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h3 class="u-sv2">Kubernetes resources</h3>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
+                alt="",
+                width="32",
+                height="28",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+          }}
+          <h4 class="p-heading-icon__title">DATA SHEET</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Kubernetes for the enterprise</a></h3>
+    </div>
+
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+                alt="",
+                width="32",
+                height="28",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+          }}
+          <h4 class="p-heading-icon__title">WEBINAR</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/362200">Kubernetes at the edge: Why use Kubernetes as part of your edge strategy?</a></h3>
+    </div>
+
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon--muted">
+      <div class="p-heading-icon__header">
+          {{
+            image(
+                url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+                alt="",
+                width="32",
+                height="28",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              ) | safe
+          }}
+          <h4 class="p-heading-icon__title">WHITEPAPER</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/engage/kubernetes-deployment-enterprise-whitepaper">Five strategies to accelerate Kubernetes deployment in the enterprise</a></h3>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
   <div class="row u-equal-height">
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
@@ -379,10 +446,11 @@
       }}   
     </div>
     <div class="col-8">
-      <h2>Contact us</h2>
-      <p>Let our cloud team help with:</p>
+      <h2>Need help with K8s?</h2>
+      <p>Let our expert cloud team help with:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Project evaluation</li>
+        <li class="p-list__item is-ticked">Requirements and feature parity</li>
         <li class="p-list__item is-ticked">Pricing and TCO assessment</li>
       </ul>
       <p>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -4,6 +4,8 @@
 
 {% block meta_description %}Feature and price comparison of enterprise Kubernetes offerings from Canonical, Red Hat and Rancher.{% endblock meta_description %}
 
+{% block meta_image%}https://assets.ubuntu.com/v1/22ff1a55-twitter_wide_banner+%2810%29.jpeg{% endblock meta_image%}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1JngYmRhohPo62yU72V1xpzCCILI21SmHKKttBxHjPog/edit?ts=5faa80b7{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -70,9 +70,9 @@
         </tr>
         <tr>
           <td colspan="2">Edge support</td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>MicroK8s</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>Openshift</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>K3s</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>MicroK8s</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>Openshift</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>K3s</p></td>
         </tr>
         <tr>
           <td colspan="2">Single-node edition</td>
@@ -88,21 +88,21 @@
         </tr>
         <tr>
           <td colspan="2">Container runtime and registries</td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>ContainerD, Docker</p><p>DockerHub, Private registries, public cloud registries</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--4"></span><p>ContainerD, Docker</p><p>DockerHub, Private registries, public cloud registries</p></td>
         </tr>
         <tr>
           <td colspan="2">Networking</td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>Canal, Calico, Flannel, Weave</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--4-half"></span><p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>Canal, Calico, Flannel, Weave</p></td>
         </tr>
         <tr>
           <td colspan="2">Storage</td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--4-half"></span><p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--4-half"></span><p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p></td>
         </tr>
         <tr>
           <td colspan="2">Monitoring and Operations Management</td>
@@ -112,9 +112,9 @@
         </tr>
         <tr>
           <td colspan="2">Multi cloud deployments</td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>Juju</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>Ansible</p></td>
-          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>Helm</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>Juju</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>Ansible</p></td>
+          <td class="u-align--center"><span class="p-rating p-rating--4"></span><p>Helm</p></td>
         </tr>
         <tr>
           <td colspan="2">Native AWS/GCP/Azure integration</td>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -17,9 +17,9 @@
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/91154a9f-Managed+Kubernetes.svg",
+        url="https://assets.ubuntu.com/v1/198b738b-Compare_Kubernetes-Openshift-Rancher.svg",
         alt="Kubernetes Certified Service Provider",
-        width="280",
+        width="300",
         height="200",
         hi_def=True,
         loading="auto",
@@ -87,7 +87,7 @@
           <td colspan="2">Container runtime and registries</td>
           <td class="u-align--center">5*<p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
           <td class="u-align--center">3*<p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
-          <td class="u-align--center">3*<p>ContainerD, Docker</p><p>DockerHub, private registries, public cloud registries</p></td>
+          <td class="u-align--center">3*<p>ContainerD, Docker</p><p>DockerHub, Private registries, public cloud registries</p></td>
         </tr>
         <tr>
           <td colspan="2">Networking</td>
@@ -161,13 +161,13 @@
      <p class="p-heading--4">Predictable pricing model. No license fees. Enterprise support.</p>
      <p>Canonical’s support services for Kubernetes follow a per host pricing model to bring you the best price-performance. Just count the number of physical or virtual machines you want support for and get coverage through <a href="/advantage">Ubuntu Advantage</a>, without any additional license or support fees.</p>
    </div>
-   <div class="col-4 u-align--center u-vertically-center u-hide--small">
+   <div class="col-4 u-vertically-center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
-        alt="Kubernetes Certified Service Provider",
-        width="280",
-        height="150",
+        url="https://assets.ubuntu.com/v1/d399db60-save-money.svg",
+        alt="Pricing",
+        width="220",
+        height="220",
         hi_def=True,
         loading="auto",
         ) | safe
@@ -181,10 +181,10 @@
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
-        alt="Kubernetes Certified Service Provider",
-        width="280",
-        height="150",
+        url="https://assets.ubuntu.com/v1/990738e2-kubernetes-cloud.svg",
+        alt="Kubernetes cloud",
+        width="300",
+        height="170",
         hi_def=True,
         loading="auto",
         ) | safe
@@ -209,8 +209,8 @@
       {{
         image(
         url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
-        alt="Kubernetes Certified Service Provider",
-        width="280",
+        alt="Security shields",
+        width="255",
         height="150",
         hi_def=True,
         loading="auto",
@@ -219,4 +219,38 @@
    </div>
   </div>
 </section>
+
+<section class="p-strip--light is-shallow">
+  <div class="row u-equal-height">
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/0e5f4269-questions.svg",
+        alt="Contact us",
+        width="180",
+        height="180",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}   
+    </div>
+    <div class="col-8">
+      <h2>Contact us</h2>
+      <p>Let our cloud team help with:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Project evaluation</li>
+        <li class="p-list__item is-ticked">Pricing and TCO assessment</li>
+      </ul>
+      <p>
+        <a href="/kubernetes/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+      <p>
+    </div>
+  </div>
+</section>
+
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-compare" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
 {% endblock content %}

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -33,6 +33,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
+    <p>Each category is rated out of 5 for easy comparison</p>
     <table>
       <thead>
         <tr>
@@ -69,9 +70,9 @@
         </tr>
         <tr>
           <td colspan="2">Edge support</td>
-          <td class="u-align--center">5*<p>MicroK8s</p></td>
-          <td class="u-align--center">3*<p>Openshift</p></td>
-          <td class="u-align--center">5*<p>K3s</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>MicroK8s</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>Openshift</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>K3s</p></td>
         </tr>
         <tr>
           <td colspan="2">Single-node edition</td>
@@ -87,21 +88,21 @@
         </tr>
         <tr>
           <td colspan="2">Container runtime and registries</td>
-          <td class="u-align--center">5*<p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
-          <td class="u-align--center">3*<p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
-          <td class="u-align--center">3*<p>ContainerD, Docker</p><p>DockerHub, Private registries, public cloud registries</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>ContainerD, Docker</p><p>DockerHub, Private registries, public cloud registries</p></td>
         </tr>
         <tr>
           <td colspan="2">Networking</td>
-          <td class="u-align--center">5*<p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p></td>
-          <td class="u-align--center">4*<p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p></td>
-          <td class="u-align--center">3*<p>Canal, Calico, Flannel, Weave</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>Canal, Calico, Flannel, Weave</p></td>
         </tr>
         <tr>
           <td colspan="2">Storage</td>
-          <td class="u-align--center">5*<p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p></td>
-          <td class="u-align--center">4*<p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p></td>
-          <td class="u-align--center">4*<p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p></td>
         </tr>
         <tr>
           <td colspan="2">Monitoring and Operations Management</td>
@@ -111,9 +112,9 @@
         </tr>
         <tr>
           <td colspan="2">Multi cloud deployments</td>
-          <td class="u-align--center">5*<p>Juju</p></td>
-          <td class="u-align--center">3*<p>Ansible</p></td>
-          <td class="u-align--center">4*<p>Helm</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--5"></span><p>Juju</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--3"></span><p>Ansible</p></td>
+          <td class="u-align--center"><span class="l-tutorials-meter l-tutorials-meter--4"></span><p>Helm</p></td>
         </tr>
         <tr>
           <td colspan="2">Native AWS/GCP/Azure integration</td>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -74,10 +74,10 @@
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
           </td>
           <td aria-label="Red Hat Openshift" class="u-align--center">
-            <span>&ndash;</span>
+            <span aria-label="No">&ndash;</span>
           </td>
           <td aria-label="Rancher" class="u-align--center">
-            <span>&ndash;</span>
+            <span aria-label="No">&ndash;</span>
           </td>
         </tr>
         <tr>
@@ -86,7 +86,7 @@
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
           </td>
           <td aria-label="Red Hat Openshift"class="u-align--center" >
-            <span>&ndash;</span>
+            <span aria-label="No">&ndash;</span>
           </td>
           <td aria-label="Rancher" class="u-align--center">
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
@@ -96,19 +96,19 @@
           <td aria-label="Category">Edge support</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5"></span>
+              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
               <p>MicroK8s</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3"></span>
+              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
               <p>Openshift</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5"></span>
+              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
               <p>K3s</p>
             </div>
           </td>
@@ -119,7 +119,7 @@
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
           </td>
           <td aria-label="Red Hat Openshift" class="u-align--center">
-            <span>&ndash;</span>
+            <span aria-label="No">&ndash;</span>
           </td>
           <td aria-label="Rancher" class="u-align--center">
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
@@ -127,35 +127,35 @@
         </tr>
         <tr>
           <td aria-label="Category">Managed Kubernetes offering</td>
-          <td aria-label="Canonical Kubernetes" class="u-align--center" >
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
           </td>
-          <td aria-label="Red Hat Openshift" class="u-align--center" >
+          <td aria-label="Red Hat Openshift" class="u-align--center">
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
           </td>
-          <td aria-label="Rancher" class="u-align--center" >
-          <span>&ndash;</span>
+          <td aria-label="Rancher" class="u-align--center">
+          <span aria-label="No">&ndash;</span>
         </td>
         </tr>
         <tr>
           <td aria-label="Category">Container runtime and registries</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5"></span>
+              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
               <p>ContainerD, Docker, Kata</p>
               <p>Private registries, DockerHub, ROCKs, public cloud registries</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3"></span>
+              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
               <p>CRI-O, Kata</p>
               <p>DockerHub Private registries, public cloud registries</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4"></span>
+              <span class="p-rating p-rating--4" role="img" aria-label="4 out of 5"></span>
               <p>ContainerD, Docker</p>
               <p>DockerHub, Private registries, public cloud registries</p>
             </div>
@@ -165,19 +165,19 @@
           <td aria-label="Category">Networking</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5"></span>
+              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
               <p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4-half"></span>
+              <span class="p-rating p-rating--4-half" role="img" aria-label="4.5 out of 5"></span>
               <p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3"></span>
+              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
               <p>Canal, Calico, Flannel, Weave</p>
             </div>
           </td>
@@ -186,19 +186,19 @@
           <td aria-label="Category">Storage</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5"></span>
+              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
               <p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4-half"></span>
+              <span class="p-rating p-rating--4-half" role="img" aria-label="4.5 out of 5"></span>
               <p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4-half"></span>
+              <span class="p-rating p-rating--4-half" role="img" aria-label="4.5 out of 5"></span>
               <p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p>
             </div>
           </td>
@@ -219,19 +219,19 @@
           <td aria-label="Category">Multi cloud deployments</td>
           <td aria-label="Canonical Kubernetes">
             <div class="u-align--center">
-              <span class="p-rating p-rating--5"></span>
+              <span class="p-rating p-rating--5" role="img" aria-label="5 out of 5"></span>
               <p>Juju</p>
             </div>
           </td>
           <td aria-label="Red Hat Openshift">
             <div class="u-align--center">
-              <span class="p-rating p-rating--3"></span>
+              <span class="p-rating p-rating--3" role="img" aria-label="3 out of 5"></span>
               <p>Ansible</p>
             </div>
           </td>
           <td aria-label="Rancher">
             <div class="u-align--center">
-              <span class="p-rating p-rating--4"></span>
+              <span class="p-rating p-rating--4" role="img" aria-label="4 out of 5"></span>
               <p>Helm</p>
             </div>
           </td>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -33,11 +33,11 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <p>Each category is rated out of 5 for easy comparison</p>
-    <table>
+    <p><small>Some categories are rated out of 5 for easy comparison</small></p>
+    <table class="p-table--mobile-card">
       <thead>
         <tr>
-          <th colspan="2">&nbsp;</th>
+          <th>&nbsp;</th>
           <th class="u-align--center">Canonical Kubernetes</th>
           <th class="u-align--center">Red Hat Openshift</th>
           <th class="u-align--center">Rancher</th>
@@ -45,112 +45,253 @@
       </thead>
       <tbody>
         <tr>
-          <td colspan="2">CNCF Conformant</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">CNCF Conformant</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">High availability</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">High availability</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Enterprise update control</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center">&ndash;</td>
-          <td class="u-align--center">&ndash;</td>
+          <td aria-label="Category">Enterprise update control</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <span>&ndash;</span>
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <span>&ndash;</span>
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Automated upgrades between versions</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center">&ndash;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">Automated upgrades between versions</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift"class="u-align--center" >
+            <span>&ndash;</span>
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Edge support</td>
-          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>MicroK8s</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>Openshift</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>K3s</p></td>
+          <td aria-label="Category">Edge support</td>
+          <td aria-label="Canonical Kubernetes">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--5"></span>
+              <p>MicroK8s</p>
+            </div>
+          </td>
+          <td aria-label="Red Hat Openshift">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--3"></span>
+              <p>Openshift</p>
+            </div>
+          </td>
+          <td aria-label="Rancher">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--5"></span>
+              <p>K3s</p>
+            </div>
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Single-node edition</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center">&ndash;</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">Single-node edition</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <span>&ndash;</span>
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Managed Kubernetes offering</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center">&ndash;</td>
+          <td aria-label="Category">Managed Kubernetes offering</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center" >
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center" >
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center" >
+          <span>&ndash;</span>
+        </td>
         </tr>
         <tr>
-          <td colspan="2">Container runtime and registries</td>
-          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>ContainerD, Docker, Kata</p><p>Private registries, DockerHub, ROCKs, public cloud registries</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>CRI-O, Kata</p><p>DockerHub Private registries, public cloud registries</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--4"></span><p>ContainerD, Docker</p><p>DockerHub, Private registries, public cloud registries</p></td>
+          <td aria-label="Category">Container runtime and registries</td>
+          <td aria-label="Canonical Kubernetes">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--5"></span>
+              <p>ContainerD, Docker, Kata</p>
+              <p>Private registries, DockerHub, ROCKs, public cloud registries</p>
+            </div>
+          </td>
+          <td aria-label="Red Hat Openshift">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--3"></span>
+              <p>CRI-O, Kata</p>
+              <p>DockerHub Private registries, public cloud registries</p>
+            </div>
+          </td>
+          <td aria-label="Rancher">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--4"></span>
+              <p>ContainerD, Docker</p>
+              <p>DockerHub, Private registries, public cloud registries</p>
+            </div>
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Networking</td>
-          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--4-half"></span><p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>Canal, Calico, Flannel, Weave</p></td>
+          <td aria-label="Category">Networking</td>
+          <td aria-label="Canonical Kubernetes">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--5"></span>
+              <p>Flannel, Calico, Canal, TIgera EE, Multus,  SR-IOV, Juniper Contrail</p>
+            </div>
+          </td>
+          <td aria-label="Red Hat Openshift">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--4-half"></span>
+              <p>OpenShift SDN, Flannel, Nuage, Kuryr, OvS, Multus, SR-IOV</p>
+            </div>
+          </td>
+          <td aria-label="Rancher">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--3"></span>
+              <p>Canal, Calico, Flannel, Weave</p>
+            </div>
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Storage</td>
-          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--4-half"></span><p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--4-half"></span><p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p></td>
+          <td aria-label="Category">Storage</td>
+          <td aria-label="Canonical Kubernetes">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--5"></span>
+              <p>Ceph, NFS, Cloud Storage, NetApp, vSphere, FlexVolume</p>
+            </div>
+          </td>
+          <td aria-label="Red Hat Openshift">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--4-half"></span>
+              <p>Ceph/Rook, Gluster, NFS, Cinder, Flexvolume, vSphere</p>
+            </div>
+          </td>
+          <td aria-label="Rancher">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--4-half"></span>
+              <p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p>
+            </div>
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Monitoring and Operations Management</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">Monitoring and Operations Management</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center" >
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center" >
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center" >
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Multi cloud deployments</td>
-          <td class="u-align--center"><span class="p-rating p-rating--5"></span><p>Juju</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--3"></span><p>Ansible</p></td>
-          <td class="u-align--center"><span class="p-rating p-rating--4"></span><p>Helm</p></td>
+          <td aria-label="Category">Multi cloud deployments</td>
+          <td aria-label="Canonical Kubernetes">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--5"></span>
+              <p>Juju</p>
+            </div>
+          </td>
+          <td aria-label="Red Hat Openshift">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--3"></span>
+              <p>Ansible</p>
+            </div>
+          </td>
+          <td aria-label="Rancher">
+            <div class="u-align--center">
+              <span class="p-rating p-rating--4"></span>
+              <p>Helm</p>
+            </div>
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Native AWS/GCP/Azure integration</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">Native AWS/GCP/Azure integration</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Native Openstack/VMware integration</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">Native Openstack/VMware integration</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">GPGPU support for accelerated workloads</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">GPGPU support for accelerated workloads</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
+          </td>
         </tr>
         <tr>
-          <td colspan="2">Bare metal deployment</td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
-          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Category">Bare metal deployment</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
+          <td aria-label="Rancher" class="u-align--center">
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes"></td>
         </tr>
         <tr>
-          <td colspan="2">Architectures supported</td>
-          <td class="u-align--center">X86, POWER, ARM, Z</td>
-          <td class="u-align--center">X86, POWER, Z</td>
-          <td class="u-align--center">X86</td>
+          <td aria-label="Category">Architectures supported</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">X86, POWER, ARM, Z</td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">X86, POWER, Z</td>
+          <td aria-label="Rancher" class="u-align--center">X86</td>
         </tr>
         <tr>
-          <td colspan="2">Pricing</td>
-          <td class="u-align--center">$</td>
-          <td class="u-align--center">$$$$$</td>
-          <td class="u-align--center">$$$</td>
+          <td aria-label="Category">Pricing</td>
+          <td aria-label="Canonical Kubernetes" class="u-align--center">$</td>
+          <td aria-label="Red Hat Openshift" class="u-align--center">$$$$$</td>
+          <td aria-label="Rancher" class="u-align--center">$$$</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Build new `/kubernetes/compare` page 
- Add to secondary nav
- Add meta image

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/compare
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1JngYmRhohPo62yU72V1xpzCCILI21SmHKKttBxHjPog/edit?ts=5faa80b7)

**NOTE**: A new pattern was made for the ratings meter, as the l-tutorials-meter which is used on the tutorials page 1) has a very specific class name and 2) doesn't allow for ratings which aren't whole numbers.  Should we combine these two patterns somehow using a more generic class name? 


## Issue / Card

Fixes #8680 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/99090671-d4455d00-25c6-11eb-80b5-8cba95572453.png)

