### PR TITLE
Add contact-us pages and cta to /financial-services

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -184,6 +184,20 @@ raspberrypi:
     - title: Server
       path: /raspberry-pi/server
 
+financial-services:
+  title: Finance
+  path: /financial-services
+
+  children:
+    - title: Contact us
+      path: /financial-services/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /financial-services/thank-you
+          hidden: True
+
 smartstart:
   title: SMART START
   path: /smartstart

--- a/templates/c/contact-us.html
+++ b/templates/c/contact-us.html
@@ -1,0 +1,33 @@
+{% extends "support/base_support.html" %}
+
+{% block title %}Contact Canonical | Support{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1rWgWFGtal7ddDAkIOKtA6M3wXKd7gX-ABQtyhwbqjyk/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% if product == 'education-discount' %}
+
+{% with h1="Contact us about discounts for education and research",
+  intro_text="Considering Ubuntu for your school, research or academic organisation? Just fill in the form below and a member of our team will be in touch.",
+  formid="3762",
+  lpId="2065",
+  returnURL="https://www.ubuntu.com/support/thank-you?product=education-discount" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+{% else %}
+
+{% with h1="Contact Canonical about Ubuntu Advantage",
+  intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch.",
+  formid="1240",
+  lpId="2065",
+  returnURL="https://www.ubuntu.com/support/thank-you" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+{% endif %}
+
+
+
+
+{% endblock content %}

--- a/templates/financial-services/_base_financial-services.html
+++ b/templates/financial-services/_base_financial-services.html
@@ -1,0 +1,9 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+{% endblock %}

--- a/templates/financial-services/contact-us.html
+++ b/templates/financial-services/contact-us.html
@@ -1,0 +1,18 @@
+{% extends "financial-services/_base_financial-services.html" %}
+
+{% block title %}Contact Canonical | Financial services{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1CG04ASLyc_Q8rtoKwBXQk3YfT5B_Mbdv5B1iZNlYzBw/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% with h1="Contact Canonical",
+  intro_text="Considering Ubuntu? Just fill in the form below and a member of our team will be in touch.",
+  formid="3709",
+  lpId="2065",
+  returnURL="https://ubuntu.com/financial-services/thank-you" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+
+
+{% endblock content %}

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -1,4 +1,4 @@
-{% extends "templates/one-column.html" %}
+{% extends "financial-services/_base_financial-services.html" %}
 
 
 {% block title %}Financial services{% endblock %}
@@ -12,6 +12,11 @@
     <div class="col-8">
       <h1>Canonical empowers the financial services industry</h1>
       <p>With evolving regulations, growing security threats and increasing costs – plus the emergence of game-changing new technologies like AI and Blockchain – the finance world needs practical solutions, now more than ever. That’s why Canonical enables sellside and buyside financial services institutions, retail banking operations and insurance and fintech firms to build secure, agile infrastructure with the flexibility to scale.</p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/financial-services/contact-us">
+          Get in touch
+        </a>
+      </p>
     </div>
   </div>
 </section>
@@ -430,7 +435,7 @@
   <div class="row u-equal-height">
     <div class="col-8 u-vertically-center">
       <h4>Talk to us about how Canonical can help you build a secure, agile infrastructure designed for scale.</h4>
-      <div><a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></div>
+      <div><a href="/financial-services/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></div>
     </div>
     <div class="col-4 u-hide--small u-align--center">
       {{
@@ -446,11 +451,5 @@
     </div>
   </div>
 </section>
-
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-
-
 
 {% endblock content %}

--- a/templates/financial-services/thank-you.html
+++ b/templates/financial-services/thank-you.html
@@ -1,0 +1,32 @@
+{% extends "financial-services/_base_financial-services.html" %}
+
+{% block title %}Thank you | Financial services{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+{% block meta_description %}Ubuntu enables sellside and buyside financial services institutions, retail banking operations and insurance and fintech firms to build secure, agile infrastructure with the flexibility to scale.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1qDjpWQx5T49danAFbH1KcbacV5UqK9c_LRKMF_cpOzM/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+  {% with thanks_context="contacting us about Ubuntu for financial services" %}{% include "shared/_thank_you.html" %}{% endwith %}
+
+{% endblock content %}
+{% block footer_extra %}
+<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+<script>
+  /* <![CDATA[ */
+  var google_conversion_id = 1012391776;
+  var google_conversion_language = "en";
+  var google_conversion_format = "3";
+  var google_conversion_color = "ffffff";
+  var google_conversion_label = "utP4CMDOwQMQ4L7f4gM";
+  var google_conversion_value = 0;
+  /* ]]> */
+</script>
+<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+  <div style="display:inline;">
+    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  </div>
+</noscript>
+{% endblock footer_extra %}

--- a/templates/financial-services/thank-you.html
+++ b/templates/financial-services/thank-you.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-  {% with thanks_context="contacting us about Ubuntu for financial services" %}{% include "shared/_thank_you.html" %}{% endwith %}
+  {% with thanks_context="contacting us about Ubuntu for financial services", details='within one working day or you can <a href="/advantage">visit our store</a> to purchase UA Infrastructure.' %}{% include "shared/_thank_you.html" %}{% endwith %}
 
 {% endblock content %}
 {% block footer_extra %}

--- a/templates/shared/_thank_you.html
+++ b/templates/shared/_thank_you.html
@@ -2,7 +2,7 @@
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Thank you for {{ thanks_context }}</h1>
-      <p class="p-heading--four">{% if thanks_message %}{{ thanks_message | safe }}{% else %}A member of our team will be in touch {{ details }}within one working day{% endif %}</p>
+      <p class="p-heading--four">{% if thanks_message %}{{ thanks_message | safe }}{% else %}A member of our team will be in touch {{ details | safe }}within one working day{% endif %}</p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Added 'Get in touch' CTA to top of /financial-services
- Created /financial-services/contact-us and /financial-services/thank-you
- I didn't change the modal form, just the form-id

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/financial-services and  http://0.0.0.0:8001/financial-services/contact-us and http://0.0.0.0:8001/financial-services/thank-you
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the copy doc for [index](https://docs.google.com/document/d/1o9s_MFaiZZIS26tusRi0ALNrcqUihhTSZgxS55oHZj4/edit#), [contact-us](https://docs.google.com/document/d/1CG04ASLyc_Q8rtoKwBXQk3YfT5B_Mbdv5B1iZNlYzBw/edit#) and [thank-you](https://docs.google.com/document/d/1qDjpWQx5T49danAFbH1KcbacV5UqK9c_LRKMF_cpOzM/edit#) page


## Issue / Card

Fixes #8500
