### PR TITLE
Fix squashed passed badge from badgr issue

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -205,20 +205,14 @@
             </div>
           </td>
           <td aria-label="Badge" class="u-no-padding--left u-no-padding--right">
-            {% if module.status == "passed" %}
               <img
                 class="p-table--cube__badge"
                 src="{{ module.badge.url }}"
                 alt="Badge for {{ module.name }}"
+                {% if module.status == 'passed' %}
                 style="margin-left: -0.2rem;"
+                {% endif %}
               />
-            {% else %}
-              <img
-                class="p-table--cube__badge"
-                src="{{ module.badge.url }}"
-                alt="Badge for {{ module.name }}"
-              />
-            {% endif %}
           </td>
           <td aria-label="Module">
             <div class="p-table--cube__contents">

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -143,11 +143,12 @@
               <p class="u-text--muted">{{ loop.index }}</p>
             </div>
           </td>
-          <td class="u-hide--small" aria-label="Badge">
+          <td class="u-hide--small u-no-padding--left u-no-padding--right" aria-label="Badge">
               <img 
                 src="{{ module.badge.url }}"
                 alt="Badge for {{ module.name }}"
-              />
+                style="margin-left: -0.2rem;"
+              >
           </td>
           <td aria-label="Module">
             <div class="p-table--cube__contents">
@@ -203,12 +204,21 @@
               <p class="u-text--muted">{{ loop.index }}</p>
             </div>
           </td>
-          <td aria-label="Badge">
+          <td aria-label="Badge" class="u-no-padding--left u-no-padding--right">
+            {% if module.status == "passed" %}
+              <img
+                class="p-table--cube__badge"
+                src="{{ module.badge.url }}"
+                alt="Badge for {{ module.name }}"
+                style="margin-left: -0.2rem;"
+              />
+            {% else %}
               <img
                 class="p-table--cube__badge"
                 src="{{ module.badge.url }}"
                 alt="Badge for {{ module.name }}"
               />
+            {% endif %}
           </td>
           <td aria-label="Module">
             <div class="p-table--cube__contents">


### PR DESCRIPTION
## Issue

Passed microcert badge received from badger was squashed 

## Done

- Fix size and position of passed badge to line up with not yet passed badges 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- Check the passed badge is the correct shape and lines up with the not yet passed badges


## Screenshots

![image](https://user-images.githubusercontent.com/58959073/105521961-88a0e500-5cd4-11eb-8a25-3a58b2b7b14b.png)

