### PR TITLE
Replace Anbox support with Anbox Cloud as a supported app

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -777,18 +777,18 @@
         <span class="p-media-object__image">
           {{
             image(
-            url="https://assets.ubuntu.com/v1/54482fc6-1031px-Anbox_logo.svg.png",
-            alt="Anbox",
+            url="https://assets.ubuntu.com/v1/ee29de9e-Anbox_favicon_64px.png",
+            alt="Anbox Cloud",
             width="40",
             height="40",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-media-object__image", "title": "Anbox"},
+            attrs={"class": "p-media-object__image", "title": "Anbox Cloud"},
             ) | safe
           }}
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Anbox</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Anbox Cloud</h4>
         </span>
       </div>
       <div class="col-3 col-medium-3 p-media-object">


### PR DESCRIPTION
## Done
- Replace Anbox with Anbox Cloud and used the logo from the anbox-cloud.io website

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- See that Anbox is now Anbox Cloud and the logo matches the favicon from anbox-cloud.io

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8763
