### PR TITLE
Add RSS metatag

### DIFF
--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -1,5 +1,10 @@
 {% extends "templates/one-column.html" %}
 {% block title %}Ubuntu Blog{% endblock %}
+
+{% block extra_metatags %}
+  <link rel="alternate" type="application/rss+xml"  href="/blog/feed" title="Ubuntu.com's Blog RSS feed">
+{% endblock %}
+
 {% block content%}
 
 {% if current_page and current_page == 1 and featured_articles %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -60,6 +60,8 @@
   <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
   {% endif %}
 
+  {% block extra_metatags %}{% endblock %}
+
   {% include "templates/_tag_manager.html" %}
 </head>
 


### PR DESCRIPTION
## Done

- Add RSS metatag for blog

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- Make sure that blog index page has the metatag for rss feed
