### PR TITLE
Update /training with new Landscape course and Kubeflow pdf

### DIFF
--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -64,6 +64,16 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=maas-training-onsit
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
+{% elif product == 'landscape-training-onsite' %}
+
+{% with h1="Contact us about our Landscape Deployment and Operations training",
+intro_text="Fill in your details below and a member of our training team will be in touch.",
+formid="1448",
+lpId="2661",
+returnURL="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite" %}
+{% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
 
   {% else %}
 

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -244,7 +244,7 @@
   <div class="row p-divider">
     <div class="col-7 p-divider__block">
       <p>A four-day workshop-like course at your premises for up to 15 people that guides you through all aspects of performing effective Machine Learning and Deep Learning automation on your Kubeflow cluster. A follow-up course to Kubernetes Explorer, it guides you through common tasks such as creating Pipelines, working with Notebooks, training models, visualizing results, model serving, and troubleshooting, as well as introducing MLOps practices for streamlined data science using containerized frameworks and infrastructure.</p>
-      <p><a href="https://assets.ubuntu.com/v1/4d0487aa-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 p-divider__block">
       <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
@@ -262,7 +262,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip is-bordered">
   <div class="row">
     <div class="col-7">
       <h2>Metal as a Service (MAAS)</h2>
@@ -295,7 +295,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered u-no-padding--top">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-7">
       <h2>Ceph Operations</h2>
@@ -324,6 +324,39 @@
         <dd class="p-inline-definition-list__item">Private groups only</dd>
       </dl>
       <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h2>Landscape</h2>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr />
+    <h3>Deployment and Operations training</h3>
+  </div>
+
+  <div class="row p-divider">
+    <div class="col-7 p-divider__block">
+      <p>A two-day hands-on course at your premises for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.</p>
+      <p><a href="https://assets.ubuntu.com/v1/d55c5afe-Landscape+Deployment+and+Operations+Canonical+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 p-divider__block">
+      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
+        <dt class="p-inline-definition-list__title">Duration</dt>
+        <dd class="p-inline-definition-list__item">2 days</dd>
+        <dt class="p-inline-definition-list__title">Cost</dt>
+        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+        <dt class="p-inline-definition-list__title">Location</dt>
+        <dd class="p-inline-definition-list__item">Your premises or remote</dd>
+        <dt class="p-inline-definition-list__title">Availability</dt>
+        <dd class="p-inline-definition-list__item">Private groups only</dd>
+      </dl>
+      <p><a href="/training/contact-us?product=landscape-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -20,6 +20,8 @@
   {% endwith %}
 {% elif product == 'maas-training-onsite' %}
   {% with thanks_context="enquiring about our MAAS Deployment and Operations training course" %}{% include "shared/_thank_you.html" %} {% endwith %}
+{% elif product == 'landscape-training-onsite' %}
+  {% with thanks_context="enquiring about our Landscape Deployment and Operations training course" %}{% include "shared/_thank_you.html" %} {% endwith %}
 {% else %}
   {% with thanks_context="enquiring about training" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
## Done

- Update /training with new Landscape course and Kubeflow pdf including the contact-us and thank-you pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/training
    - http://0.0.0.0:8001/training/contact-us?product=landscape-training-onsite
    - http://0.0.0.0:8001/training/thank-you?product=landscape-training-onsite
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?ts=5fbbe101#)


## Issue / Card

Fixes #8816


