### PR TITLE
Enable CVE in /security subnav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1385,9 +1385,8 @@ security:
       path: /security/certifications#cis
     - title: Certifications
       path: /security/certifications
-    # Hidden for soft launch
-    # - title: CVEs
-    # path: /security/cve
+    - title: CVEs
+      path: /security/cve
     - title: Notices
       path: /security/notices
       persist: True


### PR DESCRIPTION
Enable CVE in /security subnav. It's time. This has been the official CVE portal for a while now.

Fixes #7301

## QA

Go to https://ubuntu-com-9067.demos.haus/security. See "CVEs" in nav.

![image](https://user-images.githubusercontent.com/519935/105383140-b4ef2f80-5c08-11eb-9475-151b8f36b4ac.png)

Click it, check it works (CVE section will be empty).
 