### PR TITLE
Add not-in-ubuntu details

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -30,10 +30,10 @@
 </nav>
 
 {% if cve.status == 'rejected' or cve.status == 'not-in-ubuntu' %}
-<section class="p-strip--light is-bordered--top">
-  {% else %}
+  <section class="p-strip--light is-bordered--top">
+{% else %}
   <section class="p-strip">
-    {% endif %}
+{% endif %}
 
     <div class="row">
       <div class="col-9">
@@ -41,6 +41,10 @@
 
         {% if cve.published %}
         <p>Published: <strong>{{ cve.published.strftime("%d %B %Y") }}</strong></p>
+        {% endif %}
+
+        {% if cve.status == 'not-in-ubuntu' %}
+          <p>This CVE does not apply to software in Ubuntu archives.</p>
         {% endif %}
 
         {% if cve.description %}


### PR DESCRIPTION
## Done

- Add the body text “This CVE does not apply to software in Ubuntu archives.” for `not-in-ubuntu` CVEs.


## QA

- Have a database.
- Fetch changes
- You need a `not-in-ubuntu` CVE, run following commands:
```
docker-compose up -d  # start db
docker exec -it db psql -U postgres  # open postgresql shell
update cve set bugs=null, cvss3=null, description=null, notes=null, published=null, patches=null, tags=null, ubuntu_description=null, status='not-in-ubuntu' where id='CVE-2005-4890';  # update cve to be a not-in-ubuntu CVE
```
- Launch website with `dotrun` and go to http://0.0.0.0:8001/security/CVE-2005-4890
- You will see the body text “This CVE does not apply to software in Ubuntu archives.”

## Issue / Card

Fixes #9060

