### PR TITLE
K8sDocs add clarifications for etcd upgrade

### DIFF
--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -74,8 +74,6 @@ This includes:
 
 Note that this may include other applications which you may have installed, such as Elasticsearch, Prometheus, Nagios, Helm, etc.
 
-
-
 <a id='upgrading-containerd'> </a>
 
 ### Upgrading Containerd
@@ -162,14 +160,27 @@ this data before running an upgrade. This is covered in more detail in the
 ```bash
 juju run-action etcd/0 snapshot --wait
 ```
-You should see confirmation of the snapshot being created, and the location of the file
-_on the **etcd** unit_
+You should see confirmation of the snapshot being created, and the command needed to download the snapshot  
+_from the **etcd** unit_. See the following truncated, example output:
+
+```
+...
+copy:
+      cmd: juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz
+        .
+...
+```
 
 #### 2. Fetch a local copy of the snapshot
 
-Knowing the path to the snapshot file from the output of the above command, you can
-download a local copy:
-`bash juju scp etcd/0:/home/ubuntu/etcd-snapshots/<filename>.tar.gz .`
+You can use the `juju scp` command from the output above to download a local copy. For example:
+
+```
+juju scp etcd/40:/home/ubuntu/etcd-snapshots/etcd-snapshot-2020-11-18-21.37.11.tar.gz .
+```
+
+Substitute in your own etcd unit number and filename, or copy and paste the command from the previous
+output. Remember to add the ` .` at the end to copy to your local directory! 
 
 #### 3. Upgrade
 
@@ -459,7 +470,7 @@ kube-system                       monitoring-influxdb-grafana-v4-65cc9bb8c8-mwvc
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
+<p class="p-notification__response">
     We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/upgrading.md" class="p-notification__action">edit this page</a>
     or


### PR DESCRIPTION
## Done

Adds some additional text to clarify commands for etcd upgrade steps

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
