### PR TITLE
Add different views for microcerts page

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "url-polyfill": "1.1.11",
     "date-fns": "2.14.0",
     "url-search-params-polyfill": "8.1.0",
-    "vanilla-framework": "2.20.0"
+    "vanilla-framework": "2.21.0"
   },
   "resolutions": {
     "lodash": "4.17.20",

--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -56,7 +56,7 @@ function attachHoverEvent(toggle) {
 
 function setupContextualMenuListeners(contextualMenuToggleSelector) {
   const toggles = document.querySelectorAll(contextualMenuToggleSelector);
-
+  console.log(toggles);
   toggles.forEach((toggle) => {
     if (toggle.getAttribute("data-trigger") === "click") {
       attachClickEvent(toggle);

--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,7 +1,5 @@
 function toggleMenu(element, show) {
-  const dropdown = document.querySelector(
-    element.getAttribute("aria-controls")
-  );
+  const dropdown = element.nextElementSibling;
 
   element.setAttribute("aria-expanded", show);
   dropdown.setAttribute("aria-hidden", !show);
@@ -56,7 +54,6 @@ function attachHoverEvent(toggle) {
 
 function setupContextualMenuListeners(contextualMenuToggleSelector) {
   const toggles = document.querySelectorAll(contextualMenuToggleSelector);
-  console.log(toggles);
   toggles.forEach((toggle) => {
     if (toggle.getAttribute("data-trigger") === "click") {
       attachClickEvent(toggle);
@@ -67,9 +64,7 @@ function setupContextualMenuListeners(contextualMenuToggleSelector) {
 
   document.addEventListener("click", (e) => {
     toggles.forEach((toggle) => {
-      const contextualMenu = document.querySelector(
-        toggle.getAttribute("aria-controls")
-      );
+      const contextualMenu = document.querySelector(".p-contextual-menu");
 
       const clickOutside = !(
         toggle.contains(e.target) || contextualMenu.contains(e.target)

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -110,3 +110,15 @@
     margin-top: -0.4rem !important;
   }
 }
+
+.p-table__cell--share-actions {
+  overflow: visible;
+
+  .p-share-button {
+    position: relative;
+
+    [class*="p-button"] {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -42,6 +42,9 @@
     td {
       &:nth-child(1) {
         width: 4%;
+        @media only screen and (max-width: $breakpoint-small) {
+          width: 6%;
+        }
       }
 
       &:nth-child(2) {

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -115,6 +115,7 @@
   overflow: visible;
 
   .p-share-button {
+    margin-top: 0.5rem;
     position: relative;
 
     [class*="p-button"] {

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -36,6 +36,34 @@
       width: 19%;
     }
   }
+
+  &.is-passed {
+    th,
+    td {
+      &:nth-child(1) {
+        width: 4%;
+      }
+
+      &:nth-child(2) {
+        width: 5%;
+        img {
+          height: 3rem;
+          margin-top: 0.25rem;
+        }
+      }
+
+      &:nth-child(3) {
+        width: 70%;
+        @media only screen and (max-width: $breakpoint-small) {
+          width: 40%;
+        }
+      }
+
+      &:nth-child(4) {
+        width: 17%;
+      }
+    }
+  }
 }
 
 .p-table--cube__contents {

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -963,7 +963,7 @@
       linear-gradient(-89deg, #e95420 0%, #772953 38%, #2c001e 85%);
     background-position: top right, top left, left top;
     background-repeat: no-repeat;
-    background-size: 86% 105%, 67% 152%, 100% 99.8%;
+    background-size: 86% 105%, 67% 152%, 100% 99.9%;
     color: $color-x-light;
   }
 }
@@ -983,6 +983,9 @@
     }
     * {
       z-index: 2;
+    }
+    > div a {
+      position: relative;
     }
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -984,7 +984,7 @@
     * {
       z-index: 2;
     }
-    > div a {
+    > div .cube-access {
       position: relative;
     }
   }

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -412,7 +412,7 @@
   <div class="u-fixed-width">
     <h2>Apply for beta access</h2>
     <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
-    <button href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</button>
+    <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
   </div>
 </section>
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -23,12 +23,10 @@
 
         <h1>The road to CUBE</h1>
         <p class="p-heading--4">The path to certification is clear and convenient. Complete 15 microcerts to attain CUBE.</p>
-        <div>
           <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a></br>
           {% if not user %}
-            <a href="/login" class="p-link--inverted">Sign in&nbsp;&rsaquo;</a>
+          <a href="/login" class="p-link--inverted">Sign in&nbsp;&rsaquo;</a>
           {% endif %}
-        </div>
 
       {% endif %}
     </div>
@@ -262,26 +260,29 @@
               {% endif %}
             </div>
           </td>
-          <td aria-label="Action" class="p-table__cell--share-actions">
-
+          {% if module.status == "passed" %}
+          <td aria-label="Action" class="p-table__cell--share-actions u-hide--small">
           <div class="p-share-button u-align--right">
-            <span class="p-contextual-menu p-contextual-menu--right">
-              <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="#share-menu" aria-expanded="false" aria-haspopup="true" data-trigger="click"><i class="p-icon--chevron-down is-light p-contextual-menu__indicator"></i><span>Share</span></button>
+            <span class="p-contextual-menu p-contextual-menu--right u-hide--small">
+              <button class="p-button--neutral p-contextual-menu__toggle has-icon" aria-controls="#share-menu" aria-expanded="false" aria-haspopup="true" data-trigger="click"><i class="p-icon--chevron-down p-contextual-menu__indicator"></i><span>Share</span></button>
               <span class="p-contextual-menu__dropdown" id="share-menu" aria-hidden="true">
                 <span class="p-contextual-menu__group">
-                  <a href="#" class="p-contextual-menu__link">Share via LinkedIn</a>
-                  <a href="#" class="p-contextual-menu__link">Share via Twitter</a>
+                  <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.ubuntu.com" class="p-contextual-menu__link">Share via LinkedIn</a>
+                  <a href="https://twitter.com/share?text=My Tweet&amp;url=https://www.ubuntu.com/cube&amp;hashtags=ubuntu" class="p-contextual-menu__link">Share via Twitter</a>
                   <a href="#" class="p-contextual-menu__link">Copy to clipboard</a>
                 </span>
               </span>
             </span>
           </div>
-            <!-- <div class="p-table--cube__contents u-align--right">
+        </td>
+          {% elif module.status == "enrolled" %}
+          <td>
+            <div class="p-table--cube__contents u-align--right">
               <a class="p-button--neutral u-no-margin--right" href="{{ module.training_url }}">Prepare</a>
               <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.test_url }}">{{ module.action }}</a>
-            </div> -->
-
+            </div>
           </td>
+          {% endif %}
         </tr>
       {% endfor %}
       </tbody>
@@ -305,7 +306,7 @@
   <div class="u-fixed-width">
     <h2>Apply for beta access</h2>
     <p>Canonical are seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
-    <a  href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
+    <a  href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Apply for access</a>
   </div>
 </section>
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -6,41 +6,178 @@
 
 {% block content %}
 
-{% if user %}
 <section class="p-strip--square-suru has-cube is-dark is-slanted--bottom-left">
   <div class="row u-equal-height u-vertically-center">
-    <div class="col-6">
-      <h1>Your progress to CUBEdom</h1>
-      <p class="p-heading--4">You have completed {{ passed_courses }} out of 15 MicroCertifications</p>
+    <div id="hero-content" class="col-6">
+      {% if passed_courses == 15 %}
+
+        <h1>CUBE 2020 complete</h1>
+        <p class="p-heading--4">You have completed all 15 microcerts, proving your Ubuntu expertise. You are now a Certified Ubuntu Engineer.</p>
+
+      {% elif has_enrollment %}
+
+        <h1>Your road to CUBE</h1>
+        <p class="p-heading--4">You have completed {{ passed_courses }} microcerts.</br>Complete {{ (15 - passed_courses) }} more microcerts to attain CUBE.</p>
+
+      {% else %}
+
+        <h1>The road to CUBE</h1>
+        <p class="p-heading--4">The path to certification is clear and convenient. Complete 15 microcerts to attain CUBE.</p>
+        <div>
+          <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a></br>
+          {% if not user %}
+            <a href="/login" class="p-link--inverted">Sign in&nbsp;&rsaquo;</a>
+          {% endif %}
+        </div>
+
+      {% endif %}
     </div>
+    {% if has_enrollment %}
     <div class="col-6 p-cube-progression u-hide--medium u-hide--small">
-      <div class="p-cube-progression is-architecture {% if modules[12].status != 'Passed' %}is-faded{% endif %}"></div>
-      <div class="p-cube-progression is-bash {% if modules[10].status != 'Passed' %}is-faded--right{% endif %}"></div>
-      <div class="p-cube-progression is-devices {% if modules[2].status != 'Passed' %}is-faded--left{% endif %}"></div>
-      <div class="p-cube-progression is-packages {% if modules[8].status != 'Passed' %}is-faded{% endif %}"></div>
-      <div class="p-cube-progression is-services"></div>
-      <div class="p-cube-progression is-admin {% if modules[0].status != 'Passed' %}is-faded--left{% endif %}"></div>
-      <div class="p-cube-progression is-commands {% if modules[1].status != 'Passed' %}is-faded{% endif %}"></div>
-      <div class="p-cube-progression is-security {% if modules[9].status != 'Passed' %}is-faded--right{% endif %}"></div>
-      <div class="p-cube-progression is-networking {% if modules[7].status != 'Passed' %}is-faded--left{% endif %}"></div>
-      <div class="p-cube-progression is-kernel {% if modules[4].status != 'Passed' %}is-faded{% endif %}"></div>
-      <div class="p-cube-progression is-microk8s {% if modules[6].status != 'Passed' %}is-faded--right{% endif %}"></div>
-      <div class="p-cube-progression is-virtualisation"></div>
-      <div class="p-cube-progression is-storage {% if modules[11].status != 'Passed' %}is-faded{% endif %}"></div>
-      <div class="p-cube-progression is-juju {% if modules[3].status != 'Passed' %}is-faded--right{% endif %}"></div>
-      <div class="p-cube-progression is-maas {% if modules[5].status != 'Passed' %}is-faded--left{% endif %}"></div>
+      <div class="p-cube-progression is-architecture {% if modules[12].status != 'passed' %}is-faded{% endif %}"></div>
+      <div class="p-cube-progression is-bash {% if modules[10].status != 'passed' %}is-faded--right{% endif %}"></div>
+      <div class="p-cube-progression is-devices {% if modules[2].status != 'passed' %}is-faded--left{% endif %}"></div>
+      <div class="p-cube-progression is-packages {% if modules[8].status != 'passed' %}is-faded{% endif %}"></div>
+      <div class="p-cube-progression is-services {% if modules[13].status != 'passed' %}is-faded--right{% endif %}"></div>
+      <div class="p-cube-progression is-admin {% if modules[0].status != 'passed' %}is-faded--left{% endif %}"></div>
+      <div class="p-cube-progression is-commands {% if modules[1].status != 'passed' %}is-faded{% endif %}"></div>
+      <div class="p-cube-progression is-security {% if modules[9].status != 'passed' %}is-faded--right{% endif %}"></div>
+      <div class="p-cube-progression is-networking {% if modules[7].status != 'passed' %}is-faded--left{% endif %}"></div>
+      <div class="p-cube-progression is-kernel {% if modules[4].status != 'passed' %}is-faded{% endif %}"></div>
+      <div class="p-cube-progression is-microk8s {% if modules[6].status != 'passed' %}is-faded--right{% endif %}"></div>
+      <div class="p-cube-progression is-virtualisation {% if modules[14].status != 'passed' %}is-faded--left{% endif %}"></div>
+      <div class="p-cube-progression is-storage {% if modules[11].status != 'passed' %}is-faded{% endif %}"></div>
+      <div class="p-cube-progression is-juju {% if modules[3].status != 'passed' %}is-faded--right{% endif %}"></div>
+      <div class="p-cube-progression is-maas {% if modules[5].status != 'passed' %}is-faded--left{% endif %}"></div>
+    </div>
+    {% else %}
+    <div class="col-6 p-cube-progression u-hide--medium u-hide--small">
+      <div class="p-cube-progression is-architecture is-faded"></div>
+      <div class="p-cube-progression is-bash is-faded--right"></div>
+      <div class="p-cube-progression is-devices is-faded--left"></div>
+      <div class="p-cube-progression is-packages is-faded"></div>
+      <div class="p-cube-progression is-services is-faded--right"></div>
+      <div class="p-cube-progression is-admin is-faded--left"></div>
+      <div class="p-cube-progression is-commands is-faded"></div>
+      <div class="p-cube-progression is-security is-faded--right"></div>
+      <div class="p-cube-progression is-networking is-faded--left"></div>
+      <div class="p-cube-progression is-kernel is-faded"></div>
+      <div class="p-cube-progression is-microk8s is-faded--right"></div>
+      <div class="p-cube-progression is-virtualisation is-faded--left"></div>
+      <div class="p-cube-progression is-storage  is-faded"></div>
+      <div class="p-cube-progression is-juju is-faded--right"></div>
+      <div class="p-cube-progression is-maas is-faded--left"></div>
+    </div>
+    {% endif %}
+  </div>
+</section>
+
+{% if passed_courses == 15 %}
+
+<section class="p-strip--light is-slanted--top-right">
+  <div class="row">
+    <div class="col-3 col-start-large-2 u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/37fab8d1-CUBE+Certified.svg",
+        alt="CUBE certified",
+        width="175",
+        height="252",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>Badge of honor</h2>
+      <p>Share your certification with your network</p>
+      <ul class="p-inline-list-icons u-no-padding--left u-no-margin--left">
+        <li class="p-inline-list__item">
+          <a title="Share on Twitter" href="https://twitter.com/share?text=My Tweet&amp;url=https://www.ubuntu.com/cube&amp;hashtags=ubuntu">
+            <img src="https://assets.ubuntu.com/v1/3688269e-Twitter-share-button.png" alt="Share on twitter"/>
+          </a>
+        </li>
+        <li class="p-inline-list__item">
+          <a title="Share on LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.ubuntu.com">
+            <img src="https://assets.ubuntu.com/v1/1af29aea-LindedIn_share-button.png" alt="Share on Linkedin"/>
+          </a>
+        </li>
+      </ul>
+      <p>You can <a href="https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Test%20Certificate&organizationName=LinkedIn&issueYear=2018&issueMonth=2&expirationYear=2020&expirationMonth=5&certUrl=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Flearn%2Fcertifications%2Fd365-functional-consultant-sales&certId=1234">add this badge</a> to the Certification section of your LinkedIn profile</p>
+      <code>https://api.badgr.io/public/assertions/MPhZ1kQGT061-hl</code>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-slanted--top-right">
-  <div class="u-fixed-width">
-    <h2> Courseware access</h2>
-    <p><strong>Reccomended preparation</strong></p>
-    <p class="u-sv2">Access to the CUBE courseware. Be prepared for all modules.</p>
-    <a href="https://qa.cube.ubuntu.com/" class="p-button--positive">Prepare</a>
+{% elif user %}
+
+<section class="p-strip--light is-slanted--top-right is-shallow">
+  <div class="row">
+    <div class="col-5" style="margin-top: 3rem;">
+      <h2>Refresh your knowledge</h2>
+      <p><strong>Be prepared for every exam</strong></p>
+      <p class="u-sv2">Brush up on your Ubuntu skills with preparatory materials that cover every microcert.</p>
+      <a href="https://qa.cube.ubuntu.com/" class="p-button--positive">Prepare</a>
+    </div>
   </div>
 </section>
+
+{% else %}
+{% endif %}
+
+{% if passed_courses == 15 %}
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Microcertification history</h2>
+    <table class="p-table--cube is-passed">
+      <thead>
+          <tr>
+            <th>#</th>
+            <th class="u-hide--small"></th>
+            <th>Module</th>
+            <th class="p-table__cell--icon-placeholder">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for module in modules %}
+        <tr>
+          <td aria-label="Module number">
+            <div class="p-table--cube__contents">
+              <p class="u-text--muted">{{ module.number }}</p>
+            </div>
+          </td>
+          <td class="u-hide--small" aria-label="Badge">
+              <img 
+                src="{{ module.badge }}"
+                alt="Badge for {{ module.name }}"
+              />
+          </td>
+          <td aria-label="Module">
+            <div class="p-table--cube__contents">
+              <h5>{{ module.name }}</h5>
+            </div>
+            <p class="u-text--muted u-hide--small">
+              <small>{{ module.topics|length }} topics</small>
+            </p>
+          </td>
+          <td class="p-table__cell--icon-placeholder" aria-label="Status">
+            <div class="p-table--cube__contents">
+              <p>
+                <i class="p-icon--success"></i>Passed
+              </p>
+            </div>
+            <p class="u-text--muted u-hide--small">
+              <small>{{ module.date_attempted }}</small>
+            </p>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+{% else %}
 
 <section class="p-strip">
   <div class="u-fixed-width">
@@ -119,20 +256,29 @@
     </table>
   </div>
 </section>
-
-{% else %}
-
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>Microcertifications</h2>
-    <p>Sign in to see your microcertifications</p>
-    <p>
-      <a href="/login" class="p-button--neutral">
-        Sign in
-      </a>
-    </p>
-  </div>
-</section>
-
 {% endif %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
+</div>
+
+<script>
+  const myObserver = new ResizeObserver(entries => {
+    entries.forEach(entry => {
+    const width = Math.floor(entry.contentRect.width);
+    if(width < 1035) {
+      entry.target.classList.remove("is-shallow");
+      document.getElementById("hero-content").style.marginTop = "2rem";
+    } else {
+      entry.target.classList.add("is-shallow")
+      document.getElementById("hero-content").style.marginTop = "-2rem";
+    }
+    })
+  });
+ 
+  const strip = document.querySelector(".p-strip--square-suru");
+  myObserver.observe(strip);
+</script>
+
+
 {% endblock content %}

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -273,6 +273,14 @@
 </section>
 {% endif %}
 
+<section class="p-strip--square-suru has-cube is-slanted--top-right">
+  <div class="u-fixed-width">
+    <h2>Apply for beta access</h2>
+    <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
+    <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
+  </div>
+</section>
+
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
 </div>

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -89,26 +89,42 @@
     </div>
     <div class="col-7">
       <h2>Badge of honor</h2>
-      <p>Share your certification with your network</p>
-      <ul class="p-inline-list-icons u-no-padding--left u-no-margin--left">
+      <p style="margin-bottom:0.5rem;">Share your certification with your network</p>
+      <ul class="p-inline-list-icons u-no-padding--left u-no-margin--left u-no-padding--top">
         <li class="p-inline-list__item">
           <a title="Share on Twitter" href="https://twitter.com/share?text=My Tweet&amp;url=https://www.ubuntu.com/cube&amp;hashtags=ubuntu">
-            <img src="https://assets.ubuntu.com/v1/3688269e-Twitter-share-button.png" alt="Share on twitter"/>
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6d51a38d-Twitter.png",
+            alt="",
+            width="61",
+            height="20",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
           </a>
         </li>
         <li class="p-inline-list__item">
           <a title="Share on LinkedIn" href="https://www.linkedin.com/shareArticle?mini=true&amp;url=https://www.ubuntu.com">
-            <img src="https://assets.ubuntu.com/v1/1af29aea-LindedIn_share-button.png" alt="Share on Linkedin"/>
+          {{ image (
+            url="https://assets.ubuntu.com/v1/72040dde-LindedIn.png",
+            alt="",
+            width="60",
+            height="20",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
           </a>
         </li>
       </ul>
       <p>You can <a href="https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=Test%20Certificate&organizationName=LinkedIn&issueYear=2018&issueMonth=2&expirationYear=2020&expirationMonth=5&certUrl=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Flearn%2Fcertifications%2Fd365-functional-consultant-sales&certId=1234">add this badge</a> to the Certification section of your LinkedIn profile</p>
-      <code>https://api.badgr.io/public/assertions/MPhZ1kQGT061-hl</code>
+      <p class="u-no-padding--top"><small>https://api.badgr.io/public/assertions/MPhZ1kQGT061-hl</small></p>
     </div>
   </div>
 </section>
 
-{% elif user %}
+{% elif has_enrollment %}
 
 <section class="p-strip--light is-slanted--top-right is-shallow">
   <div class="row">
@@ -121,7 +137,6 @@
   </div>
 </section>
 
-{% else %}
 {% endif %}
 
 {% if passed_courses == 15 %}

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -273,13 +273,26 @@
 </section>
 {% endif %}
 
+{% if has_enrollment %}
+
+<section class="p-strip--square-suru has-cube is-slanted--top-right">
+  <div class="u-fixed-width">
+    <h2>Thank you for joining the beta</h2>
+    <p>Canonical are grateful for your participation. We look forward to hearing your feedback.</p>
+  </div>
+</section>
+
+{% else %}
+
 <section class="p-strip--square-suru has-cube is-slanted--top-right">
   <div class="u-fixed-width">
     <h2>Apply for beta access</h2>
-    <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
+    <p>Canonical are seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
     <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
   </div>
 </section>
+
+{% endif %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -204,8 +204,13 @@
           <th></th>
           <th>Module</th>
           <th>Topics</th>
+          {% if has_enrollment %}
           <th class="p-table__cell--icon-placeholder">Status</th>
           <th class="u-align--right">Action</th>
+          {% else %}
+          <th></th>
+          <th></th>
+          {% endif %}
         </tr>
       </thead>
       <tbody>
@@ -259,10 +264,22 @@
           </td>
           <td aria-label="Action">
             {% if module.status == "enrolled" %}
-            <div class="p-table--cube__contents u-align--right">
+            <div class="p-table--cube__contents u-align--right" style="margin-top:-0.5rem;">
+            <span class="p-contextual-menu--left">
+              <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="share-menu" aria-expanded="false" aria-haspopup="true"><i class="p-icon--chevron-down is-light p-contextual-menu__indicator"></i><span>Share</span></button>
+              <span class="p-contextual-menu__dropdown" id="share-menu" aria-hidden="true">
+                <span class="p-contextual-menu__group">
+                  <a href="#" class="p-contextual-menu__link">Share via Linkedin</a>
+                  <a href="#" class="p-contextual-menu__link">Share via Twitter</a>
+                  <a href="#" class="p-contextual-menu__link">Copy to clipboaord</a>
+                </span>
+              </span>
+            </span>
+            </div>
+            <!-- <div class="p-table--cube__contents u-align--right">
               <a class="p-button--neutral u-no-margin--right" href="{{ module.training_url }}">Prepare</a>
               <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.test_url }}">{{ module.action }}</a>
-            </div>
+            </div> -->
             {% endif %}
           </td>
         </tr>
@@ -288,7 +305,7 @@
   <div class="u-fixed-width">
     <h2>Apply for beta access</h2>
     <p>Canonical are seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
-    <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
+    <a  href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
   </div>
 </section>
 
@@ -314,6 +331,7 @@
  
   const strip = document.querySelector(".p-strip--square-suru");
   myObserver.observe(strip);
+
 </script>
 
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -262,25 +262,25 @@
               {% endif %}
             </div>
           </td>
-          <td aria-label="Action">
-            {% if module.status == "enrolled" %}
-            <div class="p-table--cube__contents u-align--right" style="margin-top:-0.5rem;">
-            <span class="p-contextual-menu--left">
-              <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="share-menu" aria-expanded="false" aria-haspopup="true"><i class="p-icon--chevron-down is-light p-contextual-menu__indicator"></i><span>Share</span></button>
+          <td aria-label="Action" class="p-table__cell--share-actions">
+
+          <div class="p-share-button u-align--right">
+            <span class="p-contextual-menu p-contextual-menu--right">
+              <button class="p-button--positive p-contextual-menu__toggle has-icon" aria-controls="#share-menu" aria-expanded="false" aria-haspopup="true" data-trigger="click"><i class="p-icon--chevron-down is-light p-contextual-menu__indicator"></i><span>Share</span></button>
               <span class="p-contextual-menu__dropdown" id="share-menu" aria-hidden="true">
                 <span class="p-contextual-menu__group">
-                  <a href="#" class="p-contextual-menu__link">Share via Linkedin</a>
+                  <a href="#" class="p-contextual-menu__link">Share via LinkedIn</a>
                   <a href="#" class="p-contextual-menu__link">Share via Twitter</a>
-                  <a href="#" class="p-contextual-menu__link">Copy to clipboaord</a>
+                  <a href="#" class="p-contextual-menu__link">Copy to clipboard</a>
                 </span>
               </span>
             </span>
-            </div>
+          </div>
             <!-- <div class="p-table--cube__contents u-align--right">
               <a class="p-button--neutral u-no-margin--right" href="{{ module.training_url }}">Prepare</a>
               <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.test_url }}">{{ module.action }}</a>
             </div> -->
-            {% endif %}
+
           </td>
         </tr>
       {% endfor %}
@@ -328,7 +328,7 @@
     }
     })
   });
- 
+
   const strip = document.querySelector(".p-strip--square-suru");
   myObserver.observe(strip);
 

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -112,7 +112,7 @@ def cube_microcerts():
         "user": {"name": user["fullname"]} if user else None,
         "modules": modules,
         "passed_courses": 0,
-        "has_enrollment": True,
+        "has_enrollment": False,
     }
     response = flask.make_response(
         flask.render_template("cube/microcerts.html", **data)

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -111,7 +111,7 @@ def cube_microcerts():
     data = {
         "user": {"name": user["fullname"]} if user else None,
         "modules": modules,
-        "passed_courses": 15,
+        "passed_courses": 0,
         "has_enrollment": True,
     }
     response = flask.make_response(

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -111,8 +111,8 @@ def cube_microcerts():
     data = {
         "user": {"name": user["fullname"]} if user else None,
         "modules": modules,
-        "passed_courses": 2,
-        "has_enrollment": False,
+        "passed_courses": 15,
+        "has_enrollment": True,
     }
     response = flask.make_response(
         flask.render_template("cube/microcerts.html", **data)

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -111,8 +111,8 @@ def cube_microcerts():
     data = {
         "user": {"name": user["fullname"]} if user else None,
         "modules": modules,
-        "passed_courses": 15,
-        "has_enrollment": True,
+        "passed_courses": 2,
+        "has_enrollment": False,
     }
     response = flask.make_response(
         flask.render_template("cube/microcerts.html", **data)

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -80,21 +80,45 @@ def cube_microcerts():
                     "date_attempted": "20-12-07",
                 }
             )
+    else:
+        courses = cube_api.get_courses(organization="ubuntu")["results"]
+        modules = []
+        for course in courses:
+            course_id = course["id"]
+            if course_id not in COURSE_DATA:
+                continue
 
-        data = {
-            "user": {"name": user["fullname"]},
-            "modules": modules,
-            "passed_courses": 2,
-        }
+            course_uri = (
+                f"https://qa.cube.ubuntu.com/courses/{course_id}/course"
+            )
 
-        response = flask.make_response(
-            flask.render_template("cube/microcerts.html", **data)
-        )
-        response.cache_control.private = True
+            badge = COURSE_DATA[course_id].get("logo")
+            topics = COURSE_DATA[course_id].get("topics")
 
-        return response
-
-    return flask.render_template("cube/microcerts.html")
+            modules.append(
+                {
+                    "number": len(modules) + 1,
+                    "badge": badge,
+                    "name": course["name"],
+                    "topics": topics,
+                    "test_url": course_uri,
+                    "training_url": course_uri,
+                    "status": "Not enrolled",
+                    "action": "Test",
+                    "date_attempted": "20-12-07",
+                }
+            )
+    data = {
+        "user": {"name": user["fullname"]} if user else None,
+        "modules": modules,
+        "passed_courses": 15,
+        "has_enrollment": True,
+    }
+    response = flask.make_response(
+        flask.render_template("cube/microcerts.html", **data)
+    )
+    response.cache_control.private = True
+    return response
 
 
 def cube_home():

--- a/yarn.lock
+++ b/yarn.lock
@@ -8346,10 +8346,10 @@ vanilla-framework@2.19.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
   integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
-vanilla-framework@2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.20.0.tgz#e3cc831fc1cf49e0863c286d61443f35ac43ba43"
-  integrity sha512-wN+R94p4dzrWSGa5F0H8ki+bRsoADVdVyyX5GKIk3Ecl3KO6XXvLFhknLx6jh8E3MEF/xOtiJxv3nb8PxYPB2g==
+vanilla-framework@2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.21.0.tgz#9d0b9b7cabd2a8cd4ccf452c471445e611868d69"
+  integrity sha512-KIX/hBl3b7vN3B0HDCj+1NadDUa6WtOEC0HTHNVvyQ2yC+pvQN2WHA1yVbUn7KaGLdv0RBqfNm88YlQ1wRPtbA==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done


- Add conditionals to render different views of the microcerts depending on if the user is:
- - not logged in or enrolled
- - logged in but not enrolled
- - enrolled
- - enrolled and passed all 15 microcerts

**Note**: The links for LinkedIn, twitter and copy to clipboard will be completed in the following issue

## QA

*Design*
- View the page at: https://ubuntu-com-9008.demos.haus/cube/microcerts

*qa* 
- Run the site using the command ./run serve or dotrun
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- Check not logged in or enrolled view by clearing cookies, and changing 'has_enrollment' on line 115 in `webapp/cube/views.py` to false.
- Check logged in and enrolled view by logging in
- Check enrolled and still in progress view by changing 'has_enrollment' in `webapp/cube/views.py` to true
- Check passed all certifications view by changing `passed_courses` on line 114 in `views.py` to 15


## Issue / Card

Fixes [#8976](https://github.com/canonical-web-and-design/ubuntu.com/issues/8976)

## Screenshots

Not logged in or enrolled

![image](https://user-images.githubusercontent.com/58959073/104310157-27566600-54cb-11eb-9115-2c00317f788e.png)

Logged in but not enrolled (remove sign in link on hero everything else the same)

![image](https://user-images.githubusercontent.com/58959073/104310443-a055bd80-54cb-11eb-8095-46077f82c060.png)


Enrolled but still in progress

![image](https://user-images.githubusercontent.com/58959073/104310763-27a33100-54cc-11eb-87b5-1909eea17e1c.png)


Enrolled and passed all 15 microcerts view (note - faked passed all 15 status to show this view so the progression hero doesn't reflect the passed certifications)

![image](https://user-images.githubusercontent.com/58959073/104192321-93c35d80-5416-11eb-86a1-54ca33175bc4.png)
