### PR TITLE
Create horizontal latest news strip for the homepage, /telco and /wsl

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -85,64 +85,9 @@
   </div>
 </section>
 
-<noscript>
-  <section class="p-strip u-no-padding--top">
-    <div class="row">
-      <h3 class="p-heading--three"><a href="/blog">Read the latest news on our blog&nbsp;&rsaquo;</a></h3>
-    </div>
-  </section>
-</noscript>
-<section class="p-strip u-no-padding--top u-hide" data-js="latest-news">
-  <div class="row">
-    <h1 class="p-heading--three">
-        Latest news from <a href="/blog" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">our blog&nbsp;&rsaquo;</a>
-    </h1>
-  </div>
-  <div class="row p-divider">
-    <div class="col-9">
-      <div id="latest-articles" class="row">
-        <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
-      </div>
-    </div>
-
-    <div id="spotlight" class="col-3 p-divider__block">
-    </div>
-  </div>
-
-  <template style="display:none" id="articles-template">
-    <div class="col-3">
-      <p class="u-no-margin--bottom p-muted-heading">
-        <time datetime="" class="article-time"></time>
-      </p>
-      <h2 class="p-heading--five">
-          <a class="article-link article-title"></a>
-      </h2>
-    </div>
-  </template>
-
-  <template style="display:none" id="spotlight-template">
-    <div>
-      <p class="u-no-margin--bottom p-muted-heading">
-        Spotlight
-      </p>
-      <h2 class="p-heading--five">
-          <a class="article-link article-title"></a>
-      </h2>
-    </div>
-  </template>
-
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
-    canonicalLatestNews.fetchLatestNews({
-      articlesContainerSelector: "#latest-articles",
-      articleTemplateSelector: "#articles-template",
-      spotlightContainerSelector: "#spotlight",
-      spotlightTemplateSelector: "#spotlight-template",
-      gtmEventLabel: "ubuntu.com homepage"
-    })
-  </script>
-</section>
-
+{% with section_classes='p-strip u-no-padding--top', spotlight='True' %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
 
 <section class="p-strip--light">
   <div class="row">

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -21,8 +21,10 @@
         <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
       </div>
     </div>
+    {% if spotlight %}
     <div id="spotlight" class="col-3 p-divider__block">
     </div>
+    {% endif %}
   </div>
 
   <template style="display:none" id="horizontal-articles-template">

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -2,13 +2,13 @@
   <div class="row p-divider">
     <div class="col-12">
       <h3>Latest {{ heading_topic }} news from our blog</h3>
-      <div id="vertical-latest-articles" class="row">
+      <div id="horizontal-latest-articles" class="row">
         <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
       </div>
     </div>
   </div>
 
-  <template style="display:none" id="vertical-articles-template">
+  <template style="display:none" id="horizontal-articles-template">
     <div class="col-3">
       <p><a class="article-link article-title"></a></p>
       <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
@@ -25,8 +25,8 @@
   <script>
     canonicalLatestNews.fetchLatestNews(
       {
-        articlesContainerSelector: "#vertical-latest-articles",
-        articleTemplateSelector: "#vertical-articles-template",
+        articlesContainerSelector: "#horizontal-latest-articles",
+        articleTemplateSelector: "#horizontal-articles-template",
         gtmEventLabel: "ubuntu.com/{{ tag_name }}",
         tagId: "{{ tag_id }}",
         limit: "{% if limit %}{{ limit }}{% else %}4{% endif %}",

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -1,36 +1,62 @@
+<noscript>
+  <section class="{% if section_classes %}{{ section_classes }}{% else %}p-strip{% endif %}">
+    <div class="row">
+      <h3><a href="/blog{% if tag_name %}/tag/{{ tag_name }}{% endif %}">Read the latest {{ heading_topic }} news on our blog&nbsp;&rsaquo;</a></h3>
+    </div>
+  </section>
+</noscript>
+
 <section class="u-hide {% if section_classes %}{{ section_classes }}{% else %}p-strip{% endif %}" data-js="latest-news">
+  <div class="row">
+    <h3>
+      Latest {{ heading_topic }} news from
+      <a href="/blog{% if tag_name %}/tag/{{ tag_name }}{% endif %}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com{% if tag_name %}/{{ tag_name }}{% else %} homepage{% endif %}', 'eventValue' : undefined });">
+        our blog&nbsp;&rsaquo;
+      </a>
+    </h3>
+  </div>
   <div class="row p-divider">
-    <div class="col-12">
-      <h3>Latest {{ heading_topic }} news from our blog</h3>
+    <div class="{% if spotlight %}col-9{% else %}col-12{% endif %}">
       <div id="horizontal-latest-articles" class="row">
         <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
       </div>
+    </div>
+    <div id="spotlight" class="col-3 p-divider__block">
     </div>
   </div>
 
   <template style="display:none" id="horizontal-articles-template">
     <div class="col-3">
-      <p><a class="article-link article-title"></a></p>
-      <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
+      <p class="u-no-margin--bottom p-muted-heading"><time datetime="" class="article-time"></time></p>
+      <h2 class="p-heading--five"><a class="article-link article-title"></a></h2>
     </div>
   </template>
 
-  <div class="u-fixed-width">
-    <a href="/blog/tag/{{ tag_name }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com/{{ tag_name }}', 'eventValue' : undefined });">
-      View more from our blog&nbsp;&rsaquo;
-    </a>
-  </div>
+  {% if spotlight %}
+  <template style="display:none" id="spotlight-template">
+    <div>
+      <p class="u-no-margin--bottom p-muted-heading">
+        Spotlight
+      </p>
+      <h2 class="p-heading--five">
+        <a class="article-link article-title"></a>
+      </h2>
+    </div>
+  </template>
+  {% endif %}
 
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
   <script>
     canonicalLatestNews.fetchLatestNews(
-      {
-        articlesContainerSelector: "#horizontal-latest-articles",
-        articleTemplateSelector: "#horizontal-articles-template",
-        gtmEventLabel: "ubuntu.com/{{ tag_name }}",
-        tagId: "{{ tag_id }}",
-        limit: "{% if limit %}{{ limit }}{% else %}4{% endif %}",
-      }
+    {
+      articlesContainerSelector: "#horizontal-latest-articles",
+      articleTemplateSelector: "#horizontal-articles-template",
+      {% if spotlight %}spotlightContainerSelector: "#spotlight",
+      spotlightTemplateSelector: "#spotlight-template",{% endif %}
+      gtmEventLabel: "ubuntu.com{% if tag_name %}/{{ tag_name }}{% else %} homepage{% endif %}",
+      {% if tag_name %}tagId: "{{ tag_id }}",{% endif %}
+      {% if limit %}limit: "{{ limit }}",{% endif %}
+    }
     )
   </script>
 </section>

--- a/templates/shared/_latest_news_strip.html
+++ b/templates/shared/_latest_news_strip.html
@@ -1,0 +1,36 @@
+<section class="u-hide {% if section_classes %}{{ section_classes }}{% else %}p-strip{% endif %}" data-js="latest-news">
+  <div class="row p-divider">
+    <div class="col-12">
+      <h3>Latest {{ heading_topic }} news from our blog</h3>
+      <div id="vertical-latest-articles" class="row">
+        <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
+      </div>
+    </div>
+  </div>
+
+  <template style="display:none" id="vertical-articles-template">
+    <div class="col-3">
+      <p><a class="article-link article-title"></a></p>
+      <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
+    </div>
+  </template>
+
+  <div class="u-fixed-width">
+    <a href="/blog/tag/{{ tag_name }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com/{{ tag_name }}', 'eventValue' : undefined });">
+      View more from our blog&nbsp;&rsaquo;
+    </a>
+  </div>
+
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews(
+      {
+        articlesContainerSelector: "#vertical-latest-articles",
+        articleTemplateSelector: "#vertical-articles-template",
+        gtmEventLabel: "ubuntu.com/{{ tag_name }}",
+        tagId: "{{ tag_id }}",
+        limit: "{% if limit %}{{ limit }}{% else %}4{% endif %}",
+      }
+    )
+  </script>
+</section>

--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -43,6 +43,10 @@
   </div>
 </section>
 
+{%with section_classes='p-strip is-bordered', heading_topic='Telco', tag_name='telco', tag_id='1377', limit='4'  %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
+
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-no-max-width u-align--center ">TRUSTED BY LEADING SERVICE PROVIDERS, GLOBALLY</h2>
@@ -470,7 +474,7 @@
     <div class="col-7">
       <h2 class="u-sv3">Far edge: gateways, networking, digital signage and more</h2>
       <p>
-        Avoid device lock and benefit from fully automated updates and operations by using an embedded version of the Ubuntu operating system - <a href="/core">Ubuntu Core</a>. 
+        Avoid device lock and benefit from fully automated updates and operations by using an embedded version of the Ubuntu operating system - <a href="/core">Ubuntu Core</a>.
       </p>
       <p>
         Gateways, network devices and digital signage. Designed for devices with limited hardware resources, Ubuntu Core is both lightweight and robust.

--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -43,7 +43,7 @@
   </div>
 </section>
 
-{%with section_classes='p-strip is-bordered', heading_topic='Telco', tag_name='telco', tag_id='1377', limit='4'  %}
+{% with section_classes='p-strip is-bordered', heading_topic='Telco', tag_name='telco', tag_id='1377', limit='4' %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 
@@ -89,7 +89,6 @@
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
-      </li>
       </li>
       <li class="p-inline-images__item">
         {{

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -355,7 +355,7 @@
   </div>
 </section>
 
-{%with section_classes='p-strip is-deep is-bordered', heading_topic='WSL', tag_name='wsl', tag_id='3328', limit='4'  %}
+{% with section_classes='p-strip is-deep is-bordered', heading_topic='WSL', tag_name='wsl', tag_id='3328', limit='4'  %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -355,7 +355,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip is-deep is-bordered', heading_topic='WSL', tag_name='wsl', tag_id='3328', limit='4'  %}
+{% with section_classes='p-strip is-deep is-bordered', heading_topic='WSL', tag_name='wsl', tag_id='3328', limit='4' %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -355,42 +355,9 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered u-hide" data-js="latest-news">
-  <div class="row p-divider">
-    <div class="col-12">
-      <h3>Latest WSL news from our blog</h3>
-      <div id="latest-articles" class="row">
-        <div style="min-height: 9.1rem"><i class="p-icon--spinner u-animation--spin">Loading...</i></div>
-      </div>
-    </div>
-  </div>
-
-  <template style="display:none" id="articles-template">
-    <div class="col-3">
-      <p><a class="article-link article-title"></a></p>
-      <p class="u-no-padding--top"><em><time datetime="" class="article-time"></time></em></p>
-    </div>
-  </template>
-
-  <div class="u-fixed-width">
-    <a href="/blog/tag/wsl" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'blog', 'eventAction' : 'clicks blog feed link', 'eventLabel' : 'ubuntu.com/wsl', 'eventValue' : undefined });">
-      View more from our blog&nbsp;&rsaquo;
-    </a>
-  </div>
-
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
-    canonicalLatestNews.fetchLatestNews(
-      {
-        articlesContainerSelector: "#latest-articles",
-        articleTemplateSelector: "#articles-template",
-        gtmEventLabel: "ubuntu.com/wsl",
-        tagId: "3328",
-        limit: "4"
-      }
-    )
-  </script>
-</section>
+{%with section_classes='p-strip is-deep is-bordered', heading_topic='WSL', tag_name='wsl', tag_id='3328', limit='4'  %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
 
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Create horizontal latest news strip for the hompage, /telco and /wsl

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001, http://0.0.0.0:8001/telco and http://0.0.0.0:8001/wsl
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a horizontal strip of news at the top of the homepage, /telco and bottom of /wsl and that the links and text make sense


## Issue / Card

Fixes #8776

## Screenshots

![image](https://user-images.githubusercontent.com/441217/100122417-3e84ba00-2e71-11eb-9004-7d34af413dd9.png)

