### PR TITLE
Fix alignment of headings on large screens on /download/raspberry-pi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -34,7 +34,7 @@
   </div>
 </section>
 <section class="p-strip u-no-padding--bottom u-hide--small">
-  <div class="row u-equal-height u-vertically-center u-sv3">
+  <div class="row u-equal-height u-vertically-center">
     <div class="col-3">
       <h2 class="u-no-margin--bottom">Download your Ubuntu Pi image</h2>
     </div>
@@ -51,7 +51,6 @@
           ) | safe
         }}
       </div>
-      <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 2</h3>
     </div>
     <div class="col-2">
       <div>
@@ -66,7 +65,6 @@
           ) | safe
         }}
       </div>
-      <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 3</h3>
     </div>
     <div class="col-2">
       <div>
@@ -81,7 +79,6 @@
           ) | safe
         }}
       </div>
-      <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 4</h3>
     </div>
     <div class="col-3">
       <div>
@@ -96,6 +93,21 @@
           ) | safe
         }}
       </div>
+    </div>
+  </div>
+  <div class="row u-vertically-center u-sv3">
+    <div class="col-3">
+    </div>
+    <div class="col-2">
+      <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 2</h3>
+    </div>
+    <div class="col-2">
+      <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 3</h3>
+    </div>
+    <div class="col-2">
+      <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 4</h3>
+    </div>
+    <div class="col-3">
       <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 400</h3>
     </div>
   </div>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -96,9 +96,7 @@
     </div>
   </div>
   <div class="row u-vertically-center u-sv3">
-    <div class="col-3">
-    </div>
-    <div class="col-2">
+    <div class="col-start-large-4 col-2">
       <h3 class="p-heading--four u-no-margin--bottom">Raspberry Pi 2</h3>
     </div>
     <div class="col-2">


### PR DESCRIPTION
## Done

- Add row for headings on /download/raspberry-pi

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the images and heading stay aligned at various screen widths

## Issue / Card

Fixes #8749

## Screenshots

[v. wide]
![image](https://user-images.githubusercontent.com/441217/100852483-806bbc80-347e-11eb-8682-44d9bfd5b2f4.png)

[tablet]
![image](https://user-images.githubusercontent.com/441217/100852577-9b3e3100-347e-11eb-98a0-cd622571eb55.png)
