### PR TITLE
Remove Pricing from /support secondary nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -963,8 +963,6 @@ support:
   children:
     - title: Overview
       path: /support
-    - title: Pricing
-      path: /support/plans-and-pricing
     - title: Your subscriptions
       path: /advantage
       persist: True


### PR DESCRIPTION
## Done

- Remove Pricing from /support secondary nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link 'Pricing' was removed from the secondary nav

## Issue / Card

Fixes #8787

