### PR TITLE
Update logos on /telco

### DIFF
--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -59,7 +59,7 @@
           height="120",
           width="120",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -72,7 +72,7 @@
           height="55",
           width="83",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -85,7 +85,7 @@
           height="160",
           width="160",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -98,7 +98,7 @@
           height="33",
           width="97",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -111,7 +111,7 @@
           height="29",
           width="130",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -124,7 +124,7 @@
           height="64",
           width="64",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -137,7 +137,7 @@
           height="75",
           width="100",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -150,7 +150,7 @@
           height="30",
           width="80",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -163,7 +163,7 @@
           height="40",
           width="100",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -176,7 +176,7 @@
           height="50",
           width="144",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -189,7 +189,7 @@
           height="28",
           width="100",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}
@@ -202,7 +202,31 @@
           height="27",
           width="100",
           hi_def=True,
-          loading="auto",
+          loading="lazy",
+          attrs={"class": "p-inline-images__logo"}
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d2bfbb2b-MTS_logo_%282016%29.svg",
+            alt="MTS",
+            width="114",
+            height="42",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-inline-images__logo"}
+            ) | safe
+          }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/1459d379-tmn_logo.png",
+          alt="tmn",
+          width="159",
+          height="70",
+          hi_def=True,
+          loading="lazy",
           attrs={"class": "p-inline-images__logo"}
           ) | safe
         }}


### PR DESCRIPTION
## Done

- Update logos on /telco added 2 and made the rest lazy load

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/telco
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit?ts=5fd92d66#)

## Issue / Card

Fixes [#3593](https://github.com/canonical-web-and-design/web-squad/issues/3593)
