### PR TITLE
Fix dependency conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ marshmallow==3.10.0
 mistune==0.8.4
 psycopg2-binary==2.8.6
 pyyaml==5.3.1
-ubuntu-release-info==20.2
+ubuntu-release-info==21.1
 launchpadlib==1.10.13
 macaroonbakery==1.3.1
 sortedcontainers==2.3.0


### PR DESCRIPTION
Upgrade ubuntu-release-info to 21.1, which loosens dependencies
so they no longer conflict.

See https://github.com/powersj/ubuntu-release-info/issues/4

## QA

``` bash
dotrun exec pip3 install --upgrade pip  # Get on pip 21
dotrun install  # See install succeed
```