### PR TITLE
Include the grecaptcha script in the contact us form

### DIFF
--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -111,3 +111,5 @@
       </div>
     </div>
   </section>
+
+  <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>


### PR DESCRIPTION
## Done
Include the grecaptcha script in the contact us form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/contact-us/form?product=generic-contact-us
- Fill in the form and see it works

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/8980