### PR TITLE
K8sDocs: update store link for coredns

### DIFF
--- a/templates/kubernetes/docs/cdk-addons.md
+++ b/templates/kubernetes/docs/cdk-addons.md
@@ -157,4 +157,4 @@ a Prometheus/Grafana/Telegraf stack in the [monitoring docs][].
 [GPU workers page]: /kubernetes/docs/gpu-workers
 [LDAP and Keystone page]: /kubernetes/docs/ldap
 [monitoring docs]: /kubernetes/docs/monitoring
-[coredns-charm]: /kubernetes/docs/charm-coredns
+[coredns-charm]: https://jaas.ai/u/containers/coredns


### PR DESCRIPTION
## Done

Update a 404 to point to the store for coredns

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes charmed-kubernetes/kubernetes-docs#524

