### PR TITLE
Switch account name property to the right case

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -29,7 +29,7 @@ export async function ensurePurchaseAccount(
     },
     body: JSON.stringify({
       email: email,
-      accountName: accountName,
+      account_name: accountName,
       payment_method_id: paymentMethodID,
     }),
   });


### PR DESCRIPTION
## Done

- Fix the case of `account_name`

## QA

- View the site https://ubuntu-com-9007.demos.haus/advantage/subscribe?test_backend=true
- Make a purchase using a new email and check in the network tab that the right username is used in the customer-info response


## Issue / Card

Fixes #8997 
