### PR TITLE
Consistent appliance page titles

### DIFF
--- a/templates/appliance/adguard/intel-nuc.html
+++ b/templates/appliance/adguard/intel-nuc.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
+{% block title %}Install {{ appliance.name }} on an Intel NUC{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 

--- a/templates/appliance/adguard/raspberry-pi.html
+++ b/templates/appliance/adguard/raspberry-pi.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
 

--- a/templates/appliance/adguard/raspberry-pi2.html
+++ b/templates/appliance/adguard/raspberry-pi2.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2 - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi 2.{% endblock meta_description %}
 

--- a/templates/appliance/lxd/intel-nuc.html
+++ b/templates/appliance/lxd/intel-nuc.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
+{% block title %}Install {{ appliance.name }} on an Intel NUC{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 

--- a/templates/appliance/lxd/raspberry-pi.html
+++ b/templates/appliance/lxd/raspberry-pi.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
 

--- a/templates/appliance/mosquitto/intel-nuc.html
+++ b/templates/appliance/mosquitto/intel-nuc.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
+{% block title %}Install {{ appliance.name }} on an Intel NUC{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 

--- a/templates/appliance/mosquitto/raspberry-pi.html
+++ b/templates/appliance/mosquitto/raspberry-pi.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.name }} on a Raspberry Pi{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
 

--- a/templates/appliance/mosquitto/raspberry-pi2.html
+++ b/templates/appliance/mosquitto/raspberry-pi2.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2 - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi 2.{% endblock meta_description %}
 

--- a/templates/appliance/openhab/intel-nuc.html
+++ b/templates/appliance/openhab/intel-nuc.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on an Intel NUC{% endblock title %}
+{% block title %}Install {{ appliance.name }} on an Intel NUC{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on an Intel NUC.{% endblock meta_description %}
 

--- a/templates/appliance/openhab/raspberry-pi.html
+++ b/templates/appliance/openhab/raspberry-pi.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.name }} on a Raspberry Pi - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.name }} on a Raspberry Pi{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi.{% endblock meta_description %}
 

--- a/templates/appliance/openhab/raspberry-pi2.html
+++ b/templates/appliance/openhab/raspberry-pi2.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2 - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi 2.{% endblock meta_description %}
 

--- a/templates/appliance/plex/intel-nuc.html
+++ b/templates/appliance/plex/intel-nuc.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Intel NUC{% endblock title %}
+{% block title %}Install {{ appliance.name }} on a Intel NUC{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
 

--- a/templates/appliance/plex/intel-nuc.html
+++ b/templates/appliance/plex/intel-nuc.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.name }} on a Intel NUC{% endblock title %}
+{% block title %}Install {{ appliance.name }} on an Intel NUC{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Intel NUC.{% endblock meta_description %}
 

--- a/templates/appliance/plex/raspberry-pi.html
+++ b/templates/appliance/plex/raspberry-pi.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install the {{ appliance.name }} Ubuntu Appliance on a Raspberry Pi{% endblock title %}
+{% block title %}Install {{ appliance.name }} on a Raspberry Pi{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu Appliance on the Raspberry Pi.{% endblock meta_description %}
 

--- a/templates/appliance/plex/raspberry-pi2.html
+++ b/templates/appliance/plex/raspberry-pi2.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2 - Ubuntu Appliance{% endblock title %}
+{% block title %}Install {{ appliance.appliance_name }} on a Raspberry Pi 2{% endblock title %}
 
 {% block meta_description %}Install and setup the {{ appliance.name }} Ubuntu appliance on the Raspberry Pi 2.{% endblock meta_description %}
 

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -1,6 +1,6 @@
 {% extends "appliance/_base-appliance.html" %}
 
-{% block title %}{{ appliance_name }} | Ubuntu Appliance{% endblock %}
+{% block title %}Install {{ appliance_name }} | Ubuntu Appliance{% endblock %}
 
 {% block meta_description %}{{ meta_description }}{% endblock %}
 


### PR DESCRIPTION
## Done

Changed appliance page titles of various forms to one of these three:
- “Install {appliance name}”
- “Install {appliance name} on a {hardware}”
- “Try the {appliance name} Ubuntu Appliance in a virtual machine” (left unchanged).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/appliances and browse the sub-pages

## Issue / Card

Fixes #8914.