### PR TITLE
Update Fips to FIPS

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -7,7 +7,7 @@ azure:
       path: /azure
     - title: Pro
       path: /azure/pro
-    - title: Fips
+    - title: FIPS
       path: /azure/fips
     - title: Contact us
       path: /azure/contact-us


### PR DESCRIPTION
## Done
Update navigation item from Fips to FIPS in Azure

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure
- See that the navigation is FIPS and not Fips

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8867
