### PR TITLE
Changes CVE table from 0.8rem to 0.875rem

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -17,7 +17,7 @@
   }
 
   .cve-table {
-    font-size: 0.8rem;
+    font-size: 0.875rem;
     line-height: 1rem;
   }
 

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -17,8 +17,7 @@
   }
 
   .cve-table {
-    font-size: 0.875rem;
-    line-height: 1rem;
+    @extend %small-text;
   }
 
   .cve-table thead tr {


### PR DESCRIPTION
To match the Vanilla font size scale.

## Done

- Changed CVE table font size from 0.8rem to 0.875rem.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Check that the table still looks okay

## Issue / Card

No issue, but raised by @lyubomir-popov in [vanilla-framework#3399](https://github.com/canonical-web-and-design/vanilla-framework/issues/3399).