### PR TITLE
Remove openstack charm diagram from /openstack

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -179,7 +179,7 @@
       <p>Every business is different, and every sector faces unique constraints. That creates real reasons to have your own OpenStack architecture. At the same time, reinventing all of the operations for a large open source codebase makes no sense. Canonical encodes operations in a way that is shared across all our customers, while retaining the ability to craft the most efficient architecture for a particular deployment. This is why Canonical can consistently and repeatedly outperform the competition on delivery and flexibility for OpenStack, and why Canonical leads on day-2 operations such as upgrades and scaling for the private cloud.</p>
     </div>
     <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
-      <object wmode="transparent" class="bundle-card__bundle-image" type="image/svg+xml" data="https://api.jujucharms.com/charmstore/v5/bundle/openstack-base-55/diagram.svg" width="100%"></object>
+      {{  image(      url="https://assets.ubuntu.com/v1/c4596e41-openstack-charm-diagram.png",      alt="",      width="422",      height="333",      hi_def=True,      loading="lazy",   ) | safe}}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Created a flat version of the OpenStack charm diagram and added image tag tool

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page goes from

|    | Requests | MBs | resouces | time |
| -- | -------- | --- | -------- | ---- |
| original |294|3|8.9|7.8min|
| this version |63|1.5|3|2.15min|


