### PR TITLE
Fix JS error on renewal form blocking purchases

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -248,8 +248,13 @@ function attachFormEvents() {
     checkVAT();
   });
 
-  forMyselfRadio.addEventListener("change", handleNameFieldRadio);
-  forOrganisationRadio.addEventListener("change", handleNameFieldRadio);
+  // these elements aren't rendered on the renewal form
+  // or if an account isn't present, so check for their
+  // existence first
+  if (forMyselfRadio && forOrganisationRadio) {
+    forMyselfRadio.addEventListener("change", handleNameFieldRadio);
+    forOrganisationRadio.addEventListener("change", handleNameFieldRadio);
+  }
 
   termsCheckbox.addEventListener("change", () => {
     if (termsCheckbox.checked) {


### PR DESCRIPTION
## Done

- Check for existence of "I'm purchasing for" fields before attaching events to them

## QA


- View the site in your web browser at: https://ubuntu-com-9037.demos.haus/advantage?test_backend=true
- Log in with your SSO account
- If you don't see a contract up for renewal, ask @alnvdl to create one for you
- When you have that, find it in the table, open the dropdown, and click "Renew"
- The payment modal should launch and the Stripe field should render correctly

This is related to, but doesn't fix #9018 - this fixes the problem the user was seeing, we should still handle Stripe failing to initialise.

## Screenshots

Before:
![Screenshot from 2021-01-15 14-13-16](https://user-images.githubusercontent.com/2376968/104737537-4a3b8100-573c-11eb-86da-77cd248c6962.png)

After:
![Screenshot from 2021-01-15 14-11-57](https://user-images.githubusercontent.com/2376968/104737535-4871bd80-573c-11eb-9d4c-0616d08a767b.png)


