### PR TITLE
Add Industrial link to Sectors section of the footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -78,6 +78,7 @@
               <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">
+              <li class="p-footer-list--margin"><a href="/industrial">Industrial</a></li>
               <li class="p-footer-list--margin"><a href="/telco">Telco</a></li>
               <li class="p-footer-list--margin"><a href="/financial-services">Finance</a></li>
             </ul>


### PR DESCRIPTION
## Done

- Add Industrial link to Sectors section of the footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See a link to /industrial in the footer in the Sector's list


## Issue / Card

Fixes #9134 
