### PR TITLE
CVE results cells: Make “Does not exist” more compact

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -107,7 +107,7 @@
     border-bottom: 10px solid #b0b0b0;
   }
 
-  .cve-table-cell--muted {
+  .cve-table-cell.status-DNE, .cve-table-cell.status-not-affected {
     @extend .cve-table-cell;
 
     color: $color-mid-dark;

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -46,7 +46,7 @@
   .cve-table .icon-container__text {
     width: calc(100% - 3rem);
   }
-  
+
   .cve-table .status-DNE .icon-container__text {
     width: calc(100% - 1.5rem);
   }

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -46,6 +46,10 @@
   .cve-table .icon-container__text {
     width: calc(100% - 3rem);
   }
+  
+  .cve-table .status-DNE .icon-container__text {
+    width: calc(100% - 1.5rem);
+  }
 
   .cve-table .p-icon--information {
     opacity: 0.6;

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -107,7 +107,8 @@
     border-bottom: 10px solid #b0b0b0;
   }
 
-  .cve-table-cell.status-DNE, .cve-table-cell.status-not-affected {
+  .cve-table-cell.status-DNE,
+  .cve-table-cell.status-not-affected {
     @extend .cve-table-cell;
 
     color: $color-mid-dark;

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -44,7 +44,7 @@
                 <div class="cve-color-strip--released"></div>
               {% endif %}
               <div class="icon-container__icon">
-                {% if statuses[release.codename].status != 'DNE' and statuses[release.codename].status == 'not-affected' %}
+                {% if statuses[release.codename].status != 'DNE' and statuses[release.codename].status != 'not-affected' %}
                   {% if cve.priority == 'unknown' %}
                     <i class="p-icon--placeholder"></i>
                   {% elif cve.priority == 'negligible' %}

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -25,11 +25,7 @@
           <td>{{ package_name }}</td>
           {% for release in releases %}
             {% if release.codename in statuses %}
-              {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
-                <td class="cve-table-cell--muted">
-              {% else %}
-                <td class="cve-table-cell">
-              {% endif %}
+              <td class="cve-table-cell status-{{ statuses[release.codename].status }} priority-{{ cve.priority }}">
               {% if statuses[release.codename].status == "DNE" %}
                 <div class="cve-color-strip--dne"></div>
               {% elif statuses[release.codename].status == "needs-triage" %}
@@ -48,9 +44,7 @@
                 <div class="cve-color-strip--released"></div>
               {% endif %}
               <div class="icon-container__icon">
-                {% if statuses[release.codename].status == 'DNE' or statuses[release.codename].status == 'not-affected' %}
-                  <i class="p-icon--placeholder"></i>
-                {% else %}
+                {% if statuses[release.codename].status != 'DNE' and statuses[release.codename].status == 'not-affected' %}
                   {% if cve.priority == 'unknown' %}
                     <i class="p-icon--placeholder"></i>
                   {% elif cve.priority == 'negligible' %}


### PR DESCRIPTION
## Done

- Applied semantic classes to the CVE cells, for easier styling changes later
- Removed the invisible (i) icon from cells where it never appears
- Expanded the cell text to use the space taken by the never-appearing icon

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Observe that the “Recent CVEs” table is now more compact

## Issue / Card

Fixes #8832.

## Screenshots

I cannot test this or make screenshots because there is no local access to the CVE database.