### PR TITLE
Ammend navigation items for core docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1017,20 +1017,6 @@ core:
     - title: Docs
       path: /core/docs
       persist: True
-      hidden: True
-
-      children:
-        - title: Bluetooth management
-          path: /core/docs/bluetooth-management
-          persist: True
-        - title: Network management
-          path: /core/docs/network-management-services
-          persist: True
-        - title: Audio management
-          path: /core/docs/audio-management
-          persist: True
-
-
 
     - title: Contact us
       path: /core/contact-us
@@ -1040,7 +1026,6 @@ core:
         - title: Thank you
           path: /core/thank-you
           hidden: True
-
 
 
 iot:


### PR DESCRIPTION
## Done

Core docs navigation changes

## QA

- View the site locally in your web browser at: https://ubuntu-com-9098.demos.haus
- Check that the items in the docs navigation appears
- Removed obselete sub-docs from navigation


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3663

## Screenshots

![core-docs-release](https://user-images.githubusercontent.com/14939793/105976500-2820f780-6088-11eb-9142-7faa6eff2ef9.png)
