### PR TITLE
Update ctas and image in /kubeflow/what-is-kubeflow

### DIFF
--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -14,7 +14,7 @@
         <p class="p-heading--4">Kubeflow is the open source machine learning toolkit on top of Kubernetes. </p>
         <p class="u-sv3">Kubernetes is the industry standard for software delivery at scale and Kubeflow provides the cloud-native interface between K8s and data science tools - libraries, frameworks, pipelines, notebooks - bringing the Ops to ML.</p>
         <p>
-          <a class="p-button--positive" href="/kubeflow/install">
+          <a class="p-button--positive p-link--external" href="https://charmed-kubeflow.io/docs/install">
           Try Kubeflow
           </a>
           <a class="p-link--external" href="https://charmed-kubeflow.io">Kubeflow operators</a>
@@ -78,7 +78,7 @@
             loading="lazy",
           ) | safe
         }}
-      </li> 
+      </li>
       <li class="p-inline-images__item">
         {{
           image(
@@ -104,7 +104,7 @@
             loading="lazy",
           ) | safe
         }}
-      </li>   
+      </li>
       <li class="p-inline-images__item">
         {{
           image(
@@ -141,7 +141,7 @@
       <p>Kubeflow started as part of TensorFlow Extended (TFX) and naturally, it includes <a class="p-link--external" href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow training</a>, <a class="p-link--external" href="https://www.kubeflow.org/docs/components/serving/tfserving_new/">TensorFlow serving</a> and even <a class="p-link--external" href="https://www.tensorflow.org/tensorboard">TensorBoard</a>.</p>
 
       <p class="p-heading--4">ML libraries & frameworks</p>
-      <p>For training - <a class="p-link--external" href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch Training</a>, 
+      <p>For training - <a class="p-link--external" href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch Training</a>,
       <a class="p-link--external" href="https://www.kubeflow.org/docs/components/training/mxnet/">MXNet</a>
       <a class="p-link--external" href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>
       <a class="p-link--external" href="https://medium.com/kubeflow/introduction-to-kubeflow-mpi-operator-and-industry-adoption-296d5f2e6edc">MPI for distributed training</a> and <a class="p-link--external" href="https://scikit-learn.org/stable/">scikit-learn</a> For model serving - <a class="p-link--external" href="https://www.seldon.io/">Seldon Core</a>, <a class="p-link--external" href="https://www.kubeflow.org/docs/components/serving/kfserving/">KFserving</a> and <a class="p-link--external" href="https://www.kubeflow.org/docs/components/serving/">more</a>.</p>
@@ -169,7 +169,7 @@
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
           ) | safe
-        }}        
+        }}
         </li>
         <li class="p-inline-images__item ">
         {{
@@ -182,7 +182,7 @@
             attrs={"class": "p-inline-images__logos"},
             loading="lazy",
           ) | safe
-        }}        
+        }}
         </li>
         <li class="p-inline-images__item">
         {{
@@ -327,7 +327,7 @@
           ) | safe
         }}
         </li>
-      </ul>     
+      </ul>
     </div>
   </div>
 </section>
@@ -339,21 +339,20 @@
         <h2>Kubeflow, well packaged</h2>
         <p>Charmed Kubeflow integrates the <a href="https://jaas.ai/u/kubeflow-charmers#charms" class="p-link--external p-link--inverted">30+ apps</a> that make up Kubeflow with ops code to provide the best Kubeflow experience, from deployment to day-2 operations.</p>
         <br />
-          <a class="p-link--external p-link--inverted" href="https://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
+          <a class="p-link--external p-button--positive" href="https://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
       </div>
     </div>
     <div class="col-5 u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/2b8bb6e7-Kubeflow-packaged-transparent.svg",
+          url="https://assets.ubuntu.com/v1/20f5bfae-Kubeflow-nicely-packaged-simple-transparent.svg",
           alt="",
-          width="195",
-          height="180",
+          width="212",
+          height="201",
           hi_def=True,
-          attrs={"class": "u-hide--small"},
-          loading="lazy",
         ) | safe
       }}
+
   </div>
 </section>
 
@@ -491,7 +490,7 @@
           }}
         </li>
       </ul>
-    </div> 
+    </div>
   </div>
 </section>
 
@@ -513,8 +512,8 @@
     <div class="col-8">
       <h2 class="u-fixed-width u-sv1">Get started today</h2>
       <p class="u-sv2">Try-out Kubeflow on MicroK8s - Zero-ops Kubernetes with high availability. Single-command deploy locally on your desktop, public cloud VM or on-prem server.</p>
-      <a class="p-button--positive" href="/kubeflow/install">
-      Try Kubeflow
+      <a class="p-button--positive p-link--external" href="https://charmed-kubeflow.io/docs/install">
+        Try Kubeflow
       </a>
     </div>
   </div>

--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -514,11 +514,11 @@
       <p class="u-sv2 p-heading--four">Try-out Kubeflow on your K8s deployment. Or on MicroK8s - Zero-ops Kubernetes with high availability.</p>
       <p>Single-command deploy locally on your desktop, public cloud VM or on-prem server.</p>
       <p>
-        <a class="p-button--positive p-link--external" href="https://charmed-kubeflow.io/docs/install">
-        Try Kubeflow
+        <a class="p-button--positive p-link--external" href="http://charmed-kubeflow.io/docs/install">
+        Try Kubeflow on any K8s
         </a>
-        <a class="p-link--external" href="https://charmed-kubeflow.io">
-          Kubeflow operators
+        <a class="p-link--external" href="https://microk8s.io/docs/addon-kubeflow">
+          Kubeflow on MicroK8s
         </a>
       </p>
     </div>

--- a/templates/kubeflow/what-is-kubeflow.html
+++ b/templates/kubeflow/what-is-kubeflow.html
@@ -511,14 +511,18 @@
     </div>
     <div class="col-8">
       <h2 class="u-fixed-width u-sv1">Get started today</h2>
-      <p class="u-sv2">Try-out Kubeflow on MicroK8s - Zero-ops Kubernetes with high availability. Single-command deploy locally on your desktop, public cloud VM or on-prem server.</p>
-      <a class="p-button--positive p-link--external" href="https://charmed-kubeflow.io/docs/install">
+      <p class="u-sv2 p-heading--four">Try-out Kubeflow on your K8s deployment. Or on MicroK8s - Zero-ops Kubernetes with high availability.</p>
+      <p>Single-command deploy locally on your desktop, public cloud VM or on-prem server.</p>
+      <p>
+        <a class="p-button--positive p-link--external" href="https://charmed-kubeflow.io/docs/install">
         Try Kubeflow
-      </a>
+        </a>
+        <a class="p-link--external" href="https://charmed-kubeflow.io">
+          Kubeflow operators
+        </a>
+      </p>
     </div>
   </div>
-
-
 </section>
 
 


### PR DESCRIPTION
## Done

- Updated a few links
- Used the new illustration

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubeflow/what-is-kubeflow
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit?ts=5fb7b3eb#)


## Issue / Card

Fixes #8795 
