### PR TITLE
Inline the sign out button in the advantage dashboard

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -22,15 +22,16 @@
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
 
-        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})</p>
-
-        <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral u-no-margin--bottom" onclick="dataLayer.push({
-          'event' : 'GAEvent',
-          'eventCategory' : 'Advantage',
-          'eventAction' : 'Authentication',
-          'eventLabel' : 'Sign out',
-          'eventValue' : undefined
-        });">Sign out</a>
+        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})
+          <span class="u-hide--large u-hide--medium"><br/></br/></span>
+          <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral is-inline is-dense u-no-margin--bottom" onclick="dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'Advantage',
+            'eventAction' : 'Authentication',
+            'eventLabel' : 'Sign out',
+            'eventValue' : undefined
+          });">Sign out</a>
+        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done
Inline the sign out button in the advantage dashboard

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Login
- See the Sign out button is inline and dense on large screens
- Wraps on medium and small screens
- See there is padding now between the text and the button on small screens 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8633

