### PR TITLE
Send a GA impression event when displaying a takeover

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -139,7 +139,6 @@ function addGAContentEvents(target) {
   }
 }
 
-addGAImpressionEvents(".js-takeover", "takeover");
 addGAImpressionEvents(".js-product-card", "product-card");
 
 function addGAImpressionEvents(target, category) {

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1505,6 +1505,14 @@
     } else {
       secondaryUrl.remove();
     }
+
+    dataLayer.push({
+      event: "NonInteractiveGAEvent",
+      eventCategory: "www.ubuntu.com-impression-takeover",
+      eventAction: "from:" + window.location.href + " to:" + selectedTakeover.primary_url,
+      eventLabel: selectedTakeover.primary_cta,
+      eventValue: undefined,
+    });
   }
 </script>
 


### PR DESCRIPTION
## Done
Send a GA impression event when displaying a takeover
@caldav can you confirm you are happy with the structure of the event. I couldn't find any "www.ubuntu.com-impression-takeover" events in GA.

## QA
- Check out the demo link
- In the network tab see a GA event is triggered when the takeover is displayed

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9075

