### PR TITLE
Update sitemap.xml for static files

### DIFF
--- a/static/files/sitemap.xml
+++ b/static/files/sitemap.xml
@@ -5,5373 +5,1990 @@
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   
-    <url>
-      <loc>https://ubuntu.com/engage/trilio-backup-recovery</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/enable-the-livepatch-service</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/ssh-keygen-on-windows</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/starting-with-ai</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4583-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-6301</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4552-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25654</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/app-charm-list</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/containers/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/hardware-setup</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/data-lake_2_server_webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/online-purchase</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/oval</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2005-1514</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/contact-us/form</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/finserv-multi-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=focal&amp;page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi/thank-you?version=20.04.1&amp;architecture=server-arm64+raspi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/guidelines</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?topic=server</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4604-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-core-and-kura</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us?product=iot-overview</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/motd</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/es/guia-para-la-implementacion-de-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/desktop/thank-you?version=20.10&amp;architecture=amd64</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/northstar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2005-1513</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/industrial-drones-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14793</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/contact-us?product=ai-index</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/about</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/embedded</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/aws/outposts</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/snap-store</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/technical-support</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/partner-portal</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-city-network</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/vm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=6</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/requirements</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/supported-ceph-versions</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/sso</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/eu-kubernetes-event</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=mozjs68</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=groovy&amp;page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-16127</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/redhat-openstack-comparison-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-20916</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=7</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/companies</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/esm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/iot-device-management-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-install-ubuntu-on-your-raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-imsevolve</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/migration-von-vmware-zu-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/kubernetes-deployment-enterprise-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-6305</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/financial-services</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/terms-and-policies/snap-store-terms</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-20.10</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=trusty&amp;page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/power-cycling-nodes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=thunderbird</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-ubuntu-desktop-id</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/developer-desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/guide-du-DSI-pour-les-operations-multicloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/unilateral-nda</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/community</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us?product=kubernetes-add-on</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/ubuntu-desktop-aws</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/case-study-rigado</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-compliance</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/14-04-esm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/basic-snap-usage-pl</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-botsandus</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/operating-an-app-store</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4556-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4613-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/interana-casestudy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support/contact-us?product=contextual-footer-ua</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4593-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/wayland-kiosk</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-microk8s-on-windows</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-ubuntu-on-chromebook</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/secure-device-onboarding</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/x11-kiosk</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community/mission</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/contact-us?product=contextual-footer-server-maas</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-16125</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi/thank-you?version=20.10&amp;architecture=desktop-arm64+raspi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-integrate-onlyoffice-with-nextcloud-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/smart-card-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-integrate-alfresco-with-onlyoffice-online-editors-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/es/redhat-openstack-comparacion-manual</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=bionic</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-onlyoffice-desktop-editors-on-ubuntu1804</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us?product=openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>http://ubuntu.com/appliance/nextcloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tco-calculator</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/pricing/consulting</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-rocketchat</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4579-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=groovy&amp;page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-install-adguard-home-raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/survey</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/terms</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/adding-mons</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/qualcomm-dragonboard-410c</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-sdcard-ubuntu-server-raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/docs</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/microsoft-active-directory</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4605-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/server/s390x</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-a-usb-stick-on-macos</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi/thank-you?version=20.10&amp;architecture=server-armhf+raspi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/intro-to-microk8s-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/mosquitto</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/cto-guide-sdn-nfv-vnf</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4597-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/openstack-telco-clouds</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4605-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-10322</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=groovy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/wsl</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us?product=cloud-managed-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/dell-openstack-reference-architecture</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4588-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/stuckstack-ebook</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/kubernetes-event-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/device-enablement</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-24490</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/custom-image-creation</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/upgrading-nodes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-a-local-kubernetes-with-microk8s</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4602-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=maas-training-onsite</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/future-proof-iot</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/object-storage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4617-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/whats-new-ubuntu-14-04-lts</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ml-dell-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/plex/raspberry-pi2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-16119</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/public-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi-core</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/organisations</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/command-line-for-beginners</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-12351</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/what-can-you-do-with-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4599-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/contact-us?product=server-overview</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/nextcloud/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/get-in-touch</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-core-security-audit</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support/contact-us?product=support-overview</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/desktop-authentication-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/launchpad-terms-of-service</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-0452</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4583-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-13934</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=focal&amp;page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14392</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/yahoo-japan-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14314</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/adguard/vm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=ceph-training-onsite</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/app-client-setup</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/openstack-made-easy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15999</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/moving-to-opensource-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=xenial&amp;page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-6807</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-install-onlyoffice-server-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-14466</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/lxd/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/using-intel-realsense-sdk</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/lxd/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=precise&amp;page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-verify-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms/2015-09-09</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/openstack-made-easy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/utiliser-gpgpus-avec-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/replicated-pools</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/online-competitions</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4623-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/upgrading-ceph</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14771</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-description</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-ubuntu-desktop-1604</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/containers/contact-us?product=containers-overview</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/rfp</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14001</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-11037</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/telco</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14355</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/lxd</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=focal&amp;page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/features</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/hardware</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25212</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-an-ubuntu-image-for-a-raspberry-pi-on-macos</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/setup-ubuntu-core-intel-joule</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/migrer-de-vmware-a-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-11187</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-jre</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi/thank-you</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/20.04-webinars</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=phpldapadmin</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4621-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/online-account-terms</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage/personal</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/openstack-security-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=mozjs60</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=precise&amp;page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=precise&amp;page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=focal</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/rss.xml</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/atom.xml</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/anbox-cloud-gaming-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/alternative-downloads</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/2013-03-25</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/cyberdyne</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-1000179</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25285</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15861</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-2760</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/erasure-coded-pools</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-and-configure-samba</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-14500</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-assurance</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/terms-and-policies/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/portfolio</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us?product=kubernetes-kubeadm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=tmux</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/desktop/thank-you?version=20.04.1&amp;architecture=amd64</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/intro-to-anbox-cloud-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4603-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/esm_1404</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/kafka-in-production</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-ubuntu-server-1604</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/smart-start-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://login.ubuntu.com/08cMdXgxCrxsnS7A/+decide</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/licensing</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us?product=kubernetes-install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/anbox-cloud-terms-of-service</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4580-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-install-ubuntu-core-on-raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=trusty&amp;page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/smart-start-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/devops-cicd-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/using-zfs-snapshots-clones</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/containers</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4596-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/consulting</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4625-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us?product=gateways</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4599-3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4624-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ebook-maas</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/setting-up-lxd-1604-fr</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/redhat-openstack-vergleich</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/server/power</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/vmware-to-charmed-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/2016-02-08</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4503-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/snap-application-packaging</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/setup-zfs-storage-pool</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14383</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-20444</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/private-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/aws/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/anbox-cloud-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=focal&amp;page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-3081-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/private-cloud-build-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-sensape</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.25</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=precise&amp;page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4600-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/server/provisioning</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/pt/vmware-para-o-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/upgrading-charms</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=dom4j</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/intel-nuc-desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=trusty</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4616-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/scaling-securely-ubuntu-azure</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=xenial</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14798</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-pro-intro</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://discourse.ubuntu.com/t/tools-logwatch/15590</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/getting-started-with-ros-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms/2016-05-20</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us?product=kubernetes-features</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/advanced-options</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-cinergy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-26116</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-26950</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/cloud-init-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15682</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/raspberry-pi-livestream</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/dell-kubernetes-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us?product=automotive</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/livepatch-terms-of-service</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/managed</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/vmware-to-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/low-latency-report</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/managed/cassandra</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/deploy-ai-ml-model</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2016-1240</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?page=6</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/vmware-to-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support/community-support</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14323</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-istio-on-charmed-distribution-of-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4587-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=xenial&amp;page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/events</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=kubeflow-training-onsite</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/training-workshops</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4599-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-2752</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15238</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/gsi-webinar-series</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/451-automotive</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/managed/kafka</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/font-licence</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-11612</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/contributors/faq</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/managed</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14363</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=bionic&amp;page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/openhab/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-ubuntu-desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/ubuntu-on-windows</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/terms-of-service</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/managed/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/contact-us?product=server-hyperscale</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support/contact-us?product=contextual-footer-landscape</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/mosquitto/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/core/contact-us?product=core-overview</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community/diversity</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/certification-and-validation</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/plex</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25692</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4609-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/support/contact-us?product=openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=openstack-training-server-admin</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/pricing</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4572-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-10878</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-onlyoffice-on-ubuntu1804</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-20749</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/contact-us?product=server-arm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/access-remote-desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us?product=foundation-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/anbox-cloud-privacy-notice</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/cloud-economics</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/developers</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/migrating-to-20.04</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4611-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-integrate-confluence-with-onlyoffice-docs-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4595-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4594-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2014-6052</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-1000632</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-your-first-snap</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-1000178</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-20919</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/microk8s-451research</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/nextcloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us?product=networking</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ai-ml-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=xenial&amp;page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/it/da-vmware-a-charmed-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-12352</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community/code-of-conduct</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/pricing/devices</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/f5-big-ip-load-balancers-with-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/apparmor-intro</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/block-storage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=xenial&amp;page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/certifications</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/features</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/contributors</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/hyperscale</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/snapcraft-nps</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/whitepaper-iot-security</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/data-pipelines-kubeflow</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/introduction-to-lxd-projects</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4552-3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-10543</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-16869</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/contact-us?product=contextual-footer-ua</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4578-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4607-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-7070</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms/2015-06-24</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14344</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=bionic&amp;page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/get-started-with-Corda</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/kvm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-26088</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-3811</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/configure-ssh-2fa</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/desktop/thank-you</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/wslconf</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/overview</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-3878</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/azure/pro</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-20024</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2016-9956</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fingbox-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-an-ubuntu-image-for-a-raspberry-pi-on-windows</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-openstack-with-conjure-up</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=focal&amp;page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/k8s-allan-gray</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/server/docs</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/burn-a-dvd-on-macos</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=bionic&amp;page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/contact-us?product=ai-features</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-6299</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/case-study-acuris</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4610-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=openldap</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/linux-enterprise-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-27638</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4598-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/automotive</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/intellectual-property-policy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4562-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15953</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=openstack-training-onsite</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/devops-iot-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/evolving-software</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4593-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/file-storage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/gateways</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/iot/installation-media</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/try-ubuntu-before-you-install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-nexiona</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/advantage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/quickstart</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4618-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4620-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-9484</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-14036</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/private-cloud-cost-analysis-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/developing-android-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/contact-us?product=contextual-footer-desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/what-is-kubeflow</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/confidentiality-agreement</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4581-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ai-edge-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4608-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/deeptech</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/appstore</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community/debian</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/dell-k8s-reference-architecture</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/openhab/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/plex/vm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/features</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/public-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ai-gettingstarted</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/websites</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/flavours</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/pre-kubecon-event</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us?product=kubernetes-consulting</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/whitepaper-containers</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4615-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/openstack-made-easy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/intel-iei-tank-870</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/setting-up-lxd-1604</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=accountsservice</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/telco-virtual-event</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=bionic&amp;page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/openstack-security-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4600-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-azlogica</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/pricing/infra</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/19-10-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-an-ubuntu-image-for-a-raspberry-pi-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-11107</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-a-usb-stick-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=netqmail</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://snapcraft.io/docs/node-apps</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2017-12904</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/contact-us/form?product=generic-contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/contact</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-kubernetes-cluster-on-raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14836</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/features</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-13249</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/raspberry-pi/desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms/2016-06-24</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://discourse.ubuntu.com/t/draft-logging-monitoring-and-alerting/19151</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4585-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/linux_security_webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=pacemaker</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us?product=appstore</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/app-upgrade-notes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4619-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15680</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>http://ubuntu.com/</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=trusty&amp;page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/partner-portal-terms</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-11996</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/deploy-clustered-redis</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=precise</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/kubernetes-implementierung-fur-unternehmen</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=xenial&amp;page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us?product=kubernetes-managed</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/about/packages</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4622-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/integration-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/candid-authentication-lxd</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4476-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25653</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/domotz-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/snapd-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4614-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4586-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/secure-ubuntu-kiosk</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/consulting</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/what-is-ceph</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/shift-to-app-store-experience</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=libexif</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/release-cycle</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/kata-containers-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/adguard/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=qmail</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubeflow/contact-us?product=ai-install</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us?product=openstack-install-build</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>http://ubuntu.com/tutorials</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community/canonical</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=trusty&amp;page=3</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us?product=openstack-managed-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/setup-rocketchat-server-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/statistics</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/server</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/integration-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms/ja</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/edge-month</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14781</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-innovapos</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/viewing-and-monitoring-log-files</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25650</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/systems-information-notice</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/encryption-at-rest</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15862</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi/thank-you?version=20.04.1&amp;architecture=server-armhf+raspi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14792</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/modern-cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/enquiry</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/azure/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/telco-cloudification-ebook</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/about</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/openhab/raspberry-pi2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-20445</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/es/kubernetes-despliegue-empresa-manual</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/integration-lxd</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=openstack-training</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/burn-a-dvd-on-windows</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/livepatch</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/get-started-with-ai-part-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/burn-a-dvd-on-ubuntu</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=mozjs38</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4616-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/contact-us?product=digital-signage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/adguard</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/beginning-apparmor-profile-development</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/app-store-commissioning</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/what-is-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/how-to-integrate-onlyoffice-with-moodle</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/at&amp;t-azure-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/digital-signage</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-azeti</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/about/release-cycle</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4591-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/multi-cloud-guide</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=7</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/openhab/vm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/hiri-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-7069</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/adguard/raspberry-pi2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/de/openstack-security-de</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/managed-apps-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/essential-guide-big-data-solutions</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/trademarks</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/raspberry-pi/server</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/kernel-telco-nfv</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ITstrategen-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-custom-lxd-images</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/sbi-casestudy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4534-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/cloud-fray</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-16126</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/community/governance</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-18-10</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/integration-vmware</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25652</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/terms-and-policies</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4602-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/maas-hardware-testing</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/upgrading-ubuntu-desktop</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/static/files/humans.txt?v=44f44f8</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/openhab</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/software-upgrades</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2015-0258</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/adguard/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/managed</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/kubernetes/what-is-kubernetes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training/contact-us?product=kubernetes-training-onsite</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4590-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/fr/managed-apps</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/iot-disk-encryption</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=mozjs52</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-12723</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/charmed-openstack-adoption-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/industrial-drones</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/electron-kiosk</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/networking</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/snap-deltas</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/desktop/partners</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials?page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/internet-of-things/edgex</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-27347</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/casestudy-commercetools</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4471-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/core18-security</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/microstack-get-started</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/firefox-for-web-developers</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/training</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/plex/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/es/vmware-a-charmed-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-15681</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-the-arduino-ide</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/ubuntu-lime-telco</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/jaas-beta-terms-of-service</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/blog?page=6</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/compare</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/getting-started-with-kubernetes-ha</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/create-a-usb-stick-on-windows</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/cve?q=&amp;package=firefox</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4592-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-microk8s-on-mac-os</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/esxi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/raspberry-pi/thank-you?version=20.10&amp;architecture=server-arm64+raspi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/aws/pro</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=bionic&amp;page=1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/cloud</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/smartstart/guide/snap-publishing</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/masters-conference</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/pac-radar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/server/arm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-16729</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/aws</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/core/contact-us</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/data-privacy/newsletter</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/iot-devops</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/case-study-gmo-pepabo</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/deploy-kubeflow-ubuntu-windows-mac</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=precise&amp;page=4</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/azure</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/nextcloud/vm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/lxd-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-7729</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-7238</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/19-04-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4601-1</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/azure-webinar</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/nfv-sdn-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/plex/intel-nuc</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/financial-services-month</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/openstack/contact-us?product=openstack-managed-cloud-demo</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/core</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>1</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices/USN-4487-2</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/esm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/finance</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2019-3877</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/adding-osds</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/iot-business-model</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2018-1000528</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/ceph/docs/release-notes</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/download/iot</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-14318</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/wellcome-sanger-case-study</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/build-smart-devices-with-mir-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/developer-terms-and-conditions</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/azure-cloud-init-whitepaper</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-25659</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/legal/contributors/agreement</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/mosquitto/vm</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/disclosure-policy</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/enterprise-snap-management</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/engage/it/da-vmware-a-openstack</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/CVE-2020-12403</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/tutorials/install-ubuntu-server</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.333333333333333</priority>
-    </url>
-    
-    <url>
-      <loc>https://ubuntu.com/security/notices?release=trusty&amp;page=5</loc>
-      <lastmod>2020-11-10T16:49:17Z</lastmod>
-      <changefreq>hourly</changefreq>
-      <priority>0.5</priority>
-    </url>
-    
+      <url>
+        <loc>https://ubuntu.com</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>1</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/about</loc>
+        <lastmod>2021-01-06T11:35:07Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/about/packages</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/about/release-cycle</loc>
+        <lastmod>2021-01-06T11:35:07Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/advantage</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/advantage/maintenance</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/advantage/subscribe</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/about</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/adguard</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/adguard/intel-nuc</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/adguard/raspberry-pi</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/adguard/raspberry-pi2</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/adguard/vm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/community</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/hardware</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/lxd</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/lxd/intel-nuc</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/lxd/raspberry-pi</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/mosquitto</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/mosquitto/intel-nuc</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi2</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/mosquitto/vm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/nextcloud</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/nextcloud/intel-nuc</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi2</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/nextcloud/vm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/openhab</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/openhab/intel-nuc</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/openhab/raspberry-pi</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/openhab/raspberry-pi2</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/openhab/vm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/plex</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/plex/intel-nuc</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/plex/raspberry-pi</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/plex/raspberry-pi2</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/plex/vm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/portfolio</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/appliance/vm</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/automotive</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/aws</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/aws/fips</loc>
+        <lastmod>2020-12-15T14:50:28Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/aws/outposts</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/aws/pro</loc>
+        <lastmod>2020-12-15T14:50:28Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/azure</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/azure/fips</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/azure/pro</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog</loc>
+        <lastmod>2020-12-15T14:50:28Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/archives</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/article</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/author</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/blog-card</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/blog-card-header</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/blog-card-large</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/blog-card-upcoming</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/cloud-and-server</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/desktop</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/featured-articles</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/filters</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/internet-of-things</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/newsletter-form</loc>
+        <lastmod>2021-01-05T16:12:05Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/posts</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/press-centre</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/product-cards</loc>
+        <lastmod>2020-11-18T11:28:30Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/singular-category</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/tag</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/topics/design</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/topics/juju</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/topics/maas</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/topics/robotics</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/topics/snapcraft</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/blog/upcoming</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/ceph</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/ceph/what-is-ceph</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/cloud</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community/canonical</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community/code-of-conduct</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community/debian</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community/diversity</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community/governance</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/community/mission</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/containers</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/core</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/core/build</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/core/build/error</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/dell</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/desktop</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/desktop/developers</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/desktop/features</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/desktop/organisations</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/desktop/partners</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/desktop/statistics</loc>
+        <lastmod>2021-01-06T11:35:07Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/alternative-downloads</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/cloud</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/desktop</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/flavours</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/intel-iei-tank-870</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/intel-nuc</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/intel-nuc-desktop</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/iot</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/iot/installation-media</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/kvm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/qualcomm-dragonboard-410c</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/raspberry-pi</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/raspberry-pi-core</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/arm</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/choose</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/download</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/power</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/provisioning</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/s390x</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/step1</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/server/step2</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/download/up-squared-iot-grove-server</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/embedded</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/engage</loc>
+        <lastmod>2020-11-25T17:30:42Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/engage/es/guia-implementacion-openstack</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/financial-services</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/global</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/gov</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/gov/form</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/ibm</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/industrial</loc>
+        <lastmod>2020-12-11T20:11:16Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/internet-of-things</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/internet-of-things/appstore</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/internet-of-things/digital-signage</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/internet-of-things/edgex</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/internet-of-things/gateways</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/internet-of-things/networking</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kernel</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kernel/lifecycle</loc>
+        <lastmod>2021-01-06T11:35:07Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kernel/variants</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubeconeurope2020</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubeflow</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubeflow/consulting</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubeflow/features</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubeflow/install</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubeflow/what-is-kubeflow</loc>
+        <lastmod>2020-11-25T17:30:45Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/compare</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/audit-logging</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/auth</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/aws-iam-auth</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/aws-integration</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/azure-integration</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/backups</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cdk-addons</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/ceph</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/certs-and-trust</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-aws-iam</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-aws-integrator</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-azure-integrator</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-calico</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-canal</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-containerd</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-docker</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-docker-registry</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-easyrsa</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-etcd</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-flannel</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-gcp-integrator</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-kata</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-keepalived</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-kubeapi-load-balancer</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-kubernetes-master</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-kubernetes-worker</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-openstack-integrator</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-reference</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-tigera-secure-ee</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/charm-vsphere-integrator</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cis-compliance</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cni-calico</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cni-canal</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cni-flannel</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cni-multus</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cni-overview</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/cni-sriov</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/container-runtime</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/custom-loadbalancer</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/decommissioning</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/docker-registry</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/encryption-at-rest</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/gcp-integration</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/get-in-touch</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/gpu-workers</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/hacluster</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/high-availability</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/install-local</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/install-manual</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/ipv6</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/kata</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/keepalived</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/ldap</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/logging</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/metallb</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/monitoring</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/multiple-networks</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/openstack-integration</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/operations</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/overview</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/packages</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/quickstart</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/release-notes</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/release-notes-historic</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/scaling</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/security</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/snap-coherence</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/snap-refresh</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/storage</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/supported-versions</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/tigera-secure-ee</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/troubleshooting</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/upgrade-notes</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/upgrading</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/using-vault</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/docs/validation</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/features</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/install</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/managed</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/partners</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/kubernetes/what-is-kubernetes</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal</loc>
+        <lastmod>2020-12-09T15:07:55Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/anbox-cloud-terms-of-service</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/companies</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/confidentiality-agreement</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/contributors</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/contributors/agreement</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/contributors/faq</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/contact</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/enquiry</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/esxi</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/events</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/newsletter</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/online-competitions</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/online-purchase</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/partner-portal</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/snap-store</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/snapcraft-nps</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/sso</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/survey</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/unilateral-nda</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/user-survey</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/data-privacy/webinar</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/developer-terms-and-conditions</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/font-licence</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/font-licence/differences</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/font-licence/faq</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/intellectual-property-policy</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/jaas-beta-terms-of-service</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/launchpad-terms-of-service</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/livepatch-terms-of-service</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/motd</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/online-account-terms</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/partner-portal-terms</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/terms</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/terms-and-policies</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/terms-and-policies/snap-store-terms</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/terms-of-service</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/trademarks</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ua-dell-tc</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ua-miracle-tc</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ua-miracle-tc-ja</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage-assurance</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage-service-description</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage-service-description/ja</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage-service-terms/ja</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/ubuntu-advantage/personal</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/legal/websites</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/licensing</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/managed</loc>
+        <lastmod>2020-12-15T14:50:28Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/managed/cassandra</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/managed/kafka</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/masters-conference</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack/compare</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack/consulting</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack/features</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack/install</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack/managed</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/openstack/what-is-openstack</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/pricing</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/pricing/consulting</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/pricing/devices</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/pricing/infra</loc>
+        <lastmod>2020-12-03T13:10:54Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/public-cloud</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/raspberry-pi</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/raspberry-pi/desktop</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/raspberry-pi/server</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/resources</loc>
+        <lastmod>2020-11-17T13:53:25Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/rfp</loc>
+        <lastmod>2020-12-09T15:06:52Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/robotics</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/robotics/community</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/robotics/what-is-ros</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security-series</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security/certifications</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security/disclosure-policy</loc>
+        <lastmod>2020-11-25T17:30:42Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security/docker-images</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security/esm</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security/livepatch</loc>
+        <lastmod>2020-11-25T17:30:42Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/security/oval</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/server</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/server/hyperscale</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/advanced-options</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/app-store-commissioning</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/certification-and-validation</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/custom-image-creation</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/device-enablement</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/hardware-setup</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/operating-an-app-store</loc>
+        <lastmod>2020-12-07T15:39:50Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/secure-device-onboarding</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/snap-application-packaging</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/snap-publishing</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/technical-support</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/smartstart/guide/training-workshops</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.25</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/support</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/support/community-support</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.333333333333333</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/tco-calculator</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/telco</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/training</loc>
+        <lastmod>2020-12-09T09:58:56Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
+      <url>
+        <loc>https://ubuntu.com/wsl</loc>
+        <lastmod>2021-01-05T08:52:47Z</lastmod>
+        <changefreq>hourly</changefreq>
+        <priority>0.5</priority>
+      </url>
 </urlset>


### PR DESCRIPTION
## Done

- Update sitemap.xml for static files
- I changed my script to just look at the files in the /templates directory as we now have code to generate most of the module created pages (docs, engage pages, tutorials, cves, usns).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/static/files/sitemap.xml
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it looks correct and validates

