### PR TITLE
redirect /guide

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -857,3 +857,6 @@ shared/forms/interactive/_(?P<path>.*)/?: /shared/forms/interactive/{path}
 
 # Download harness
 download/server/thank-you: /download/server
+
+# Server guide
+server/guide: /server/docs


### PR DESCRIPTION
## QA

Check you get a redirect at /server/guide

``` bash
dotrun

# Then in another terminal
curl -sI http://127.0.0.1:8001/server/guide | grep -i location
```

Check you see a location header for `/server/docs`.