### PR TITLE
sitemap.xml autogenerated for discourse module 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==2.0.2
+canonicalwebteam.discourse==2.1.0
 canonicalwebteam.launchpad==0.7.8
 python-dateutil==2.8.1
 pytz==2020.1


### PR DESCRIPTION
## Done

This is a demo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Navigate in the different sections that use the discourse docs module and check the `/sitemap.xml` eg. `/server/docs/sitemap.xml`
