### PR TITLE
Replace text describing Landscape

### DIFF
--- a/templates/advantage/_ubuntu_version_select.html
+++ b/templates/advantage/_ubuntu_version_select.html
@@ -12,7 +12,7 @@
           <li class="p-tabs__item" role="presentation">
             <a id="focal-tab" href="#focal" class="p-tabs__link" role="tab" aria-controls="focal" aria-selected="true">20.04 LTS</a>
           </li>
-          
+
           <li class="p-tabs__item" role="presentation">
             <a id="bionic-tab" href="#bionic" class="p-tabs__link" role="tab" aria-controls="bionic">18.04 LTS</a>
           </li>
@@ -20,7 +20,7 @@
           <li class="p-tabs__item" role="presentation">
             <a id="xenial-tab" href="#xenial" class="p-tabs__link" role="tab" aria-controls="xenial">16.04 LTS</a>
           </li>
-          
+
           <li class="p-tabs__item" role="presentation">
             <a id="trusty-tab" href="#trusty" class="p-tabs__link" role="tab" aria-controls="trusty">14.04 LTS</a>
           </li>
@@ -43,7 +43,7 @@
             <div class="col-10">
               <ul class="p-list--ticked u-no-margin--left u-no-padding--left is-split">
                 <li class="p-list__item is-ticked">Kernel Livepatch to avoid unscheduled reboots</li>
-                <li class="p-list__item is-ticked">Landscape on-prem systems management</li>
+                <li class="p-list__item is-ticked">Ubuntu systems management with Landscape</li>
                 <li class="p-list__item is-ticked">Knowledge base access</li>
                 <li class="p-list__item is-ticked">Certified Windows drivers for KVM guests</li>
                 <li class="p-list__item is-ticked">CIS benchmark</li>
@@ -64,7 +64,7 @@
             <div class="col-10">
               <ul class="p-list--ticked u-no-margin--left u-no-padding--left is-split">
                 <li class="p-list__item is-ticked">Kernel Livepatch to avoid unscheduled reboots</li>
-                <li class="p-list__item is-ticked">Landscape on-prem systems management</li>
+                <li class="p-list__item is-ticked">Ubuntu systems management with Landscape</li>
                 <li class="p-list__item is-ticked">Knowledge base access</li>
                 <li class="p-list__item is-ticked">Certified Windows drivers for KVM guests</li>
                 <li class="p-list__item is-ticked">FIPS 140-2 Level 1 certified crypto modules</li>
@@ -87,7 +87,7 @@
             <div class="col-10">
               <ul class="p-list--ticked u-no-margin--left u-no-padding--left is-split">
                 <li class="p-list__item is-ticked">Kernel Livepatch to avoid unscheduled reboots</li>
-                <li class="p-list__item is-ticked">Landscape on-prem systems management</li>
+                <li class="p-list__item is-ticked">Ubuntu systems management with Landscape</li>
                 <li class="p-list__item is-ticked">Knowledge base access</li>
                 <li class="p-list__item is-ticked">Certified Windows drivers for KVM guests</li>
                 <li class="p-list__item is-ticked">FIPS 140-2 Level 1 certified crypto modules</li>
@@ -112,7 +112,7 @@
               <ul class="p-list--ticked u-no-margin--left u-no-padding--left is-split">
                 <li class="p-list__item is-ticked">Extended Security Maintenance (ESM) until 2022</li>
                 <li class="p-list__item is-ticked">Kernel Livepatch to avoid unscheduled reboots</li>
-                <li class="p-list__item is-ticked">Landscape on-prem systems management</li>
+                <li class="p-list__item is-ticked">Ubuntu systems management with Landscape</li>
                 <li class="p-list__item is-ticked">Knowledge base access</li>
                 <li class="p-list__item is-ticked">Certified Windows drivers for KVM guests</li>
                 <li class="p-list__item is-ticked">CIS benchmark</li>

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -672,7 +672,7 @@
           </tr>
 
           <tr>
-            <td><a href="https://landscape.canonical.com" class="p-link--external">Landscape</a> on-prem systems management</td>
+            <td>Ubuntu systems management with <a href="https://landscape.canonical.com" class="p-link--external">Landscape</a></td>
             <td class="u-align--center">{{
               image(
               url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg",

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -71,7 +71,7 @@
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
-          <td><a href="https://landscape.canonical.com/" class="p-link--external">Landscape</a> on-prem systems management</td>
+          <td>Ubuntu systems management with <a href="https://landscape.canonical.com" class="p-link--external">Landscape</a></td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>

--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -638,7 +638,7 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">Aggressive SLAs</li>
         <li class="p-list__item is-ticked">24/7 phone and ticket support</li>
-        <li class="p-list__item is-ticked">Landscape on-prem management system</li>
+        <li class="p-list__item is-ticked">Ubuntu systems management with Landscape</li>
         <li class="p-list__item is-ticked">Knowledgebase access</li>
         <li class="p-list__item is-ticked">Fully-managed service option</li>
       </ul>


### PR DESCRIPTION
## Done

- Replace text describing Landscape from 'Landscape on-prem management system' to either a version with a link or not of 'Ubuntu systems management with Landscape'
- 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/telco [copy doc](https://docs.google.com/document/d/15FY_IaT39V81FQcoSoEJpmRRjBX80PJ7uxjgzHnDDws/edit#heading=h.3nuxg1fpsqog)
    - http://0.0.0.0:8001/pricing/infra [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit)
    - http://0.0.0.0:8001/pricing/devices [copy doc](https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit#)
    - https://ubuntu.com/advantage/subscribe [copy doc](https://docs.google.com/document/d/1AW8wQu1Uvq0xFtd_c2JwNdic075MPOTx7k2KHqFPPeo/edit#)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the copy docs


## Issue / Card

Fixes #9030

