### PR TITLE
Update text _raspberry-pi_2010-livestream.html

### DIFF
--- a/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
+++ b/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
@@ -5,6 +5,6 @@
     <a href="/engage/raspberry-pi-livestream">Ubuntu Desktop for Raspberry Pi</a>
   </h3>
   <iframe width="560" height="315" src="https://www.youtube.com/embed/0pT4-RcTERU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  <p>Join our live event on the 23rd of October, 5pm BST, and find out all the news about the new Ubuntu Desktop image for Raspberry Pi.</p>
+  <p>Watch the live event of the 20.10 launch the and find out all the news about the new Ubuntu Desktop image for Raspberry Pi.</p>
   <p><a href="/engage/raspberry-pi-livestream">Discover more&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

- Updated the text from the product card (it was talking  to the live stream & invited people to join it) as it was outdated
## QA

- Check the product card appears on Raspberry-pi tags (eg:[ blog post](https://ubuntu.com/blog/raspberry-pi-and-ubuntu-2020-roundup) )

-Check the text from the product card text updated

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
