### PR TITLE
centos notice on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -38,8 +38,8 @@
   <div class="row">
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
-        <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/engage/ubuntu-20.10?utm_source=Takeover&amp;utm_medium=Takeover&amp;utm_campaign=7013z000001WldOAAS">Find out what's new in Ubuntu 20.10 in our webinar</a></h4>
+        <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="Migrating to Ubuntu LTS: five facts for CentOS users" class="p-heading-icon__img" >
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOs users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></h4>
       </div>
     </div>
   </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -39,7 +39,7 @@
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
         <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="Migrating to Ubuntu LTS: five facts for CentOS users" class="p-heading-icon__img" >
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOs users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></h4>
+        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOS users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></h4>
       </div>
     </div>
   </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -38,7 +38,7 @@
   <div class="row">
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
-        <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="Migrating to Ubuntu LTS: five facts for CentOS users" class="p-heading-icon__img" >
+        <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="CentOS users, 6 things to know when considering a migration to Ubuntu LTS" class="p-heading-icon__img" >
         <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOS users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></h4>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Adding CentOS notice on homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the notice is visible on the homepage and links to the relevant blog post

![Screenshot from 2020-12-17 16-45-53](https://user-images.githubusercontent.com/18480003/102509895-5d98f500-4087-11eb-8420-50f1db244c1e.png)

