### PR TITLE
Fix badge alignment on mobile view

### DIFF
--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -116,7 +116,7 @@
     justify-content: flex-start;
     padding-top: 0 !important;
 
-    > img {
+    > .p-table--cube__badge {
       align-self: center !important;
     }
   }

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -105,6 +105,13 @@
   }
 }
 
+.p-table--cube__badge-column {
+  @media only screen and (min-width: $breakpoint-medium) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
 .p-table--cube__badge {
   @media only screen and (max-width: $breakpoint-medium) {
     margin-top: -0.4rem !important;

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -110,11 +110,15 @@
     padding-left: 0;
     padding-right: 0;
   }
-}
-
-.p-table--cube__badge {
   @media only screen and (max-width: $breakpoint-medium) {
-    margin-top: -0.4rem !important;
+    align-items: center !important;
+    display: grid;
+    justify-content: flex-start;
+    padding-top: 0 !important;
+
+    > img {
+      align-self: center !important;
+    }
   }
 }
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -204,7 +204,7 @@
               <p class="u-text--muted">{{ loop.index }}</p>
             </div>
           </td>
-          <td aria-label="Badge" class="u-no-padding--left u-no-padding--right">
+          <td class="p-table--cube__badge-column" aria-label="Badge">
               <img
                 class="p-table--cube__badge"
                 src="{{ module.badge.url }}"

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -206,6 +206,7 @@
           </td>
           <td class="p-table--cube__badge-column" aria-label="Badge">
               <img
+                class="p-table--cube__badge"
                 src="{{ module.badge.url }}"
                 alt="Badge for {{ module.name }}"
                 {% if module.status == 'passed' %}

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -199,14 +199,13 @@
       <tbody>
       {% for module in modules %}
         <tr>
-          <td aria-label="Module number">
+          <td class="u-vertically-center" aria-label="Module number">
             <div class="p-table--cube__contents">
-              <p class="u-text--muted">{{ loop.index }}</p>
+              <p class="u-text--muted" style="margin-bottom: auto; margin-top: auto;" >{{ loop.index }}</p>
             </div>
           </td>
           <td class="p-table--cube__badge-column" aria-label="Badge">
               <img
-                class="p-table--cube__badge"
                 src="{{ module.badge.url }}"
                 alt="Badge for {{ module.name }}"
                 {% if module.status == 'passed' %}


### PR DESCRIPTION
## Done

- Add a new class for the badge column so the badge lines up correctly in mobile view

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- Check the badges line up correctly in the mobile view of the table. 


## Screenshots

![image](https://user-images.githubusercontent.com/58959073/105855781-5cd97400-5fe0-11eb-8ddd-b3355f9b394d.png)

![image](https://user-images.githubusercontent.com/58959073/105856163-cc4f6380-5fe0-11eb-9a70-7df7d55363e2.png)
