### PR TITLE
Redirect wordpress sitemap to ubuntu.com/blog

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -15,4 +15,7 @@
   <sitemap>
     <loc>https://ubuntu.com/ceph/docs/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+      <loc>https://ubuntu.com/blog/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -40,6 +40,8 @@ from webapp.views import (
     BlogCustomGroup,
     BlogCustomTopic,
     BlogPressCentre,
+    BlogSitemapIndex,
+    BlogSitemapPage,
     build,
     build_tutorials_index,
     download_harness,
@@ -263,6 +265,14 @@ app.add_url_rule(
 app.add_url_rule(
     "/blog/press-centre",
     view_func=BlogPressCentre.as_view("press_centre", blog_views=blog_views),
+)
+app.add_url_rule(
+    "/blog/sitemap.xml",
+    view_func=BlogSitemapIndex.as_view("sitemap", blog_views=blog_views),
+)
+app.add_url_rule(
+    "/blog/sitemap/<regex('.+'):slug>.xml",
+    view_func=BlogSitemapPage.as_view("sitemap_page", blog_views=blog_views),
 )
 app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import math
 import os
+import re
 
 # Packages
 import dateutil.parser
@@ -1255,6 +1256,40 @@ class BlogPressCentre(BlogView):
         )
 
         return flask.render_template("blog/press-centre.html", **context)
+
+
+class BlogSitemapIndex(BlogView):
+    def dispatch_request(self):
+        response = session.get(
+            "https://admin.insights.ubuntu.com/sitemap_index.xml"
+        )
+
+        xml = response.text.replace(
+            "https://admin.insights.ubuntu.com/",
+            "https://ubuntu.com/blog/sitemap/",
+        )
+        xml = re.sub(r"<\?xml-stylesheet.*\?>", "", xml)
+
+        response = flask.make_response(xml)
+        response.headers["Content-Type"] = "application/xml"
+        return response
+
+
+class BlogSitemapPage(BlogView):
+    def dispatch_request(self, slug):
+        response = session.get(f"https://admin.insights.ubuntu.com/{slug}.xml")
+
+        if response.status_code == 404:
+            return flask.abort(404)
+
+        xml = response.text.replace(
+            "https://admin.insights.ubuntu.com/", "https://ubuntu.com/blog/"
+        )
+        xml = re.sub(r"<\?xml-stylesheet.*\?>", "", xml)
+
+        response = flask.make_response(xml)
+        response.headers["Content-Type"] = "application/xml"
+        return response
 
 
 def sitemap_index():


### PR DESCRIPTION
## Done

- Redirect sitemap generated by yoast and wordpress to ubuntu.com/blog/sitemap.xml 
- Add sitemap index for blog
- Add sitemaps for blog

Known issue:
- Unknown Links for webinars
- I am not excluding tags here, I would say that this is ok for now as a first iteration of the sitemap madness

## QA

- Check out this feature branch
- Connect to the VPN
- Run the site using the command `./run serve` or `dotrun`
- http://0.0.0.0:8001/blog/sitemap.xml
- Make sure that the links in there are ok!