### PR TITLE
UA shop: increase the amount of time we wait for a payment to process

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -494,10 +494,10 @@ function enableProcessingState(mode) {
         progressIndicator.querySelector("span").innerHTML = "Still trying...";
 
         progressTimer4 = setTimeout(() => {
-          // the renewal payment is taking time to process, reload the page
+          // the payment is taking time to process, reload the page
           // and highlight the in-progress renewal
           if (mode === "payment") {
-            sendGAEvent("page reload: payment processing > 30s");
+            sendGAEvent("page reload: payment processing > 60s");
             reloadPage();
           }
 
@@ -510,7 +510,7 @@ function enableProcessingState(mode) {
               type: "dialog",
             });
           }
-        }, 15000);
+        }, 45000);
       }, 11000);
     }, 2000);
   }, 2000);


### PR DESCRIPTION
## Done

Increased maximum waiting time during payment processing from 30 to 60 seconds.

There are three messages presented to the user over time while a payment is processing, one after two seconds, another after a further two seconds, and a third after a further 11 seconds. We then waited another 15 seconds before sending the user to /advantage. This PR increases that final wait to 45 seconds, rather than 15, for a total of 60.

## QA

- Check the code


## Issue / Card

Fixes #8811 
