### PR TITLE
WIP Get live data from GA

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -13,6 +13,11 @@ env:
       key: database_url
       name: usn-db-url
 
+  - name: GOOGE_SERVICE_ACCOUNT_ANALYTICS
+    secretKeyRef:
+      key: google-service-account-analytics
+      name: google-api
+
   - name: SEARCH_API_KEY
     secretKeyRef:
       key: google-custom-search-key

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ ubuntu-release-info==20.2
 launchpadlib==1.10.13
 macaroonbakery==1.3.1
 sortedcontainers==2.2.2
+google-api-python-client==1.12.8
+oauth2client==4.1.3

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -64,6 +64,7 @@ from webapp.views import (
     build_engage_index,
     engage_thank_you,
     sitemap_index,
+    stats_view,
 )
 from webapp.login import login_handler, logout, user_info
 from webapp.security.database import db_session
@@ -163,6 +164,7 @@ def utility_processor():
 # Simple routes
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 app.add_url_rule("/advantage", view_func=advantage_view)
+app.add_url_rule("/desktop/statistics", view_func=stats_view)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule(
     "/advantage/subscribe/thank-you", view_func=advantage_thanks_view

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -23,7 +23,7 @@ from geolite2 import geolite2
 from requests.exceptions import HTTPError
 from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
-from googleapiclient.discovery import build
+from googleapiclient import discovery
 from google.oauth2 import service_account
 
 
@@ -1394,13 +1394,13 @@ def sitemap_index():
 def stats_view():
     try:
         creds = service_account.Credentials.from_service_account_info(
-            json.loads(os.getenv("CLIENT_JSON")),
+            json.loads(os.getenv("GOOGE_SERVICE_ACCOUNT_ANALYTICS")),
             scopes=[
                 "https://www.googleapis.com/auth/analytics",
                 "https://www.googleapis.com/auth/analytics.readonly",
             ],
         )
-        service = build(
+        service = discovery.build(
             "analytics", "v3", credentials=creds, cache_discovery=False
         )
         response = (

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -23,6 +23,8 @@ from geolite2 import geolite2
 from requests.exceptions import HTTPError
 from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
+from googleapiclient.discovery import build
+from google.oauth2 import service_account
 
 
 # Local
@@ -1390,24 +1392,17 @@ def sitemap_index():
 
 
 def stats_view():
-    from googleapiclient.discovery import build
-    from google.oauth2 import service_account
-
-    SCOPES = [
-        "https://www.googleapis.com/auth/analytics",
-        "https://www.googleapis.com/auth/analytics.readonly",
-    ]
-    SERVICE_ACCOUNT_FILE = "client.json"
-
-    creds = service_account.Credentials.from_service_account_file(
-        SERVICE_ACCOUNT_FILE, scopes=SCOPES
-    )
-
-    service = build(
-        "analytics", "v3", credentials=creds, cache_discovery=False
-    )
-
     try:
+        creds = service_account.Credentials.from_service_account_info(
+            json.loads(os.getenv("CLIENT_JSON")),
+            scopes=[
+                "https://www.googleapis.com/auth/analytics",
+                "https://www.googleapis.com/auth/analytics.readonly",
+            ],
+        )
+        service = build(
+            "analytics", "v3", credentials=creds, cache_discovery=False
+        )
         response = (
             service.data()
             .realtime()


### PR DESCRIPTION
## Done

- Get live data from GA

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Ask toto to get the credentials
- Put then in `.env.local` with the var `GOOGE_SERVICE_ACCOUNT_ANALYTICS`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/statistics