### PR TITLE
Fix CVE broken links

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -209,7 +209,12 @@
                           Fixed by
                           <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}" target="_blank">{{ patch.content.fixed }}</a>
                         {% elif patch.type == "link" %}
-                          {{ patch.content.prefix }}: <a href="{{ patch.content.suffix }}" target="_blank">{{ patch.content.suffix }}</a>
+                          {{ patch.content.prefix }}:
+                          {% if cve._clean_url(patch.content.suffix) %}
+                            <a href="{{ cve._clean_url(patch.content.suffix) }}" target="_blank">{{ patch.content.suffix }}</a>
+                          {% else %}
+                            {{ patch.content.suffix }}
+                          {% endif %}
                         {% endif %}
                         <br>
                       {% endfor %}
@@ -275,7 +280,9 @@
         <ul>
           {% if cve.references %}
             {% for reference in cve.references %}
-            <li><a href="{{ reference }}">{{ reference }}</a></li>
+              {% if cve._clean_url(reference) %}
+                <li><a href="{{ cve._clean_url(reference) }}">{{ reference }}</a></li>
+              {% endif %}
             {% endfor %}
           {% else %}
             <li>
@@ -300,12 +307,14 @@
         </ul>
 
         {% if cve.bugs %}
-        <h2>Bugs</h2>
-        <ul>
-          {% for bug in cve.bugs %}
-          <li><a href="{{ bug }}">{{ bug }}</a></li>
-          {% endfor %}
-        </ul>
+          <h2>Bugs</h2>
+          <ul>
+            {% for bug in cve.bugs %}
+              {% if cve._clean_url(bug) %}
+                <li><a href="{{ cve._clean_url(bug) }}">{{ bug }}</a></li>
+              {% endif %}
+            {% endfor %}
+          </ul>
         {% endif %}
       </div>
     </div>

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -121,6 +121,18 @@ class CVE(Base):
 
         return {"type": "text", "content": patch}
 
+    def _clean_url(self, dirty_url):
+        new_url = re.sub(r"\(.*?\)", "", dirty_url)
+        url_check_regex = re.compile(
+            r"^(?:http|ftp)s?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}\."
+            r"[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)",
+            re.IGNORECASE,
+        )
+
+        is_url = re.match(url_check_regex, new_url) is not None
+
+        return new_url if is_url else ""
+
 
 class Notice(Base):
     __tablename__ = "notice"


### PR DESCRIPTION
## Done

- Fix CVE broken links. We worked with the assumption that all the patches/references/bugs are simple links. But it turns out some links can have an invalid format or have a comment in parenthesis. 
- Before Examples:
![image](https://user-images.githubusercontent.com/6387619/105875829-30c8ed80-5ff6-11eb-807d-ff8f3721a048.png)
![image](https://user-images.githubusercontent.com/6387619/105875885-450cea80-5ff6-11eb-8173-3b458631306f.png)

- Make the links work even by removing the `(exmaple)`.

## QA

- Have a database
- Fetch changes
- Go to http:/0.0.0.0:8001/security/CVE-2002-2439 
- Check that the patch link works:
![image](https://user-images.githubusercontent.com/6387619/105873830-ce6eed80-5ff3-11eb-82e6-e9cafd8b8a3a.png)
- Check that the references links and the bug links work.

## Issue / Card

Fixes #8918 