### PR TITLE
Simplify the advantage hero sections

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 {% if user_info %}
-  <section class="p-strip--suru-topped is-shallow" style="padding-top: 6rem;">
+  <section class="p-strip--suru-topped">
     <script>
       dataLayer.push({
         'event' : 'GAEvent',
@@ -392,7 +392,7 @@
   {% endwith %}
 
 {% else %}
-  <section class="p-strip--suru-topped is-shallow" style="padding-top: 6rem;"></section>
+  <section class="p-strip--suru-topped">
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>


### PR DESCRIPTION
## Done
Simplify the advantage hero sections and remove an erroneous closing section tag.

## QA

- Visit the demo link
- Check that the title starts at the same point as https://ubuntu.com/security/esm
- Login and check that is also at the same place

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9038

