### PR TITLE
Remove the date based padding on the k8s release chart

### DIFF
--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -225,7 +225,8 @@ export function createChart(
   taskTypes,
   taskStatus,
   tasks,
-  taskVersions
+  taskVersions,
+  removePadding
 ) {
   var margin = {
     top: 0,
@@ -234,8 +235,15 @@ export function createChart(
     left: 150,
   };
   var rowHeight = 32;
-  var timeDomainStart = d3.timeYear.offset(tasks[0].startDate, -1);
-  var timeDomainEnd = d3.timeYear.offset(tasks[tasks.length - 1].endDate, +1);
+  var timeDomainStart;
+  var timeDomainEnd;
+  if (removePadding) {
+    timeDomainStart = tasks[0].startDate;
+    timeDomainEnd = tasks[tasks.length - 1].endDate;
+  } else {
+    timeDomainStart = d3.timeYear.offset(tasks[0].startDate, -1);
+    timeDomainEnd = d3.timeYear.offset(tasks[tasks.length - 1].endDate, +1);
+  }
   var height = taskTypes.length * rowHeight;
   var containerWidth = document.querySelector(chartSelector).clientWidth;
   if (containerWidth <= 0) {

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -122,7 +122,9 @@ function buildCharts() {
       "#kubernetes-eol",
       kubernetesReleaseNames,
       kubernetesStatus,
-      kubernetesReleases
+      kubernetesReleases,
+      false,
+      true
     );
   }
   if (document.querySelector("#kernel-schedule")) {


### PR DESCRIPTION
## Done
Added an optional boolean param to the `createChart` function which removes the date based padding. 

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#charmed-kubernetes-release-cycle
- See that the yAxis no longer overlap

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8875

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/101674117-fe682e80-3a4f-11eb-8d10-6d467e658f20.png) | ![image](https://user-images.githubusercontent.com/1413534/101674088-f3150300-3a4f-11eb-9e75-0eccfad2a015.png) |

