### PR TITLE
Exclude x-frame-options header for templatefinder

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -416,6 +416,7 @@ engage_pages.init_app(app)
 
 # All other routes
 template_finder_view = TemplateFinder.as_view("template_finder")
+template_finder_view._exclude_xframe_options_header = True
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/snaps", view_func=search_snaps)
 app.add_url_rule("/core/build", view_func=build)


### PR DESCRIPTION
The x-frame-options is primarily to protect us against clickjacking attacks against logged-in users.

(The attack would involve hiding an iframe of one of our sites behind a link or button on the attacker's site, and presenting that site to a user who is already logged in to our site. You could then trick the user into unknowingly clicking on a logged-in action on our site.)

However, the TemplateFinder pages are always static content, and so don't include any logged-in actions that could be exploited.

The x-frame-options header caused an issue where a PDF is supposed to include a frame of https://ubuntu.com/legal/ubuntu-advantage-service-terms. If we're too broad with x-frame-options we could well see further issues of the same type.

## QA

``` bash
$ curl -sI https://ubuntu-com-9052.demos.haus/advantage | grep -i x-frame  # Check /advantage still has x-frame-options
x-frame-options: SAMEORIGIN
$ curl -sI https://ubuntu-com-9052.demos.haus/ | grep -i x-frame    # Homepage does too
x-frame-options: SAMEORIGIN
$ curl -sI https://ubuntu-com-9052.demos.haus/legal/ubuntu-advantage-service-terms | grep -i x-frame  # But the legal page doesn't
$ 
```

