### PR TITLE
Clarifies description of community support sources

### DIFF
--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -30,7 +30,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <h3><a href="https://discourse.ubuntu.com/t/community-support/709" class="p-link--external">Find community support</a></h3>
-      <p><a href="https://askubuntu.com/" class="p-link--external">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimizing Ubuntu. And if you want to speak with the Ubuntu Community directly, try one of these <a href="https://wiki.ubuntu.com/IRC/ChannelList" class="p-link--external">IRC channels</a> or our <a href="https://discourse.ubuntu.com/" class="p-link--external">discourse site</a>.</p>
+      <p><a href="https://askubuntu.com/" class="p-link--external">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimizing Ubuntu. For more info on support forums, including IRC channels, see <a href="https://discourse.ubuntu.com/t/community-support/709" class="p-link--external">our Discourse site</a>.</p>
     </div>
     <div class="col-4 p-card">
       <h3><a href="https://help.ubuntu.com/" class="p-link--external">Read the docs</a></h3>


### PR DESCRIPTION
## Done

- Removes the implication that Discourse is a support forum
- Links to a more complete list of support forums
- As a bonus, shortens the “Find community support” section to more closely match the other cards

[Copy doc updated](https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support/community-support
- Read the “Find community support” card

## Issue / Card

Fixes #8654.

## Screenshots

![image](https://user-images.githubusercontent.com/19801137/105686341-06d8d380-5eef-11eb-8597-385251158831.png)