### PR TITLE
Add contact us for CUBE beta

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1393,3 +1393,12 @@ cube:
       path: /cube
     - title: MicroCerts
       path: /cube/microcerts
+
+    - title: Contact us
+      path: /cube/contact-us
+      hidden: True
+
+      children:
+        - title: Thank you
+          path: /cube/thank-you
+          hidden: True

--- a/templates/cube/contact-us.html
+++ b/templates/cube/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Fill in your details below and a member of our team will be in touch.",
   formid="3801",
   lpId="7140",
-  returnURL="https://ubuntu.com/cube/thank-you?product=cube-beta" %}
+  returnURL="https://ubuntu.com/cube/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 {% endblock content %}

--- a/templates/cube/contact-us.html
+++ b/templates/cube/contact-us.html
@@ -1,0 +1,14 @@
+{% extends "cube/base_cube.html" %}
+
+{% block title %}Contact us | CUBE {% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block content %}
+{% with h1="Contact us about CUBE Beta",
+  intro_text="Fill in your details below and a member of our team will be in touch.",
+  formid="3801",
+  lpId="7140",
+  returnURL="https://ubuntu.com/cube/thank-you?product=cube-beta" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+{% endblock content %}

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -123,7 +123,7 @@
 
 <section class="p-strip u-image-position is-grid-pinned" id="syllabus">
   <div class="u-fixed-width">
-  <h2 class="u-sv2">Complete CUBE Syllabus - At a Glance</h2>
+  <h2 class="u-sv2">Complete CUBE Syllabus - at a Glance</h2>
     <ul class="p-matrix">
       <li class="p-matrix__item">
           {{ 
@@ -138,7 +138,7 @@
             ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Architecture</a></h3>
+          <h3 class="p-matrix__title">Architecture</h3>
           <div class="p-matrix__desc">
             <p>Understand how the system is built, from top to bottom.</p>
           </div>
@@ -157,7 +157,7 @@
             ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Packages</a></h3>
+          <h3 class="p-matrix__title">Packages</h3>
           <div class="p-matrix__desc">
             <p>Control and customize installations.</p>
           </div>
@@ -176,7 +176,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Commands</a></h3>
+          <h3 class="p-matrix__title">Commands</h3>
           <p class="p-matrix__desc">Direct system actions and complete important tasks.</p>
         </div>
       </li>
@@ -193,7 +193,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Devices & files</a></h3>
+          <h3 class="p-matrix__title">Devices & files</h3>
           <div class="p-matrix__desc">
             <p>Configure files and where they are stored.</p>
           </div>
@@ -212,7 +212,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">bash</a></h3>
+          <h3 class="p-matrix__title">bash</h3>
           <p class="p-matrix__desc">Automate tasks with scripts.</p>
         </div>
       </li>
@@ -229,7 +229,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Admin</a></h3>
+          <h3 class="p-matrix__title">Admin</h3>
           <p class="p-matrix__desc">Master useful tasks for working with shared and individual systems.</p>
         </div>
       </li>
@@ -246,7 +246,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Services</a></h3>
+          <h3 class="p-matrix__title">Services</h3>
           <div class="p-matrix__desc">
             <p>Fine-tune systems for optimal performance.</p>
           </div>
@@ -265,7 +265,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Networking</a></h3>
+          <h3 class="p-matrix__title">Networking</h3>
           <div class="p-matrix__desc">
             <p>Link machines to perform advanced tasks.</p>
           </div>
@@ -284,7 +284,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Security</a></h3>
+          <h3 class="p-matrix__title">Security</h3>
           <div class="p-matrix__desc">
             <p>Protect systems and servers from unwelcome intrusions.</p>
           </div>
@@ -303,7 +303,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Kernel</a></h3>
+          <h3 class="p-matrix__title">Kernel</h3>
           <div class="p-matrix__desc">
             <p>Manage the heart of your Ubuntu system.</p>
           </div>
@@ -322,7 +322,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Storage</a></h3>
+          <h3 class="p-matrix__title">Storage</h3>
           <div class="p-matrix__desc">
             <p>Archive and retrieve data safely and securely.</p>
           </div>
@@ -341,7 +341,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Virtualisation</a></h3>
+          <h3 class="p-matrix__title">Virtualisation</h3>
           <div class="p-matrix__desc">
             <p>Create, configure, and use virtual machines.</p>
           </div>
@@ -360,7 +360,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">MicroK8s</a></h3>
+          <h3 class="p-matrix__title">MicroK8s</h3>
           <div class="p-matrix__desc">
             <p>Streamline your Kubernetes usage with Canonical&rsquo;s efficient deployment solution.</p>
           </div>
@@ -379,7 +379,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">MAAS</a></h3>
+          <h3 class="p-matrix__title">MAAS</h3>
           <div class="p-matrix__desc">
             <p>Turn data centers into bare-metal clouds using Canonical&rsquo;s server provisioning technology.</p>
           </div>
@@ -398,7 +398,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title"><a class="p-matrix__link" href="#">Juju</a></h3>
+          <h3 class="p-matrix__title">Juju</h3>
           <div class="p-matrix__desc">
             <p>Keep complexity low and productivity high with Canonical&rsquo;s universal operator lifecycle manager.</p>
           </div>
@@ -409,21 +409,16 @@
 </section>
 
 <section class="p-strip--square-suru has-cube is-slanted--top-right">
-  <div class="row u-equal-height">
-    <div class="col-6">
-      <blockquote class="p-pull-quote">
-        <p class="p-pull-quote__quote">&nbsp;Lorem ipsum dolor sit amet, consectetur adipisicing, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
-        <cite class="p-pull-quote__citation">&mdash; A.N. Author</cite>
-      </blockquote>
-    </div>
-    <div class="col-6">
-      <blockquote class="p-pull-quote">
-        <p class="p-pull-quote__quote">&nbsp;Mauris non tempor quam, et lacinia sapien. Mauris accumsan eros eget libero posuere vulputate.</p>
-        <cite class="p-pull-quote__citation">&mdash; A.N. Author</cite>
-      </blockquote>
-    </div>
+  <div class="u-fixed-width">
+    <h2>Lorem ipsum dolor sit amet</h2>
+    <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
+    <button href="cube/contact-us" class="p-button--positive js-invoke-modal">Request beta access</button>
   </div>
 </section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
+</div>
 
 <script>
 window.addEventListener('load', (event) => {

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -412,7 +412,7 @@
   <div class="u-fixed-width">
     <h2>Apply for beta access</h2>
     <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
-    <button href="cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</button>
+    <button href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</button>
   </div>
 </section>
 

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -410,9 +410,9 @@
 
 <section class="p-strip--square-suru has-cube is-slanted--top-right">
   <div class="u-fixed-width">
-    <h2>Lorem ipsum dolor sit amet</h2>
+    <h2>Apply for beta access</h2>
     <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
-    <button href="cube/contact-us" class="p-button--positive js-invoke-modal">Request beta access</button>
+    <button href="cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</button>
   </div>
 </section>
 

--- a/templates/cube/thank-you.html
+++ b/templates/cube/thank-you.html
@@ -1,0 +1,30 @@
+{% extends "cube/base_cube.html" %}
+
+{% block title %}Thank you | CUBE{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block content %}
+    {% with thanks_context="enquiring about CUBE beta" %}{% include "shared/_thank_you.html" %}{% endwith %}
+{% endblock content %}
+
+{% block footer_extra %}
+<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+<script>
+/* <![CDATA[ */
+var google_conversion_id = 1012391776;
+var google_conversion_language = "en";
+var google_conversion_format = "3";
+var google_conversion_color = "ffffff";
+var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+var google_conversion_value = 0;
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
+<noscript>
+  <div style="display:inline;">
+    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  </div>
+</noscript>
+{{ marketo }}
+{% endblock footer_extra %}

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -1,0 +1,95 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="border-bottom: 0; display: block;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Join the CUBE beta test</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="FirstName" class="mktoLabel">First name:</label>
+                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="LastName" class="mktoLabel">Last name:</label>
+                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="Email" class="mktoLabel">Work email:</label>
+                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+            </div>
+
+            <div class="pagination">
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--two">Thank you for enquiring about CUBE beta</h3>
+            <p class="p-heading--four">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-align--center u-hide--small">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Add modal contact us form for requesting beta access
- Add `/cube/contact-us` and `/cube/thank-you` pages
- Remove links from titles on `/cube`
- Edit quote section on `/cube` to content about requesting beta access

## QA

- View the page at: https://ubuntu-com-8982.demos.haus/cube
- At the bottom of the page, use the *Request beta access* cta to view the modal. 
- Check the modal against the [design](https://app.zeplin.io/project/5f5268731d98b38800528395/screen/5fc4e38351755eb3e8ccbfbb)
- Check the Contact us page for non JavaScript enabled users at `/cube/contact-us`

## Issue / Card

Fixes #8972 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/103769480-4319c200-501c-11eb-80f1-44b9e7a808f7.png)

