### PR TITLE
Update images on /download/raspberry-pi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -12,7 +12,7 @@
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Install Ubuntu on a Raspberry Pi 2, 3 or 4</h1>
+      <h1>Install Ubuntu on a <br class="u-hide--small">Raspberry Pi 2, 3 or 4</h1>
       <p>Running Ubuntu on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your Pi and away you go.</p>
       <p>First time installing Ubuntu on Raspberry Pi?</p>
       <p>
@@ -22,10 +22,10 @@
     <div class="col-5 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
+          url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
           alt="",
-          height="123",
-          width="100",
+          height="184",
+          width="148",
           hi_def=True,
           loading="auto"
         ) | safe
@@ -89,8 +89,8 @@
           image(
             url="https://assets.ubuntu.com/v1/9df28d88-RPI_400_rotated.png",
             alt="",
-            height="87",
-            width="121",
+            height="92",
+            width="127",
             hi_def=True,
             loading="auto"
           ) | safe


### PR DESCRIPTION
## Done

- See that there is a new pi logo
- See that the h1 has a bread on large and medium screens
- See that the 400 heading is inline

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes #8749

## Screenshots

![image](https://user-images.githubusercontent.com/441217/99382008-c7c14d00-28c3-11eb-885c-08cd6edd8f22.png)

