### PR TITLE
3448 build tutorials search

### DIFF
--- a/static/js/src/tutorial-list.js
+++ b/static/js/src/tutorial-list.js
@@ -1,5 +1,6 @@
 const topicsFilter = document.getElementById("tutorials-topic");
 const sortFilter = document.getElementById("tutorials-sort");
+const searchFilter = document.getElementById("tutorials-search");
 const urlObj = new URL(window.location);
 
 function handleFilter(key, el, url) {
@@ -34,5 +35,6 @@ function handleFilter(key, el, url) {
 
 handleFilter("topic", topicsFilter, urlObj);
 handleFilter("sort", sortFilter, urlObj);
+handleFilter("q", searchFilter, urlObj);
 
 export { handleFilter };

--- a/static/js/src/tutorial-list.js
+++ b/static/js/src/tutorial-list.js
@@ -4,34 +4,6 @@ const searchFilter = document.getElementById("tutorials-search");
 const searchInput = document.getElementById("tutorials-search-input");
 const urlObj = new URL(window.location);
 
-if (urlObj.searchParams.has("q")) {
-  searchInput.value = urlObj.searchParams.get("q");
-} else {
-  searchInput.value = "";
-}
-
-searchFilter.addEventListener("submit", (e) => {
-  e.preventDefault();
-  if (urlObj.searchParams.has("page")) {
-    urlObj.searchParams.delete("page");
-  }
-  if (urlObj.searchParams.has("q")) {
-    urlObj.searchParams.delete("q");
-  }
-  urlObj.searchParams.append("q", searchInput.value);
-  window.location = urlObj;
-});
-
-searchFilter.addEventListener("reset", (e) => {
-  e.preventDefault();
-  if (urlObj.searchParams.has("page")) {
-    urlObj.searchParams.delete("page");
-  }
-  console.log("reset");
-  urlObj.searchParams.delete("q");
-  window.location = urlObj;
-});
-
 function handleFilter(key, el, url) {
   if (!el) {
     return;
@@ -62,7 +34,41 @@ function handleFilter(key, el, url) {
   });
 }
 
+function setUpSearch(form, input, url) {
+  if (!form || !input) {
+    return;
+  }
+
+  if (url.searchParams.has("q")) {
+    input.value = url.searchParams.get("q");
+  } else {
+    input.value = "";
+  }
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    if (url.searchParams.has("page")) {
+      url.searchParams.delete("page");
+    }
+    if (url.searchParams.has("q")) {
+      url.searchParams.delete("q");
+    }
+    url.searchParams.append("q", input.value);
+    window.location = url;
+  });
+
+  form.addEventListener("reset", (e) => {
+    e.preventDefault();
+    if (url.searchParams.has("page")) {
+      url.searchParams.delete("page");
+    }
+    url.searchParams.delete("q");
+    window.location = url;
+  });
+}
+
 handleFilter("topic", topicsFilter, urlObj);
 handleFilter("sort", sortFilter, urlObj);
+setUpSearch(searchFilter, searchInput, urlObj);
 
-export { handleFilter };
+export { handleFilter, setUpSearch };

--- a/static/js/src/tutorial-list.js
+++ b/static/js/src/tutorial-list.js
@@ -1,7 +1,36 @@
 const topicsFilter = document.getElementById("tutorials-topic");
 const sortFilter = document.getElementById("tutorials-sort");
 const searchFilter = document.getElementById("tutorials-search");
+const searchInput = document.getElementById("tutorials-search-input");
 const urlObj = new URL(window.location);
+
+if (urlObj.searchParams.has("q")) {
+  searchInput.value = urlObj.searchParams.get("q");
+} else {
+  searchInput.value = "";
+}
+
+searchFilter.addEventListener("submit", (e) => {
+  e.preventDefault();
+  if (urlObj.searchParams.has("page")) {
+    urlObj.searchParams.delete("page");
+  }
+  if (urlObj.searchParams.has("q")) {
+    urlObj.searchParams.delete("q");
+  }
+  urlObj.searchParams.append("q", searchInput.value);
+  window.location = urlObj;
+});
+
+searchFilter.addEventListener("reset", (e) => {
+  e.preventDefault();
+  if (urlObj.searchParams.has("page")) {
+    urlObj.searchParams.delete("page");
+  }
+  console.log("reset");
+  urlObj.searchParams.delete("q");
+  window.location = urlObj;
+});
 
 function handleFilter(key, el, url) {
   if (!el) {
@@ -35,6 +64,5 @@ function handleFilter(key, el, url) {
 
 handleFilter("topic", topicsFilter, urlObj);
 handleFilter("sort", sortFilter, urlObj);
-handleFilter("q", searchFilter, urlObj);
 
 export { handleFilter };

--- a/static/js/src/tutorial-list.test.js
+++ b/static/js/src/tutorial-list.test.js
@@ -1,8 +1,13 @@
-import { handleFilter } from "./tutorial-list.js";
+import { handleFilter, setUpSearch } from "./tutorial-list.js";
 
 describe("handleFilter", () => {
   // Setup DOM elements
-  const topicFilter = `
+  const Filters = `
+    <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
+      <input type="search" class="p-search-box__input" id="tutorials-search-input" name="search" placeholder="Search" required="" autocomplete="on">
+      <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
+      <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+    </form>
     <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
       <option value="">Any</option>
       <option value="cloud">Cloud</option>
@@ -10,7 +15,7 @@ describe("handleFilter", () => {
   `;
 
   it("sets the option value to supplied key", () => {
-    document.body.innerHTML = topicFilter;
+    document.body.innerHTML = Filters;
     const topicEl = document.querySelector("#tutorials-topic");
     const url = new URL("http://localhost?topic=cloud");
     handleFilter("topic", topicEl, url);
@@ -18,7 +23,7 @@ describe("handleFilter", () => {
   });
 
   it("removes the page parameter from the URL", () => {
-    document.body.innerHTML = topicFilter;
+    document.body.innerHTML = Filters;
     const topicEl = document.querySelector("#tutorials-topic");
     const url = new URL("http://localhost?page=1");
     handleFilter("topic", topicEl, url);
@@ -27,7 +32,7 @@ describe("handleFilter", () => {
   });
 
   it("adds filter query param to URL", () => {
-    document.body.innerHTML = topicFilter;
+    document.body.innerHTML = Filters;
     const topicEl = document.querySelector("#tutorials-topic");
     const url = new URL("http://localhost");
     handleFilter("topic", topicEl, url);
@@ -36,13 +41,34 @@ describe("handleFilter", () => {
     expect(url.toString()).toEqual("http://localhost/?topic=cloud");
   });
 
-  it("removes all query params from URL", () => {
-    document.body.innerHTML = topicFilter;
-    const topicEl = document.querySelector("#tutorials-topic");
-    const url = new URL("http://localhost?page=1&topic=cloud");
-    handleFilter("topic", topicEl, url);
-    topicEl.value = null;
-    topicEl.dispatchEvent(new Event("change"));
+  it("adds the search parameter to the url", () => {
+    document.body.innerHTML = Filters;
+    const searchForm = document.querySelector("#tutorials-search");
+    const searchInput = document.querySelector("#tutorials-search-input");
+    const url = new URL("http://localhost");
+    setUpSearch(searchForm, searchInput, url);
+    expect(searchInput.value).toBe("");
+    searchInput.value = "windows";
+    searchForm.dispatchEvent(new Event("submit"));
+    expect(url.toString()).toEqual("http://localhost/?q=windows");
+  });
+
+  it("populates the field if the query param is set", () => {
+    document.body.innerHTML = Filters;
+    const searchForm = document.querySelector("#tutorials-search");
+    const searchInput = document.querySelector("#tutorials-search-input");
+    const url = new URL("http://localhost/?q=windows");
+    setUpSearch(searchForm, searchInput, url);
+    expect(searchInput.value).toBe("windows");
+  });
+
+  it("populates the field if the query param is set", () => {
+    document.body.innerHTML = Filters;
+    const searchForm = document.querySelector("#tutorials-search");
+    const searchInput = document.querySelector("#tutorials-search-input");
+    const url = new URL("http://localhost/?q=windows");
+    setUpSearch(searchForm, searchInput, url);
+    searchForm.dispatchEvent(new Event("reset"));
     expect(url.toString()).toEqual("http://localhost/");
   });
 });

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -1,8 +1,8 @@
 {% extends "tutorials/base_tutorials.html" %}
 
-{% block title %}Tutorials{% endblock %}	
+{% block title %}Tutorials{% endblock %}
 
-{% block content %}	
+{% block content %}
 
 {% if page == 1 %}
 <section class="p-strip--suru-blog-header is-dark">
@@ -115,12 +115,12 @@
     {% endif %} {% endfor %}
   </div>
 </section>
-{% endif %} 
+{% endif %}
 
 {% with %}
-  {% set total_pages = total_pages %}	
-  {% set current_page = page %}	
-  {% include "shared/_pagination.html" %}	
-{% endwith %}	
+  {% set total_pages = total_pages %}
+  {% set current_page = page %}
+  {% include "shared/_pagination.html" %}
+{% endwith %}
 
 {% endblock %}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -64,6 +64,39 @@ endblock %} {% block content %} {% if page == 1 %}
   </div>
 </section>
 
+{% if query and result_number == 0 %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h3>Why not try widening your search?</h3>
+      <p>You can do this by:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          Adding alternative words or phrases
+        </li>
+        <li class="p-list__item is-ticked">
+          Using individual words instead of phrases
+        </li>
+        <li class="p-list__item is-ticked">Trying a different spelling</li>
+      </ul>
+    </div>
+    <div class="col-6">
+      <h3>Still no luck?</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          <a href="/">Visit the Ubuntu homepage</a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a href="/desktop/contact-us?product=search-page">Contact us</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{% else %}
+
 <section class="p-strip has-shadow">
   <div class="row u-equal-height">
     {% if query %}
@@ -94,6 +127,5 @@ endblock %} {% block content %} {% if page == 1 %}
     {% endif %} {% endfor %}
   </div>
 </section>
-
-{% with %} {% set total_pages = total_pages %} {% set current_page = page %} {%
-include "shared/_pagination.html" %} {% endwith %} {% endblock %}
+{% endif %} {% with %} {% set total_pages = total_pages %} {% set current_page =
+page %} {% include "shared/_pagination.html" %} {% endwith %} {% endblock %}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -1,16 +1,20 @@
-{% extends "tutorials/base_tutorials.html" %}
-
-{% block title %}Tutorials{% endblock %}
-
-{% block content %}
-
-{% if page == 1 %}
+{% extends "tutorials/base_tutorials.html" %} {% block title %} Tutorials {%
+endblock %} {% block content %} {% if page == 1 %}
 <section class="p-strip--suru-blog-header is-dark">
   <div class="row">
     <div class="col-6">
       <h1>Tutorials</h1>
-      <p>These tutorials provide a step-by-step process to doing development and dev-ops activities on Ubuntu machines, servers or devices.</p>
-      <p><a class="p-link--inverted" href="https://discourse.ubuntu.com/c/tutorials">You can write your own&nbsp;&rsaquo;</a></p>
+      <p>
+        These tutorials provide a step-by-step process to doing development and
+        dev-ops activities on Ubuntu machines, servers or devices.
+      </p>
+      <p>
+        <a
+          class="p-link--inverted"
+          href="https://discourse.ubuntu.com/c/tutorials"
+          >You can write your own&nbsp;&rsaquo;</a
+        >
+      </p>
     </div>
   </div>
 </section>
@@ -18,16 +22,20 @@
 
 <section class="p-strip is-shallow l-tutorials__filters">
   <div class="row">
-    <!-- <div class="col-4">
+    <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-search">Search tutorials containing:</label>
-        <input type="search" name="tutorials-search" id="tutorials-search">
+        <input type="search" name="tutorials-search" id="tutorials-search" />
       </div>
-    </div> -->
+    </div>
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>
-        <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
+        <select
+          name="tutorials-topic"
+          id="tutorials-topic"
+          class="u-no-margin--bottom"
+        >
           <option value="">Any</option>
           <option value="cloud">Cloud</option>
           <option value="community">Community</option>
@@ -43,7 +51,11 @@
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-sort">Sorted by:</label>
-        <select name="tutorials-sort" id="tutorials-sort" class="u-no-margin--bottom">
+        <select
+          name="tutorials-sort"
+          id="tutorials-sort"
+          class="u-no-margin--bottom"
+        >
           <option value="difficulty-asc">Least difficult</option>
           <option value="difficulty-desc">Most difficult</option>
         </select>
@@ -54,33 +66,34 @@
 
 <section class="p-strip has-shadow">
   <div class="row u-equal-height">
-    {% for item in metadata %}
-      {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
-        <div class="col-4 blog-p-card--post">
-          <header class="blog-p-card__header--tutorial">
-            <h5 class="p-muted-heading u-no-margin--bottom">
-              {{ item.categories }}
-            </h5>
-          </header>
-          <div class="blog-p-card__content">
-            <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">
-              {{ item.topic | replace("inline-onebox", "p-link--soft") | safe }}
-            </h3>
-            <p class="u-sv3">{{ item.summary | safe }}</p>
-          </div>
-          <footer class="blog-p-card__footer">
-            Difficulty: <span class="l-tutorials-meter l-tutorials-meter--{{ item.difficulty }}">{{ item.difficulty }} out of 5</span>
-          </footer>
-        </div>
-      {% endif %}
-    {% endfor %}
+    {% if query %}
+    <h4 class="col-12">
+      {{result_number}} search result{% if result_number > 1 %}s{% endif %}
+    </h4>
+    {% endif %} {% for item in metadata %} {% if loop.index <= posts_per_page *
+    page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          {{ item.categories }}
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">
+          {{ item.topic | replace("inline-onebox", "p-link--soft") | safe }}
+        </h3>
+        <p class="u-sv3">{{ item.summary | safe }}</p>
+      </div>
+      <footer class="blog-p-card__footer">
+        Difficulty:
+        <span class="l-tutorials-meter l-tutorials-meter--{{ item.difficulty }}"
+          >{{ item.difficulty }} out of 5</span
+        >
+      </footer>
+    </div>
+    {% endif %} {% endfor %}
   </div>
 </section>
 
-{% with %}
-  {% set total_pages = total_pages %}
-  {% set current_page = page %}
-  {% include "shared/_pagination.html" %}
-{% endwith %}
-
-{% endblock %}
+{% with %} {% set total_pages = total_pages %} {% set current_page = page %} {%
+include "shared/_pagination.html" %} {% endwith %} {% endblock %}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -77,7 +77,7 @@
       <h3>Still no luck?</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">
-          <a href="/">Visit the Ubuntu homepage</a>
+          <a href="/tutorials">View all Tutorials</a>
         </li>
         <li class="p-list__item is-ticked">
           <a href="/desktop/contact-us?product=search-page">Contact us</a>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -20,10 +20,12 @@
   <div class="row">
     <div class="col-4">
       <div class="p-form__group">
-        <label for="tutorials-search">Search tutorials containing:</label>
-        <input
-          type="search" name="tutorials-search" id="tutorials-search" class="u-no-margin--bottom"
-        />
+        <label for="tutorials-search-input">Search tutorials containing:</label>
+        <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
+          <input type="search" class="p-search-box__input" id="tutorials-search-input" name="search" placeholder="Search" required="" autocomplete="on">
+          <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
+          <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+        </form>
       </div>
     </div>
     <div class="col-4">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -1,20 +1,16 @@
-{% extends "tutorials/base_tutorials.html" %} {% block title %} Tutorials {%
-endblock %} {% block content %} {% if page == 1 %}
+{% extends "tutorials/base_tutorials.html" %}
+
+{% block title %}Tutorials{% endblock %}	
+
+{% block content %}	
+
+{% if page == 1 %}
 <section class="p-strip--suru-blog-header is-dark">
   <div class="row">
     <div class="col-6">
       <h1>Tutorials</h1>
-      <p>
-        These tutorials provide a step-by-step process to doing development and
-        dev-ops activities on Ubuntu machines, servers or devices.
-      </p>
-      <p>
-        <a
-          class="p-link--inverted"
-          href="https://discourse.ubuntu.com/c/tutorials"
-          >You can write your own&nbsp;&rsaquo;</a
-        >
-      </p>
+      <p>These tutorials provide a step-by-step process to doing development and dev-ops activities on Ubuntu machines, servers or devices.</p>
+      <p><a class="p-link--inverted" href="https://discourse.ubuntu.com/c/tutorials">You can write your own&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -26,21 +22,14 @@ endblock %} {% block content %} {% if page == 1 %}
       <div class="p-form__group">
         <label for="tutorials-search">Search tutorials containing:</label>
         <input
-          type="search"
-          name="tutorials-search"
-          id="tutorials-search"
-          class="u-no-margin--bottom"
+          type="search" name="tutorials-search" id="tutorials-search" class="u-no-margin--bottom"
         />
       </div>
     </div>
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>
-        <select
-          name="tutorials-topic"
-          id="tutorials-topic"
-          class="u-no-margin--bottom"
-        >
+        <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
           <option value="">Any</option>
           <option value="cloud">Cloud</option>
           <option value="community">Community</option>
@@ -56,11 +45,7 @@ endblock %} {% block content %} {% if page == 1 %}
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-sort">Sorted by:</label>
-        <select
-          name="tutorials-sort"
-          id="tutorials-sort"
-          class="u-no-margin--bottom"
-        >
+        <select name="tutorials-sort" id="tutorials-sort" class="u-no-margin--bottom">
           <option value="difficulty-asc">Least difficult</option>
           <option value="difficulty-desc">Most difficult</option>
         </select>
@@ -108,8 +93,7 @@ endblock %} {% block content %} {% if page == 1 %}
     <h4 class="col-12">
       {{result_number}} search result{% if result_number > 1 %}s{% endif %}
     </h4>
-    {% endif %} {% for item in metadata %} {% if loop.index <= posts_per_page *
-    page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
+    {% endif %} {% for item in metadata %} {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
@@ -123,14 +107,18 @@ endblock %} {% block content %} {% if page == 1 %}
         <p class="u-sv3">{{ item.summary | safe }}</p>
       </div>
       <footer class="blog-p-card__footer">
-        Difficulty:
-        <span class="l-tutorials-meter l-tutorials-meter--{{ item.difficulty }}"
-          >{{ item.difficulty }} out of 5</span
-        >
+        Difficulty:<span class="l-tutorials-meter l-tutorials-meter--{{ item.difficulty }}">{{ item.difficulty }} out of 5</span>
       </footer>
     </div>
     {% endif %} {% endfor %}
   </div>
 </section>
-{% endif %} {% with %} {% set total_pages = total_pages %} {% set current_page =
-page %} {% include "shared/_pagination.html" %} {% endwith %} {% endblock %}
+{% endif %} 
+
+{% with %}
+  {% set total_pages = total_pages %}	
+  {% set current_page = page %}	
+  {% include "shared/_pagination.html" %}	
+{% endwith %}	
+
+{% endblock %}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -25,7 +25,12 @@ endblock %} {% block content %} {% if page == 1 %}
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-search">Search tutorials containing:</label>
-        <input type="search" name="tutorials-search" id="tutorials-search" />
+        <input
+          type="search"
+          name="tutorials-search"
+          id="tutorials-search"
+          class="u-no-margin--bottom"
+        />
       </div>
     </div>
     <div class="col-4">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -56,7 +56,7 @@
   </div>
 </section>
 
-{% if query and result_number == 0 %}
+{% if query and total_results == 0 %}
 
 <div class="p-strip">
   <div class="row">
@@ -93,7 +93,7 @@
   <div class="row u-equal-height">
     {% if query %}
     <h4 class="col-12">
-      {{result_number}} search result{% if result_number > 1 %}s{% endif %}
+      {{total_results}} search result{% if total_results > 1 %}s{% endif %}
     </h4>
     {% endif %} {% for item in metadata %} {% if loop.index <= posts_per_page * page and loop.index >= posts_per_page * page - posts_per_page + 1 %}
     <div class="col-4 blog-p-card--post">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -21,16 +21,13 @@ from canonicalwebteam.launchpad import Launchpad
 from geolite2 import geolite2
 from requests.exceptions import HTTPError
 from canonicalwebteam.search.models import get_search_results
+from canonicalwebteam.search.views import NoAPIKeyError
 
 
 # Local
 from webapp.login import empty_session, user_info
 from webapp.advantage import AdvantageContracts, UnauthorizedError
 from webapp.decorators import store_maintenance
-
-
-class NoAPIKeyError(Exception):
-    pass
 
 
 ip_reader = geolite2.reader()

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1077,7 +1077,7 @@ def build_tutorials_index(tutorials_docs):
 
         if query:
             temp_metadata = []
-            if results.get('entries'):
+            if results.get("entries"):
                 for result in results["entries"]:
                     start = result["link"].find("tutorials/")
                     end = len(result["link"])

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -20,6 +20,7 @@ from canonicalwebteam.store_api.stores.snapstore import SnapStore
 from canonicalwebteam.launchpad import Launchpad
 from geolite2 import geolite2
 from requests.exceptions import HTTPError
+from canonicalwebteam.search.models import get_search_results
 
 
 # Local
@@ -1037,7 +1038,33 @@ def build_tutorials_index(tutorials_docs):
         page = flask.request.args.get("page", default=1, type=int)
         topic = flask.request.args.get("topic", default=None, type=str)
         sort = flask.request.args.get("sort", default=None, type=str)
+        query = flask.request.args.get("q", default=None, type=str)
         posts_per_page = 15
+
+        """
+        Get search results from Google Custom Search
+        """
+
+        # The webteam's default custom search ID
+        search_engine_id = "009048213575199080868:i3zoqdwqk8o"
+
+        # API key should always be provided as an environment variable
+        search_api_key = os.getenv("SEARCH_API_KEY")
+
+        if not search_api_key:
+            raise NoAPIKeyError("Unable to search: No API key provided")
+
+        params = flask.request.args
+        results = None
+
+        if query:
+            results = get_search_results(
+                api_key=search_api_key,
+                search_engine_id=search_engine_id,
+                siteSearch='ubuntu.com/tutorials',
+                query=query,
+            )
+
         tutorials_docs.parser.parse()
         if not topic:
             metadata = tutorials_docs.parser.metadata
@@ -1047,6 +1074,19 @@ def build_tutorials_index(tutorials_docs):
                 for doc in tutorials_docs.parser.metadata
                 if topic in doc["categories"]
             ]
+
+        if query:
+            temp_metadata = []
+            for result in results['entries']:
+                start = result['link'].find("tutorials/")
+                end = len(result['link'])
+                identifier = result['link'][start:end]
+                if start != -1:
+                    for doc in metadata:
+                        if identifier in doc["topic"]:
+                            temp_metadata.append(doc)
+            metadata = temp_metadata
+
 
         if sort == "difficulty-desc":
             metadata = sorted(
@@ -1058,7 +1098,8 @@ def build_tutorials_index(tutorials_docs):
                 metadata, key=lambda k: k["difficulty"], reverse=False
             )
 
-        total_pages = math.ceil(len(metadata) / posts_per_page)
+        result_number = len(metadata)
+        total_pages = math.ceil(result_number / posts_per_page)
 
         return flask.render_template(
             "tutorials/index.html",
@@ -1068,8 +1109,10 @@ def build_tutorials_index(tutorials_docs):
             page=page,
             topic=topic,
             sort=sort,
+            query=query,
             posts_per_page=posts_per_page,
-            total_pages=total_pages,
+            result_number=result_number,   
+            total_pages=total_pages,   
         )
 
     return tutorials_index

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1098,8 +1098,8 @@ def build_tutorials_index(tutorials_docs):
                 metadata, key=lambda k: k["difficulty"], reverse=False
             )
 
-        result_number = len(metadata)
-        total_pages = math.ceil(result_number / posts_per_page)
+        total_results = len(metadata)
+        total_pages = math.ceil(total_results / posts_per_page)
 
         return flask.render_template(
             "tutorials/index.html",
@@ -1111,7 +1111,7 @@ def build_tutorials_index(tutorials_docs):
             sort=sort,
             query=query,
             posts_per_page=posts_per_page,
-            result_number=result_number,
+            total_results=total_results,
             total_pages=total_pages,
         )
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1080,14 +1080,15 @@ def build_tutorials_index(tutorials_docs):
 
         if query:
             temp_metadata = []
-            for result in results["entries"]:
-                start = result["link"].find("tutorials/")
-                end = len(result["link"])
-                identifier = result["link"][start:end]
-                if start != -1:
-                    for doc in metadata:
-                        if identifier in doc["topic"]:
-                            temp_metadata.append(doc)
+            if results.get('entries'):
+                for result in results["entries"]:
+                    start = result["link"].find("tutorials/")
+                    end = len(result["link"])
+                    identifier = result["link"][start:end]
+                    if start != -1:
+                        for doc in metadata:
+                            if identifier in doc["topic"]:
+                                temp_metadata.append(doc)
             metadata = temp_metadata
 
         if sort == "difficulty-desc":

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -29,6 +29,10 @@ from webapp.advantage import AdvantageContracts, UnauthorizedError
 from webapp.decorators import store_maintenance
 
 
+class NoAPIKeyError(Exception):
+    pass
+
+
 ip_reader = geolite2.reader()
 session = talisker.requests.get_session()
 store_api = SnapStore(session=talisker.requests.get_session())
@@ -1054,14 +1058,13 @@ def build_tutorials_index(tutorials_docs):
         if not search_api_key:
             raise NoAPIKeyError("Unable to search: No API key provided")
 
-        params = flask.request.args
         results = None
 
         if query:
             results = get_search_results(
                 api_key=search_api_key,
                 search_engine_id=search_engine_id,
-                siteSearch='ubuntu.com/tutorials',
+                siteSearch="ubuntu.com/tutorials",
                 query=query,
             )
 
@@ -1077,16 +1080,15 @@ def build_tutorials_index(tutorials_docs):
 
         if query:
             temp_metadata = []
-            for result in results['entries']:
-                start = result['link'].find("tutorials/")
-                end = len(result['link'])
-                identifier = result['link'][start:end]
+            for result in results["entries"]:
+                start = result["link"].find("tutorials/")
+                end = len(result["link"])
+                identifier = result["link"][start:end]
                 if start != -1:
                     for doc in metadata:
                         if identifier in doc["topic"]:
                             temp_metadata.append(doc)
             metadata = temp_metadata
-
 
         if sort == "difficulty-desc":
             metadata = sorted(
@@ -1111,8 +1113,8 @@ def build_tutorials_index(tutorials_docs):
             sort=sort,
             query=query,
             posts_per_page=posts_per_page,
-            result_number=result_number,   
-            total_pages=total_pages,   
+            result_number=result_number,
+            total_pages=total_pages,
         )
 
     return tutorials_index

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1052,7 +1052,7 @@ def build_tutorials_index(tutorials_docs):
         # API key should always be provided as an environment variable
         search_api_key = os.getenv("SEARCH_API_KEY")
 
-        if not search_api_key:
+        if query and not search_api_key:
             raise NoAPIKeyError("Unable to search: No API key provided")
 
         results = None


### PR DESCRIPTION
## Done

- Added support for searching tutorials using google API in `views.py`
- Uncommented the search bar and added an event listener so it would update the query parameters on change
- Added a "No results found" state

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Check [design](https://app.zeplin.io/project/5df26dadead180a5c29b569d/screen/5dfa10d6d30a77171fd01cbe)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3448
