### PR TITLE
Cube watermark background

### DIFF
--- a/static/sass/_layout-cube.scss
+++ b/static/sass/_layout-cube.scss
@@ -1,0 +1,9 @@
+@media (min-width: $breakpoint-medium) {
+  .large-column {
+    @include ubuntu-u-indent(3.5rem);
+  }
+
+  .small-column {
+    @include ubuntu-u-indent(1.1rem);
+  }
+}

--- a/static/sass/_layout-cube.scss
+++ b/static/sass/_layout-cube.scss
@@ -4,6 +4,6 @@
   }
 
   .small-column {
-    @include ubuntu-u-indent(1.1rem);
+    @include ubuntu-u-indent(1.2rem);
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -14,6 +14,7 @@
   @include ubuntu-p-strip-suru-square-darksuru;
   @include ubuntu-p-strip-suru-square-lightsuru;
   @include ubuntu-p-strip-suru-square-suru;
+  @include ubuntu-p-strip-suru-cube;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -957,6 +958,19 @@
       background-position: top right, top left, left top;
       background-repeat: no-repeat;
       background-size: 86% 105%, 67% 152%, 100% 99.8%;
+    }
+  }
+}
+
+@mixin ubuntu-p-strip-suru-cube {
+  [class*="p-strip"].has-cube {
+    &::after {
+      background: url("https://assets.ubuntu.com/v1/ea4d2cfd-CUBE-pattern.svg");
+      content: "";
+      height: 100%;
+      position: absolute;
+      top: 0;
+      width: 100%;
     }
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -968,9 +968,16 @@
       background: url("https://assets.ubuntu.com/v1/ea4d2cfd-CUBE-pattern.svg");
       content: "";
       height: 100%;
+      pointer-events: none;
       position: absolute;
       top: 0;
       width: 100%;
+      z-index: 1;
+    }
+
+    * {
+      position: relative;
+      z-index: 2;
     }
   }
 }

--- a/static/sass/_utility_animations.scss
+++ b/static/sass/_utility_animations.scss
@@ -18,7 +18,7 @@
   transform: translateY(3rem);
 }
 
-@mixin u-animations {
+@mixin ubuntu-u-animations {
   .u-fade-left {
     @include fade-left;
   }

--- a/static/sass/mixins/_utility_indent.scss
+++ b/static/sass/mixins/_utility_indent.scss
@@ -1,0 +1,7 @@
+@mixin ubuntu-u-indent($indent-value) {
+  padding-left: $indent-value;
+
+  .is-reset {
+    margin-left: -#{$indent-value};
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -30,6 +30,7 @@ $font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen
 $color-shadow: rgba(0, 0, 0, 0.5) !default;
 
 // import site specific patterns and overrides
+@import "mixins/utility_indent";
 @import "pattern_blog-featured";
 @import "pattern_blog-list";
 @import "pattern_blog-post";
@@ -69,7 +70,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_table";
 @import "pattern_ubuntu_intro";
 @import "takeovers/financial-services";
-@import "utility-animations";
+@import "utility_animations";
 @import "utility_crop";
 @import "utility_vertically-center";
 
@@ -113,22 +114,20 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include ubuntu-p-engage-banner;
 @include ubuntu-p-ubuntu-intro;
 @include ubuntu-p-tabs;
+@include ubuntu-u-animations;
 @include ubuntu-u-vertically-center;
 @include p-takeover-financial-services;
-@include u-animations;
 
 // Layouts:
 @import "layout-documentation";
 
 @include layout-documentation;
 
+@import "layout-cube";
+
 @import "layout-legal-pages";
 
 @include layout-legal-pages;
-
-@import "layout-whitepapers";
-
-@include layout-whitepapers;
 
 @import "layout-tutorials";
 
@@ -137,6 +136,10 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "layout-tutorial";
 
 @include layout-tutorial;
+
+@import "layout-whitepapers";
+
+@include layout-whitepapers;
 
 // Bug fixes
 // Each of the the rules below are bug fixes which need to be addressed further upstream

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<section class="p-takeover--dark">
+<section class="p-strip--suru has-cube">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
@@ -49,7 +49,7 @@
     <div class="col-6">
       <h3>Upgrade Your Career</h3>
       <p class="p-heading--4">Onwards and upwards.</p>
-      <p>Show current and prospective employers how you stand out from the rest. Individualised CUBE badges can be shared on social media, meaning that your successes will always remain visible and tied to you.</p>    
+      <p>Show current and prospective employers how you stand out from the rest. Individualised CUBE badges can be shared on social media, meaning that your successes will always remain visible and tied to you.</p>
     </div>
   </div>
   <div class="row u-equal-height">

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -1,26 +1,189 @@
-{% extends "cube/base_cube.html" %}
-
-{% block title %}Microcerts | CUBE{% endblock %}
-
-{% block meta_description %}This is the CUBE Microcerts page{% endblock meta_description %}
-
-{% block content %}
-
-{% if user %}
+{% extends "cube/base_cube.html" %} {% block title %}Microcerts | CUBE{%
+endblock %} {% block meta_description %}This is the CUBE Microcerts page{%
+endblock meta_description %} {% block content %} {% if user %}
 <section class="p-strip--suru is-dark is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>Your progress to CUBEdom</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor.
+      </p>
     </div>
     <div class="col-4"></div>
   </div>
 </section>
 
-
 <section class="p-strip">
   <div class="u-fixed-width">
-    <h2>Microcertifications - {{user.name}}</h2>
+    <h2>Microcertifications</h2>
+    <table class="p-table--mobile-card">
+      <thead>
+        <tr>
+          <th style="width: 5%" colspan="1">#</th>
+          <th colspan="3" class="large-column">Module</th>
+          <th colspan="4">Topics</th>
+          <th colspan="1" style="padding-left: 1rem">Status</th>
+          <th colspan="2" class="u-align--right">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td aria-label="#">1.</td>
+          <td aria-label="Module" colspan="3" class="large-column">
+            <div class="p-heading-icon is-reset">
+              <div class="p-heading-icon__header">
+                <img
+                  class="p-heading-icon__img"
+                  src="https://assets.ubuntu.com/v1/75f71a36-placeholder-badge-orange.svg"
+                  alt=""
+                />
+                <h5 class="p-heading-icon__title">
+                  <strong>Ubuntu system architecture</strong>
+                </h5>
+              </div>
+              <div class="large-column">
+                <p class="p-muted-text u-no-padding--top">
+                  <small>8 topics</small>
+                </p>
+              </div>
+            </div>
+          </td>
+          <td aria-label="Topics" colspan="4">
+            <div>
+              <p>Disable a faulty device</p>
+              <p>Disable specific hardware</p>
+              <p>Adjust Kernel module parameters</p>
+              <p>Record the Ubuntu version information</p>
+              <p>Determine and record specific CPU capabilities</p>
+              <p>Create a stsyem information Tarball</p>
+              <p>Create a system information JSON</p>
+              <p>Identify the running Kernel and associated files</p>
+            </div>
+          </td>
+          <td class="small-column" aria-label="Status">
+            <div class="is-reset">
+              {{ image(
+              url="https://assets.ubuntu.com/v1/8b3432c9-status-succeeded.svg",
+              alt="", width="15", height="15", hi_def=True, loading="auto", ) |
+              safe }}
+              <span>Passed</span>
+              <div class="small-column">
+                <p class="p-muted-text">
+                  <small>Yesterday</small>
+                </p>
+              </div>
+            </div>
+          </td>
+          <td colspan="2" aria-label="Action"></td>
+        </tr>
+        <tr>
+          <td aria-label="#">2.</td>
+          <td aria-label="module" colspan="3" class="large-column">
+            <div class="p-heading-icon is-reset">
+              <div class="p-heading-icon__header">
+                <img
+                  class="p-heading-icon__img"
+                  src="https://assets.ubuntu.com/v1/e3dd001a-placeholder-badge-white.svg"
+                  alt=""
+                />
+                <h5 class="p-heading-icon__title">
+                  <strong>Managing packages in Ubuntu</strong>
+                </h5>
+              </div>
+              <div class="large-column">
+                <p class="p-muted-text u-no-padding--top">
+                  <small>10 topics</small>
+                </p>
+              </div>
+            </div>
+          </td>
+          <td aria-label="Topics" colspan="4">
+            <div>
+              <p>Install a sepcific Snap</p>
+              <p>Configuring Snap updates</p>
+              <p>Determine Snap confirnement level</p>
+              <p>Identify package dependencies</p>
+              <p>Find and install a pervious package verison</p>
+              <p>Control package upgrades</p>
+              <p>Install from a PPA respository</p>
+              <p>Reconfigure an installed package</p>
+              <p>Change the Binary used for a Utility</p>
+              <p>Configure automatic updates</p>
+            </div>
+          </td>
+          <td aria-label="Status" class="u-no-padding--right">
+            <div>
+              <span>Failed once</span>
+              <p class="p-muted-text"><small>Yesterday</small></p>
+            </div>
+          </td>
+          <td
+            colspan="2"
+            aria-label="Action"
+            class="u-align--right u-no-padding--right"
+          >
+            <p>
+              <a class="p-button--neutral u-no-margin--right" href="#"
+                >Prepare</a
+              >
+              <a class="p-button--positive u-no-margin--left" href="#"
+                >Retest</a
+              >
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>3.</td>
+          <td colspan="3" class="large-column">
+            <div class="p-heading-icon is-reset">
+              <div class="p-heading-icon__header">
+                <img
+                  class="p-heading-icon__img"
+                  src="https://assets.ubuntu.com/v1/e3dd001a-placeholder-badge-white.svg"
+                  alt=""
+                />
+                <h5 class="p-heading-icon__title">
+                  <strong>Using Command Line Tools</strong>
+                </h5>
+              </div>
+              <div class="large-column">
+                <p class="p-muted-text u-no-padding--top">
+                  <small>7 topics</small>
+                </p>
+              </div>
+            </div>
+          </td>
+          <td colspan="4">
+            <div>
+              <p>Install a sepcific Snap</p>
+              <p>Configuring Snap updates</p>
+              <p>Determine Snap confirnement level</p>
+              <p>Identify package dependencies</p>
+              <p>Find and install a pervious package verison</p>
+              <p>Control package upgrades</p>
+              <p>Install from a PPA respository</p>
+            </div>
+          </td>
+          <td class="u-no-padding--left u-no-padding--right">
+            <p>Never tried</p>
+            <p class="p-muted-text"><small>Yesterday</small></p>
+          </td>
+          <td
+            colspan="2"
+            aria-label="Action"
+            class="u-align--right u-no-padding--right"
+          >
+            <p>
+              <a class="p-button--neutral u-no-margin--right" href="#"
+                >Prepare</a
+              >
+              <a class="p-button--positive u-no-margin--left" href="#">Test</a>
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </section>
 
@@ -50,7 +213,7 @@
           </td>
           <td colspan="3" aria-label="Topics" class="u-align--center">
             {% for topic in module.topics%}
-              <p>{{ topic }}</p>
+            <p>{{ topic }}</p>
             {% endfor%}
           </td>
           <td colspan="2" aria-label="Status" class="u-align--center">
@@ -58,8 +221,12 @@
           </td>
           <td colspan="2" aria-label="Action" class="u-align--center">
             <p>
-              <a class="p-button--neutral" href={{module.trainingurl}}>Prepare</a>
-              <a class="p-button--positive" href={{module.testurl}}>{{ module.action }}</a>
+              <a class="p-button--neutral" href="{{module.trainingurl}}"
+                >Prepare</a
+              >
+              <a class="p-button--positive" href="{{module.testurl}}"
+                >{{ module.action }}</a
+              >
             </p>
           </td>
         </tr>
@@ -69,25 +236,27 @@
   </div>
 </section>
 {% else %}
-  <section>
-    <section class="p-strip">
-      <div class="u-fixed-width">
-        <h2>Microcertifications</h2>
-        <p>Sign in to see your microcertifications</p>
-        <p>
-          <a href="/login" class="p-button--neutral"
-            onclick="dataLayer.push({
+<section>
+  <section class="p-strip">
+    <div class="u-fixed-width">
+      <h2>Microcertifications</h2>
+      <p>Sign in to see your microcertifications</p>
+      <p>
+        <a
+          href="/login"
+          class="p-button--neutral"
+          onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage',
               'eventAction' : 'Authentication',
               'eventLabel' : 'Sign in',
               'eventValue' : undefined
-            });">
-            Sign in
-          </a>
-        </p>
-      </div>
-    </section>
+            });"
+        >
+          Sign in
+        </a>
+      </p>
+    </div>
   </section>
-{% endif %}
-{% endblock content %}
+</section>
+{% endif %} {% endblock content %}

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -1,6 +1,12 @@
-{% extends "cube/base_cube.html" %} {% block title %}Microcerts | CUBE{%
-endblock %} {% block meta_description %}This is the CUBE Microcerts page{%
-endblock meta_description %} {% block content %} {% if user %}
+{% extends "cube/base_cube.html" %}
+
+{% block title %} Microcerts | CUBE {% endblock %}
+
+{% block meta_description %}This is the CUBE Microcerts page{% endblock meta_description %}
+
+{% block content %}
+
+{% if user %}
 <section class="p-strip--suru is-dark is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
@@ -23,211 +29,86 @@ endblock meta_description %} {% block content %} {% if user %}
           <th style="width: 5%" colspan="1">#</th>
           <th colspan="3" class="large-column">Module</th>
           <th colspan="4">Topics</th>
-          <th colspan="1" style="padding-left: 1rem">Status</th>
+          <th colspan="1" class="small-column">Status</th>
           <th colspan="2" class="u-align--right">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td aria-label="#">1.</td>
-          <td aria-label="Module" colspan="3" class="large-column">
-            <div class="p-heading-icon is-reset">
-              <div class="p-heading-icon__header">
-                <img
-                  class="p-heading-icon__img"
-                  src="https://assets.ubuntu.com/v1/75f71a36-placeholder-badge-orange.svg"
-                  alt=""
-                />
-                <h5 class="p-heading-icon__title">
-                  <strong>Ubuntu system architecture</strong>
-                </h5>
-              </div>
-              <div class="large-column">
-                <p class="p-muted-text u-no-padding--top">
-                  <small>8 topics</small>
-                </p>
-              </div>
-            </div>
-          </td>
-          <td aria-label="Topics" colspan="4">
-            <div>
-              <p>Disable a faulty device</p>
-              <p>Disable specific hardware</p>
-              <p>Adjust Kernel module parameters</p>
-              <p>Record the Ubuntu version information</p>
-              <p>Determine and record specific CPU capabilities</p>
-              <p>Create a stsyem information Tarball</p>
-              <p>Create a system information JSON</p>
-              <p>Identify the running Kernel and associated files</p>
-            </div>
-          </td>
-          <td class="small-column" aria-label="Status">
-            <div class="is-reset">
-              {{ image(
-              url="https://assets.ubuntu.com/v1/8b3432c9-status-succeeded.svg",
-              alt="", width="15", height="15", hi_def=True, loading="auto", ) |
-              safe }}
-              <span>Passed</span>
-              <div class="small-column">
-                <p class="p-muted-text">
-                  <small>Yesterday</small>
-                </p>
-              </div>
-            </div>
-          </td>
-          <td colspan="2" aria-label="Action"></td>
-        </tr>
-        <tr>
-          <td aria-label="#">2.</td>
-          <td aria-label="module" colspan="3" class="large-column">
-            <div class="p-heading-icon is-reset">
-              <div class="p-heading-icon__header">
-                <img
-                  class="p-heading-icon__img"
-                  src="https://assets.ubuntu.com/v1/e3dd001a-placeholder-badge-white.svg"
-                  alt=""
-                />
-                <h5 class="p-heading-icon__title">
-                  <strong>Managing packages in Ubuntu</strong>
-                </h5>
-              </div>
-              <div class="large-column">
-                <p class="p-muted-text u-no-padding--top">
-                  <small>10 topics</small>
-                </p>
-              </div>
-            </div>
-          </td>
-          <td aria-label="Topics" colspan="4">
-            <div>
-              <p>Install a sepcific Snap</p>
-              <p>Configuring Snap updates</p>
-              <p>Determine Snap confirnement level</p>
-              <p>Identify package dependencies</p>
-              <p>Find and install a pervious package verison</p>
-              <p>Control package upgrades</p>
-              <p>Install from a PPA respository</p>
-              <p>Reconfigure an installed package</p>
-              <p>Change the Binary used for a Utility</p>
-              <p>Configure automatic updates</p>
-            </div>
-          </td>
-          <td aria-label="Status" class="u-no-padding--right">
-            <div>
-              <span>Failed once</span>
-              <p class="p-muted-text"><small>Yesterday</small></p>
-            </div>
-          </td>
-          <td
-            colspan="2"
-            aria-label="Action"
-            class="u-align--right u-no-padding--right"
-          >
-            <p>
-              <a class="p-button--neutral u-no-margin--right" href="#"
-                >Prepare</a
-              >
-              <a class="p-button--positive u-no-margin--left" href="#"
-                >Retest</a
-              >
-            </p>
-          </td>
-        </tr>
-        <tr>
-          <td>3.</td>
-          <td colspan="3" class="large-column">
-            <div class="p-heading-icon is-reset">
-              <div class="p-heading-icon__header">
-                <img
-                  class="p-heading-icon__img"
-                  src="https://assets.ubuntu.com/v1/e3dd001a-placeholder-badge-white.svg"
-                  alt=""
-                />
-                <h5 class="p-heading-icon__title">
-                  <strong>Using Command Line Tools</strong>
-                </h5>
-              </div>
-              <div class="large-column">
-                <p class="p-muted-text u-no-padding--top">
-                  <small>7 topics</small>
-                </p>
-              </div>
-            </div>
-          </td>
-          <td colspan="4">
-            <div>
-              <p>Install a sepcific Snap</p>
-              <p>Configuring Snap updates</p>
-              <p>Determine Snap confirnement level</p>
-              <p>Identify package dependencies</p>
-              <p>Find and install a pervious package verison</p>
-              <p>Control package upgrades</p>
-              <p>Install from a PPA respository</p>
-            </div>
-          </td>
-          <td class="u-no-padding--left u-no-padding--right">
-            <p>Never tried</p>
-            <p class="p-muted-text"><small>Yesterday</small></p>
-          </td>
-          <td
-            colspan="2"
-            aria-label="Action"
-            class="u-align--right u-no-padding--right"
-          >
-            <p>
-              <a class="p-button--neutral u-no-margin--right" href="#"
-                >Prepare</a
-              >
-              <a class="p-button--positive u-no-margin--left" href="#">Test</a>
-            </p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="u-fixed-width">
-    <table class="p-table--mobile-card">
-      <thead>
-        <tr>
-          <th>&nbsp;</th>
-          <th colspan="2" class="u-align--center">Module</th>
-          <th colspan="3" class="u-align--center">Topics</th>
-          <th colspan="2" class="u-align--center">Status</th>
-          <th colspan="2" class="u-align--center">Action</th>
         </tr>
       </thead>
       <tbody>
         {% for module in modules %}
         <tr>
-          <td aria-label="Badge">
-            <p>{{ module.badge }}</p>
-          </td>
-          <td colspan="2" aria-label="Module" class="u-align--center">
-            <div>
-              <p>{{ module.name }}</p>
-              <p><small>{{module.topics|length}}</small> Topics</p>
+          <td aria-label="#">{{ module.number }}.</td>
+          <td aria-label="Module" colspan="3" class="large-column">
+            <div class="p-heading-icon is-reset">
+              <div class="p-heading-icon__header">
+                <img
+                  class="p-heading-icon__img"
+                  src="{{ module.badge }}"
+                  alt="Badge for {{ module.name }}"
+                />
+                <h5 class="p-heading-icon__title">
+                  <strong>{{ module.name }}</strong>
+                </h5>
+              </div>
+              <div class="large-column">
+                <p class="p-muted-text u-no-padding--top">
+                  <small>{{ module.topics|length }} topics</small>
+                </p>
+              </div>
             </div>
           </td>
-          <td colspan="3" aria-label="Topics" class="u-align--center">
-            {% for topic in module.topics%}
-            <p>{{ topic }}</p>
-            {% endfor%}
+          <td aria-label="Topics" colspan="4">
+            <div>
+              {% for topic in module.topics %}
+              <p>{{ topic }}</p>
+              {% endfor %}
+            </div>
           </td>
-          <td colspan="2" aria-label="Status" class="u-align--center">
-            <p>{{ module.status }}</p>
+          <td class="small-column" aria-label="Status">
+            {% if module.status != "Never tried" %}
+            <div class="is-reset">
+              {% if module.status == "Passed" %}
+              {{ 
+                image(
+                url="https://assets.ubuntu.com/v1/8b3432c9-status-succeeded.svg",
+                alt="{{ module.status }}", 
+                width="15", 
+                height="15", 
+                hi_def=True, 
+                loading="auto",
+                ) |
+                safe }}
+                {% elif module.status == "Failed" %}
+              {{ 
+                image(
+                url="https://assets.ubuntu.com/v1/8bb9fc23-status-failed.svg",
+                alt="{{ module.status }}", 
+                width="15", 
+                height="15", 
+                hi_def=True, 
+                loading="auto",
+                ) |
+                safe }}
+                {% endif %}
+              <span>{{ module.status }}</span>
+              <div class="small-column">
+                <p class="p-muted-text">
+                  <small>{{ module.date_attempted }}</small>
+                </p>
+              </div>
+            </div>
+            {% else %}
+            <div class="is-reset">
+              <p>Never tried</p>
+            </div>
+            {% endif %}
           </td>
-          <td colspan="2" aria-label="Action" class="u-align--center">
+          <td colspan="2" aria-label="Action">
+            {% if module.status != "Passed" %}
             <p>
-              <a class="p-button--neutral" href="{{module.trainingurl}}"
-                >Prepare</a
-              >
-              <a class="p-button--positive" href="{{module.testurl}}"
-                >{{ module.action }}</a
-              >
+              <a class="p-button--neutral u-no-margin--right" href="{{ module.training_url }}">Prepare</a>
+              <a class="p-button--positive u-no-margin--left" href="{{ module.test_url }}">{{ module.action }}</a>
             </p>
+            {% endif %}
           </td>
         </tr>
         {% endfor %}
@@ -235,6 +116,7 @@ endblock meta_description %} {% block content %} {% if user %}
     </table>
   </div>
 </section>
+
 {% else %}
 <section>
   <section class="p-strip">
@@ -259,4 +141,5 @@ endblock meta_description %} {% block content %} {% if user %}
     </div>
   </section>
 </section>
-{% endif %} {% endblock content %}
+{% endif %}
+{% endblock content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1254,31 +1254,74 @@ def cube_microcerts():
             "user": {"name": user["fullname"]},
             "modules": [
                 {
-                    "badge": "badge1",
-                    "name": "module1",
-                    "topics": ["topic1", "topic2", "topic7", "topic8"],
-                    "test_url": "http://module1.url",
-                    "training_url": "http://module3.url",
-                    "status": "open",
-                    "action": "Test",
+                    "badge": (
+                        "https://assets.ubuntu.com/v1/"
+                        "75f71a36-placeholder-badge-orange.svg"
+                    ),
+                    "name": "Ubuntu system architecture",
+                    "number": "1",
+                    "topics": [
+                        "Disable a faulty device",
+                        "Disable specific hardware",
+                        "Adjust Kernel module parameters",
+                        "Record the Ubuntu version information",
+                        "Determine and record specific CPU capabilities",
+                        "Create a system information Tarball",
+                        "Create a system information JSON",
+                        "Identify the running Kernel and associated files",
+                    ],
+                    "test_url": "",
+                    "training_url": "",
+                    "status": "Passed",
+                    "action": "",
+                    "date_attempted": "20-12-07",
                 },
                 {
-                    "badge": "badge2",
-                    "name": "module2",
-                    "topics": ["topic3", "topic4"],
+                    "badge": (
+                        "https://assets.ubuntu.com/v1/"
+                        "e3dd001a-placeholder-badge-white.svg"
+                    ),
+                    "name": "Managing packages in Ubuntu",
+                    "number": "2",
+                    "topics": [
+                        "Install a sepcific Snap",
+                        "Configuring Snap updates",
+                        "Determine Snap confirnement level",
+                        "Identify package dependencies",
+                        "Find and install a pervious package verison",
+                        "Control package upgrades",
+                        "Install from a PPA respository",
+                        "Reconfigure an installed package",
+                        "Change the Binary used for a Utility",
+                        "Configure automatic updates",
+                    ],
                     "test_url": "http://module2.url",
                     "training_url": "http://module3.url",
-                    "status": "Failed once",
+                    "status": "Failed",
                     "action": "Retest",
+                    "date_attempted": "20-12-07",
                 },
                 {
-                    "badge": "badge3",
-                    "name": "module3",
-                    "topics": ["topic5", "topic6", "topic9"],
+                    "badge": (
+                        "https://assets.ubuntu.com/v1/"
+                        "e3dd001a-placeholder-badge-white.svg"
+                    ),
+                    "name": "Using Command Line Tools",
+                    "number": "3",
+                    "topics": [
+                        "Install a sepcific Snap",
+                        "Configuring Snap updates",
+                        "Determine Snap confirnement level",
+                        "Identify package dependencies",
+                        "Find and install a pervious package verison",
+                        "Control package upgrades",
+                        "Install from a PPA respository",
+                    ],
                     "test_url": "http://module3.url",
                     "training_url": "http://module3.url",
-                    "status": "Passed",
+                    "status": "Never tried",
                     "action": "Test",
+                    "date_attempted": "",
                 },
             ],
         }


### PR DESCRIPTION
## Done
Add state class to add cube watermark with `has-cube`

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube
- Check the hero has the cube watermark background.

## Issue / Card
Fixes #8882 

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/101375349-308a5c80-38a7-11eb-98d0-999bc1bd8cf0.png)

