### PR TITLE
Cube topics badges

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -32,6 +32,8 @@ from webapp.context import (
     releases,
 )
 
+from webapp.cube.views import cube_home, cube_microcerts
+
 from webapp.views import (
     accept_renewal,
     advantage_view,
@@ -42,8 +44,6 @@ from webapp.views import (
     BlogPressCentre,
     build,
     build_tutorials_index,
-    cube_home,
-    cube_microcerts,
     download_harness,
     download_thank_you,
     appliance_install,

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -2,7 +2,7 @@ import urllib
 from requests import Session
 
 
-class CubeAPI:
+class CubeEdxAPI:
     def __init__(
         self,
         base_url: str,

--- a/webapp/cube/mappings/courses.yaml
+++ b/webapp/cube/mappings/courses.yaml
@@ -1,0 +1,94 @@
+course-v1:ubuntu+cubereview+admintasksdev:
+  logo: "https://assets.ubuntu.com/v1/7bf909cc-Admin.svg"
+  topics:
+    - Find and review information about activities and processes
+    - Manage user privileges
+    - Create backups
+
+course-v1:ubuntu+cubereview+commandsdev:
+  logo: "https://assets.ubuntu.com/v1/43f7d2a3-Commands.svg"
+  topics:
+    - Work with file contents
+    - Process data using the command line
+    - Use essential utilities
+
+course-v1:ubuntu+cubereview+devicesdev:
+  logo: "https://assets.ubuntu.com/v1/093b57b6-Devices+%26+files.svg"
+  topics:
+    - Configure volumes and subvolumes
+    - Create and configure partitions
+    - Encrypt disks
+    - Manage and configure block devices, Device Mapper, and filesystems
+
+course-v1:ubuntu+cubereview+jujudev:
+  logo: "https://assets.ubuntu.com/v1/5be7daa5-Juju.svg"
+  topics:
+    - Juju fundamentals
+    - Everyday Juju usage
+    - Juju administration
+
+course-v1:ubuntu+cubereview+kerneldev:
+  logo: "https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg"
+  topics:
+    - Install and boot to specific kernels
+    - Configure kernel and module parameters
+    - Configure kernel and module debugging options
+
+course-v1:ubuntu+cubereview+maasdev:
+  logo: "https://assets.ubuntu.com/v1/8e0dd19e-MAAS.svg"
+  topics:
+    - MAAS fundamentals
+    - Everyday MAAS usage
+    - MAAS administration
+
+course-v1:ubuntu+cubereview+microk8sdev:
+  logo: "https://assets.ubuntu.com/v1/1812ec49-MicroK8s.svg"
+  topics:
+    - MicroK8s installation
+    - MicroK8s configuration
+    - Common MicroK8s use cases
+
+course-v1:ubuntu+cubereview+networkingdev:
+  logo: "https://assets.ubuntu.com/v1/f59674b7-Networking.svg"
+  topics:
+    - Set up common networking components
+    - Configure common networking utilities
+    - Verify connectivity and features of remote services
+
+course-v1:ubuntu+cubereview+packagedev:
+  logo: "https://assets.ubuntu.com/v1/c19e9931-Packages.svg"
+  topics:
+    - Assess package information
+    - Use and configure snaps
+    - Manage Debian packages
+    - Manage executables with alternatives
+
+course-v1:ubuntu+cubereview+securitydev:
+  logo: "https://assets.ubuntu.com/v1/2291952a-Security.svg"
+  topics:
+    - Operate secure encryption utilities
+    - Set up and manage firewalls
+    - Solve common security issues
+    - Perform basic hardening operations
+
+course-v1:ubuntu+cubereview+shellscriptdev:
+  logo: "https://assets.ubuntu.com/v1/30af430c-bash.svg"
+  topics:
+    - Create, check, and test files
+    - Work with logs
+    - Monitor and gather information from other systems
+    - Automate tasks with loops and conditionals
+
+course-v1:ubuntu+cubereview+storagedev:
+  logo: "https://assets.ubuntu.com/v1/cd7785d1-Storage.svg"
+  topics:
+    - Repair unclean filesystems
+    - Manage storage lifecycles
+    - Test storage capabilities
+
+course-v1:ubuntu+cubereview+sysarchdev:
+  logo: "https://assets.ubuntu.com/v1/9ef4a092-Architecture.svg"
+  topics:
+    - Review and record relevant system information
+    - Manage kernels and devices
+    - Make administrative changes to devices and hardware

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -1,13 +1,15 @@
 import os
 import flask
 import talisker.requests
+import yaml
 
 from webapp.cube.api import CubeEdxAPI
 from webapp.login import user_info
 
 
-# Cube
-# ===
+with open("webapp/cube/mappings/courses.yaml", "r") as stream:
+    COURSE_DATA = yaml.load(stream.read(), Loader=yaml.Loader)
+
 cube_api = CubeEdxAPI(
     "https://qa.cube.ubuntu.com",
     os.getenv("CUBE_EDX_CLIENT_ID"),
@@ -24,15 +26,23 @@ def cube_microcerts():
 
         modules = []
         for course in courses:
+            course_id = course["id"]
+            if course_id not in COURSE_DATA:
+                continue
+
             course_uri = (
-                f"https://qa.cube.ubuntu.com/courses/{course['id']}/course"
+                f"https://qa.cube.ubuntu.com/courses/{course_id}/course"
             )
+
+            badge = COURSE_DATA[course_id].get("logo")
+            topics = COURSE_DATA[course_id].get("topics")
+
             modules.append(
                 {
-                    "number": 1,
-                    "badge": "Badge",
+                    "number": len(modules) + 1,
+                    "badge": badge,
                     "name": course["name"],
-                    "topics": [],
+                    "topics": topics,
                     "test_url": course_uri,
                     "training_url": course_uri,
                     "status": "Hardcoded",

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -1,0 +1,61 @@
+import os
+import flask
+import talisker.requests
+
+from webapp.cube.api import CubeEdxAPI
+from webapp.login import user_info
+
+
+# Cube
+# ===
+cube_api = CubeEdxAPI(
+    "https://qa.cube.ubuntu.com",
+    os.getenv("CUBE_EDX_CLIENT_ID"),
+    os.getenv("CUBE_EDX_CLIENT_SECRET"),
+    talisker.requests.get_session(),
+)
+
+
+def cube_microcerts():
+    user = user_info(flask.session)
+
+    if user:
+        courses = cube_api.get_courses(organization="ubuntu")["results"]
+
+        modules = []
+        for course in courses:
+            course_uri = (
+                f"https://qa.cube.ubuntu.com/courses/{course['id']}/course"
+            )
+            modules.append(
+                {
+                    "number": 1,
+                    "badge": "Badge",
+                    "name": course["name"],
+                    "topics": [],
+                    "test_url": course_uri,
+                    "training_url": course_uri,
+                    "status": "Hardcoded",
+                    "action": "Test",
+                    "date_attempted": "20-12-07",
+                }
+            )
+
+        data = {
+            "user": {"name": user["fullname"]},
+            "modules": modules,
+        }
+
+        response = flask.make_response(
+            flask.render_template("cube/microcerts.html", **data)
+        )
+        response.cache_control.private = True
+
+        return response
+
+    return flask.render_template("cube/microcerts.html")
+
+
+def cube_home():
+    data = {}
+    return flask.render_template("cube/index.html", **data)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -28,7 +28,6 @@ from canonicalwebteam.search.views import NoAPIKeyError
 from webapp.login import empty_session, user_info
 from webapp.advantage import AdvantageContracts, UnauthorizedError
 from webapp.decorators import store_maintenance
-from webapp.api.cube import CubeAPI
 
 
 ip_reader = geolite2.reader()
@@ -1243,58 +1242,3 @@ class BlogPressCentre(BlogView):
         )
 
         return flask.render_template("blog/press-centre.html", **context)
-
-
-# Cube
-# ===
-cube_api = CubeAPI(
-    "https://qa.cube.ubuntu.com",
-    os.getenv("CUBE_EDX_CLIENT_ID"),
-    os.getenv("CUBE_EDX_CLIENT_SECRET"),
-    talisker.requests.get_session(),
-)
-
-
-def cube_microcerts():
-    user = user_info(flask.session)
-
-    if user:
-        courses = cube_api.get_courses(organization="ubuntu")["results"]
-
-        modules = []
-        for course in courses:
-            course_uri = (
-                f"https://qa.cube.ubuntu.com/courses/{course['id']}/course"
-            )
-            modules.append(
-                {
-                    "number": 1,
-                    "badge": "Badge",
-                    "name": course["name"],
-                    "topics": [],
-                    "test_url": course_uri,
-                    "training_url": course_uri,
-                    "status": "Hardcoded",
-                    "action": "Test",
-                    "date_attempted": "20-12-07",
-                }
-            )
-
-        data = {
-            "user": {"name": user["fullname"]},
-            "modules": modules,
-        }
-
-        response = flask.make_response(
-            flask.render_template("cube/microcerts.html", **data)
-        )
-        response.cache_control.private = True
-
-        return response
-
-    return flask.render_template("cube/microcerts.html")
-
-
-def cube_home():
-    data = {}
-    return flask.render_template("cube/index.html", **data)


### PR DESCRIPTION
## Done

Adds a mapping for course topics and badges, so we can list them on the microcerts page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Visit `http://localhost:8001/cube/microcerts`
- See you have a list of courses with topics and badges


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3585
