### PR TITLE
Lazy load the default takeover image

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -28,8 +28,8 @@
         </p>
       </div>
     </div>
-    <div class="col-5 u-vertically-center u-align--center u-align--left-medium">
-      <img src="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg" alt="" style="width: 250px; height: 388px;">
+    <div class="col-5 u-vertically-center u-align--center u-align--left-medium u-hide--small">
+      {{  image(      url="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",      alt="",      width="250",      height="388",      hi_def=True,      loading="lazy",      attrs={"style": "width: 250px; height: 388px;"},  ) | safe }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- To reduce the chance you see a flash of the gorilla while the homepage loads, I have turn on lazy loading

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Turn off JS and see that the 20.10 takeover loads
- Turn on JS and see less flash than on live.
