### PR TITLE
Added missing instruction to WSL page

### DIFF
--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -195,6 +195,10 @@
           </p>
           <pre><code>dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart</code></pre>
           <p>
+            Type the following command to enable WSL 2:
+          </p>
+          <pre><code>dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart</code></pre>
+          <p>
             Restart your computer.
           </p>
           <pre><code>Restart-Computer</code></pre>


### PR DESCRIPTION
Added; 
Type the following command to enable WSL 2:
dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart

As per the [copy doc](https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit#).

## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Accept comment in copy doc if correct.

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
