### PR TITLE
Explain that attaching is unnecessary on 16.04/18.04

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -87,6 +87,7 @@
               <div class="col-12 u-align--center u-sv3">
                   <h4>Ubuntu 14.04 ESM and 20.04 LTS</h4>
                   <p>To attach a machine: <br /><code>sudo ua attach {{ contract['token'] }}</code></p>
+                  <p>To detach a machine: <code>sudo ua detach</code></p>
                   <h4>Ubuntu 16.04 and 18.04 LTS</h4>
                   <p>You don’t need to attach machines before setting up UA services.</p>
               </div>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -78,13 +78,17 @@
             <hr class="u-sv1">
             <div class="row p-card__content">
               {% if new_subscription_id == contract['contractInfo']['id'] %}
-              <h4>Welcome to your new subscription.</h4>
-              <p>To get started, first attach each machine:</p>
-              <p>To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code></p>
-              <p>To detach a machine: <code>sudo ua detach</code></p>
+                <h4>Welcome to your new subscription</h4>
+                <p>If you’re using Ubuntu 14.04 ESM or 20.04 LTS, first attach each machine.</p>
+                <p>To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code></p>
+                <p>To detach a machine: <code>sudo ua detach</code></p>
+                <p>If you’re using Ubuntu 16.04 or 18.04 LTS, you don’t need to attach machines.</p>
               {% else %}
               <div class="col-12 u-align--center u-sv3">
-                To attach a machine: <br /><code>sudo ua attach {{ contract['token'] }}</code>
+                  <h4>Ubuntu 14.04 ESM and 20.04 LTS</h4>
+                  <p>To attach a machine: <br /><code>sudo ua attach {{ contract['token'] }}</code></p>
+                  <h4>Ubuntu 16.04 and 18.04 LTS</h4>
+                  <p>You don’t need to attach machines before setting up UA services.</p>
               </div>
               {% endif %}
             </div>

--- a/templates/advantage/table/_attached-machines.html
+++ b/templates/advantage/table/_attached-machines.html
@@ -2,14 +2,14 @@
 <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="false">
   <div class="row">
     <div class="col-12">
-      <h4>Welcome to your new subscription.</h4>
-      <p>To get started, first attach each machine:</p>
+      <p>If you’re using Ubuntu 14.04 ESM or 20.04 LTS, first attach each machine.</p>
       <p>To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code></p>
       <p>To detach a machine: <code>sudo ua detach</code></p>
       <p>
         Once a machine is attached, you can configure its services.&nbsp;&nbsp;
         <button class="p-button is-dense u-no-margin--bottom js-entitlements-callout" data-entitlements='{{ contract["entitlements"]|tojson }}'>Where?</button>
       </p>
+      <p>If you’re using Ubuntu 16.04 or 18.04 LTS, you don’t need to attach machines.</p>
     </div>
   </div>
   <script src="{{ versioned_static('js/dist/ua-entitlements-callout.js') }}" defer></script>
@@ -18,7 +18,11 @@
 <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
   <div class="row">
     <div class="col-12 u-align--center">
-      To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code>
+      <h4>Ubuntu 14.04 ESM and 20.04 LTS</h4>
+      <p>To attach a machine: <br /><code>sudo ua attach {{ contract['token'] }}</code></p>
+      <p>To detach a machine: <code>sudo ua detach</code></p>
+      <h4>Ubuntu 16.04 and 18.04 LTS</h4>
+      <p>You don’t need to attach machines before setting up UA services.</p>
     </div>
   </div>
 </td>

--- a/templates/advantage/table/_attached-machines.html
+++ b/templates/advantage/table/_attached-machines.html
@@ -2,6 +2,7 @@
 <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="false">
   <div class="row">
     <div class="col-12">
+      <h4>Welcome to your new subscription</h4>
       <p>If you’re using Ubuntu 14.04 ESM or 20.04 LTS, first attach each machine.</p>
       <p>To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code></p>
       <p>To detach a machine: <code>sudo ua detach</code></p>

--- a/templates/advantage/table/_attached-machines.html
+++ b/templates/advantage/table/_attached-machines.html
@@ -1,7 +1,7 @@
 {% if new_subscription_id == contract['contractInfo']['id'] %}
 <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="false">
   <div class="row">
-    <div class="col-12">
+    <div class="col-12" style="margin: 0 auto">
       <h4>Welcome to your new subscription</h4>
       <p>If you’re using Ubuntu 14.04 ESM or 20.04 LTS, first attach each machine.</p>
       <p>To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code></p>
@@ -18,9 +18,9 @@
 {% else %}
 <td id="expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="true">
   <div class="row">
-    <div class="col-12 u-align--center">
+    <div class="col-12" style="margin: 0 auto">
       <h4>Ubuntu 14.04 ESM and 20.04 LTS</h4>
-      <p>To attach a machine: <br /><code>sudo ua attach {{ contract['token'] }}</code></p>
+      <p>To attach a machine: <code>sudo ua attach {{ contract['token'] }}</code></p>
       <p>To detach a machine: <code>sudo ua detach</code></p>
       <h4>Ubuntu 16.04 and 18.04 LTS</h4>
       <p>You don’t need to attach machines before setting up UA services.</p>


### PR DESCRIPTION
## Done

Changed the subscription table “Attached” expanded cell to explain that attaching is not necessary on Ubuntu 16.04/18.04.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Sign in
- In the “Your paid subscriptions” table, expand any of the “Attached” cells

## Issue / Card

Fixes PART OF #9001. DOES NOT fix the Livepatch token part of it.