### PR TITLE
UA: make form inputs readonly when submitting customer info

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -506,8 +506,8 @@ function disableProcessingState() {
   clearProgressTimers();
   resetProgressIndicator();
 
-  formInputs.forEach((input) => (input.disabled = false));
-  formSelects.forEach((select) => (select.disabled = false));
+  formInputs.forEach((input) => (input.readonly = false));
+  formSelects.forEach((select) => (select.readonly = false));
   cancelModalButton.disabled = false;
   cardInput.classList.remove("u-disabled");
 
@@ -523,8 +523,8 @@ function enableProcessingState(mode) {
   cancelModalButton.disabled = true;
   processPaymentButton.disabled = true;
 
-  formInputs.forEach((input) => (input.disabled = true));
-  formSelects.forEach((select) => (select.disabled = true));
+  formInputs.forEach((input) => (input.readonly = true));
+  formSelects.forEach((select) => (select.readonly = true));
   cardField.classList.add("u-disabled");
 
   // show a progress indicator that evolves over time


### PR DESCRIPTION
## Done

Related to this PR (https://github.com/canonical-web-and-design/ubuntu.com/pull/9058) - disabling all the fields prevented the form values from being read at key points and made payments impossible, `readonly` achieves a similar thing but allows the values to be read and payments to be made.

## QA

- Check out this feature branch or visit the demo
- Easy way to QA is to be logged out of SSO, then visit /advantage/subscribe and select a product as a guest
- Open the network tab in your dev tools
- Click "Add", then "Buy Now".
- Fill out the modal form with the following card details:
  - 4242 4242 4242 4242 / expiry: 04/24 / cvc: 242 / zip: 42424
  - And then any valid details for the rest of the form
- When you click "Continue", you should see a request made to purchase_account, the headers for which will include information from the form
- This PR works if you are able to get to the second screen of the modal, instead of seeing a generic error message. You can verify this locally by attempting the same on the master branch, and seeing the error message appear.
