### PR TITLE
Correct Livepatch instructions for 16.04/18.04

### DIFF
--- a/templates/advantage/shared/_livepatch-info.html
+++ b/templates/advantage/shared/_livepatch-info.html
@@ -22,7 +22,7 @@
       <tbody>
         <tr>
           <td>To activate Livepatch:</td>
-          <td><code>sudo snap install canonical-livepatch && sudo canonical-livepatch enable {{ contract['token'] }}</code></td>
+          <td><a class="p-link--external" href="https://auth.livepatch.canonical.com/">Follow the instructions on the Livepatch site</a></td>
         </tr>
 
         <tr>


### PR DESCRIPTION
## Done

- Replaced the Livepatch command line, which contains the wrong token, with a link to auth.livepatch.canonical.com.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Sign in, then expand the “Livepatch” cell for any of your paid subscriptions

## Issue / Card

Fixes the rest of #9001.

## Screenshots

![image](https://user-images.githubusercontent.com/19801137/106006043-b6a77000-60ac-11eb-897e-16efa2907683.png)