### PR TITLE
Move google recaptcha script into form load

### DIFF
--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -48,12 +48,22 @@
           setProductContext(contactButton);
           setUTMs();
           setGclid();
+          loadCaptchaScript();
           initialiseForm();
           window.CaptchaCallback();
         })
         .catch(function (error) {
           console.log("Request failed", error);
         });
+    }
+
+    // Load the google recaptcha noscript
+    function loadCaptchaScript() {
+      var head = document.head;
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit";
+      head.appendChild(script);
     }
 
     // Open the contact us modal

--- a/static/js/src/dynamic-contact-form.js
+++ b/static/js/src/dynamic-contact-form.js
@@ -60,9 +60,10 @@
     // Load the google recaptcha noscript
     function loadCaptchaScript() {
       var head = document.head;
-      var script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.src = "https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit";
+      var script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src =
+        "https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit";
       head.appendChild(script);
     }
 

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -115,6 +115,7 @@
       {% endif %}
 
     </div>
+    <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>
     {% endif %}
   </div>
 

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -89,3 +89,4 @@
     </div>
   </div>
 </section>
+<script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -106,3 +106,4 @@
       </div>
     </div>
   </section>
+<script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -12,7 +12,6 @@
   {% block content_experiment %}{% endblock %}
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 
-  <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
   <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">


### PR DESCRIPTION
## Done

- Move google recaptcha script into form so that it doesn't load on every page, even if you never fill in a form
- *Note - please confirm I did it correctly in the `static/js/src/dynamic-contact-form.js`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/openstack#get-in-touch
    - http://0.0.0.0:8001/openstack/contact-us
    - http://0.0.0.0:8001/engage/it/deployment-azienda-manuale
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the recaptcha loads and works


## Issue / Card

Fixes #5229

