### PR TITLE
Only move chars with versions right

### DIFF
--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -267,47 +267,34 @@ export function createChart(
 
   var yAxis = d3.axisRight(y).tickPadding(-margin.left).tickSize(0);
 
+  var chartTranslateX = margin.left;
+
   if (taskVersions) {
     var versionAxis = d3
       .axisRight(version)
       .tickPadding(-margin.left * 1.6)
       .tickSize(0);
 
-    var svg = d3
-      .select(chartSelector)
-      .append("svg")
-      .attr("class", "chart")
-      .attr("width", width + margin.left + margin.right)
-      .attr("height", height + margin.top + margin.bottom)
-      .append("g")
-      .attr("class", "gantt-chart")
-      .attr("width", width + margin.left + margin.right)
-      .attr("height", height + margin.top + margin.bottom)
-      .attr(
-        "transform",
-        "translate(" + margin.left * 1.6 + ", " + margin.top + ")"
-      );
-  } else {
-    // Build initial chart body
-    var svg = d3
-      .select(chartSelector)
-      .append("svg")
-      .attr("class", "chart")
-      .attr("width", width + margin.left + margin.right)
-      .attr("height", height + margin.top + margin.bottom)
-      .append("g")
-      .attr("class", "gantt-chart")
-      .attr("width", width + margin.left + margin.right)
-      .attr("height", height + margin.top + margin.bottom)
-      .attr(
-        "transform",
-        "translate(" + margin.left + ", " + margin.top + ")"
-      );
+    chartTranslateX = margin.left * 1.6;
   }
-
+  
   sortTasks(tasks);
 
-
+  // Build initial chart body
+  var svg = d3
+    .select(chartSelector)
+    .append("svg")
+    .attr("class", "chart")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+    .attr("class", "gantt-chart")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .attr(
+      "transform",
+      "translate(" + chartTranslateX + ", " + margin.top + ")"
+    );
 
   addBarsToChart(svg, tasks, taskStatus, x, y);
   addXAxis(svg, height, margin, xAxis);

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -272,25 +272,42 @@ export function createChart(
       .axisRight(version)
       .tickPadding(-margin.left * 1.6)
       .tickSize(0);
+
+    var svg = d3
+      .select(chartSelector)
+      .append("svg")
+      .attr("class", "chart")
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+      .attr("class", "gantt-chart")
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .attr(
+        "transform",
+        "translate(" + margin.left * 1.6 + ", " + margin.top + ")"
+      );
+  } else {
+    // Build initial chart body
+    var svg = d3
+      .select(chartSelector)
+      .append("svg")
+      .attr("class", "chart")
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .append("g")
+      .attr("class", "gantt-chart")
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom)
+      .attr(
+        "transform",
+        "translate(" + margin.left + ", " + margin.top + ")"
+      );
   }
 
   sortTasks(tasks);
 
-  // Build initial chart body
-  var svg = d3
-    .select(chartSelector)
-    .append("svg")
-    .attr("class", "chart")
-    .attr("width", width + margin.left + margin.right)
-    .attr("height", height + margin.top + margin.bottom)
-    .append("g")
-    .attr("class", "gantt-chart")
-    .attr("width", width + margin.left + margin.right)
-    .attr("height", height + margin.top + margin.bottom)
-    .attr(
-      "transform",
-      "translate(" + margin.left * 1.6 + ", " + margin.top + ")"
-    );
+
 
   addBarsToChart(svg, tasks, taskStatus, x, y);
   addXAxis(svg, height, margin, xAxis);

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -277,7 +277,7 @@ export function createChart(
 
     chartTranslateX = margin.left * 1.6;
   }
-  
+
   sortTasks(tasks);
 
   // Build initial chart body


### PR DESCRIPTION
## Done

- Only move chars with versions right

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-openstack-release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all charts align properly
