### PR TITLE
Add general /security/api to path

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -106,7 +106,7 @@ production:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths: [/security/cves\.json, /security/cves/.*\.json, /security/notices\.json, /security/notices/.*\.json, /security/spec\.json, /security/docs]
+    - paths: [/security/cves\.json, /security/cves/.*\.json, /security/notices\.json, /security/notices/.*\.json, /security/api/.*]
       service_name: ubuntu-com-security-api
 
   nginxConfigurationSnippet: |
@@ -210,7 +210,7 @@ staging:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths: [/security/cves\.json, /security/cves/.*\.json, /security/notices\.json, /security/notices/.*\.json, /security/spec\.json, /security/docs]
+    - paths: [/security/cves\.json, /security/cves/.*\.json, /security/notices\.json, /security/notices/.*\.json, /security/api/.*]
       service_name: ubuntu-com-security-api
 
   nginxConfigurationSnippet: |


### PR DESCRIPTION
## Done

Do not merge until https://github.com/canonical-web-and-design/ubuntu-com-security-api/pull/18 is merged!

Changes the paths we link to the API app.

## Issue
Fixes https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/6