### PR TITLE
fix appliance regex

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,7 +44,7 @@ from webapp.views import (
     BlogSitemapPage,
     build,
     build_tutorials_index,
-    download_harness,
+    download_server_steps,
     download_thank_you,
     appliance_install,
     appliance_portfolio,
@@ -236,9 +236,9 @@ app.add_url_rule(
 )
 
 app.add_url_rule(
-    "/download/<regex('server'):category>",
+    "/download/server",
     methods=["GET", "POST"],
-    view_func=download_harness,
+    view_func=download_server_steps,
 )
 
 app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -246,7 +246,10 @@ app.add_url_rule(
     "/search", "search", build_search_view(template_path="search.html")
 )
 app.add_url_rule(
-    "/appliance/<regex('.+'):app>/<regex('.+'):device>",
+    (
+        "/appliance/<regex('[a-z-]+'):appliance>/"
+        "<regex('(raspberry-pi2?|intel-nuc|vm)'):device>"
+    ),
     view_func=appliance_install,
 )
 app.add_url_rule(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -114,14 +114,14 @@ def download_thank_you(category):
     )
 
 
-def appliance_install(app, device):
+def appliance_install(appliance, device):
     with open("appliances.yaml") as appliances:
         appliances = yaml.load(appliances, Loader=yaml.FullLoader)
 
     return flask.render_template(
-        f"appliance/{app}/{device}.html",
+        f"appliance/{appliance}/{device}.html",
         http_host=flask.request.host,
-        appliance=appliances["appliances"][app],
+        appliance=appliances["appliances"][appliance],
     )
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -69,12 +69,12 @@ def _build_mirror_list():
     return mirror_list
 
 
-def download_harness(category):
+def download_server_steps():
     templates = {
-        "step1": f"download/{category}/step1.html",
-        "step2": f"download/{category}/step2.html",
-        "choose": f"download/{category}/choose.html",
-        "download": f"download/{category}/download.html",
+        "step1": "download/server/step1.html",
+        "step2": "download/server/step2.html",
+        "choose": "download/server/choose.html",
+        "download": "download/server/download.html",
     }
     context = {}
     step = "step1"


### PR DESCRIPTION
Make appliance URL regex more specific

To avoid error when people request invalid URLs e.g. https://ubuntu.com/appliance/docs/distribution/tour_page1.htm, and show a 404 instead.

See https://sentry.is.canonical.com/canonical/ubuntu-com/issues/10662/.

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9028

Also did a drive-by tidy of server steps code.

## QA

- [ ] Go to https://ubuntu-com-9070.demos.haus/appliance, click through to each appliance and then each device download page. Check they all work.
- [ ] Go to e.g. https://ubuntu-com-9070.demos.haus/appliance/docs/distribution/tour_page1.htm, check you get a 404, not a 500.
- [ ] Go to https://ubuntu-com-9070.demos.haus/server/download, check the journey still works.