### PR TITLE
Fix prepare button - broken link

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -38,7 +38,7 @@
     <h2> Courseware access</h2>
     <p><strong>Reccomended preparation</strong></p>
     <p class="u-sv2">Access to the CUBE courseware. Be prepared for all modules.</p>
-    <a href="{module.training_url}" class="p-button--positive">Prepare</a>
+    <a href="https://qa.cube.ubuntu.com/" class="p-button--positive">Prepare</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- link the prepare button on `/cube/microcerts` to `qa.cube.ubuntu.com` until we have a link to the correct preparation material

## QA

- View page at: https://ubuntu-com-8991.demos.haus/cube/microcerts
- Check Prepare button link works 

