### PR TITLE
Add /cloud to the footer

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -242,6 +242,14 @@ publiccloud:
     - title: Overview
       path: /public-cloud
 
+cloud:
+  title: Cloud
+  path: /cloud
+
+  children:
+    - title: Overview
+      path: /cloud
+
 server:
   title: Server
   path: /server
@@ -1021,7 +1029,7 @@ core:
         - title: Audio management
           path: /core/docs/audio-management
           persist: True
-          
+
 
 
     - title: Contact us
@@ -1032,8 +1040,8 @@ core:
         - title: Thank you
           path: /core/thank-you
           hidden: True
-    
-    
+
+
 
 iot:
   title: IoT

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -87,6 +87,9 @@
               {% with section=nav_sections.publiccloud %}
               {% include 'templates/_footer_item.html' %}
               {% endwith %}
+              {% with section=nav_sections.cloud %}
+              {% include 'templates/_footer_item.html' %}
+              {% endwith %}
               {% with section=nav_sections.containers %}
               {% include 'templates/_footer_item.html' %}
               {% endwith %}


### PR DESCRIPTION
## Done

- Add Cloud (/cloud) to the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Look in the footer and see "Cloud" below "Public cloud"


## Issue / Card

Fixes #9010

## Screenshots

![image](https://user-images.githubusercontent.com/441217/104606695-f0718300-5677-11eb-95de-03f2d145fc0b.png)

