### PR TITLE
Update the release charts for Kernel and OpenStack

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -169,147 +169,227 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
-    startDate: new Date("2020-10-22T00:00:00"),
-    endDate: new Date("2021-07-28T00:00:00"),
-    taskName: "Ubuntu 20.10 (v5.8)",
-    status: "INTERIM_RELEASE"
-  },
-  {
-    startDate: new Date("2020-08-01T00:00:00"),
-    endDate: new Date("2023-04-20T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
+    startDate: new Date("2022-08-01T00:00:00"),
+    endDate: new Date("2025-04-30T00:00:00"),
+    taskName: "Ubuntu 20.04.5 LTS",
+    taskVersion: "Kernel version",
     status: "LTS"
   },
   {
-    startDate: new Date("2023-04-20T00:00:00"),
-    endDate: new Date("2028-04-18T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
+    startDate: new Date("2025-04-30T00:00:00"),
+    endDate: new Date("2030-04-29T00:00:00"),
+    taskName: "Ubuntu 20.04.5 LTS",
+    taskVersion: "Kernel version",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS",
+    taskVersion: "22.04 kernel",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2027-04-01T00:00:00"),
+    endDate: new Date("2032-03-30T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS",
+    taskVersion: "22.04 kernel",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2022-02-01T00:00:00"),
+    endDate: new Date("2022-07-01T00:00:00"),
+    taskName: "Ubuntu 20.04.4 LTS",
+    taskVersion: "",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2021-10-01T00:00:00"),
+    endDate: new Date("2022-07-07T00:00:00"),
+    taskName: "Ubuntu 21.10",
+    taskVersion: "",
+    status: "INTERIM_RELEASE"
+  },
+  {
+    startDate: new Date("2021-08-01T00:00:00"),
+    endDate: new Date("2022-01-01T00:00:00"),
+    taskName: "Ubuntu 20.04.3 LTS",
+    taskVersion: "",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2021-04-01T00:00:00"),
+    endDate: new Date("2022-01-05T00:00:00"),
+    taskName: "Ubuntu 21.04",
+    taskVersion: "",
+    status: "INTERIM_RELEASE"
+  },
+  {
+    startDate: new Date("2021-02-01T00:00:00"),
+    endDate: new Date("2021-07-01T00:00:00"),
+    taskName: "Ubuntu 20.04.2 LTS",
+    taskVersion: "",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2020-10-22T00:00:00"),
+    endDate: new Date("2021-07-28T00:00:00"),
+    taskName: "Ubuntu 20.10",
+    taskVersion: "5.8 kernel",
+    status: "INTERIM_RELEASE"
+  },
+  {
+    startDate: new Date("2020-08-13T00:00:00"),
+    endDate: new Date("2023-04-30T00:00:00"),
+    taskName: "Ubuntu 18.04.5 LTS",
+    taskVersion: "",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2023-04-30T00:00:00"),
+    endDate: new Date("2028-04-28T00:00:00"),
+    taskName: "Ubuntu 18.04.5 LTS",
+    taskVersion: "",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2020-08-06T00:00:00"),
+    endDate: new Date("2025-04-30T00:00:00"),
+    taskName: "Ubuntu 20.04.1 LTS",
+    taskVersion: "5.4 kernel",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2025-04-30T00:00:00"),
+    endDate: new Date("2030-04-29T00:00:00"),
+    taskName: "Ubuntu 20.04.1 LTS",
+    taskVersion: "5.4 kernel",
     status: "ESM"
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
-    endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS (v5.4)",
+    endDate: new Date("2025-04-30T00:00:00"),
+    taskName: "Ubuntu 20.04.0 LTS",
+    taskVersion: "",
     status: "LTS"
   },
   {
-    startDate: new Date("2025-04-22T00:00:00"),
-    endDate: new Date("2030-04-21T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS (v5.4)",
+    startDate: new Date("2025-04-30T00:00:00"),
+    endDate: new Date("2030-04-29T00:00:00"),
+    taskName: "Ubuntu 20.04.0 LTS",
+    taskVersion: "",
     status: "ESM"
   },
   {
-    startDate: new Date("2020-02-01T00:00:00"),
-    endDate: new Date("2020-08-05T00:00:00"),
-    taskName: "Ubuntu 18.04.4 LTS (v5.3)",
+    startDate: new Date("2018-08-02T00:00:00"),
+    endDate: new Date("2021-04-30T00:00:00"),
+    taskName: "Ubuntu 16.04.5 LTS",
+    taskVersion: "",
     status: "LTS"
   },
   {
-    startDate: new Date("2019-08-01T00:00:00"),
-    endDate: new Date("2020-02-03T00:00:00"),
-    taskName: "Ubuntu 18.04.3 LTS (v5.0)",
-    status: "LTS"
-  },
-  {
-    startDate: new Date("2019-02-01T00:00:00"),
-    endDate: new Date("2019-08-06T00:00:00"),
-    taskName: "Ubuntu 18.04.2 LTS (v4.18)",
-    status: "LTS"
-  },
-  {
-    startDate: new Date("2018-07-01T00:00:00"),
-    endDate: new Date("2023-04-20T00:00:00"),
-    taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "LTS"
-  },
-  {
-    startDate: new Date("2023-04-20T00:00:00"),
-    endDate: new Date("2028-04-18T00:00:00"),
-    taskName: "Ubuntu 18.04.1 LTS (v4.15)",
+    startDate: new Date("2021-04-30T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
+    taskName: "Ubuntu 16.04.5 LTS",
+    taskVersion: "",
     status: "ESM"
   },
   {
-    startDate: new Date("2018-08-21T00:00:00"),
-    endDate: new Date("2021-04-20T00:00:00"),
-    taskName: "Ubuntu 16.04.5 LTS (v4.15)",
+    startDate: new Date("2018-07-26T00:00:00"),
+    endDate: new Date("2023-04-30T00:00:00"),
+    taskName: "Ubuntu 18.04.1 LTS",
+    taskVersion: "4.15 kernel",
     status: "LTS"
   },
   {
-    startDate: new Date("2021-04-20T00:00:00"),
-    endDate: new Date("2024-04-19T00:00:00"),
-    taskName: "Ubuntu 16.04.5 LTS (v4.15)",
+    startDate: new Date("2023-04-30T00:00:00"),
+    endDate: new Date("2028-04-28T00:00:00"),
+    taskName: "Ubuntu 18.04.1 LTS",
+    taskVersion: "4.15 kernel",
     status: "ESM"
   },
   {
-    startDate: new Date("2018-04-21T00:00:00"),
-    endDate: new Date("2023-04-20T00:00:00"),
-    taskName: "Ubuntu 18.04.0 LTS (v4.15)",
+    startDate: new Date("2018-04-26T00:00:00"),
+    endDate: new Date("2023-04-30T00:00:00"),
+    taskName: "Ubuntu 18.04.0 LTS",
+    taskVersion: "",
     status: "LTS"
   },
   {
-    startDate: new Date("2023-04-20T00:00:00"),
-    endDate: new Date("2028-04-18T00:00:00"),
-    taskName: "Ubuntu 18.04.0 LTS (v4.15)",
+    startDate: new Date("2023-04-30T00:00:00"),
+    endDate: new Date("2028-04-28T00:00:00"),
+    taskName: "Ubuntu 18.04.0 LTS",
+    taskVersion: "",
     status: "ESM"
   },
   {
-    startDate: new Date("2016-08-21T00:00:00"),
-    endDate: new Date("2021-04-20T00:00:00"),
-    taskName: "Ubuntu 16.04.1 LTS (v4.4)",
+    startDate: new Date("2016-08-04T00:00:00"),
+    endDate: new Date("2019-04-30T00:00:00"),
+    taskName: "Ubuntu 14.04.5 LTS",
+    taskVersion: "",
     status: "LTS"
   },
   {
-    startDate: new Date("2021-04-20T00:00:00"),
-    endDate: new Date("2024-04-19T00:00:00"),
-    taskName: "Ubuntu 16.04.1 LTS (v4.4)",
+    startDate: new Date("2019-04-30T00:00:00"),
+    endDate: new Date("2022-04-29T00:00:00"),
+    taskName: "Ubuntu 14.04.5 LTS",
+    taskVersion: "",
     status: "ESM"
   },
   {
-    startDate: new Date("2016-08-21T00:00:00"),
-    endDate: new Date("2019-04-20T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    startDate: new Date("2016-07-21T00:00:00"),
+    endDate: new Date("2021-04-30T00:00:00"),
+    taskName: "Ubuntu 16.04.1 LTS",
+    taskVersion: "4.4 kernel",
     status: "LTS"
   },
   {
-    startDate: new Date("2019-04-20T00:00:00"),
-    endDate: new Date("2022-04-19T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    startDate: new Date("2021-04-30T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
+    taskName: "Ubuntu 16.04.1 LTS",
+    taskVersion: "4.4 kernel",
     status: "ESM"
   },
   {
     startDate: new Date("2016-04-21T00:00:00"),
-    endDate: new Date("2021-04-20T00:00:00"),
-    taskName: "Ubuntu 16.04.0 LTS (v4.4)",
+    endDate: new Date("2021-04-30T00:00:00"),
+    taskName: "Ubuntu 16.04.0 LTS",
+    taskVersion: "",
     status: "LTS"
   },
   {
-    startDate: new Date("2021-04-20T00:00:00"),
-    endDate: new Date("2024-04-19T00:00:00"),
-    taskName: "Ubuntu 16.04.0 LTS (v4.4)",
+    startDate: new Date("2021-04-30T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
+    taskName: "Ubuntu 16.04.0 LTS",
+    taskVersion: "",
     status: "ESM"
   },
   {
-    startDate: new Date("2014-08-21T00:00:00"),
-    endDate: new Date("2019-04-20T00:00:00"),
-    taskName: "Ubuntu 14.04.1 LTS (v3.13)",
+    startDate: new Date("2014-07-24T00:00:00"),
+    endDate: new Date("2019-04-30T00:00:00"),
+    taskName: "Ubuntu 14.04.1 LTS",
+    taskVersion: "",
     status: "LTS"
   },
   {
-    startDate: new Date("2019-04-20T00:00:00"),
-    endDate: new Date("2022-04-19T00:00:00"),
-    taskName: "Ubuntu 14.04.1 LTS (v3.13)",
+    startDate: new Date("2019-04-30T00:00:00"),
+    endDate: new Date("2022-04-29T00:00:00"),
+    taskName: "Ubuntu 14.04.1 LTS",
+    taskVersion: "",
     status: "ESM"
   },
   {
-    startDate: new Date("2014-04-21T00:00:00"),
-    endDate: new Date("2019-04-20T00:00:00"),
-    taskName: "Ubuntu 14.04.0 LTS (v3.13)",
+    startDate: new Date("2014-04-17T00:00:00"),
+    endDate: new Date("2019-04-30T00:00:00"),
+    taskName: "Ubuntu 14.04.0 LTS",
+    taskVersion: "3.13 kernel",
     status: "LTS"
   },
   {
-    startDate: new Date("2019-04-20T00:00:00"),
-    endDate: new Date("2022-04-19T00:00:00"),
-    taskName: "Ubuntu 14.04.0 LTS (v3.13)",
+    startDate: new Date("2019-04-30T00:00:00"),
+    endDate: new Date("2022-04-29T00:00:00"),
+    taskName: "Ubuntu 14.04.0 LTS",
+    taskVersion: "3.13 kernel",
     status: "ESM"
   },
 ];
@@ -1290,20 +1370,47 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
-  "Ubuntu 20.10 (v5.8)",
-  "Ubuntu 18.04.5 LTS (v5.4)",
-  "Ubuntu 20.04 LTS (v5.4)",
-  "Ubuntu 18.04.4 LTS (v5.3)",
-  "Ubuntu 18.04.3 LTS (v5.0)",
-  "Ubuntu 18.04.2 LTS (v4.18)",
-  "Ubuntu 18.04.1 LTS (v4.15)",
-  "Ubuntu 16.04.5 LTS (v4.15)",
-  "Ubuntu 18.04.0 LTS (v4.15)",
-  "Ubuntu 16.04.1 LTS (v4.4)",
-  "Ubuntu 14.04.5 LTS (v3.13)",
-  "Ubuntu 16.04.0 LTS (v4.4)",
-  "Ubuntu 14.04.1 LTS (v3.13)",
-  "Ubuntu 14.04.0 LTS (v3.13)",
+  "Ubuntu 20.04.5 LTS",
+  "Ubuntu 22.04.0 LTS",
+  "Ubuntu 20.04.4 LTS",
+  "Ubuntu 21.10",
+  "Ubuntu 20.04.3 LTS",
+  "Ubuntu 21.04",
+  "Ubuntu 20.04.2 LTS",
+  "Ubuntu 20.10",
+  "Ubuntu 18.04.5 LTS",
+  "Ubuntu 20.04.1 LTS",
+  "Ubuntu 20.04.0 LTS",
+  "Ubuntu 16.04.5 LTS",
+  "Ubuntu 18.04.1 LTS",
+  "Ubuntu 18.04.0 LTS",
+  "Ubuntu 14.04.5 LTS",
+  "Ubuntu 16.04.1 LTS",
+  "Ubuntu 16.04.0 LTS",
+  "Ubuntu 14.04.1 LTS",
+  "Ubuntu 14.04.0 LTS",
+];
+
+export var kernelVersionNames = [
+  "22.04 kernel",
+  "",
+  "21.10 kernel",
+  "",
+  "21.04 kernel",
+  "",
+  "5.8 kernel",
+  "",
+  "5.4 kernel",
+  "",
+  "",
+  "4.15 kernel",
+  "",
+  "",
+  "4.4 kernel",
+  "",
+  "",
+  "3.13 kernel",
+  "",
 ];
 
 export var kernelReleaseNames2004 = [

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -173,224 +173,224 @@ export var kernelReleases = [
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
     taskVersion: "Kernel version",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-30T00:00:00"),
     endDate: new Date("2030-04-29T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
     taskVersion: "Kernel version",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2022-04-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "Ubuntu 22.04.0 LTS",
     taskVersion: "22.04 kernel",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2027-04-01T00:00:00"),
     endDate: new Date("2032-03-30T00:00:00"),
     taskName: "Ubuntu 22.04.0 LTS",
     taskVersion: "22.04 kernel",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2022-02-01T00:00:00"),
     endDate: new Date("2022-07-01T00:00:00"),
     taskName: "Ubuntu 20.04.4 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-10-01T00:00:00"),
     endDate: new Date("2022-07-07T00:00:00"),
     taskName: "Ubuntu 21.10",
     taskVersion: "",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2021-08-01T00:00:00"),
     endDate: new Date("2022-01-01T00:00:00"),
     taskName: "Ubuntu 20.04.3 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2022-01-05T00:00:00"),
     taskName: "Ubuntu 21.04",
     taskVersion: "",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2021-02-01T00:00:00"),
     endDate: new Date("2021-07-01T00:00:00"),
     taskName: "Ubuntu 20.04.2 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2020-10-22T00:00:00"),
     endDate: new Date("2021-07-28T00:00:00"),
     taskName: "Ubuntu 20.10",
     taskVersion: "5.8 kernel",
-    status: "INTERIM_RELEASE"
+    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-08-13T00:00:00"),
     endDate: new Date("2023-04-30T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-30T00:00:00"),
     endDate: new Date("2028-04-28T00:00:00"),
     taskName: "Ubuntu 18.04.5 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-08-06T00:00:00"),
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
     taskVersion: "5.4 kernel",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-30T00:00:00"),
     endDate: new Date("2030-04-29T00:00:00"),
     taskName: "Ubuntu 20.04.1 LTS",
     taskVersion: "5.4 kernel",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2025-04-30T00:00:00"),
     endDate: new Date("2030-04-29T00:00:00"),
     taskName: "Ubuntu 20.04.0 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-08-02T00:00:00"),
     endDate: new Date("2021-04-30T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
     endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-07-26T00:00:00"),
     endDate: new Date("2023-04-30T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS",
     taskVersion: "4.15 kernel",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-30T00:00:00"),
     endDate: new Date("2028-04-28T00:00:00"),
     taskName: "Ubuntu 18.04.1 LTS",
     taskVersion: "4.15 kernel",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2018-04-26T00:00:00"),
     endDate: new Date("2023-04-30T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-04-30T00:00:00"),
     endDate: new Date("2028-04-28T00:00:00"),
     taskName: "Ubuntu 18.04.0 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-08-04T00:00:00"),
     endDate: new Date("2019-04-30T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
     endDate: new Date("2022-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-07-21T00:00:00"),
     endDate: new Date("2021-04-30T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS",
     taskVersion: "4.4 kernel",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
     endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS",
     taskVersion: "4.4 kernel",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2016-04-21T00:00:00"),
     endDate: new Date("2021-04-30T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
     endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2014-07-24T00:00:00"),
     endDate: new Date("2019-04-30T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS",
     taskVersion: "",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
     endDate: new Date("2022-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS",
     taskVersion: "",
-    status: "ESM"
+    status: "ESM",
   },
   {
     startDate: new Date("2014-04-17T00:00:00"),
     endDate: new Date("2019-04-30T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS",
     taskVersion: "3.13 kernel",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
     endDate: new Date("2022-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS",
     taskVersion: "3.13 kernel",
-    status: "ESM"
+    status: "ESM",
   },
 ];
 

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1,32 +1,26 @@
 export var smallReleases = [
   {
-    startDate: new Date("2019-10-01T00:00:00"),
-    endDate: new Date("2020-07-06T00:00:00"),
-    taskName: "Ubuntu 19.10",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2022-10-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2022-10-01T00:00:00"),
     endDate: new Date("2025-04-02T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2025-04-02T00:00:00"),
     endDate: new Date("2030-04-02T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "ESM",
   },
   {
     startDate: new Date("2020-10-01T00:00:00"),
     endDate: new Date("2021-07-07T00:00:00"),
-    taskName: "Ubuntu 20.10",
+    taskName: "Ubuntu 20.10 (v5.8)",
     status: "INTERIM_RELEASE",
   },
   {
@@ -118,33 +112,27 @@ export var serverAndDesktopReleases = [
     status: "ESM",
   },
   {
-    startDate: new Date("2019-10-01T00:00:00"),
-    endDate: new Date("2020-07-06T00:00:00"),
-    taskName: "Ubuntu 19.10",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2022-10-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2022-10-01T00:00:00"),
     endDate: new Date("2025-04-02T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2025-04-02T00:00:00"),
     endDate: new Date("2030-04-02T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "ESM",
   },
   {
     startDate: new Date("2020-10-01T00:00:00"),
     endDate: new Date("2021-07-07T00:00:00"),
-    taskName: "Ubuntu 20.10",
+    taskName: "Ubuntu 20.10 (v5.8)",
     status: "INTERIM_RELEASE",
   },
   {
@@ -181,154 +169,148 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
-    startDate: new Date("2014-04-01T00:00:00"),
-    endDate: new Date("2019-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2019-04-01T00:00:00"),
-    endDate: new Date("2022-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.0 LTS (v3.13)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2014-08-01T00:00:00"),
-    endDate: new Date("2019-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2019-04-01T00:00:00"),
-    endDate: new Date("2022-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.1 LTS (v3.13)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2016-04-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2021-04-01T00:00:00"),
-    endDate: new Date("2024-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04.0 LTS (v4.4)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2016-08-01T00:00:00"),
-    endDate: new Date("2019-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2019-04-01T00:00:00"),
-    endDate: new Date("2022-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2016-08-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2021-04-01T00:00:00"),
-    endDate: new Date("2024-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04.1 LTS (v4.4)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2018-04-01T00:00:00"),
-    endDate: new Date("2023-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-04-01T00:00:00"),
-    endDate: new Date("2028-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04.0 LTS (v4.15)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2018-08-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2021-04-01T00:00:00"),
-    endDate: new Date("2024-04-01T00:00:00"),
-    taskName: "Ubuntu 16.04.5 LTS (v4.15)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2018-07-01T00:00:00"),
-    endDate: new Date("2023-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-04-01T00:00:00"),
-    endDate: new Date("2028-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04.1 LTS (v4.15)",
-    status: "ESM",
-  },
-  {
-    startDate: new Date("2019-02-01T00:00:00"),
-    endDate: new Date("2019-08-01T00:00:00"),
-    taskName: "Ubuntu 18.04.2 LTS (v4.18)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2019-04-01T00:00:00"),
-    endDate: new Date("2020-01-01T00:00:00"),
-    taskName: "Ubuntu 19.04 (v5.0)",
-    status: "INTERIM_RELEASE",
-  },
-  {
-    startDate: new Date("2019-08-01T00:00:00"),
-    endDate: new Date("2020-02-01T00:00:00"),
-    taskName: "Ubuntu 18.04.3 LTS (v5.0)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2019-10-01T00:00:00"),
-    endDate: new Date("2020-07-01T00:00:00"),
-    taskName: "Ubuntu 19.10 (v5.3)",
-    status: "INTERIM_RELEASE",
-  },
-  {
-    startDate: new Date("2020-02-01T00:00:00"),
-    endDate: new Date("2020-08-01T00:00:00"),
-    taskName: "Ubuntu 18.04.4 LTS",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2020-04-01T00:00:00"),
-    endDate: new Date("2025-04-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2025-04-01T00:00:00"),
-    endDate: new Date("2030-04-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
-    status: "ESM",
+    startDate: new Date("2020-10-22T00:00:00"),
+    endDate: new Date("2021-07-28T00:00:00"),
+    taskName: "Ubuntu 20.10 (v5.8)",
+    status: "INTERIM_RELEASE"
   },
   {
     startDate: new Date("2020-08-01T00:00:00"),
-    endDate: new Date("2023-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
-    status: "LTS",
+    endDate: new Date("2023-04-20T00:00:00"),
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
+    status: "LTS"
   },
   {
-    startDate: new Date("2023-04-01T00:00:00"),
-    endDate: new Date("2028-04-01T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
-    status: "ESM",
+    startDate: new Date("2023-04-20T00:00:00"),
+    endDate: new Date("2028-04-18T00:00:00"),
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2020-04-23T00:00:00"),
+    endDate: new Date("2025-04-22T00:00:00"),
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2025-04-22T00:00:00"),
+    endDate: new Date("2030-04-21T00:00:00"),
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2020-02-01T00:00:00"),
+    endDate: new Date("2020-08-05T00:00:00"),
+    taskName: "Ubuntu 18.04.4 LTS (v5.3)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2019-08-01T00:00:00"),
+    endDate: new Date("2020-02-03T00:00:00"),
+    taskName: "Ubuntu 18.04.3 LTS (v5.0)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2019-02-01T00:00:00"),
+    endDate: new Date("2019-08-06T00:00:00"),
+    taskName: "Ubuntu 18.04.2 LTS (v4.18)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2018-07-01T00:00:00"),
+    endDate: new Date("2023-04-20T00:00:00"),
+    taskName: "Ubuntu 18.04.1 LTS (v4.15)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2023-04-20T00:00:00"),
+    endDate: new Date("2028-04-18T00:00:00"),
+    taskName: "Ubuntu 18.04.1 LTS (v4.15)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2018-08-21T00:00:00"),
+    endDate: new Date("2021-04-20T00:00:00"),
+    taskName: "Ubuntu 16.04.5 LTS (v4.15)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2021-04-20T00:00:00"),
+    endDate: new Date("2024-04-19T00:00:00"),
+    taskName: "Ubuntu 16.04.5 LTS (v4.15)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2018-04-21T00:00:00"),
+    endDate: new Date("2023-04-20T00:00:00"),
+    taskName: "Ubuntu 18.04.0 LTS (v4.15)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2023-04-20T00:00:00"),
+    endDate: new Date("2028-04-18T00:00:00"),
+    taskName: "Ubuntu 18.04.0 LTS (v4.15)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2016-08-21T00:00:00"),
+    endDate: new Date("2021-04-20T00:00:00"),
+    taskName: "Ubuntu 16.04.1 LTS (v4.4)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2021-04-20T00:00:00"),
+    endDate: new Date("2024-04-19T00:00:00"),
+    taskName: "Ubuntu 16.04.1 LTS (v4.4)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2016-08-21T00:00:00"),
+    endDate: new Date("2019-04-20T00:00:00"),
+    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2019-04-20T00:00:00"),
+    endDate: new Date("2022-04-19T00:00:00"),
+    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2016-04-21T00:00:00"),
+    endDate: new Date("2021-04-20T00:00:00"),
+    taskName: "Ubuntu 16.04.0 LTS (v4.4)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2021-04-20T00:00:00"),
+    endDate: new Date("2024-04-19T00:00:00"),
+    taskName: "Ubuntu 16.04.0 LTS (v4.4)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2014-08-21T00:00:00"),
+    endDate: new Date("2019-04-20T00:00:00"),
+    taskName: "Ubuntu 14.04.1 LTS (v3.13)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2019-04-20T00:00:00"),
+    endDate: new Date("2022-04-19T00:00:00"),
+    taskName: "Ubuntu 14.04.1 LTS (v3.13)",
+    status: "ESM"
+  },
+  {
+    startDate: new Date("2014-04-21T00:00:00"),
+    endDate: new Date("2019-04-20T00:00:00"),
+    taskName: "Ubuntu 14.04.0 LTS (v3.13)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2019-04-20T00:00:00"),
+    endDate: new Date("2022-04-19T00:00:00"),
+    taskName: "Ubuntu 14.04.0 LTS (v3.13)",
+    status: "ESM"
   },
 ];
 
@@ -393,13 +375,13 @@ export var kernelReleases1804 = [
   {
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2023-04-20T00:00:00"),
     endDate: new Date("2028-04-18T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
     status: "ESM",
   },
   {
@@ -411,7 +393,7 @@ export var kernelReleases1804 = [
   {
     startDate: new Date("2019-08-08T00:00:00"),
     endDate: new Date("2020-02-10T00:00:00"),
-    taskName: "Ubuntu 18.04.3 LTS  (v5.0)",
+    taskName: "Ubuntu 18.04.3 LTS (v5.0)",
     status: "LTS",
   },
   {
@@ -700,22 +682,10 @@ export var kernelReleasesALL = [
     status: "LTS",
   },
   {
-    startDate: new Date("2019-04-16T00:00:00"),
-    endDate: new Date("2020-01-20T00:00:00"),
-    taskName: "Ubuntu 19.04 (v5.0)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2019-08-01T00:00:00"),
     endDate: new Date("2020-02-03T00:00:00"),
     taskName: "Ubuntu 18.04.3 LTS (v5.0)",
     status: "LTS",
-  },
-  {
-    startDate: new Date("2019-10-15T00:00:00"),
-    endDate: new Date("2020-07-20T00:00:00"),
-    taskName: "Ubuntu 19.10 (v5.3)",
-    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2020-02-01T00:00:00"),
@@ -750,13 +720,13 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2020-05-01T00:00:00"),
     endDate: new Date("2020-08-01T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
     status: "EARLY",
   },
   {
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
     status: "LTS",
   },
   {
@@ -975,13 +945,13 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2020-08-01T00:00:00"),
     endDate: new Date("2022-04-23T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2022-04-23T00:00:00"),
     endDate: new Date("2023-04-20T00:00:00"),
-    taskName: "Ubuntu 18.04.5 LTS",
+    taskName: "Ubuntu 18.04.5 LTS (v5.4)",
     status: "CVE",
   },
   {
@@ -1036,21 +1006,9 @@ export var kernelReleaseSchedule = [
     status: "LTS",
   },
   {
-    startDate: new Date("2019-04-16T00:00:00"),
-    endDate: new Date("2020-01-20T00:00:00"),
-    taskName: "Ubuntu 19.04 (v5.0)",
-    status: "INTERIM_RELEASE",
-  },
-  {
-    startDate: new Date("2019-10-15T00:00:00"),
-    endDate: new Date("2020-07-20T00:00:00"),
-    taskName: "Ubuntu 19.10 (v5.3)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "LTS",
   },
 ];
@@ -1095,13 +1053,13 @@ export var openStackReleases = [
   {
     startDate: new Date("2021-04-01T00:00:00"),
     endDate: new Date("2022-10-01T00:00:00"),
-    taskName: "OpenStack W",
+    taskName: "OpenStack Wallaby",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
     startDate: new Date("2022-10-01T00:00:00"),
     endDate: new Date("2024-04-01T00:00:00"),
-    taskName: "OpenStack W",
+    taskName: "OpenStack Wallaby",
     status: "EXTENDED_SUPPORT_FOR_CUSTOMERS",
   },
   {
@@ -1131,13 +1089,13 @@ export var openStackReleases = [
   {
     startDate: new Date("2020-04-01T00:00:00"),
     endDate: new Date("2025-04-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2030-04-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
+    taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "ESM",
   },
   {
@@ -1316,30 +1274,27 @@ export var smallReleaseNames = [
   "Ubuntu 22.04 LTS",
   "Ubuntu 21.10",
   "Ubuntu 21.04",
-  "Ubuntu 20.10",
-  "Ubuntu 20.04 LTS",
-  "Ubuntu 19.10",
+  "Ubuntu 20.10 (v5.8)",
+  "Ubuntu 20.04 LTS (v5.4)",
 ];
 
 export var desktopServerReleaseNames = [
   "Ubuntu 22.04 LTS",
   "Ubuntu 21.10",
   "Ubuntu 21.04",
-  "Ubuntu 20.10",
-  "Ubuntu 20.04 LTS",
-  "Ubuntu 19.10",
+  "Ubuntu 20.10 (v5.8)",
+  "Ubuntu 20.04 LTS (v5.4)",
   "Ubuntu 18.04 LTS",
   "Ubuntu 16.04 LTS",
   "Ubuntu 14.04 LTS",
 ];
 
 export var kernelReleaseNames = [
-  "Ubuntu 18.04.5 LTS",
-  "Ubuntu 20.04 LTS",
-  "Ubuntu 18.04.4 LTS",
-  "Ubuntu 19.10 (v5.3)",
+  "Ubuntu 20.10 (v5.8)",
+  "Ubuntu 18.04.5 LTS (v5.4)",
+  "Ubuntu 20.04 LTS (v5.4)",
+  "Ubuntu 18.04.4 LTS (v5.3)",
   "Ubuntu 18.04.3 LTS (v5.0)",
-  "Ubuntu 19.04 (v5.0)",
   "Ubuntu 18.04.2 LTS (v4.18)",
   "Ubuntu 18.04.1 LTS (v4.15)",
   "Ubuntu 16.04.5 LTS (v4.15)",
@@ -1364,9 +1319,9 @@ export var kernelReleaseNames1804 = [
   "Ubuntu 18.04.0 LTS (v4.15)",
   "Ubuntu 18.04.1 LTS (v4.15)",
   "Ubuntu 18.04.2 LTS (v4.18)",
-  "Ubuntu 18.04.3 LTS  (v5.0)",
+  "Ubuntu 18.04.3 LTS (v5.0)",
   "Ubuntu 18.04.4 LTS (v5.3)",
-  "Ubuntu 18.04.5 LTS",
+  "Ubuntu 18.04.5 LTS (v5.4)",
 ];
 
 export var kernelReleaseNames1604 = [
@@ -1403,13 +1358,11 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 18.04.1 LTS (v4.15)",
   "Ubuntu 16.04.5 LTS (v4.15)",
   "Ubuntu 18.04.2 LTS (v4.18)",
-  "Ubuntu 19.04 (v5.0)",
   "Ubuntu 18.04.3 LTS (v5.0)",
-  "Ubuntu 19.10 (v5.3)",
   "Ubuntu 18.04.4 LTS (v5.3)",
   "Ubuntu 20.04.0 LTS",
   "Ubuntu 20.04.1 LTS",
-  "Ubuntu 18.04.5 LTS",
+  "Ubuntu 18.04.5 LTS (v5.4)",
   "Ubuntu 20.04.2 LTS",
   "Ubuntu 20.04.3 LTS",
   "Ubuntu 20.04.4 LTS",
@@ -1436,7 +1389,7 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 18.04.4 LTS (v5.3)",
   "Ubuntu 20.04.0 LTS",
   "Ubuntu 20.04.1 LTS",
-  "Ubuntu 18.04.5 LTS",
+  "Ubuntu 18.04.5 LTS (v5.4)",
   "Ubuntu 20.04.2 LTS",
   "Ubuntu 20.04.3 LTS",
   "Ubuntu 20.04.4 LTS",
@@ -1448,10 +1401,10 @@ export var openStackReleaseNames = [
   "Ubuntu 22.04 LTS",
   "OpenStack Y",
   "OpenStack X",
-  "OpenStack W",
+  "OpenStack Wallaby",
   "OpenStack Victoria",
   "OpenStack Ussuri LTS",
-  "Ubuntu 20.04 LTS",
+  "Ubuntu 20.04 LTS (v5.4)",
   "OpenStack Ussuri",
   "OpenStack Train",
   "OpenStack Stein",
@@ -1476,7 +1429,5 @@ export var kernelReleaseScheduleNames = [
   "Ubuntu 14.04 LTS (v3.13)",
   "Ubuntu 16.04 LTS (v4.4)",
   "Ubuntu 18.04 LTS (v4.15)",
-  "Ubuntu 19.04 (v5.0)",
-  "Ubuntu 19.10 (v5.3)",
-  "Ubuntu 20.04 LTS",
+  "Ubuntu 20.04 LTS (v5.4)",
 ];

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -220,13 +220,13 @@ function formatKeyLabel(key) {
  *
  * Builds chart using supplied selector and data
  */
- export function createChart(
-   chartSelector,
-   taskTypes,
-   taskStatus,
-   tasks,
-   taskVersions
- ) {
+export function createChart(
+  chartSelector,
+  taskTypes,
+  taskStatus,
+  tasks,
+  taskVersions
+) {
   var margin = {
     top: 0,
     right: 40,
@@ -239,7 +239,8 @@ function formatKeyLabel(key) {
   var height = taskTypes.length * rowHeight;
   var containerWidth = document.querySelector(chartSelector).clientWidth;
   if (containerWidth <= 0) {
-    containerWidth = document.querySelector(chartSelector).closest('[class*="col-"]')
+    containerWidth =
+      document.querySelector(chartSelector).closest('[class*="col-"]')
         .clientWidth - margin.left;
   }
   var width = containerWidth - margin.right - margin.left;

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -87,6 +87,17 @@ function addYAxis(svg, yAxis) {
 /**
  *
  * @param {*} svg
+ * @param {*} versionAxis
+ *
+ * Add version axis to chart
+ */
+function addVersionAxis(svg, versionAxis) {
+  svg.append("g").attr("class", "version axis").call(versionAxis);
+}
+
+/**
+ *
+ * @param {*} svg
  *
  * Clean up unwanted elements on chart put in by d3.js
  */
@@ -98,7 +109,7 @@ function cleanUpChart(svg) {
  *
  * Embolden LTS labels on y axis**
  *
- 
+
  */
 function emboldenLTSLabels(svg) {
   svg.selectAll(".tick text").select(function () {
@@ -107,6 +118,16 @@ function emboldenLTSLabels(svg) {
     if (text.includes("LTS")) {
       this.classList.add("chart__label--bold");
     }
+  });
+}
+
+/**
+ *
+ * @param {*} svg
+ */
+function setVersionAxisLabels(svg, taskVersions) {
+  svg.selectAll(".version .tick text").select(function (tickLabel, index) {
+    this.textContent = taskVersions[index];
   });
 }
 
@@ -199,7 +220,13 @@ function formatKeyLabel(key) {
  *
  * Builds chart using supplied selector and data
  */
-export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
+ export function createChart(
+   chartSelector,
+   taskTypes,
+   taskStatus,
+   tasks,
+   taskVersions
+ ) {
   var margin = {
     top: 0,
     right: 40,
@@ -212,9 +239,8 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
   var height = taskTypes.length * rowHeight;
   var containerWidth = document.querySelector(chartSelector).clientWidth;
   if (containerWidth <= 0) {
-    containerWidth = document
-      .querySelector(chartSelector)
-      .closest('[class*="col-"]').clientWidth;
+    containerWidth = document.querySelector(chartSelector).closest('[class*="col-"]')
+        .clientWidth - margin.left;
   }
   var width = containerWidth - margin.right - margin.left;
 
@@ -230,9 +256,22 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
     .rangeRound([0, height - margin.top - margin.bottom])
     .padding(0.1);
 
+  var version = d3
+    .scaleBand()
+    .domain(taskTypes)
+    .rangeRound([0, height - margin.top - margin.bottom])
+    .padding(0.1);
+
   var xAxis = d3.axisBottom(x);
 
   var yAxis = d3.axisRight(y).tickPadding(-margin.left).tickSize(0);
+
+  if (taskVersions) {
+    var versionAxis = d3
+      .axisRight(version)
+      .tickPadding(-margin.left * 1.6)
+      .tickSize(0);
+  }
 
   sortTasks(tasks);
 
@@ -247,11 +286,20 @@ export function createChart(chartSelector, taskTypes, taskStatus, tasks) {
     .attr("class", "gantt-chart")
     .attr("width", width + margin.left + margin.right)
     .attr("height", height + margin.top + margin.bottom)
-    .attr("transform", "translate(" + margin.left + ", " + margin.top + ")");
+    .attr(
+      "transform",
+      "translate(" + margin.left * 1.6 + ", " + margin.top + ")"
+    );
 
   addBarsToChart(svg, tasks, taskStatus, x, y);
   addXAxis(svg, height, margin, xAxis);
   addYAxis(svg, yAxis);
+
+  if (taskVersions) {
+    addVersionAxis(svg, versionAxis);
+    setVersionAxisLabels(svg, taskVersions);
+  }
+
   addXAxisVerticalLines(svg, height);
   cleanUpChart(svg);
   buildChartKey(chartSelector, taskStatus);

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -23,6 +23,7 @@ import {
   smallReleaseNames,
   desktopServerReleaseNames,
   kernelReleaseNames,
+  kernelVersionNames,
   kernelReleaseScheduleNames,
   kernelReleaseNames2004,
   kernelReleaseNames1804,
@@ -56,7 +57,8 @@ function buildCharts() {
       "#kernel-eol",
       kernelReleaseNames,
       kernelStatus,
-      kernelReleases
+      kernelReleases,
+      kernelVersionNames
     );
   }
   if (document.querySelector("#kernel2004")) {

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -103,12 +103,6 @@
               <td>Apr 2028</td>
             </tr>
             <tr>
-              <td>Ubuntu 19.10</td>
-              <td>Oct 2019</td>
-              <td>Jul 2020</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
               <td><strong>Ubuntu 20.04 LTS</strong></td>
               <td>Apr 2020</td>
               <td>Apr 2025</td>
@@ -274,51 +268,39 @@
           </thead>
           <tbody>
             <tr>
-              <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+              <td><strong>Ubuntu 20.10 (v5.8)</strong></td>
+              <td>Oct 2020</td>
+              <td>Jul 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
               <td>Aug 2020</td>
               <td>Apr 2023</td>
               <td>Apr 2028</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 20.04 LTS</strong></td>
+              <td><strong>Ubuntu 20.04 LTS (v5.4)</strong></td>
               <td>Apr 2020</td>
               <td>Apr 2025</td>
               <td>Apr 2030</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 18.04.4 LTS</strong></td>
+              <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
               <td>Feb 2020</td>
               <td>Aug 2020</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>Ubuntu 19.10 (v5.3)</td>
-              <td>Oct 2019</td>
-              <td>Jul 2020</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
+              <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
               <td>Aug 2019</td>
               <td>Feb 2020</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>Ubuntu 19.04 (v5.0)</td>
-              <td>Apr 2019</td>
-              <td>Jan 2020</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
               <td>Feb 2019</td>
               <td>Aug 2019</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td>Ubuntu 18.10 (v4.18)</td>
-              <td>Oct 2018</td>
-              <td>Jul 2019</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -364,28 +346,10 @@
               <td>Apr 2022</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 12.04.5 LTS (v3.13)</strong></td>
-              <td>Aug 2014</td>
-              <td>Apr 2017</td>
-              <td>Apr 2019</td>
-            </tr>
-            <tr>
               <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
               <td>Apr 2014</td>
               <td>Apr 2019</td>
               <td>Apr 2022</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 12.04.1 LTS (v3.2)</strong></td>
-              <td>Aug 2012</td>
-              <td>Apr 2017</td>
-              <td>Apr 2019</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 12.04.0 LTS (v3.2)</strong></td>
-              <td>Apr 2012</td>
-              <td>Apr 2017</td>
-              <td>Apr 2019</td>
             </tr>
           </tbody>
         </table>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -268,85 +268,115 @@
           </thead>
           <tbody>
             <tr>
-              <td><strong>Ubuntu 20.10 (v5.8)</strong></td>
+              <td><strong>Ubuntu 20.04.5 LTS</strong></td>
+              <td>Aug 2022</td>
+              <td>Apr 2025</td>
+              <td>Apr 2030</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 22.04.0 LTS</strong></td>
+              <td>Apr 2022</td>
+              <td>Apr 2027</td>
+              <td>Mar 2032</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.04.4 LTS</strong></td>
+              <td>Feb 2022</td>
+              <td>Jul 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 21.10</strong></td>
+              <td>Oct 2021</td>
+              <td>Jul 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.04.3 LTS</strong></td>
+              <td>Aug 2021</td>
+              <td>Jan 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 21.04</strong></td>
+              <td>Apr 2021</td>
+              <td>Jan 2022</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.04.2 LTS</strong></td>
+              <td>Feb 2021</td>
+              <td>Jul 2021</td>
+              <td>&nbsp;</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.10</strong></td>
               <td>Oct 2020</td>
               <td>Jul 2021</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
+              <td><strong>Ubuntu 18.04.5 LTS</strong></td>
               <td>Aug 2020</td>
               <td>Apr 2023</td>
               <td>Apr 2028</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 20.04 LTS (v5.4)</strong></td>
+              <td><strong>Ubuntu 20.04.1 LTS</strong></td>
+              <td>Aug 2020</td>
+              <td>Apr 2025</td>
+              <td>Apr 2030</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 20.04.0 LTS</strong></td>
               <td>Apr 2020</td>
               <td>Apr 2025</td>
               <td>Apr 2030</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
-              <td>Feb 2020</td>
-              <td>Aug 2020</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
-              <td>Aug 2019</td>
-              <td>Feb 2020</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-              <td>Feb 2019</td>
-              <td>Aug 2019</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-              <td>Jul 2018</td>
-              <td>Apr 2023</td>
-              <td>Apr 2028</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
+              <td><strong>Ubuntu 16.04.5 LTS</strong></td>
               <td>Aug 2018</td>
               <td>Apr 2021</td>
               <td>Apr 2024</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
+              <td><strong>Ubuntu 18.04.1 LTS</strong></td>
+              <td>Jul 2018</td>
+              <td>Apr 2023</td>
+              <td>Apr 2028</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 18.04.0 LTS</strong></td>
               <td>Apr 2018</td>
               <td>Apr 2023</td>
               <td>Apr 2028</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-              <td>Aug 2016</td>
-              <td>Apr 2021</td>
-              <td>Apr 2024</td>
-            </tr>
-            <tr>
-              <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
+              <td><strong>Ubuntu 14.04.5 LTS</strong></td>
               <td>Aug 2016</td>
               <td>Apr 2019</td>
               <td>Apr 2022</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
+              <td><strong>Ubuntu 16.04.1 LTS</strong></td>
+              <td>Jul 2016</td>
+              <td>Apr 2021</td>
+              <td>Apr 2024</td>
+            </tr>
+            <tr>
+              <td><strong>Ubuntu 16.04.0 LTS</strong></td>
               <td>Apr 2016</td>
               <td>Apr 2021</td>
               <td>Apr 2024</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-              <td>Aug 2014</td>
+              <td><strong>Ubuntu 14.04.1 LTS</strong></td>
+              <td>Jul 2014</td>
               <td>Apr 2019</td>
               <td>Apr 2022</td>
             </tr>
             <tr>
-              <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
+              <td><strong>Ubuntu 14.04.0 LTS</strong></td>
               <td>Apr 2014</td>
               <td>Apr 2019</td>
               <td>Apr 2022</td>


### PR DESCRIPTION
## Done

- Update the release charts for Kernel and OpenStack
- Added a kernel version (thanks @steverydz) axis

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-kernel-release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the data looks like the [sheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=550510389)


## Issue / Card

Fixes #8765

## Screenshots

![image](https://user-images.githubusercontent.com/441217/99980797-8c7dbd00-2da0-11eb-836e-a4fd0ada5892.png)

