### PR TITLE
Copy update on /advantage/subscribe

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -158,7 +158,7 @@
           <input autocomplete="off" class="js-product-input" type="radio" id="support_one" name="support" value="essential">
           <label for="support_one">
             No thanks<br />
-            <small class="u-text-light">Software only</small>
+            <small class="u-text-light">Software and security updates only</small>
           </label>
         </div>
 


### PR DESCRIPTION
## Done

- Change 'Software only' to 'Software and security updates only'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that IS: “Software only” is now “Software and security updates only”



## Issue / Card

Fixes #8887

## Screenshots

![image](https://user-images.githubusercontent.com/441217/101373995-83631480-38a5-11eb-87d7-da5fe1ecc393.png)

