### PR TITLE
Restrict CUBE views to Canonical employees

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -39,7 +39,7 @@ env:
       name: launchpad-imagebuild
 
   - name: BADGR_URL
-    value: https://eu.api.badgr.com
+    value: https://test.api.badgr.com
 
   - name: BAGDR_USER
     secretKeyRef:
@@ -52,7 +52,7 @@ env:
       name: badgr
 
   - name: CUBE_EDX_URL
-    value: https://cube.ubuntu.com
+    value: https://qa.cube.ubuntu.com
 
   - name: CUBE_EDX_CLIENT_ID
     secretKeyRef:

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -7,6 +7,7 @@ from distutils.util import strtobool
 import flask
 from webapp.login import user_info
 
+
 def login_required(func):
     """
     Decorator that checks if a user is logged in, and redirects

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -5,6 +5,22 @@ from distutils.util import strtobool
 
 # Third party packages
 import flask
+from webapp.login import user_info
+
+def login_required(func):
+    """
+    Decorator that checks if a user is logged in, and redirects
+    to login page if not.
+    """
+
+    @functools.wraps(func)
+    def is_user_logged_in(*args, **kwargs):
+        if not user_info(flask.session):
+            return flask.redirect("/login?next=" + flask.request.path)
+
+        return func(*args, **kwargs)
+
+    return is_user_logged_in
 
 
 def store_maintenance(func):


### PR DESCRIPTION
## Done
Make CUBE views only accessible to users with `@canonical.com` emails.
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Make sure you can still see `/cube` and `/cube/microcerts` you should be redirected to SSO if you are not logged in.
- Login as a user that does not have a `@canonical.com` email and see you get a 403 page.


