### PR TITLE
Make cve table pretty

### DIFF
--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -104,6 +104,10 @@ tooltipIconList.forEach(function (tooltipIcon) {
         const priority = this.dataset.priority;
         const status = this.dataset.status;
 
+        if (!(priority in priorities) && !(status in statuses)) {
+          return;
+        }
+
         const tooltip = document.createElement("div");
         tooltip.classList.add("cve-tooltip");
 

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -36,24 +36,28 @@
   .cve-table .cve-table-cell {
     border-top: 0;
     overflow: visible;
-    padding-left: 0.75rem;
   }
 
   .cve-table .icon-cve-info {
     margin: 0;
     position: absolute !important;
     right: 0;
-    top: calc(0.5rem - 1px);
+    top: 6px;
   }
 
   .cve-table .icon-container__text {
     overflow: hidden;
     text-overflow: ellipsis;
+    width: 100%;
+  }
+
+  .cve-table-cell-priority .icon-container__text {
     width: calc(100% - 1.5rem);
   }
 
   .cve-table .p-icon--information {
-    opacity: 0.6;
+    background-color: #fff;
+    opacity: 0.8;
   }
 
   .cve-table-cell .p-icon--information {
@@ -71,9 +75,9 @@
     color: #111;
     padding: 10px;
     position: absolute;
-    top: 30px;
+    top: 27px;
     transform: translateX(-125px);
-    width: 275px;
+    width: 272px;
     z-index: 1;
   }
 
@@ -116,6 +120,16 @@
   .cve-tooltip .arrow-up.back {
     border-bottom: 10px solid #b0b0b0;
     top: -10px;
+  }
+
+  .cve-table-cell-priority {
+    @extend .cve-table-cell;
+
+    border-top: 1px solid $color-mid-light !important;
+  }
+
+  .capitalize {
+    text-transform: capitalize;
   }
 
   .cve-table-cell--muted,

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -1,13 +1,11 @@
 <table class="cve-table">
   <thead>
     <tr>
-      <th style="width: 12em">CVE</th>
+      <th style="width: 10em">ID</th>
+      <th>Priority</th>
       <th>Package</th>
       {% for release in releases %}
         <th>
-          <div class="icon-container__icon">
-            <i class="p-icon--placeholder"></i>
-          </div>
           <div class="icon-container__text">
             {{ release.version }} {{ release.support_tag }}
           </div>
@@ -20,7 +18,34 @@
       {% for package_name, statuses in cve.packages.items() %}
         <tr>
           {% if loop.index == 1 %}
-            <td rowspan="{{ cve.packages | length }}"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></td>
+            <td rowspan="{{ cve.packages | length }}">
+              <a href="/security/{{ cve.id }}">{{ cve.id }}</a>
+            </td>
+            <td class="cve-table-cell-priority" rowspan="{{ cve.packages | length }}">
+              <div class="icon-container__icon">
+                {% if cve.priority == 'unknown' %}
+                  <i class="p-icon--placeholder"></i>
+                {% elif cve.priority == 'negligible' %}
+                  <i class="p-icon--negligible-priority"></i>
+                {% elif cve.priority == 'low' %}
+                  <i class="p-icon--low-priority"></i>
+                {% elif cve.priority == 'medium' %}
+                  <i class="p-icon--medium-priority"></i>
+                {% elif cve.priority == 'high' %}
+                  <i class="p-icon--high-priority"></i>
+                {% elif cve.priority == 'critical' %}
+                  <i class="p-icon--critical-priority"></i>
+                {% else %}
+                  <i class="p-icon--placeholder"></i>
+                {% endif %}
+              </div>
+              <div class="icon-container__text">
+                <span class="capitalize">{{ cve.priority }}</span>
+              </div>
+              <div class="icon-container__icon icon-cve-info">
+                <i class="p-icon--information cve-tooltip-icon cve-tooltip-icon-priority" data-priority="{{ cve.priority }}"></i>
+              </div>
+            </td>
           {% endif %}
           <td>{{ package_name }}</td>
           {% for release in releases %}
@@ -43,27 +68,6 @@
               {% elif statuses[release.codename].status == "released" %}
                 <div class="cve-color-strip--released"></div>
               {% endif %}
-              <div class="icon-container__icon">
-                {% if statuses[release.codename].status == 'DNE' or statuses[release.codename].status == 'not-affected' %}
-                  <i class="p-icon--placeholder"></i>
-                {% else %}
-                  {% if cve.priority == 'unknown' %}
-                    <i class="p-icon--placeholder"></i>
-                  {% elif cve.priority == 'negligible' %}
-                    <i class="p-icon--negligible-priority"></i>
-                  {% elif cve.priority == 'low' %}
-                    <i class="p-icon--low-priority"></i>
-                  {% elif cve.priority == 'medium' %}
-                    <i class="p-icon--medium-priority"></i>
-                  {% elif cve.priority == 'high' %}
-                    <i class="p-icon--high-priority"></i>
-                  {% elif cve.priority == 'critical' %}
-                    <i class="p-icon--critical-priority"></i>
-                  {% else %}
-                    <i class="p-icon--placeholder"></i>
-                  {% endif %}
-                {% endif %}
-              </div>
               <div class="icon-container__text">
                 {% if statuses[release.codename].status == "DNE" %}
                   Does not exist
@@ -84,28 +88,27 @@
                 {% else %}
                   &mdash;
                 {% endif %}
-                <br>
-                <small class="cve-table-cell esm-info">
-                  {% if statuses[release.codename].pocket == "esm-infra" %}
-                    <a href="/advantage" target="_blank">UA Infra/Apps</a>
-                  {% endif %}
-                  {% if statuses[release.codename].pocket == "esm-apps" %}
-                    <a href="/advantage" target="_blank">UA Apps</a>
-                  {% endif %}
-                </small>
+                {% if statuses[release.codename].pocket != "esm-infra" and statuses[release.codename].pocket == "esm-apps" %}
+                  <small class="cve-table-cell esm-info">
+                    {% if statuses[release.codename].pocket == "esm-infra" %}
+                      <a href="/advantage" target="_blank">UA Infra/Apps</a>
+                    {% endif %}
+                    {% if statuses[release.codename].pocket == "esm-apps" %}
+                      <a href="/advantage" target="_blank">UA Apps</a>
+                    {% endif %}
+                  </small>
+                {% endif %}
               </div>
               <div class="icon-container__icon icon-cve-info">
-                {% if statuses[release.codename].status != 'DNE'%}
-                  <i class="p-icon--information cve-tooltip-icon" data-status="{{ statuses[release.codename].status }}" data-priority="{{ cve.priority }}"></i>
+                {% if statuses[release.codename].status == 'pending' or statuses[release.codename].status == "not-affected" %}
+                  <i class="p-icon--information cve-tooltip-icon cve-tooltip-status" data-status="{{ statuses[release.codename].status }}"></i>
                 {% endif %}
               </div>
             </td>
             {% else %}
               <td class="cve-table-cell--muted">
                 <div class="cve-color-strip--dne"></div>
-                <div class="u-align--center">
-                  &mdash;
-                </div>
+                &mdash;
               </td>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
## Done

- Make cve table pretty.

## QA

- Fetch changes
- Go to http://0.0.0.0:8001/security/cve and look at the table
- Table should have an extra column called priority. If you hover the cell you will see a tool tip with details about the priority.
- Status cells no longer display priority like https://ubuntu.com/security/cve currently does
- Status cells tooltips no longer display priority details. Only `Not vulnerable` and `Pending` have tooltips now.
- Status text will only be listed on one single line


## Issue / Card

Fixes #9057 
