### PR TITLE
Fix 12.04 esm date

### DIFF
--- a/scripts/create-releases.py
+++ b/scripts/create-releases.py
@@ -169,7 +169,7 @@ def load_releases():
             development=False,
             lts=True,
             release_date=datetime.strptime("2012-04-26", "%Y-%m-%d"),
-            esm_expires=datetime.strptime("2021-04-30", "%Y-%m-%d"),
+            esm_expires=datetime.strptime("2019-04-30", "%Y-%m-%d"),
             support_expires=datetime.strptime("2012-04-26", "%Y-%m-%d"),
         ),
         Release(

--- a/webapp/security/alembic/versions/0fe2f3a871da_update_release_12_04.py
+++ b/webapp/security/alembic/versions/0fe2f3a871da_update_release_12_04.py
@@ -1,0 +1,31 @@
+"""update-release-12-04
+
+Revision ID: 0fe2f3a871da
+Revises: 88f1398da6c1
+Create Date: 2021-01-15 15:15:19.145893
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0fe2f3a871da"
+down_revision = "88f1398da6c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE release "
+        "SET esm_expires='2019-04-30 00:00:00' "
+        "WHERE version='12.04';"
+    )
+
+
+def downgrade():
+    op.execute(
+        "UPDATE release "
+        "SET esm_expires='2021-04-30 00:00:00' "
+        "WHERE version='12.04';"
+    )


### PR DESCRIPTION
## Done

- Update 12.04 end of life date from 2021-04-30 to 2019-04-30.

## QA

- Don't fetch changes and go to http://0.0.0.0:8001/security/cve you will see the 12.04 in the table
- Fetch changes and go to http://0.0.0.0:8001/security/cve you will not see the 12.04 in the table

## Issue / Card

Fixes #9045 
