### PR TITLE
Show microcerts only if you are logged in

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -13,7 +13,7 @@
       <p>Certified Ubuntu Engineer (CUBE) designation is Canonical&rsquo;s professional endorsement indicating mastery of Ubuntu.</p>
       <p>CUBE candidates must earn 15 microcertifications across relevant subject areas.</p>
       <p>
-        <a href="#" class="p-button--positive">View MicroCerts</a>
+        <a href="/cube/microcerts" class="p-button--positive">View MicroCerts</a>
       </p>
     </div>
     <div class="col-5 u-hide--small u-vertically-center u-align--center">

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -6,6 +6,7 @@
 
 {% block content %}
 
+{% if user %}
 <section class="p-strip--suru is-dark is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
@@ -67,4 +68,26 @@
     </table>
   </div>
 </section>
+{% else %}
+  <section>
+    <section class="p-strip">
+      <div class="u-fixed-width">
+        <h2>Microcertifications</h2>
+        <p>Sign in to see your microcertifications</p>
+        <p>
+          <a href="/login" class="p-button--neutral"
+            onclick="dataLayer.push({
+              'event' : 'GAEvent',
+              'eventCategory' : 'Advantage',
+              'eventAction' : 'Authentication',
+              'eventLabel' : 'Sign in',
+              'eventValue' : undefined
+            });">
+            Sign in
+          </a>
+        </p>
+      </div>
+    </section>
+  </section>
+{% endif %}
 {% endblock content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1247,43 +1247,52 @@ class BlogPressCentre(BlogView):
 # Cube
 # ===
 def cube_microcerts():
-    data = {
-        "user": {"name": "Beth Collins"},
-        "modules": [
-            {
-                "badge": "badge1",
-                "name": "module1",
-                "topics": ["topic1", "topic2", "topic7", "topic8"],
-                "test_url": "http://module1.url",
-                "training_url": "http://module3.url",
-                "status": "open",
-                "action": "Test",
-            },
-            {
-                "badge": "badge2",
-                "name": "module2",
-                "topics": ["topic3", "topic4"],
-                "test_url": "http://module2.url",
-                "training_url": "http://module3.url",
-                "status": "Failed once",
-                "action": "Retest",
-            },
-            {
-                "badge": "badge3",
-                "name": "module3",
-                "topics": ["topic5", "topic6", "topic9"],
-                "test_url": "http://module3.url",
-                "training_url": "http://module3.url",
-                "status": "Passed",
-                "action": "Test",
-            },
-        ],
-    }
+    user = user_info(flask.session)
 
-    return flask.render_template("cube/microcerts.html", **data)
+    if user:
+        data = {
+            "user": {"name": user["fullname"]},
+            "modules": [
+                {
+                    "badge": "badge1",
+                    "name": "module1",
+                    "topics": ["topic1", "topic2", "topic7", "topic8"],
+                    "test_url": "http://module1.url",
+                    "training_url": "http://module3.url",
+                    "status": "open",
+                    "action": "Test",
+                },
+                {
+                    "badge": "badge2",
+                    "name": "module2",
+                    "topics": ["topic3", "topic4"],
+                    "test_url": "http://module2.url",
+                    "training_url": "http://module3.url",
+                    "status": "Failed once",
+                    "action": "Retest",
+                },
+                {
+                    "badge": "badge3",
+                    "name": "module3",
+                    "topics": ["topic5", "topic6", "topic9"],
+                    "test_url": "http://module3.url",
+                    "training_url": "http://module3.url",
+                    "status": "Passed",
+                    "action": "Test",
+                },
+            ],
+        }
+
+        response = flask.make_response(
+            flask.render_template("cube/microcerts.html", **data)
+        )
+        response.cache_control.private = True
+
+        return response
+
+    return flask.render_template("cube/microcerts.html")
 
 
 def cube_home():
     data = {}
-
     return flask.render_template("cube/index.html", **data)


### PR DESCRIPTION
## Done
Render different content for logged in users on `/cube/microcerts`

## QA

- dotrun
- go to `/cube/microcerts` and see you get a page with a button to login
- login and see the microcerts page
- make sure when you are logged in the cache-control headers are `Cache-Control: private`


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3499

