### PR TITLE
K8sdocs: add warning about juju/lxd bug

### DIFF
--- a/templates/kubernetes/docs/1.19/upgrading.md
+++ b/templates/kubernetes/docs/1.19/upgrading.md
@@ -44,7 +44,7 @@ You should also make sure:
 -   Your cluster is running normally
 -   You read the [Upgrade notes][notes] to see if any caveats apply to the versions you are upgrading to/from
 -   You read the [Release notes][release-notes] for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster
--   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.19 which may impact your workloads.
+-   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.19 which may impact your workloads. 
 
 ## Infrastructure updates
 
@@ -252,7 +252,7 @@ juju scp kubernetes-master/0:config ~/.kube/config
 Verify secrets have been created for expected users:
 
 ```bash
-juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get secrets'
+juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get secrets -n kube-system --field-selector type=juju.is/token-auth'
 ```
 
 Minimally, secrets for the following users should be listed:

--- a/templates/kubernetes/docs/1.20/upgrading.md
+++ b/templates/kubernetes/docs/1.20/upgrading.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "kubernetes/docs/base_docs.html"
+wrapper_template: "templates/docs/markdown.html"
 markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:

--- a/templates/kubernetes/docs/1.20/upgrading.md
+++ b/templates/kubernetes/docs/1.20/upgrading.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "templates/docs/markdown.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
@@ -26,6 +26,18 @@ This page describes the general upgrade process. It is important to follow the s
 </div>
 
 <!-- END OF UPGRADE VERSIONS-->
+
+<div class="p-notification--caution">
+  <p markdown="1" class="p-notification__response">
+    <span class="p-notification__status">Caution:</span>
+There is a known issue 
+<a href="https://bugs.launchpad.net/juju/+bug/1904619"> (https://bugs.launchpad.net/juju/+bug/1904619)</a>
+with container profiles not surviving an upgrade when deploying applications to LXD. If your 
+container-based applications fail to work properly after an upgrade, or you use the Juju `localhost` cloud,
+ please see this 
+<a href="/kubernetes/docs/troubleshooting#lxd"> topic on the troubleshooting page</a>
+  </p>
+</div>
 
 
 

--- a/templates/kubernetes/docs/troubleshooting.md
+++ b/templates/kubernetes/docs/troubleshooting.md
@@ -115,7 +115,6 @@ Running the `juju-crashdump` script will generate a tarball of debug information
 
 ## Common Problems
 
-<a id="lxd"> </a>
 ### Charms deployed to LXD containers fail after upgrade/reboot
 
 For deployments using Juju's `localhost` cloud, which deploys charms to LXD/LXC containers, or other 

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -19,6 +19,11 @@ The notes are organised according to the upgrade path below, but also be aware t
 upgrade that spans more than one minor version may need to beware of notes in
 any of the intervening steps.
 
+## Upgrades to all versions deployed to Juju's `localhost` LXD based cloud
+
+There is a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
+with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#lxd)
+
 <a  id="1.19"> </a>
 
 ## Upgrading to 1.19

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -22,7 +22,7 @@ any of the intervening steps.
 ## Upgrades to all versions deployed to Juju's `localhost` LXD based cloud
 
 There is a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
-with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#lxd)
+with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#charms-deployed-to-lxd-containers-fail-after-upgradereboot)
 
 <a  id="1.19"> </a>
 

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -19,9 +19,9 @@ toc: False
   <p markdown="1" class="p-notification__response">
     <span class="p-notification__status">Note:</span>
 This page describes the general upgrade process. It is important to follow the specific upgrade pages for each release, as these may include additional steps and workarounds for safely upgrading. <br><br>
+<a class='p-button--brand' href='/kubernetes/docs/1.20/upgrading'>Upgrade to 1.20 </a>
 <a class='p-button--brand' href='/kubernetes/docs/1.19/upgrading'>Upgrade to 1.19 </a>
 <a class='p-button--brand' href='/kubernetes/docs/1.18/upgrading'>Upgrade to 1.18 </a>
-<a class='p-button--brand' href='/kubernetes/docs/1.17/upgrading'>Upgrade to 1.17 </a>
   </p>
 </div>
 


### PR DESCRIPTION
## Done

- Adds a note on upgrade pages re Juju bug with LXD
-  Adds troubleshooting section for fixing LXD profiles

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)



