### PR TITLE
Replace link to docker snap with trad install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you have found a bug in the Ubuntu OS itself, the please file it [here](https
 
 ## Local development
 
-The simplest way to run the site locally is using the [`dotrun`](https://github.com/canonical-web-and-design/dotrun/) and [`docker`](https://snapcraft.io/docker)snaps:
+The simplest way to run the site locally is using the [`dotrun`](https://github.com/canonical-web-and-design/dotrun/) snap and [`docker`](https://docs.docker.com/engine/install/ubuntu/):
 
 ```bash
 docker-compose up -d
@@ -30,6 +30,7 @@ Once the server has started, you can visit <http://127.0.0.1:8001> in your brows
 After you close the server with `<ctrl>+c`, then you should run `docker-compose down` to stop the database.
 
 # Deploy
+
 You can find the deployment config in the deploy folder.
 
 ## License


### PR DESCRIPTION
## Done

I had some issues with the docker snap before @nottrobin told me to use the official version instead. So I'm removing links to docker snaps in the readme to prevent future headaches

- Remove the link to docker snap and replaced it with the docker.com official install instruction

## QA

- Look at the readme
