### PR TITLE
Focus quantity field when product is selected

### DIFF
--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -344,6 +344,7 @@ function productSelector() {
         } else {
           quantityTypeEl.innerHTML = `How many ${inputElement.dataset.productName}s?`;
           state.set(inputElement.name, [inputElement.value]);
+          focusQuantityField();
         }
 
         break;
@@ -439,6 +440,11 @@ function productSelector() {
     });
 
     input.closest(".p-card--radio").classList.add("is-selected");
+  }
+
+  function focusQuantityField() {
+    const quantityField = document.querySelector(".js-product-quantity");
+    quantityField.focus();
   }
 
   function setVersionTabs() {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -121,11 +121,11 @@
           </div>
         </div>
 
-        <div id="aws" class="col-12 u-hide js-public-cloud-info" style="background-color: #f7f7f7; padding: 1.5rem; margin-bottom: 1.5rem">
+        <div id="aws" class="col-12 u-hide js-public-cloud-info" style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem">
           <span>You can buy <a href="https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro" class="p-link--external">Ubuntu Pro on the AWS Marketplace</a> at an hourly, per-machine rate, with all UA software features included. If you need tech support as well, <a href="/support/contact-us">contact us</a>.</span>
         </div>
 
-        <div id="azure" class="col-12 u-hide js-public-cloud-info" style="background-color: #f7f7f7; padding: 1.5rem; margin-bottom: 1.5rem">
+        <div id="azure" class="col-12 u-hide js-public-cloud-info" style="background-color: #f7f7f7; margin-bottom: 1.5rem; padding: 1.5rem">
           <span>You can buy <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1" class="p-link--external">Ubuntu Pro on the Azure Marketplace</a> at an hourly, per-machine rate, with all UA software features included. If you need tech support as well, <a href="/support/contact-us">contact us</a>.</span>
         </div>
 
@@ -142,7 +142,7 @@
         </div>
 
         <div class="col-2">
-        <input autocomplete="off" class="js-product-input" type="number" name="quantity" placeholder="0" min="1" max="1000" step="1" data-stage="form" onwheel="this.blur()" pattern="\d+" />
+        <input autocomplete="off" class="js-product-input js-product-quantity shop-quantity-field" type="number" name="quantity" placeholder="0" min="1" max="1000" step="1" data-stage="form" onwheel="this.blur()" pattern="\d+" style="scroll-margin-bottom: 2rem;" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

Focus quantity field when option has been selected on the subscribe page

## QA

- Go to https://ubuntu-com-9055.demos.haus/advantage/subscribe
- Select either "Servers", "Other VMs", or "Desktops"
- Check that the page scrolls so the "How many ..." field is visible and that it is focused
- Select either "AWS" or "Microsoft Azure" and check that the page doesn't scroll or focus the "How many..." field


## Issue / Card

Fixes #8247 