### PR TITLE
Remove the engage takeover on the homepage

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -410,7 +410,7 @@ def build_takeovers_index(engage_pages):
     return takeover_index
 
 
-app.add_url_rule("/", view_func=build_takeovers(engage_pages))
+# app.add_url_rule("/", view_func=build_takeovers(engage_pages))
 app.add_url_rule("/takeovers", view_func=build_takeovers_index(engage_pages))
 engage_pages.init_app(app)
 


### PR DESCRIPTION
## Done
Remove the engage page part for homepage takeovers.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/