### PR TITLE
Fix index takeovers count

### DIFF
--- a/templates/takeovers/index.html
+++ b/templates/takeovers/index.html
@@ -10,10 +10,10 @@
   <div class="row">
     <ul class="p-inline-list u-no-margin--bottom">
       <li class="p-inline-list__item">
-        Active takeovers: <strong>{{ len(takeovers["active"]) }}</strong>
+        Active takeovers: <strong>{{ takeovers["active"] | length }}</strong>
       </li>
       <li class="p-inline-list__item">
-        Hidden takeovers: <strong>{{ len(takeovers["sorted"]) - len(takeovers["active"]) }}</strong>
+        Hidden takeovers: <strong>{{ (takeovers["sorted"] | length) - (takeovers["active"] | length) }}</strong>
       </li>
     </ul>
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -404,7 +404,7 @@ def takeovers_json():
 
 
 def takeovers_index():
-    takeovers = get_takeovers(engage_pages)
+    takeovers = get_takeovers()
 
     return flask.render_template(
         "takeovers/index.html",


### PR DESCRIPTION
## Done

Fix takeovers index template

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers

## Issue / Card

Fixes #9073
