### PR TITLE
Disable Recaptcha on the tutorials pages

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -11,8 +11,9 @@
 
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
-
+  {% if not disableRecaptcha %}
   <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
+  {% endif %}
   <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -1,4 +1,5 @@
 {% extends "tutorials/base_tutorials.html" %}
+{% set disableRecaptcha=True %}
 
 {% set small_footer=True %}
 


### PR DESCRIPTION
## Done
Disable Recaptcha on the tutorials pages as there are no forms

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials/how-to-sdcard-ubuntu-server-raspberry-pi#1-overview
- Check it still works
- Check there are no recaptcha scripts in the Network tab
