### PR TITLE
Add were hiring link to global nav

### DIFF
--- a/static/js/src/core.js
+++ b/static/js/src/core.js
@@ -2,7 +2,10 @@ import { createNav } from "@canonical/global-nav";
 import { cookiePolicy } from "@canonical/cookie-policy";
 
 // Initalise the global navigation.
-createNav({ showLogins: false });
+createNav({
+  showLogins: false,
+  hiring: 'https://canonical.com/careers/start',
+});
 
 // Initalise the cookie policy notification.
 

--- a/static/js/src/core.js
+++ b/static/js/src/core.js
@@ -4,7 +4,7 @@ import { cookiePolicy } from "@canonical/cookie-policy";
 // Initalise the global navigation.
 createNav({
   showLogins: false,
-  hiring: 'https://canonical.com/careers/start',
+  hiring: "https://canonical.com/careers/start",
 });
 
 // Initalise the cookie policy notification.


### PR DESCRIPTION
## Done

- Add were hiring link to global nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Look at the global nav, see that it says "We're hiring" and links to https://canonical.com/careers/start


