### PR TITLE
Remove Tech Preview from Openstack chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1149,16 +1149,16 @@ export var openStackReleases = [
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
-    startDate: new Date("2020-04-01T00:00:00"),
-    endDate: new Date("2020-05-15T00:00:00"),
-    taskName: "OpenStack Ussuri LTS",
-    status: "TECH_PREVIEW",
-  },
-  {
     startDate: new Date("2020-05-15T00:00:00"),
     endDate: new Date("2025-04-01T00:00:00"),
     taskName: "OpenStack Ussuri LTS",
-    status: "LTS",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT"
+  },
+  {
+    startDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2030-04-01T00:00:00"),
+    taskName: "OpenStack Ussuri LTS",
+    status: "EXTENDED_SUPPORT_MAINTENANCE"
   },
   {
     startDate: new Date("2025-04-01T00:00:00"),
@@ -1177,12 +1177,6 @@ export var openStackReleases = [
     endDate: new Date("2030-04-01T00:00:00"),
     taskName: "Ubuntu 20.04 LTS (v5.4)",
     status: "ESM",
-  },
-  {
-    startDate: new Date("2020-04-01T00:00:00"),
-    endDate: new Date("2020-05-15T00:00:00"),
-    taskName: "OpenStack Ussuri",
-    status: "TECH_PREVIEW",
   },
   {
     startDate: new Date("2020-05-15T00:00:00"),
@@ -1338,7 +1332,7 @@ export var kernelStatusALL = {
 };
 
 export var openStackStatus = {
-  TECH_PREVIEW: "chart__bar--orange-light",
+  //TECH_PREVIEW: "chart__bar--orange-light",
   LTS: "chart__bar--orange",
   MATCHING_OPENSTACK_RELEASE_SUPPORT: "chart__bar--grey",
   ESM: "chart__bar--aubergine",


### PR DESCRIPTION
## Done

> The OpenStack Ussuri LTS line, the period between May 2020 and April 2025 should be represented in grey - matching OpenStack release support - rather than in orange.

> drop the tech preview period from OpenStack Ussuri LTS and OpenStack Ussuri. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-openstack-release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the colour is grey for the LTS bar for May 2020 to April 2025 and that the tech preview is removed (I left the key commented in the js for next time)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/103751407-2b344500-5000-11eb-9502-ef843678429b.png)

