### PR TITLE
Update the webinars on both the Kafka and Cassandra managed pages

### DIFF
--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -146,7 +146,7 @@
 </section>
 
 <section class="p-strip">
-  <div class="row" id="webinar">
+  <div class="row u-equal-height" id="webinar">
     <div class="col-5">
       <h2>
         Plan and optimise your Cassandra deployment
@@ -158,8 +158,11 @@
         <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/439718">Watch the webinar on BrightTALK</a>
       </p>
     </div>
-    <div class="col-7">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 439718, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+    <div class="col-7 u-vertically-center u-align--center u-hide--small">
+      <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
+        <img src="https://www.brighttalk.com/communication/439718/preview_1600876195.png" alt="" class="p-image--shadowed">
+      </a>
+    </div>
   </div>
   <div class="u-fixed-width">
     <hr class="p-separator">

--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -119,24 +119,6 @@
       </ul>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <hr class="p-separator">
-  </div>
-  <div class="row" id="webinar">
-    <div class="col-5">
-      <h2>
-        Plan and optimise your Cassandra deployment
-      </h2>
-      <p>
-        Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments
-      </p>
-      <p>
-        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/439718">Watch the webinar on BrightTALK</a>
-      </p>
-    </div>
-    <div class="col-7">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 439718, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
-  </div>
 </section>
 
 <section class="p-strip--light">
@@ -164,6 +146,24 @@
 </section>
 
 <section class="p-strip">
+  <div class="row" id="webinar">
+    <div class="col-5">
+      <h2>
+        Plan and optimise your Cassandra deployment
+      </h2>
+      <p>
+        Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments
+      </p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/439718">Watch the webinar on BrightTALK</a>
+      </p>
+    </div>
+    <div class="col-7">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 439718, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
   <div class="row">
     <div class="col-8">
       <h2>Key Features</h2>

--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -119,6 +119,24 @@
       </ul>
     </div>
   </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
+  <div class="row" id="webinar">
+    <div class="col-5">
+      <h2>
+        Plan and optimise your Cassandra deployment
+      </h2>
+      <p>
+        Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments
+      </p>
+      <p>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/439718">Watch the webinar on BrightTALK</a>
+      </p>
+    </div>
+    <div class="col-7">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 439718, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+  </div>
 </section>
 
 <section class="p-strip--light">
@@ -137,7 +155,7 @@
     <div class="col-7 u-vertically-center">
       <div>
         <h3>
-          Upstream Cassandra on-rails, fully automated and integrated into your infrastructure. 
+          Upstream Cassandra on-rails, fully automated and integrated into your infrastructure.
         </h3>
         <p><a href="https://ubuntu.com/managed#get-in-touch" class="js-invoke-modal">Get started with a free architecture assessment&nbsp;&rsaquo;</a></p>
       </div>
@@ -592,34 +610,6 @@
     </section>
 
     <section class="p-strip is-deep">
-      <div class="row u-equal-height">
-        <div class="col-7">
-          <h2>
-            Plan and optimise your Cassandra deployment
-          </h2>
-          <p>
-            Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments
-          </p>
-          <p>
-            <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/439718">Watch the webinar</a>
-          </p>
-        </div>
-        <div class="col-5 u-hide--small u-vertically-center u-align--center">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/7cafcb2c-Managed-apps.svg",
-            alt="",
-            height="138",
-            width="272",
-            hi_def=True,
-            loading="lazy",
-            ) | safe
-          }}
-        </div>
-      </div>
-    </section>
-
-    <section class="p-strip--light is-deep">
       <div class="row u-equal-height">
         <div class="col-4 u-align--center u-hide--small u-vertically-center">
           {{

--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -147,18 +147,20 @@
 
 <section class="p-strip--suru-accent is-dark" id="webinar">
   <div class="row">
-    <div class="col-4 p-card u-hide--small u-vertically-center">
-      <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/79990f2e-cassandra-in-production-webinar.png",
-            alt="",
-            width="640",
-            height="360",
-            hi_def=True,
-          ) | safe
-        }}
-      </a>
+    <div class="col-4 u-hide--small u-vertically-center">
+      <div class="p-card">
+        <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/79990f2e-cassandra-in-production-webinar.png",
+              alt="",
+              width="640",
+              height="360",
+              hi_def=True,
+            ) | safe
+          }}
+        </a>
+      </div>
     </div>
     <div class="col-8 col-start-large-6">
       <div class="p-heading-icon--small">

--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -145,28 +145,45 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row u-equal-height" id="webinar">
-    <div class="col-5">
-      <h2>
-        Plan and optimise your Cassandra deployment
-      </h2>
-      <p>
-        Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments
-      </p>
-      <p>
-        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/439718">Watch the webinar on BrightTALK</a>
-      </p>
-    </div>
-    <div class="col-7 u-vertically-center u-align--center u-hide--small">
+<section class="p-strip--suru-accent is-dark" id="webinar">
+  <div class="row">
+    <div class="col-4 p-card u-hide--small u-vertically-center">
       <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
-        <img src="https://www.brighttalk.com/communication/439718/preview_1600876195.png" alt="" class="p-image--shadowed">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/79990f2e-cassandra-in-production-webinar.png",
+            alt="",
+            width="640",
+            height="360",
+            hi_def=True,
+          ) | safe
+        }}
       </a>
     </div>
+    <div class="col-8 col-start-large-6">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/816ae23b-Webinar+-+white.svg",
+              alt="",
+              width="32",
+              height="32",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img"},
+            ) | safe
+          }}
+          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">WEBINAR</p>
+        </div>
+        <h4>Plan and optimise your Cassandra deployment</h4>
+        <p>Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments</p>
+        <p><a href="https://www.brighttalk.com/webcast/6793/439718" class="p-button--neutral p-link--external">Watch the webinar on BrightTALK</a></p>
+      </div>
+    </div>
   </div>
-  <div class="u-fixed-width">
-    <hr class="p-separator">
-  </div>
+</section>
+
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Key Features</h2>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -114,20 +114,6 @@
       </ul>
     </div>
   </div>
-<div class="u-fixed-width">
-  <hr class="p-separator">
-</div>
-  <div class="row" id="webinar">
-    <div class="col-5">
-      <div>
-        <h3>Kafka can be challenging. Learn&nbsp;how we simplify it.</h3>
-        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="js-invoke-modal p-link--external">Watch the webinar on BrightTALK</a></p>
-      </div>
-    </div>
-    <div class="col-7">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 410402, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
-    </div>
-  </div>
 </section>
 
 <section class="p-strip--light">
@@ -155,6 +141,20 @@
 </section>
 
 <section class="p-strip">
+  <div class="row" id="webinar">
+    <div class="col-5">
+      <div>
+        <h3>Kafka can be challenging. Learn&nbsp;how we simplify it.</h3>
+        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="js-invoke-modal p-link--external">Watch the webinar on BrightTALK</a></p>
+      </div>
+    </div>
+    <div class="col-7">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 410402, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
   <div class="row">
     <div class="col-8">
       <h2>Key Features</h2>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -140,23 +140,44 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row u-equal-height" id="webinar">
-    <div class="col-5">
-      <div>
-        <h3>Kafka can be challenging. Learn&nbsp;how we simplify it.</h3>
-        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="p-link--external">Watch the webinar on BrightTALK</a></p>
-      </div>
-    </div>
-    <div class="col-7 u-vertically-center u-align--center u-hide--small">
+<section class="p-strip--suru-accent is-dark" id="webinar">
+  <div class="row">
+    <div class="col-4 p-card u-hide--small u-vertically-center">
       <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
-        <img src="https://www.brighttalk.com/communication/410402/preview_1591721370.png" alt="" class="p-image--shadowed">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/e40b01bd-kafka-in-production-webinar.png",
+            alt="",
+            width="640",
+            height="360",
+            hi_def=True,
+          ) | safe
+        }}
       </a>
     </div>
+    <div class="col-8 col-start-large-6">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/fc781c43-Case+study+-+white.svg",
+              alt="",
+              width="32",
+              height="32",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img"},
+            ) | safe
+          }}
+          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">WEBINAR</p>
+        </div>
+        <h4>Kafka can be challenging. Learn how we simplify it</h4>
+        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="p-button--neutral p-link--external">Watch the webinar on BrightTALK</a></p>
+      </div>
+    </div>
   </div>
-  <div class="u-fixed-width">
-    <hr class="p-separator">
-  </div>
+</section>
+
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Key Features</h2>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -114,6 +114,20 @@
       </ul>
     </div>
   </div>
+<div class="u-fixed-width">
+  <hr class="p-separator">
+</div>
+  <div class="row" id="webinar">
+    <div class="col-5">
+      <div>
+        <h3>Kafka can be challenging. Learn&nbsp;how we simplify it.</h3>
+        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="js-invoke-modal p-link--external">Watch the webinar on BrightTALK</a></p>
+      </div>
+    </div>
+    <div class="col-7">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 410402, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+    </div>
+  </div>
 </section>
 
 <section class="p-strip--light">
@@ -220,30 +234,6 @@
         <li class="p-list__item is-ticked">Schedule updates to downtime windows</li>
         <li class="p-list__item is-ticked">Web-based dashboard of key health metrics</li>
       </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-5 u-vertically-center">
-      <div>
-        <h3>Kafka can be challenging. Learn&nbsp;how we simplify it.</h3>
-        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="js-invoke-modal p-link--external">Watch the full webinar on demand now</a></p>
-      </div>
-    </div>
-    <div class="col-5 col-start-large-7">
-      <a href="https://www.brighttalk.com/webcast/6793/410402" aria-hidden="true" tabindex="-1">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/8b5358eb-Banner-Kafka-in-Prod-Webinar.png",
-            alt="",
-            width="1008",
-            height="528",
-            hi_def=True,
-          ) | safe
-      }}
-      </a>
     </div>
   </div>
 </section>

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -141,15 +141,17 @@
 </section>
 
 <section class="p-strip">
-  <div class="row" id="webinar">
+  <div class="row u-equal-height" id="webinar">
     <div class="col-5">
       <div>
         <h3>Kafka can be challenging. Learn&nbsp;how we simplify it.</h3>
-        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="js-invoke-modal p-link--external">Watch the webinar on BrightTALK</a></p>
+        <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="p-link--external">Watch the webinar on BrightTALK</a></p>
       </div>
     </div>
-    <div class="col-7">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;"><script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : 6793, "language": "en-US", "commId" : 410402, "displayMode" : "portalplayer", "height" : "auto" }</script><script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script></div>
+    <div class="col-7 u-vertically-center u-align--center u-hide--small">
+      <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
+        <img src="https://www.brighttalk.com/communication/410402/preview_1591721370.png" alt="" class="p-image--shadowed">
+      </a>
     </div>
   </div>
   <div class="u-fixed-width">

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -142,25 +142,27 @@
 
 <section class="p-strip--suru-accent is-dark" id="webinar">
   <div class="row">
-    <div class="col-4 p-card u-hide--small u-vertically-center">
-      <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/e40b01bd-kafka-in-production-webinar.png",
-            alt="",
-            width="640",
-            height="360",
-            hi_def=True,
-          ) | safe
-        }}
-      </a>
+    <div class="col-4 u-hide--small">
+      <div class="p-card">
+        <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/e40b01bd-kafka-in-production-webinar.png",
+              alt="",
+              width="640",
+              height="360",
+              hi_def=True,
+            ) | safe
+          }}
+        </a>
+      </div>
     </div>
-    <div class="col-8 col-start-large-6">
+    <div class="col-8 col-start-large-6 u-vertically-center">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/fc781c43-Case+study+-+white.svg",
+              url="https://assets.ubuntu.com/v1/816ae23b-Webinar+-+white.svg",
               alt="",
               width="32",
               height="32",

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -144,7 +144,7 @@
   <div class="row">
     <div class="col-4 u-hide--small">
       <div class="p-card">
-        <a href="https://www.brighttalk.com/webcast/6793/439718" aria-hidden="true" tabindex="-1">
+        <a href="https://www.brighttalk.com/webcast/6793/410402" aria-hidden="true" tabindex="-1">
           {{
             image(
               url="https://assets.ubuntu.com/v1/e40b01bd-kafka-in-production-webinar.png",
@@ -172,7 +172,7 @@
           }}
           <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">WEBINAR</p>
         </div>
-        <h4>Kafka can be challenging. Learn how we simplify it</h4>
+        <h4>Kafka can be challenging. Learn how we simplify it.</h4>
         <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="p-button--neutral p-link--external">Watch the webinar on BrightTALK</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done
On both the Kafka and Cassandra pages:
- Move the webinar content below the logo cloud
- Replace the image with a `portalplayer` of the BrightTalk webinar
- Added "webinar" id to each section
- Updated the link to say its linking to BrightTalk.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/kafka#webinar
- Check that the webinar works in place
- Check the webinar is not at the bottom of the page anymore
- Check they match the request in [the copy doc](https://docs.google.com/document/d/15c89-PyMc-QnSHglG1hf_Tub5lMkEcVYALL0rm5-LvA/edit#heading=h.aelhh61rh94) 
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/cassandra#webinar
- Check that the webinar works in place
- Check the webinar is not at the bottom of the page anymore
- Check they match the request in [the copy doc](https://docs.google.com/document/d/1iYMH1ISY4uDtr3ZzH0f_hnEzvqaeufO43z__cMxs0vQ/edit?ts=5f71f2cb#heading=h.9cquhait6dhr) 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8775

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/99798913-b8dbd400-2b29-11eb-99d7-3813c07f802f.png)

