### PR TITLE
Optimise CVE table cells

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -47,6 +47,8 @@
   }
 
   .cve-table .icon-container__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
     width: calc(100% - 1.5rem);
   }
 

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -40,11 +40,14 @@
   }
 
   .cve-table .icon-cve-info {
-    margin: 0 0 0 0.5rem;
+    margin: 0;
+    position: absolute !important;
+    right: 0;
+    top: calc(0.5rem - 1px);
   }
 
   .cve-table .icon-container__text {
-    width: calc(100% - 3rem);
+    width: calc(100% - 1.5rem);
   }
 
   .cve-table .p-icon--information {
@@ -59,6 +62,19 @@
     visibility: visible;
   }
 
+  .cve-tooltip {
+    background: #fff;
+    border: 1px solid #b0b0b0;
+    box-shadow: 0 0 3px #b0b0b0;
+    color: #111;
+    padding: 10px;
+    position: absolute;
+    top: 30px;
+    transform: translateX(-125px);
+    width: 275px;
+    z-index: 1;
+  }
+
   .cve-table-cell .cve-tooltip {
     display: none;
   }
@@ -71,39 +87,38 @@
     position: relative;
   }
 
-  .cve-tooltip {
-    z-index: 1;
-    background: #fff;
-    position: absolute;
-    top: 30px;
-    transform: translateX(-125px);
-    width: 275px;
-    border: 1px solid #b0b0b0;
-    padding: 10px;
-    box-shadow: 0 0 3px #b0b0b0;
-    color: #111;
+  .cve-table .esm-info {
+    display: block;
+    float: left;
+    font-size: 0.6rem;
+    line-height: 0.7rem;
+    margin: 0;
+    padding: 0.2rem 0 0 0;
+    width: 100%;
   }
 
   .cve-tooltip .arrow-up {
-    position: absolute;
-    left: calc(50% - 13px);
-    width: 0;
-    height: 0;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
+    height: 0;
+    left: calc(50% - 13px);
+    position: absolute;
+    width: 0;
   }
 
   .cve-tooltip .arrow-up.front {
-    top: -9px;
     border-bottom: 10px solid #fff;
+    top: -9px;
   }
 
   .cve-tooltip .arrow-up.back {
-    top: -10px;
     border-bottom: 10px solid #b0b0b0;
+    top: -10px;
   }
 
-  .cve-table-cell--muted {
+  .cve-table-cell--muted,
+  .cve-table-cell.status-DNE,
+  .cve-table-cell.status-not-affected {
     @extend .cve-table-cell;
 
     color: $color-mid-dark;

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -25,11 +25,7 @@
           <td>{{ package_name }}</td>
           {% for release in releases %}
             {% if release.codename in statuses %}
-              {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
-                <td class="cve-table-cell--muted">
-              {% else %}
-                <td class="cve-table-cell">
-              {% endif %}
+              <td class="cve-table-cell status-{{ statuses[release.codename].status }}">
               {% if statuses[release.codename].status == "DNE" %}
                 <div class="cve-color-strip--dne"></div>
               {% elif statuses[release.codename].status == "needs-triage" %}
@@ -89,7 +85,7 @@
                   &mdash;
                 {% endif %}
                 <br>
-                <small>
+                <small class="cve-table-cell esm-info">
                   {% if statuses[release.codename].pocket == "esm-infra" %}
                     <a href="/advantage" target="_blank">UA Infra/Apps</a>
                   {% endif %}

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -91,10 +91,10 @@
                 <br>
                 <small>
                   {% if statuses[release.codename].pocket == "esm-infra" %}
-                    <a href="/advantage" target="_blank">UA Infra, UA Desktop</a>
+                    <a href="/advantage" target="_blank">UA Infra/Apps</a>
                   {% endif %}
                   {% if statuses[release.codename].pocket == "esm-apps" %}
-                    <a href="/advantage" target="_blank">UA Apps, UA Desktop</a>
+                    <a href="/advantage" target="_blank">UA Apps</a>
                   {% endif %}
                 </small>
               </div>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -190,10 +190,10 @@
                     <br>
                     <small>
                       {% if statuses[release.codename].pocket == "esm-infra" %}
-                      Requires <a href="/advantage" target="_blank">UA Infra, UA Desktop</a>
+                        Requires <a href="/advantage" target="_blank">Available with UA Infra or UA Apps</a>
                       {% endif %}
                       {% if statuses[release.codename].pocket == "esm-apps" %}
-                      Requires <a href="/advantage" target="_blank">UA Apps, UA Desktop</a>
+                        Requires <a href="/advantage" target="_blank">Available with UA Apps</a>
                       {% endif %}
                     </small>
                     </td>


### PR DESCRIPTION
## Done

- Optimise CVE table cells

## QA

Go to /security/cve look at the table it should have:
- `Does not exist` on 2 lines instead of 3
- Update the UA texts under the status, inside the cell and they should be smaller
- It should look better than https://ubuntu.com/security/cve

## Issue / Card

Fixes #8832
Fixes #9036