### PR TITLE
Update copy on /security/docker-images

### DIFF
--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -14,12 +14,9 @@
       <span class="u-sv3"><h1>LTS Docker Images</h1></span>
       <p class="u-sv2">Hardened container images, with up to ten years guaranteed security maintenance.</p>
       <p>
-        <a href="/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Read the announcement&nbsp;&rsaquo;</a>
-      </p>
-      <p>
         <a href="/security/contact-us?product=docker" class="p-button--positive js-invoke-modal">Contact Us</a>
-      </p>
-    </div>
+        <a href="/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Read the announcement&nbsp;&rsaquo;</a>
+      </p>    </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       {{
         image(
@@ -84,12 +81,13 @@
     <p class="p-heading--4"><strong>Is the LTS Docker Image Portfolio a free or a commercial offering?</strong></p>
     <p>Both. Some LTS Docker Images have a free five year maintenance period, based on the underlying Ubuntu LTS free standard security maintenance period. All LTS Images receive Extended Security Maintenance from Canonical and during that period are available to existing Canonical customers only, through Docker Hub. As with Ubuntu interim releases, ongoing development images are released regularly and receive free security updates while they are the current version.</p>
     <p class="p-heading--4"><strong>Where are the images?</strong></p>
-    <p>On Docker Hub images are provided in three groups:</p>
+    <p>On Amazon ECR Public and Docker Hub, images are provided in three groups:</p>
     <ul>
-      <li><a href="https://hub.docker.com/u/ubuntu/">Ubuntu on Docker Hub</a> has development releases with security updates</li>
-      <li>Free LTS images with up to five years fixes</li>
-      <li>Customer-only content with up to ten years fixes</li>
+      <li><a class="p-link--external" href="https://hub.docker.com/u/ubuntu/">Ubuntu on Docker Hub</a> and <a class="p-link--external" href="https://gallery.ecr.aws/?searchTerm=LTS">ECR Public</a> have development releases with security updates</li>
+      <li>LTS ("Canonical") on <a class="p-link--external" href="https://gallery.ecr.aws/?searchTerm=LTS">ECR Public</a> has Free LTS images with up to five years fixes</li>
+      <li>Customer-only content with up to ten years of fixes</li>
     </ul>
+    <p>All of our Docker Hub repositories are exempted from per-user rate limits.</p>
     <p class="p-heading--4"><strong>Is there a long-term commitment? How long?</strong></p>
     <p>LTS Images are security-maintained for the full ten year period of their underlying Ubuntu LTS release. Some applications will have versions on multiple Ubuntu LTS versions. In each case, the image is maintained for the full life of the underlying Ubuntu LTS.</p>
     <p class="p-heading--4"><strong>Can I use these images to build other applications?</strong></p>


### PR DESCRIPTION
## Done

- Update copy on /security/docker-images with links to Amazon

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/docker-images
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comment in the [copy doc](https://docs.google.com/document/d/1zZibtjU141e4mBxo_0PtfYxJ6e5fyaaAdFZ6v945XAM/edit#)


## Issue / Card

Fixes #8895
