### PR TITLE
Build draft CUBE landing page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1383,3 +1383,13 @@ robotics:
       path: /robotics/what-is-ros
     - title: Community
       path: /robotics/community
+
+cube:
+  title: CUBE
+  path: /cube
+
+  children:
+    - title: Overview
+      path: /cube
+    - title: MicroCerts
+      path: /cube/microcerts

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -4,4 +4,221 @@
 
 {% block meta_description %}This is the CUBE landing page{% endblock meta_description %}
 
-{% block content %}{% endblock content%}
+{% block content %}
+
+<section class="p-takeover--dark">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
+      <p>Certified Ubuntu Engineer (CUBE) designation is Canonical&rsquo;s professional endorsement indicating mastery of Ubuntu.</p>
+      <p>CUBE candidates must earn 15 microcertifications across relevant subject areas.</p>
+      <p>
+        <a href="#" class="p-button--positive">View MicroCerts</a>
+      </p>
+    </div>
+    <div class="col-5 u-hide--small u-vertically-center u-align--center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/22f88d02-apps.svg",
+        alt="",
+        width="290",
+        height="170",
+        hi_def=True,
+        loading="auto",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>What are Microcertifications?</h2>
+    <p class="p-heading--four">Earn your qualification one topic at a time, at your own pace, in any order.</p>
+    <p>The CUBE curriculum is perfectly portoned to accomodate your busy schedule. It consists of 15 separate microcertifications, each covering a specific subject area, that can be taken in any order and at any time.</p>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
+  <div class="row u-equal-height u-sv3">
+    <div class="col-6">
+      <h3>Crystalise Your Expertise</h3>
+      <p class="p-heading--4">You know a lot. Prove it.</p>
+      <p>Test your abilities through Canonical&rsquo;s meticulously curated exams. Canonical-backed professional credentials are awarded for passing marks.</p>
+    </div>
+    <div class="col-6">
+      <h3>Upgrade Your Career</h3>
+      <p class="p-heading--4">Onwards and upwards.</p>
+      <p>Show current and prospective employers how you stand out from the rest. Individualised CUBE badges can be shared on social media, meaning that your successes will always remain visible and tied to you.</p>    
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h3>Highlight Your Pracical Skills</h3>
+      <p class="p-heading--4">Real-world expertise for real-world problems.</p>
+      <p>Canonical&rsquo;s exams focus on useful applications of the topics at hand, ensuring that anyone with CUBE designation is well-equipped for the modern workplace.</p>
+    </div>
+    <div class="col-6">
+      <h3>Stay Relevant</h3>
+      <p class="p-heading--4">Cutting-edge credentials.</p>
+      <p>CUBE certification demonstrates mastery of the latest Canonical offerings, assuring your competency in the Ubuntu ecosystem and beyond.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip" id="syllabus">
+  <div class="u-fixed-width">
+  <h2 class="u-sv2">Complete CUBE Syllabus - At a Glance</h2>
+    <ul class="p-matrix">
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Architecture</a></h3>
+          <div class="p-matrix__desc">
+            <p>Understand how the sustem is built, from top to bottom.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Packages</a></h3>
+          <div class="p-matrix__desc">
+            <p>Control and customize installations.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Commands</a></h3>
+          <p class="p-matrix__desc">Direct system actions and complete important tasks.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/3dee82a5-landscape-logo_smaller.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Devices & files</a></h3>
+          <div class="p-matrix__desc">
+            <p>Configure files and where they are stored.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/6d382a53-image-juju-256.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">bash</a></h3>
+          <p class="p-matrix__desc">Automate tasks with scripts.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/fffc8205-lxd-logo_smaller.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Admin</a></h3>
+          <p class="p-matrix__desc">Master useful tasks for working with shared and individual systems.</p>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/19c7461a-snapcraft-primary-icon--dark.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Services</a></h3>
+          <div class="p-matrix__desc">
+            <p>Fine-tune systems for optimal performance.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/a7916513-picto-openstack.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Networking</a></h3>
+          <div class="p-matrix__desc">
+            <p>Link machines to perform advanced tasks.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Security</a></h3>
+          <div class="p-matrix__desc">
+            <p>Protect systems and servers from unwelcome intrusions.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Kernel</a></h3>
+          <div class="p-matrix__desc">
+            <p>Manage the heart of your Ubuntu system.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Storage</a></h3>
+          <div class="p-matrix__desc">
+            <p>Archive and retrieve data safely and securely.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Virtualisation</a></h3>
+          <div class="p-matrix__desc">
+            <p>Create, configure, and use virtual machines.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">MicroK8s</a></h3>
+          <div class="p-matrix__desc">
+            <p>Streamline your Kubernetes usage with Canonical&rsquo;s efficient deployment solution.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">MAAS</a></h3>
+          <div class="p-matrix__desc">
+            <p>Turn data centers into bare-metal clouds using Canonical&rsquo;s server provisioning technology.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/b81a45e4-kubernetes.svg" alt="">
+        <div class="p-matrix__content">
+          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Juju</a></h3>
+          <div class="p-matrix__desc">
+            <p>Keep complexity low and productivity high with Canonical&rsquo;s universal operator lifecycle manager.</p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="p-strip--square-darksuru is-dark">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">&nbsp;Quote from a real user about the experience.</p>
+        <cite class="p-pull-quote__citation">&mdash; Name Surname</cite>
+      </blockquote>
+    </div>
+    <div class="col-6">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">&nbsp;Quote from a real user about the experience.</p>
+        <cite class="p-pull-quote__citation">&mdash; Name Surname</cite>
+      </blockquote>
+    </div>
+  </div>
+</section>
+
+
+{% endblock content%}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,6 +42,7 @@ from webapp.views import (
     BlogPressCentre,
     build,
     build_tutorials_index,
+    cube_home,
     cube_microcerts,
     download_harness,
     download_thank_you,
@@ -449,7 +450,8 @@ app.add_url_rule(
 )
 
 # Cube docs
-app.add_url_rule("/cube", view_func=cube_microcerts)
+app.add_url_rule("/cube", view_func=cube_home)
+app.add_url_rule("/cube/microcerts", view_func=cube_microcerts)
 
 
 @app.after_request

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1229,3 +1229,9 @@ def cube_microcerts():
     }
 
     return flask.render_template("cube/microcerts.html", **data)
+
+
+def cube_home():
+    data = {}
+
+    return flask.render_template("cube/index.html", **data)


### PR DESCRIPTION
## Done

- Hard code CUBE landing page from wireframe
- Design hasn't been done yet so this is a draft only
- Add secondary nav for cube bubble

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube
- Check against [wireframe](https://app.zeplin.io/project/5f5268731d98b38800528395/screen/5fa2d5661e336e12728b56a3)


## Issue / Card

Fixes #8825 

