### PR TITLE
Enable the card field on the Silo browser

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -85,8 +85,6 @@ const elements = stripe.elements({
   fonts: [
     {
       family: "Ubuntu",
-      src:
-        'url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2") format("woff2"), url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff")',
     },
   ],
 });


### PR DESCRIPTION
## Done
Remove the font src when initialising the card input element.

**This unblocks the US Navy and other institutions that are required to use Silo browser**

## QA
- Open the demo and check the card input is working as live
- Go to https://www.authentic8.com/company/ and click "Try Silo risk free."
- Then enter the demo link into the simulated browser and check the card input works 
- If you want to switch to production in Silo and see that the card input is not rendered.
