### PR TITLE
Remove LTS from 20.10

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -42,7 +42,7 @@
 <div class="p-strip is-bordered">
   <div class="u-fixed-width">
     <h2>
-      What's new in {{ releases.latest.full_version }} LTS
+      What's new in {{ releases.latest.full_version }}
     </h2>
     <ul class="p-list is-split">
       <li class="p-list__item is-ticked">Supported by Canonical until {{ releases.latest.eol }}</li>


### PR DESCRIPTION
## Done
Remove the "LTS" from the what's new 20.10 section.

## QA
- Go to the demo
- Scroll to the "What’s new in 20.10" and see the heading doesn't have LTS.