### PR TITLE
JS homepage takeover with endpoint to avoid taking down homepage

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -12,8 +12,11 @@
     background-repeat: no-repeat;
     background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
     margin: 0;
-    padding-bottom: 9rem;
-    padding-top: 6rem;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    // 9 + 6 + 20em (default takeover)
+    height: 35rem;
 
     @media (max-width: $breakpoint-medium) {
       background-position: top right, top left, right bottom -1px, left top;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -819,8 +819,8 @@ body {
 .p-takeover-animation {
   animation: FadeIn map-get($animation-duration, "fast")
     map-get($animation-easing, "out");
-  animation-fill-mode: backwards;
   animation-delay: 2.5s;
+  animation-fill-mode: backwards;
 
   &.is-loaded {
     animation-delay: 0s !important;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -806,7 +806,6 @@ body {
   }
 }
 
-// Homepage takeover animation
 @keyframes FadeIn {
   0% {
     opacity: 0;
@@ -816,14 +815,42 @@ body {
   }
 }
 
+@keyframes SlideInFromRight {
+  0% {
+    transform: translateX(0.5rem);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes SlideInFromLeft {
+  0% {
+    transform: translateX(-0.5rem);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
 .p-takeover-animation {
-  animation: FadeIn map-get($animation-duration, "fast")
-    map-get($animation-easing, "out");
+  animation: FadeIn map-get($animation-duration, "snap")
+    map-get($animation-easing, "in");
   animation-delay: 2.5s;
   animation-fill-mode: backwards;
 
   &.is-loaded {
     animation-delay: 0s !important;
+
+    .col-7 {
+      animation: SlideInFromLeft map-get($animation-duration, "fast")
+        map-get($animation-easing, "out");
+    }
+
+    .col-5 {
+      animation: SlideInFromRight map-get($animation-duration, "fast")
+        map-get($animation-easing, "out");
+    }
   }
 
   &.is-loading {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -805,3 +805,24 @@ body {
     }
   }
 }
+
+// Homepage takeover animation
+@keyframes FadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.p-takeover-animation {
+  animation: FadeIn map-get($animation-duration, "fast")
+    map-get($animation-easing, "out");
+  animation-fill-mode: backwards;
+  animation-delay: 2.5s;
+
+  &.is-loaded {
+    animation-delay: 0s !important;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -825,4 +825,8 @@ body {
   &.is-loaded {
     animation-delay: 0s !important;
   }
+
+  &.is-loading {
+    animation-delay: 500s !important;
+  }
 }

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -8,28 +8,28 @@
 
 {% block outer_content %}
 {% block content %}
-<template id="takeovers" class="u-hide">
+<template class="u-hide">
   {% block takeover_content %}
   {% endblock takeover_content %}
 </template>
 
 <!-- Default Takeover: Download the latest Ubuntu -->
-<section data-lang="all" id="takeover" class="p-strip--image is-dark is-deep" style="background-color: #5E2750; background-image: linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%)">
-  <div class="row">
+<section data-lang="all" id="takeover" class="p-takeover--grad is-dark is-deep">
+  <div class="row p-takeover-animation">
     <div class="col-7 u-vertically-center">
-      <h1>What's new in<br>Ubuntu {{ releases.latest.short_version }}?</h1>
-      <h4>Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds.</h4>
-      <div class="u-hide--small">
-        <p><a href="/download" class="p-button--positive">Get Ubuntu {{ releases.latest.short_version }}</a></p>
+      <h1 id="takeover-title">What's new in<br>Ubuntu {{ releases.latest.short_version }}?</h1>
+      <h4 id="takeover-subtitle">Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds.</h4>
+      <div id="takeover-ctas">
+        <p><a id="takeover-primary-url" href="/download" class="p-button--positive">Get Ubuntu {{ releases.latest.short_version }}</a></p>
         <p>
-          <a href="/raspberry-pi" class=" p-link--inverted">
+          <a id="takeover-secondary-url" href="/raspberry-pi" class=" p-link--inverted">
             Learn more about Ubuntu on the Raspberry Pi&nbsp;›
           </a>
         </p>
       </div>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-      {{  image(      url="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",      alt="",      width="250",      height="388",      hi_def=True,      loading="lazy",      attrs={"style": "width: 250px; height: 388px;"},  ) | safe }}
+      <img id="takeover-image" src="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg" width="200" alt="" />
     </div>
   </div>
 </section>
@@ -1409,55 +1409,103 @@
     * Choose a takeover
     * ===
     *
-    * From the list of provided takeovers in the #takeovers template,
+    * From the list of provided takeovers from /.takeovers.json,
     * choose one (that matches the client's language), and replace the
     * base template with it.
     */
 
-    var baseTakeover = document.getElementById('takeover');  // The base takeover element
-    var takeovers = document.getElementById('takeovers');  // The list of current takeovers to choose from
-
-    // For browsers that support <template> (all but IE), grab the template's ".content"
-    takeovers = 'content' in takeovers ? takeovers.content: takeovers;
-
-    // First, select takeovers that don't specify a language and don't exclude the users language
-    var takeoverSelectors = [".js-takeover:not([lang]).js-takeover:not([lang-skip*=" + primaryParentLanguage + "])"]
-
-    // Add selectors to find takeovers for any of the user's languages
-    takeoverSelectors.push(".js-takeover[lang=" + primaryParentLanguage + "]");
-    takeoverSelectors.push(".js-takeover[data-lang-extra*=" + primaryParentLanguage + "]");
-
-    // Get the selected takeovers
-    var selectedTakeovers = (takeovers.querySelectorAll(takeoverSelectors.join(',')));
-
-    if (selectedTakeovers) {
-      var selectedIndex = null;
-
-      if (localStorage.getItem('selected_takeover_index') !== null) {
-        // If we previously chose a takeover, increment the number to show the next takeover
-        var nextIndex = parseInt(localStorage.getItem('selected_takeover_index')) + 1
-        selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
-      } else {
-        // Otherwise, randomly choose one of the takeovers and store it for next time
-        selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
-      }
-
-      // Store the current takeover
-      localStorage.setItem('selected_takeover_index', selectedIndex)
-
-      // Get the takeover element
-      var selectedTakeover = selectedTakeovers[selectedIndex]
-
-      if (! document.body.contains(selectedTakeover)) {
-        // If it's not in the current document (as in, it's in a template) import it
-        // Note: This is for all browser *except* IE, which doesn't support <template>s
-        selectedTakeover = document.importNode(selectedTakeover, true);
-      }
-
-      // Replace the base takeover with the new one
-      // Note: We can't use Node.replaceWith (which would be nice), as it's not supported in IE
-      baseTakeover.parentNode.replaceChild(selectedTakeover, baseTakeover)
+    var xhr = new XMLHttpRequest();
+    if (window.ActiveXObject) {
+      xhr = new ActiveXObject('Microsoft.XMLHTTP');
     }
+    
+    xhr.onreadystatechange = function() {
+      
+      if (xhr.readyState == XMLHttpRequest.DONE) {
+
+        var takeovers = JSON.parse(xhr.responseText);
+        var baseTakeover = document.getElementById('takeover');  // The base takeover element
+
+        // Get the selected takeovers
+        var selectedTakeovers = takeovers.filter(function(item) {
+          return item.lang === primaryParentLanguage || item.lang === ""
+        })
+
+        if (selectedTakeovers && selectedTakeovers.length > 0) {
+        var selectedIndex = null;
+
+        if (localStorage.getItem('selected_takeover_index') !== null) {
+          // If we previously chose a takeover, increment the number to show the next takeover
+          var nextIndex = parseInt(localStorage.getItem('selected_takeover_index')) + 1
+          selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
+          showTakeover(selectedTakeovers, selectedIndex);
+        } else {
+          // Otherwise, randomly choose one of the takeovers and store it for next time
+          selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
+          showTakeover(selectedTakeovers, selectedIndex);
+        }
+
+        // Store the current takeover
+        localStorage.setItem('selected_takeover_index', selectedIndex)
+
+        }
+      }
+    };
+
+    xhr.open("GET", "/takeovers.json", true);
+    xhr.send();
+
+  }
+
+  function showTakeover(takeovers, index) {
+    // Default parameter
+    index = typeof index !== 'undefined' ? index : 0;
+
+    // Get HTML elements
+    var takeover = document.getElementById("takeover");
+    var title = document.getElementById("takeover-title");
+    var subtitle = document.getElementById("takeover-subtitle");
+    var image = document.getElementById("takeover-image");
+    var primaryUrl = document.getElementById("takeover-primary-url");
+    var secondaryUrl = document.getElementById("takeover-secondary-url");
+    var get_ctas = document.getElementById("takeover-ctas").getElementsByTagName("p")[0];
+    var takeoverAnimation = document.getElementsByClassName("p-takeover-animation")
+
+    // Set values to homepage takeover
+    var selectedTakeover = takeovers[index];
+
+    takeover.className = "";
+    takeover.removeAttribute("style");
+
+    // Add takeover classes
+    var classNameString = "js-takeover p-takeover--" + selectedTakeover.class;
+    takeover.className += classNameString;
+
+    // Set language attributes
+    takeover.setAttribute("lang", selectedTakeover.lang);
+    takeover.setAttribute("lang-skip", selectedTakeover.lang_skip);
+
+    // Set takeover content
+    title.textContent = selectedTakeover.title;
+    subtitle.textContent = selectedTakeover.subtitle;
+    image.src = selectedTakeover.image;
+    image.removeAttribute("style");
+    image.style.width = selectedTakeover.image_width;
+    image.style.height = selectedTakeover.image_height;
+    primaryUrl.href = selectedTakeover.primary_url;
+    primaryUrl.textContent = selectedTakeover.primary_cta;
+    if (selectedTakeover.secondary_url && selectedTakeover.secondary_url !== "") {
+      secondaryUrl.href = selectedTakeover.secondary_url;
+      secondaryUrl.textContent = selectedTakeover.secondary_cta + " ›";
+    } else {
+      secondaryUrl.remove();
+    }
+
+    // Remove animation delay
+    if (takeoverAnimation[0]) {
+      takeoverAnimation[0].className +=  " .is-loaded";
+    }
+    
   }
 </script>
 

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -23,7 +23,7 @@
         <p><a id="takeover-primary-url" href="/download" class="p-button--positive">Get Ubuntu {{ releases.latest.short_version }}</a></p>
         <p>
           <a id="takeover-secondary-url" href="/raspberry-pi" class=" p-link--inverted">
-            Learn more about Ubuntu on the Raspberry Pi&nbsp;›
+            Learn more about Ubuntu on the Raspberry Pi&nbsp;&rsaquo;
           </a>
         </p>
       </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1404,7 +1404,9 @@
     notices[0].classList.remove("u-hide")
   }
 
-  if (window.localStorage && window.sessionStorage) {
+  var baseTakeover = document.getElementById('takeover');
+
+  if (window.localStorage && baseTakeover) {
     /**
     * Choose a takeover
     * ===
@@ -1418,43 +1420,37 @@
     if (window.ActiveXObject) {
       xhr = new ActiveXObject('Microsoft.XMLHTTP');
     }
-    
+
     xhr.onreadystatechange = function() {
-      
       if (xhr.readyState == XMLHttpRequest.DONE) {
-
         var takeovers = JSON.parse(xhr.responseText);
-        var baseTakeover = document.getElementById('takeover');  // The base takeover element
 
-        // Get the selected takeovers
+        // Get the selected takeovers based on the primary language
         var selectedTakeovers = takeovers.filter(function(item) {
           return item.lang === primaryParentLanguage || item.lang === ""
         })
 
         if (selectedTakeovers && selectedTakeovers.length > 0) {
-        var selectedIndex = null;
+          var selectedIndex = null;
 
-        if (localStorage.getItem('selected_takeover_index') !== null) {
-          // If we previously chose a takeover, increment the number to show the next takeover
-          var nextIndex = parseInt(localStorage.getItem('selected_takeover_index')) + 1
-          selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
+          if (window.localStorage.getItem('selected_takeover_index') !== null) {
+            // If we previously visited a takeover, increment the number to show the next takeover
+            var nextIndex = parseInt(window.localStorage.getItem('selected_takeover_index')) + 1
+            selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
+          } else {
+            // Otherwise, randomly choose one of the takeovers and store it for next time
+            selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
+          }
           showTakeover(selectedTakeovers, selectedIndex);
-        } else {
-          // Otherwise, randomly choose one of the takeovers and store it for next time
-          selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
-          showTakeover(selectedTakeovers, selectedIndex);
-        }
 
-        // Store the current takeover
-        localStorage.setItem('selected_takeover_index', selectedIndex)
-
+          // Store the current takeover index
+          localStorage.setItem('selected_takeover_index', selectedIndex)
         }
       }
     };
 
     xhr.open("GET", "/takeovers.json", true);
     xhr.send();
-
   }
 
   function showTakeover(takeovers, index) {
@@ -1468,7 +1464,6 @@
     var image = document.getElementById("takeover-image");
     var primaryUrl = document.getElementById("takeover-primary-url");
     var secondaryUrl = document.getElementById("takeover-secondary-url");
-    var get_ctas = document.getElementById("takeover-ctas").getElementsByTagName("p")[0];
     var takeoverAnimation = document.getElementsByClassName("p-takeover-animation")
 
     // Set values to homepage takeover
@@ -1489,23 +1484,24 @@
     title.textContent = selectedTakeover.title;
     subtitle.textContent = selectedTakeover.subtitle;
     image.src = selectedTakeover.image;
+    image.onload = function () {
+      // Remove animation delay
+      if (takeoverAnimation[0]) {
+        takeoverAnimation[0].className +=  " is-loaded";
+      }
+    }
+
     image.removeAttribute("style");
-    image.style.width = selectedTakeover.image_width;
-    image.style.height = selectedTakeover.image_height;
+    image.width = selectedTakeover.image_width;
+    image.height = selectedTakeover.image_height;
     primaryUrl.href = selectedTakeover.primary_url;
     primaryUrl.textContent = selectedTakeover.primary_cta;
     if (selectedTakeover.secondary_url && selectedTakeover.secondary_url !== "") {
       secondaryUrl.href = selectedTakeover.secondary_url;
-      secondaryUrl.textContent = selectedTakeover.secondary_cta + " ›";
+      secondaryUrl.innerHTML = selectedTakeover.secondary_cta + "&nbsp;&rsaquo;";
     } else {
       secondaryUrl.remove();
     }
-
-    // Remove animation delay
-    if (takeoverAnimation[0]) {
-      takeoverAnimation[0].className +=  " .is-loaded";
-    }
-    
   }
 </script>
 

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -8,10 +8,6 @@
 
 {% block outer_content %}
 {% block content %}
-<template class="u-hide">
-  {% block takeover_content %}
-  {% endblock takeover_content %}
-</template>
 
 <!-- Default Takeover: Download the latest Ubuntu -->
 <section data-lang="all" id="takeover" class="p-takeover--grad is-dark is-deep">

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1424,28 +1424,33 @@
 
     xhr.onreadystatechange = function() {
       if (xhr.readyState == XMLHttpRequest.DONE) {
-        var takeovers = JSON.parse(xhr.responseText);
+        if (xhr.status === 200) {
+          var takeovers = JSON.parse(xhr.responseText);
 
-        // Get the selected takeovers based on the primary language
-        var selectedTakeovers = takeovers.filter(function(item) {
-          return item.lang === primaryParentLanguage || item.lang === ""
-        })
+          // Get the selected takeovers based on the primary language
+          var selectedTakeovers = takeovers.filter(function(item) {
+            return item.lang === primaryParentLanguage || item.lang === ""
+          })
 
-        if (selectedTakeovers && selectedTakeovers.length > 0) {
-          var selectedIndex = null;
+          if (selectedTakeovers && selectedTakeovers.length > 0) {
+            var selectedIndex = null;
 
-          if (window.localStorage.getItem('selected_takeover_index') !== null) {
-            // If we previously visited a takeover, increment the number to show the next takeover
-            var nextIndex = parseInt(window.localStorage.getItem('selected_takeover_index')) + 1
-            selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
-          } else {
-            // Otherwise, randomly choose one of the takeovers and store it for next time
-            selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
+            if (window.localStorage.getItem('selected_takeover_index') !== null) {
+              // If we previously visited a takeover, increment the number to show the next takeover
+              var nextIndex = parseInt(window.localStorage.getItem('selected_takeover_index')) + 1
+              selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
+            } else {
+              // Otherwise, randomly choose one of the takeovers and store it for next time
+              selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
+            }
+            showTakeover(selectedTakeovers, selectedIndex);
+
+            // Store the current takeover index
+            localStorage.setItem('selected_takeover_index', selectedIndex)
           }
-          showTakeover(selectedTakeovers, selectedIndex);
-
-          // Store the current takeover index
-          localStorage.setItem('selected_takeover_index', selectedIndex)
+        } else {
+          takeoverAnimation.className = takeoverAnimation.className.replace(" is-loading", "");
+          takeoverAnimation.className +=  " is-loaded";
         }
       }
     };

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -15,21 +15,21 @@
 
 <!-- Default Takeover: Download the latest Ubuntu -->
 <section data-lang="all" id="takeover" class="p-takeover--grad is-dark is-deep">
-  <div class="row p-takeover-animation">
+  <div class="row p-takeover-animation" id="takeover-animaition">
     <div class="col-7 u-vertically-center">
       <h1 id="takeover-title">What's new in<br>Ubuntu {{ releases.latest.short_version }}?</h1>
       <h4 id="takeover-subtitle">Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds.</h4>
       <div id="takeover-ctas">
         <p><a id="takeover-primary-url" href="/download" class="p-button--positive">Get Ubuntu {{ releases.latest.short_version }}</a></p>
         <p>
-          <a id="takeover-secondary-url" href="/raspberry-pi" class=" p-link--inverted">
+          <a id="takeover-secondary-url" href="/raspberry-pi" class="p-link--inverted">
             Learn more about Ubuntu on the Raspberry Pi&nbsp;&rsaquo;
           </a>
         </p>
       </div>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-      <img id="takeover-image" src="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg" width="200" alt="" />
+      <img id="takeover-image" src="" width="200" alt="" />
     </div>
   </div>
 </section>
@@ -1405,6 +1405,7 @@
   }
 
   var baseTakeover = document.getElementById('takeover');
+  var takeoverAnimation = document.getElementById("takeover-animaition");
 
   if (window.localStorage && baseTakeover) {
     /**
@@ -1451,6 +1452,7 @@
 
     xhr.open("GET", "/takeovers.json", true);
     xhr.send();
+    takeoverAnimation.className +=  " is-loading";
   }
 
   function showTakeover(takeovers, index) {
@@ -1464,7 +1466,6 @@
     var image = document.getElementById("takeover-image");
     var primaryUrl = document.getElementById("takeover-primary-url");
     var secondaryUrl = document.getElementById("takeover-secondary-url");
-    var takeoverAnimation = document.getElementsByClassName("p-takeover-animation")
 
     // Set values to homepage takeover
     var selectedTakeover = takeovers[index];
@@ -1486,8 +1487,9 @@
     image.src = selectedTakeover.image;
     image.onload = function () {
       // Remove animation delay
-      if (takeoverAnimation[0]) {
-        takeoverAnimation[0].className +=  " is-loaded";
+      if (takeoverAnimation) {
+        takeoverAnimation.className = takeoverAnimation.className.replace(" is-loading", "");
+        takeoverAnimation.className +=  " is-loaded";
       }
     }
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -410,6 +410,7 @@ def build_takeovers_index(engage_pages):
 
 
 # app.add_url_rule("/", view_func=build_takeovers(engage_pages))
+app.add_url_rule("/takeovers.json", view_func=build_takeovers(engage_pages))
 app.add_url_rule("/takeovers", view_func=build_takeovers_index(engage_pages))
 engage_pages.init_app(app)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -370,42 +370,41 @@ engage_pages = EngagePages(
 app.add_url_rule(engage_path, view_func=build_engage_index(engage_pages))
 
 
-def build_takeovers(engage_pages):
-    def index_page():
-        engage_pages.parser.parse()
-
-        # Show only active
-        active_takeovers = [
-            takeover
-            for takeover in engage_pages.parser.takeovers
-            if takeover["active"] == "true"
-        ]
-        return flask.render_template("index.html", takeovers=active_takeovers)
-
-    return index_page
-
-
-def build_takeovers_index(engage_pages):
-    def takeover_index():
-        engage_pages.parser.parse()
-        sorted_takeovers = sorted(
-            engage_pages.parser.takeovers,
-            key=lambda takeover: takeover["publish_date"],
-            reverse=True,
-        )
-        active_takeovers = [
-            takeover
-            for takeover in engage_pages.parser.takeovers
-            if takeover["active"] == "true"
-        ]
-        active_count = len(active_takeovers)
-        hidden_count = len(sorted_takeovers) - active_count
+def get_takeovers(engage_pages, active=False):
+    engage_pages.parser.parse()
+    sorted_takeovers = sorted(
+        engage_pages.parser.takeovers,
+        key=lambda takeover: takeover["publish_date"],
+        reverse=True,
+    )
+    active_takeovers = [
+        takeover
+        for takeover in engage_pages.parser.takeovers
+        if takeover["active"] == "true"
+    ]
+    active_count = len(active_takeovers)
+    hidden_count = len(sorted_takeovers) - active_count
+    if active:
+        return flask.jsonify(active_takeovers)
+    else:
         return flask.render_template(
             "takeovers/index.html",
             active_count=active_count,
             hidden_count=hidden_count,
             takeovers=sorted_takeovers,
         )
+
+
+def build_takeovers(engage_pages):
+    def index_page():
+        return get_takeovers(engage_pages, True)
+
+    return index_page
+
+
+def build_takeovers_index(engage_pages):
+    def takeover_index():
+        return get_takeovers(engage_pages)
 
     return takeover_index
 


### PR DESCRIPTION
## Done

- Make sure Homepage doesn't go down if discourse APIs fail.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- To test robustness change the `/takeovers.json` endpoint to anything else, and you will see the default 20.04 takeover.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3615

