### PR TITLE
Add CUBE animation to landing page hero

### DIFF
--- a/static/sass/_pattern_cube-animation.scss
+++ b/static/sass/_pattern_cube-animation.scss
@@ -38,7 +38,7 @@
   );
 
   .p-cube-animation {
-    margin-top: -4rem;
+    margin-top: -2.9rem;
 
     &.is-transformed {
       @each $index, $position in $positions {

--- a/static/sass/_pattern_cube-animation.scss
+++ b/static/sass/_pattern_cube-animation.scss
@@ -46,12 +46,15 @@
         $coords: map-get($positions, $to);
         $xPos: map-get($coords, "x") * 1px;
         $yPos: map-get($coords, "y") * 1px;
-        .cube-#{$index} {
+        .p-cube-animation__cube--#{$index} {
+          @extend %cube-animation-item;
+
           transform: translate(#{$xPos}, #{$yPos});
         }
       }
     }
-    &__cube {
+
+    %cube-animation-item {
       background: url(https://assets.ubuntu.com/v1/c3137d5a-CUBE-2.svg);
       background-size: map-get($size, "width") * 1px map-get($size, "height") *
         1px;
@@ -64,7 +67,9 @@
     @each $index, $position in $positions {
       $xPos: map-get($position, "x") * 1px;
       $yPos: map-get($position, "y") * 1px;
-      .cube-#{$index} {
+      .p-cube-animation__cube--#{$index} {
+        @extend %cube-animation-item;
+
         transform: translate(#{$xPos}, #{$yPos});
       }
     }

--- a/static/sass/_pattern_cube-animation.scss
+++ b/static/sass/_pattern_cube-animation.scss
@@ -1,0 +1,70 @@
+$size: (
+  "width": 169,
+  "height": 195,
+);
+$speed: 2s;
+$positions: (
+  "1": (
+    "x": 100,
+    "y": 1,
+    "to": "6",
+  ),
+  "2": (
+    "x": 183,
+    "y": 49,
+    "to": "1",
+  ),
+  "3": (
+    "x": 183,
+    "y": 145.5,
+    "to": "4",
+  ),
+  "4": (
+    "x": 100,
+    "y": 193,
+    "to": "5",
+  ),
+  "5": (
+    "x": 16,
+    "y": 145.5,
+    "to": "2",
+  ),
+  "6": (
+    "x": 16,
+    "y": 49,
+    "to": "3",
+  ),
+);
+
+.cube {
+  background: url(https://assets.ubuntu.com/v1/c3137d5a-CUBE-2.svg);
+  background-size: map-get($size, "width") * 1px map-get($size, "height") * 1px;
+  height: map-get($size, "height") * 1px;
+  position: absolute;
+  transition: transform $speed;
+  width: map-get($size, "width") * 1px;
+}
+
+@each $index, $position in $positions {
+  $xPos: map-get($position, "x") * 1px;
+  $yPos: map-get($position, "y") * 1px;
+  .cube-#{$index} {
+    transform: translate(#{$xPos}, #{$yPos});
+  }
+}
+
+.hero-animation {
+  margin-top: -4rem;
+
+  &.is-transformed {
+    @each $index, $position in $positions {
+      $to: map-get($position, "to");
+      $coords: map-get($positions, $to);
+      $xPos: map-get($coords, "x") * 1px;
+      $yPos: map-get($coords, "y") * 1px;
+      .cube-#{$index} {
+        transform: translate(#{$xPos}, #{$yPos});
+      }
+    }
+  }
+}

--- a/static/sass/_pattern_cube-animation.scss
+++ b/static/sass/_pattern_cube-animation.scss
@@ -1,67 +1,69 @@
-$size: (
-  "width": 169,
-  "height": 195,
-);
-$speed: 2s;
-$positions: (
-  "1": (
-    "x": 100,
-    "y": 1,
-    "to": "6",
-  ),
-  "2": (
-    "x": 183,
-    "y": 49,
-    "to": "1",
-  ),
-  "3": (
-    "x": 183,
-    "y": 145.5,
-    "to": "4",
-  ),
-  "4": (
-    "x": 100,
-    "y": 193,
-    "to": "5",
-  ),
-  "5": (
-    "x": 16,
-    "y": 145.5,
-    "to": "2",
-  ),
-  "6": (
-    "x": 16,
-    "y": 49,
-    "to": "3",
-  ),
-);
+@mixin ubuntu-p-cube-animation {
+  $size: (
+    "width": 169,
+    "height": 195,
+  );
+  $speed: 2s;
+  $positions: (
+    "1": (
+      "x": 100,
+      "y": 1,
+      "to": "6",
+    ),
+    "2": (
+      "x": 183,
+      "y": 49,
+      "to": "1",
+    ),
+    "3": (
+      "x": 183,
+      "y": 145.5,
+      "to": "4",
+    ),
+    "4": (
+      "x": 100,
+      "y": 193,
+      "to": "5",
+    ),
+    "5": (
+      "x": 16,
+      "y": 145.5,
+      "to": "2",
+    ),
+    "6": (
+      "x": 16,
+      "y": 49,
+      "to": "3",
+    ),
+  );
 
-.cube {
-  background: url(https://assets.ubuntu.com/v1/c3137d5a-CUBE-2.svg);
-  background-size: map-get($size, "width") * 1px map-get($size, "height") * 1px;
-  height: map-get($size, "height") * 1px;
-  position: absolute;
-  transition: transform $speed;
-  width: map-get($size, "width") * 1px;
-}
+  .p-cube-animation {
+    margin-top: -4rem;
 
-@each $index, $position in $positions {
-  $xPos: map-get($position, "x") * 1px;
-  $yPos: map-get($position, "y") * 1px;
-  .cube-#{$index} {
-    transform: translate(#{$xPos}, #{$yPos});
-  }
-}
+    &.is-transformed {
+      @each $index, $position in $positions {
+        $to: map-get($position, "to");
+        $coords: map-get($positions, $to);
+        $xPos: map-get($coords, "x") * 1px;
+        $yPos: map-get($coords, "y") * 1px;
+        .cube-#{$index} {
+          transform: translate(#{$xPos}, #{$yPos});
+        }
+      }
+    }
+    &__cube {
+      background: url(https://assets.ubuntu.com/v1/c3137d5a-CUBE-2.svg);
+      background-size: map-get($size, "width") * 1px map-get($size, "height") *
+        1px;
+      height: map-get($size, "height") * 1px;
+      position: absolute;
+      transition: transform $speed;
+      width: map-get($size, "width") * 1px;
+    }
 
-.hero-animation {
-  margin-top: -4rem;
-
-  &.is-transformed {
     @each $index, $position in $positions {
-      $to: map-get($position, "to");
-      $coords: map-get($positions, $to);
-      $xPos: map-get($coords, "x") * 1px;
-      $yPos: map-get($coords, "y") * 1px;
+      $xPos: map-get($position, "x") * 1px;
+      $yPos: map-get($position, "y") * 1px;
       .cube-#{$index} {
         transform: translate(#{$xPos}, #{$yPos});
       }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -939,30 +939,27 @@
   .p-strip--square-suru {
     @extend %vf-strip;
 
+    background-blend-mode: multiply, multiply, normal;
     background-color: #2c001e;
+    background-image: linear-gradient(
+        to bottom left,
+        rgba(228, 228, 228, 0.54) 0%,
+        rgba(228, 228, 228, 0.54) 49.9%,
+        rgba(228, 228, 228, 0) 50%,
+        rgba(228, 228, 228, 0) 100%
+      ),
+      linear-gradient(
+        to bottom right,
+        rgba(228, 228, 228, 0.54) 0%,
+        rgba(228, 228, 228, 0.54) 49.9%,
+        rgba(228, 228, 228, 0) 50%,
+        rgba(228, 228, 228, 0) 100%
+      ),
+      linear-gradient(-89deg, #e95420 0%, #772953 38%, #2c001e 85%);
+    background-position: top right, top left, left top;
+    background-repeat: no-repeat;
+    background-size: 86% 105%, 67% 152%, 100% 99.8%;
     color: $color-x-light;
-
-    @media (min-width: $breakpoint-medium) {
-      background-blend-mode: multiply, multiply, normal;
-      background-image: linear-gradient(
-          to bottom left,
-          rgba(228, 228, 228, 0.54) 0%,
-          rgba(228, 228, 228, 0.54) 49.9%,
-          rgba(228, 228, 228, 0) 50%,
-          rgba(228, 228, 228, 0) 100%
-        ),
-        linear-gradient(
-          to bottom right,
-          rgba(228, 228, 228, 0.54) 0%,
-          rgba(228, 228, 228, 0.54) 49.9%,
-          rgba(228, 228, 228, 0) 50%,
-          rgba(228, 228, 228, 0) 100%
-        ),
-        linear-gradient(-89deg, #e95420 0%, #772953 38%, #2c001e 85%);
-      background-position: top right, top left, left top;
-      background-repeat: no-repeat;
-      background-size: 86% 105%, 67% 152%, 100% 99.8%;
-    }
   }
 }
 
@@ -978,6 +975,9 @@
       top: 0;
       width: 100%;
       z-index: 1;
+    }
+    * {
+      z-index: 2;
     }
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -5,6 +5,7 @@
   @include ubuntu-p-strip-suru-blog-header;
   @include ubuntu-p-strip-suru-blog-hero;
   @include ubuntu-p-strip-suru-bottomed;
+  @include ubuntu-p-strip-suru-cube;
   @include ubuntu-p-strip-suru-half-and-half;
   @include ubuntu-p-strip-suru-half-and-half-reversed;
   @include ubuntu-p-strip-suru-half-top;
@@ -14,7 +15,6 @@
   @include ubuntu-p-strip-suru-square-darksuru;
   @include ubuntu-p-strip-suru-square-lightsuru;
   @include ubuntu-p-strip-suru-square-suru;
-  @include ubuntu-p-strip-suru-cube;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -805,6 +805,10 @@
   .is-slanted {
     &--bottom-left {
       clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% calc(100% - 4rem));
+      padding-bottom: 6rem;
+    }
+    &--bottom-right {
+      clip-path: polygon(0% 0%, 100% 0%, 100% calc(100% - 4rem), 0% 100%);
       padding-bottom: 6rem;
     }
   }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -14,6 +14,7 @@
   @include ubuntu-p-strip-suru-square-darksuru;
   @include ubuntu-p-strip-suru-square-lightsuru;
   @include ubuntu-p-strip-suru-square-suru;
+  @include ubuntu-p-strip-suru-cube;
 }
 
 @mixin ubuntu-p-strip-suru {
@@ -957,6 +958,22 @@
       background-position: top right, top left, left top;
       background-repeat: no-repeat;
       background-size: 86% 105%, 67% 152%, 100% 99.8%;
+    }
+  }
+}
+
+@mixin ubuntu-p-strip-suru-cube {
+  [class*="p-strip"].has-cube,
+  [class*="p-takeover"].has-cube {
+    &::after {
+      background: url("https://assets.ubuntu.com/v1/ea4d2cfd-CUBE-pattern.svg");
+      content: "";
+      height: 100%;
+      pointer-events: none;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 1;
     }
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -966,7 +966,7 @@
   [class*="p-strip"].has-cube,
   [class*="p-takeover"].has-cube {
     &::after {
-      background: url("https://assets.ubuntu.com/v1/ea4d2cfd-CUBE-pattern.svg");
+      background: url("https://assets.ubuntu.com/v1/b3ae0076-CUBE-pattern-bigger2.svg");
       content: "";
       height: 100%;
       pointer-events: none;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -89,6 +89,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include ubuntu-p-cards;
 @include ubuntu-p-contact-modal;
 @include ubuntu-p-contextual-footer;
+@include ubuntu-p-cube-animation;
 @include ubuntu-p-cve;
 @include ubuntu-p-desktop-statistics;
 @include ubuntu-p-divider;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -42,6 +42,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_chart";
 @import "pattern_contact-modal";
 @import "pattern_contextual-footer";
+@import "pattern_cube-animation";
 @import "pattern_cube-table";
 @import "pattern_cve";
 @import "pattern_desktop-statistics";

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -17,12 +17,12 @@
       </p>
     </div>
     <div class="col-5 col-start-large-8 u-hide--small p-cube-animation">
-      <div class="p-cube-animation__cube cube-1"></div>
-      <div class="p-cube-animation__cube cube-2"></div>
-      <div class="p-cube-animation__cube cube-3"></div>
-      <div class="p-cube-animation__cube cube-4"></div>
-      <div class="p-cube-animation__cube cube-5"></div>
-      <div class="p-cube-animation__cube cube-6"></div>
+      <div class="p-cube-animation__cube--1"></div>
+      <div class="p-cube-animation__cube--2"></div>
+      <div class="p-cube-animation__cube--3"></div>
+      <div class="p-cube-animation__cube--4"></div>
+      <div class="p-cube-animation__cube--5"></div>
+      <div class="p-cube-animation__cube--6"></div>
     </div>
   </div>
 </section>

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -16,13 +16,13 @@
         <a href="/cube/microcerts" class="p-button--positive">View MicroCerts</a>
       </p>
     </div>
-    <div class="col-5 col-start-large-8 u-hide--small hero-animation">
-      <div class="cube cube-1"></div>
-      <div class="cube cube-2"></div>
-      <div class="cube cube-3"></div>
-      <div class="cube cube-4"></div>
-      <div class="cube cube-5"></div>
-      <div class="cube cube-6"></div>
+    <div class="col-5 col-start-large-8 u-hide--small p-cube-animation">
+      <div class="p-cube-animation__cube cube-1"></div>
+      <div class="p-cube-animation__cube cube-2"></div>
+      <div class="p-cube-animation__cube cube-3"></div>
+      <div class="p-cube-animation__cube cube-4"></div>
+      <div class="p-cube-animation__cube cube-5"></div>
+      <div class="p-cube-animation__cube cube-6"></div>
     </div>
   </div>
 </section>
@@ -218,7 +218,7 @@
 
 <script>
 window.addEventListener('load', (event) => {
-  const heroAnimation = document.querySelector(".hero-animation")
+  const heroAnimation = document.querySelector(".p-cube-animation")
   heroAnimation.classList.add("is-transformed")
   setInterval(() => {
     heroAnimation.classList.toggle("is-transformed")

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -6,9 +6,9 @@
 
 {% block content %}
 
-<section class="p-takeover--grad has-cube is-deep">
+<section class="p-strip--square-suru has-cube is-deep is-slanted--bottom-right">
   <div class="row u-equal-height">
-    <div class="col-7">
+    <div class="col-6">
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
       <p>Certified Ubuntu Engineer (CUBE) designation is Canonical&rsquo;s professional endorsement indicating mastery of Ubuntu.</p>
       <p>CUBE candidates must earn 15 microcertifications across relevant subject areas.</p>
@@ -16,7 +16,7 @@
         <a href="/cube/microcerts" class="p-button--positive">View MicroCerts</a>
       </p>
     </div>
-    <div class="col-5 u-hide--small hero-animation">
+    <div class="col-5 col-start-large-8 u-hide--small hero-animation">
       <div class="cube cube-1"></div>
       <div class="cube cube-2"></div>
       <div class="cube cube-3"></div>

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -10,8 +10,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
-      <p>Certified Ubuntu Engineer (CUBE) designation is Canonical&rsquo;s professional endorsement indicating mastery of Ubuntu.</p>
-      <p>CUBE candidates must earn 15 microcertifications across relevant subject areas.</p>
+      <p class="p-heading--4">Certified Ubuntu Engineer (CUBE) designation is Canonical&rsquo;s professional endorsement indicating mastery of Ubuntu. CUBE candidates must earn 15 microcertifications across relevant subject areas.</p>
       <p>
         <a href="/cube/microcerts" class="p-button--positive">View MicroCerts</a>
       </p>

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<section class="p-takeover--dark">
+<section class="p-takeover--grad has-cube is-deep">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
@@ -16,17 +16,13 @@
         <a href="/cube/microcerts" class="p-button--positive">View MicroCerts</a>
       </p>
     </div>
-    <div class="col-5 u-hide--small u-vertically-center u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/22f88d02-apps.svg",
-        alt="",
-        width="290",
-        height="170",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}
+    <div class="col-5 u-hide--small hero-animation">
+      <div class="cube cube-1"></div>
+      <div class="cube cube-2"></div>
+      <div class="cube cube-3"></div>
+      <div class="cube cube-4"></div>
+      <div class="cube cube-5"></div>
+      <div class="cube cube-6"></div>
     </div>
   </div>
 </section>
@@ -203,7 +199,7 @@
   </div>
 </section>
 
-<section class="p-strip--square-darksuru is-dark">
+<section class="p-strip--square-suru has-cube">
   <div class="row u-equal-height">
     <div class="col-6">
       <blockquote class="p-pull-quote">
@@ -220,5 +216,13 @@
   </div>
 </section>
 
-
+<script>
+window.addEventListener('load', (event) => {
+  const heroAnimation = document.querySelector(".hero-animation")
+  heroAnimation.classList.add("is-transformed")
+  setInterval(() => {
+    heroAnimation.classList.toggle("is-transformed")
+  }, 4000)
+});
+</script>
 {% endblock content%}


### PR DESCRIPTION
## Done

- Add CUBE animation to hero on `/cube`
- Add watermark cube background to hero and strip on `/cube`
- Edit `p-strip--square-suru` class, to ensure the gradient is visibile on all screen sizes. This class is only used in one other place on `/automotive`. Spoke to @anasereijo who confirmed that across ubuntu.com the suru gradient should be visible on all screen sizes. 

## QA

- View the demo at: https://ubuntu-com-8905.demos.haus/cube
- Check the CUBE animation on the hero and the watermark background. 
- Check the animation transforms on page load similar to _animation9_, see [here](https://drive.google.com/drive/folders/1nlQ-MxfebuI8T9xuczU559AOWQ4c7l9c)


## Issue / Card

Fixes #8882 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/101902374-764a6c00-3baa-11eb-908b-dde59356e025.png)




