### PR TITLE
Replace CUBE certified badge

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -412,7 +412,7 @@
   <div class="u-fixed-width">
     <h2>Apply for beta access</h2>
     <p>Canonical is seeking participants from the community for the CUBE beta test. If you would like to be considered for the beta, please enter your information in the form below. Canonical will reach out to you if you are selected.</p>
-    <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a>
+    <a href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Apply for access</a>
   </div>
 </section>
 

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -35,7 +35,7 @@
     </div>
     <div class="col-4 col-start-large-9 u-hide--small">
       {{ image (
-        url="https://assets.ubuntu.com/v1/37fab8d1-CUBE+Certified.svg",
+        url="https://assets.ubuntu.com/v1/17541ecf-CUBE+certified+-+132x190_3.svg",
         alt="CUBE certified",
         width="175",
         height="252",

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -76,7 +76,7 @@
   <div class="row">
     <div class="col-3 col-start-large-2 u-hide--small">
       {{ image (
-        url="https://assets.ubuntu.com/v1/37fab8d1-CUBE+Certified.svg",
+        url="https://assets.ubuntu.com/v1/17541ecf-CUBE+certified+-+132x190_3.svg",
         alt="CUBE certified",
         width="175",
         height="252",

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -111,8 +111,8 @@ def cube_microcerts():
     data = {
         "user": {"name": user["fullname"]} if user else None,
         "modules": modules,
-        "passed_courses": 0,
-        "has_enrollment": False,
+        "passed_courses": 15,
+        "has_enrollment": True,
     }
     response = flask.make_response(
         flask.render_template("cube/microcerts.html", **data)


### PR DESCRIPTION
## Done

- Replace CUBE certified badge on `/cube` and on `/cube/microcerts`
- Add class to `Apply for access` button on homepage to fix background watermark overlaying button

## QA

- Visit page at: https://ubuntu-com-9033.demos.haus/cube   and: https://ubuntu-com-9033.demos.haus/cube/microcerts
- Check badge matches new spec see [here](https://app.zenhub.com/workspaces/web--ubuntu-clan-5931746dba512f05402b61f6/issues/canonical-web-and-design/web-squad/3635)
- Check watermark isn't overlaying button at the bottom of homepage.

## Issue / Card

Fixes [#3635](https://github.com/canonical-web-and-design/web-squad/issues/3635)

## Screenshots

New badge:

![image](https://user-images.githubusercontent.com/58959073/104726626-d6917800-572b-11eb-9fa6-6ea9cecd0f2e.png)

Button:

![image](https://user-images.githubusercontent.com/58959073/104726679-f1fc8300-572b-11eb-83bf-bc0659f04467.png)
