### PR TITLE
Disable entire payment form whilst submitting

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -499,15 +499,33 @@ function createPaymentMethod() {
 }
 
 function disableProcessingState() {
+  const formInputs = form.querySelectorAll("input");
+  const formSelects = form.querySelectorAll("select");
+  const cardInput = document.getElementById("card-element");
+
   clearProgressTimers();
   resetProgressIndicator();
+
+  formInputs.forEach((input) => (input.disabled = false));
+  formSelects.forEach((select) => (select.disabled = false));
   cancelModalButton.disabled = false;
+  cardInput.classList.remove("u-disabled");
+
+  handleNameFieldRadio();
 }
 
 function enableProcessingState(mode) {
+  const formInputs = form.querySelectorAll("input");
+  const formSelects = form.querySelectorAll("select");
+  const cardField = document.getElementById("card-element");
+
   addPaymentMethodButton.disabled = true;
   cancelModalButton.disabled = true;
   processPaymentButton.disabled = true;
+
+  formInputs.forEach((input) => (input.disabled = true));
+  formSelects.forEach((select) => (select.disabled = true));
+  cardField.classList.add("u-disabled");
 
   // show a progress indicator that evolves over time
   progressTimer = setTimeout(() => {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -857,3 +857,8 @@ body {
     animation-delay: 500s !important;
   }
 }
+
+.u-disabled {
+  cursor: not-allowed;
+  opacity: 0.33;
+}


### PR DESCRIPTION
## Done

Disable entire payment form whilst submitting

## QA

- Go to https://ubuntu-com-9058.demos.haus/advantage/subscribe
- Select "Servers", type a number in the "How many..." field and select "No thanks" under "Do you want tech support?"
- Click the "Add" button
- Click "Buy now"
- Fill out the form with card number `4242 4242 4242 4242`, expiry date `04/24`, CVC `242` and make up a postcode
- Fill out the rest of the form with dummy information
- Click "Continue" and check that all the form fields are disabled whilst the form is submitting
- This form will fail, check that the all the form fields that should be, are enabled


## Issue / Card

Fixes #8319