### PR TITLE
filter out "closed" status renewals

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -244,7 +244,7 @@ class TestMakeRenewal(unittest.TestCase):
         self.assertEqual(got, want)
 
     def test_closed(self):
-        """Closed renewals are not renewable."""
+        """Closed renewals are not returned to the view."""
         advantage = make_advantage()
         now = datetime.now(timezone.utc)
         start = (now - timedelta(days=1)).isoformat()
@@ -257,17 +257,24 @@ class TestMakeRenewal(unittest.TestCase):
                     "actionable": True,
                     "start": start,
                     "end": end,
-                }
+                },
+                {
+                    "id": "2",
+                    "status": "pending",
+                    "actionable": True,
+                    "start": start,
+                    "end": end,
+                },
             ],
         }
         got = views.make_renewal(advantage, contract_info)
         want = {
-            "id": "1",
-            "status": "closed",
+            "id": "2",
+            "status": "pending",
             "actionable": True,
+            "renewable": True,
             "start": start,
             "end": end,
-            "renewable": False,
         }
         self.assertEqual(got, want)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -812,9 +812,12 @@ def make_renewal(advantage, contract_info):
         return None
 
     sorted_renewals = sorted(
-        renewals,
+        (r for r in renewals if r["status"] != "closed"),
         key=lambda renewal: dateutil.parser.parse(renewal["start"]),
     )
+
+    if len(sorted_renewals) == 0:
+        return None
 
     renewal = sorted_renewals[0]
 


### PR DESCRIPTION
## Done

If a user has multiple renewals, filter out any with "closed" status so we can surface any that are open.

## QA

- See that the Python tests pass.