### PR TITLE
Add pricing and what's including headings to all pricing tables and Landscape row on /advantage

### DIFF
--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -35,6 +35,12 @@
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
         </tr>
+        <tr>
+          <td>Ubuntu systems management with <a href="https://landscape.canonical.com" class="p-link--external">Landscape</a></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
+          <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
+        </tr>
         <tr id="kvm-guests">
           <td>Certified Windows drivers for KVM guests</td>
           <td class="u-align--center"><img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes" width="16" height="16"></td>
@@ -72,19 +78,19 @@
           <td class="u-align--center">Updates + support</td>
         </tr>
         <tr>
-          <td>Physical server</td>
+          <td>Physical server / year</td>
           <td class="u-align--center">$225</td>
           <td class="u-align--center">$750</td>
           <td class="u-align--center">$1,500</td>
         </tr>
         <tr>
-          <td>Virtual server</td>
+          <td>Virtual server / year</td>
           <td class="u-align--center">$75</td>
           <td class="u-align--center">$250</td>
           <td class="u-align--center">$500</td>
         </tr>
         <tr>
-          <td>Desktop</td>
+          <td>Desktop / year</td>
           <td class="u-align--center">$25</td>
           <td class="u-align--center">$150</td>
           <td class="u-align--center">$300</td>

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -10,7 +10,7 @@
           <th class="u-align--center">Advanced</th>
         </tr>
           <tr>
-            <th colspan="4" style="background-color: #efefef; padding: .75rem;"><strong>What's included</strong></th>
+            <th colspan="4" style="background-color: #f7f7f7; padding: .75rem;"><strong>What's included</strong></th>
           </tr>
         </thead>
       <tbody>
@@ -83,7 +83,7 @@
       </tbody>
       <thead>
         <tr>
-          <th colspan="4" style="background-color: #efefef; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Price per year</strong></th>
+          <th colspan="4" style="background-color: #f7f7f7; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Price per year</strong></th>
         </tr>
       </thead>
       <tbody>

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -4,12 +4,15 @@
     <table class="p-table advantage-table">
       <thead>
         <tr>
-          <th><strong>What's included</strong></th>
+          <th>&nbsp;</th>
           <th class="u-align--center">Essential</th>
           <th class="u-align--center">Standard</th>
           <th class="u-align--center">Advanced</th>
         </tr>
-      </thead>
+          <tr>
+            <th colspan="4" style="background-color: #efefef; padding: .75rem;"><strong>What's included</strong></th>
+          </tr>
+        </thead>
       <tbody>
         <tr id="esm">
           <td><a href="/esm">Extended Security Maintenance</a> (ESM) for Ubuntu 14.04 LTS</td>
@@ -77,20 +80,27 @@
           <td class="u-align--center">Updates + support</td>
           <td class="u-align--center">Updates + support</td>
         </tr>
+      </tbody>
+      <thead>
         <tr>
-          <td>Physical server / year</td>
+          <th colspan="4" style="background-color: #efefef; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Price per year</strong></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Physical server</td>
           <td class="u-align--center">$225</td>
           <td class="u-align--center">$750</td>
           <td class="u-align--center">$1,500</td>
         </tr>
         <tr>
-          <td>Virtual server / year</td>
+          <td>Virtual server</td>
           <td class="u-align--center">$75</td>
           <td class="u-align--center">$250</td>
           <td class="u-align--center">$500</td>
         </tr>
         <tr>
-          <td>Desktop / year</td>
+          <td>Desktop</td>
           <td class="u-align--center">$25</td>
           <td class="u-align--center">$150</td>
           <td class="u-align--center">$300</td>

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -24,7 +24,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-shallow" id="ua-infra">
+<section class="p-strip is-shallow" id="ua-infra">
   <div class="u-fixed-width">
     <h3>Security maintenance and support</h3>
   </div>
@@ -39,7 +39,7 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow" id="storage">
+<section class="p-strip--light is-shallow" id="storage">
   <div class="u-fixed-width">
     <h3>Software-defined storage - Ceph and Swift</h3>
     <p>Only applies if attaching more than 72TB of raw Ceph/SWIFT disks per node in the cluster. Priced by the amount exceeding the total of 72TB per node included in UA.</p>
@@ -51,7 +51,7 @@
 
 </section>
 
-<section class="p-strip--light is-shallow" id="managed">
+<section class="p-strip is-shallow" id="managed">
   <div class="u-fixed-width">
     <h3>Fully managed OpenStack, Kubernetes and LMA</h3>
     <p>We manage infrastructure at both the host and the guest level. Infrastructure includes Ceph and SWIFT storage, Kubernetes, OpenStack and the recommended logging, monitoring and alerting stack.</p>
@@ -62,7 +62,7 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered is-shallow">
+<section class="p-strip--light is-bordered is-shallow">
   <div class="u-fixed-width">
     <h3 id="maas">MAAS</h3>
     <p>Support and commercial capabilities for MAAS are included with Ubuntu Advantage for Infrastructure. These additional charges apply for machines managed by MAAS and <em>not</em> covered by a UA Infrastructure contract.</p>
@@ -75,7 +75,7 @@
   </div>
 </section>
 
-{% with colour="light", border="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
+{% with colour="white", border="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
 
 
 <!-- Set default Marketo information for contact form below-->

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -8,56 +8,73 @@
           <th width="200" class="u-align--center">Standard</th>
           <th width="200" class="u-align--center">Advanced</th>
         </tr>
+        <tr>
+          <th colspan="4" style="background-color: #efefef; padding: .75rem;"><strong>Price per year</strong></th>
+        </tr>
       </thead>
       <tbody>
         <tr>
-          <td>Physical server / year</td>
+          <td>Physical server</td>
           <td class="u-align--center">$225</td>
           <td class="u-align--center">$750</td>
           <td class="u-align--center">$1,500</td>
         </tr>
         <tr>
-          <td>Virtual server / year</td>
+          <td>Virtual server</td>
           <td class="u-align--center">$75</td>
           <td class="u-align--center">$250</td>
           <td class="u-align--center">$500</td>
         </tr>
         <tr>
-          <td>Desktop / year</td>
+          <td>Desktop</td>
           <td class="u-align--center">$25</td>
           <td class="u-align--center">$150</td>
           <td class="u-align--center">$300</td>
         </tr>
-        <tr style="background-color: #e5e5e5">
+      </tbody>
+      <thead>
+        <tr>
+          <th colspan="4" style="background-color: #efefef; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Service level</strong></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
           <td>Phone and ticket support</td>
           <td class="u-align--center">No</td>
           <td class="u-align--center">24x5</td>
           <td class="u-align--center">24x7</td>
         </tr>
-        <tr style="background-color: #e5e5e5">
+        <tr>
           <td>Initial response time SLA - Sev 1</td>
           <td class="u-align--center">&ndash;</td>
           <td class="u-align--center">4 hours</td>
           <td class="u-align--center">1 hour</td>
         </tr>
-        <tr style="background-color: #e5e5e5">
+        <tr>
           <td>Initial response time SLA - Sev 2</td>
           <td class="u-align--center">&ndash;</td>
           <td class="u-align--center">8 business hours</td>
           <td class="u-align--center">2 hours</td>
         </tr>
-        <tr style="background-color: #e5e5e5">
+        <tr>
           <td>Initial response time SLA - Sev 3</td>
           <td class="u-align--center">&ndash;</td>
           <td class="u-align--center">12 business hours</td>
           <td class="u-align--center">6 hours</td>
         </tr>
-        <tr style="background-color: #e5e5e5">
+        <tr>
           <td>Initial response time SLA - Sev 4</td>
           <td class="u-align--center">&ndash;</td>
           <td class="u-align--center">24 business hours</td>
           <td class="u-align--center">12 hours</td>
         </tr>
+        </tbody>
+        <thead>
+          <tr>
+            <th colspan="4" style="background-color: #efefef; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>What's included</strong></th>
+          </tr>
+        </thead>
+        <tbody>
         <tr>
           <td><a href="/esm">Extended Security Maintenance</a> (ESM)</td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -11,19 +11,19 @@
       </thead>
       <tbody>
         <tr>
-          <td>Physical server</td>
+          <td>Physical server / year</td>
           <td class="u-align--center">$225</td>
           <td class="u-align--center">$750</td>
           <td class="u-align--center">$1,500</td>
         </tr>
         <tr>
-          <td>Virtual server</td>
+          <td>Virtual server / year</td>
           <td class="u-align--center">$75</td>
           <td class="u-align--center">$250</td>
           <td class="u-align--center">$500</td>
         </tr>
         <tr>
-          <td>Desktop</td>
+          <td>Desktop / year</td>
           <td class="u-align--center">$25</td>
           <td class="u-align--center">$150</td>
           <td class="u-align--center">$300</td>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -9,7 +9,7 @@
           <th width="200" class="u-align--center">Advanced</th>
         </tr>
         <tr>
-          <th colspan="4" style="background-color: #efefef; padding: .75rem;"><strong>Price per year</strong></th>
+          <th colspan="4" style="background-color: #f7f7f7; padding: .75rem;"><strong>Price per year</strong></th>
         </tr>
       </thead>
       <tbody>
@@ -34,7 +34,7 @@
       </tbody>
       <thead>
         <tr>
-          <th colspan="4" style="background-color: #efefef; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Service level</strong></th>
+          <th colspan="4" style="background-color: #f7f7f7; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Service level</strong></th>
         </tr>
       </thead>
       <tbody>
@@ -71,7 +71,7 @@
         </tbody>
         <thead>
           <tr>
-            <th colspan="4" style="background-color: #efefef; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>What's included</strong></th>
+            <th colspan="4" style="background-color: #f7f7f7; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>What's included</strong></th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Done

- Add 'Pricing per year' and 'What's included' heading rows to all pricing tables 
- Add Landscape row on /advantage
- Updated /uasd copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - http://0.0.0.0:8001/advantage
    - http://0.0.0.0:8001/pricing/infra
    - http://0.0.0.0:8001/legal/ubuntu-advantage-service-description
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all tables have ' / year' added to the pricing row per #8932 
- See that /advantage has a row for landscape added


## Issue / Card

Fixes #8932 and #9065

## Screenshots

![image](https://user-images.githubusercontent.com/441217/105688742-dd6d7700-5ef1-11eb-807d-f9769893b126.png)

