### PR TITLE
/advantage copy doc link update

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Ubuntu Advantage for Infrastructure{% endblock %}
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1AW8wQu1Uvq0xFtd_c2JwNdic075MPOTx7k2KHqFPPeo/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1K65n3NpZCh7EWDXKLhG31seGJ2jKbW6lqw3BwV2mlnU/edit#heading=h.nleu1cdig11l{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -2,6 +2,7 @@
 
 {% block title %}Ubuntu Advantage for Infrastructure{% endblock %}
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1K65n3NpZCh7EWDXKLhG31seGJ2jKbW6lqw3BwV2mlnU/edit#heading=h.vlvlt0gikzjy{% endblock meta_copydoc %}
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 


### PR DESCRIPTION
## Done

- Added a copy doc link for /advantage/subscribe.
- Updated the copy doc link for /advantage.

The text on /advantage varies depending on whether you are signed in, what kind of subscriptions you have, whether any of them are new, whether any have expired (or are about to), and so on.

If this was all spelled out in a separate copy doc, that document would become very similar to the relevant section of the design specification. More accurate just to link to the design spec. In the spec, UI text is in green to make it easier to find.

## QA

With the copy doc browser extension installed:
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View http://0.0.0.0:8001/advantage and http://0.0.0.0:8001/advantage/subscribe
- Follow the “copy document” link

## Issue / Card

none