### PR TITLE
Course mappings and URLs

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -275,7 +275,7 @@
           <td>
             <div class="p-table--cube__contents u-align--right">
               <a class="p-button--neutral u-no-margin--right" href="{{ module.training_url }}">Prepare</a>
-              <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.test_url }}">Test</a>
+              <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.take_url }}">Take</a>
             </div>
           </td>
           {% elif module.status == "failed" %}

--- a/tests/cassettes/TestCube.test_microcerts_authenticated.yaml
+++ b/tests/cassettes/TestCube.test_microcerts_authenticated.yaml
@@ -1,0 +1,1048 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/user/v1/accounts?email=cube@canonical.com
+  response:
+    body:
+      string: '{"detail":"Incorrect authentication credentials."}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Length:
+      - '50'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:07 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Language, Origin, Cookie
+      WWW-Authenticate:
+      - JWT realm="api"
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '238'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://qa.cube.ubuntu.com/oauth2/access_token
+  response:
+    body:
+      string: '{"access_token": "token"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:07 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Pragma:
+      - no-cache
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '771'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/user/v1/accounts?email=cube@canonical.com
+  response:
+    body:
+      string: "[{\"secondary_email\":null,\"date_joined\":\"2020-11-25T11:18:36Z\"\
+        ,\"level_of_education\":null,\"accomplishments_shared\":true,\"year_of_birth\"\
+        :null,\"extended_profile\":[],\"phone_number\":null,\"language_proficiencies\"\
+        :[],\"time_zone\":null,\"bio\":null,\"gender\":null,\"social_links\":[],\"\
+        account_privacy\":\"private\",\"mailing_address\":\"\",\"secondary_email_enabled\"\
+        :null,\"name\":\"Cube Engineer\",\"is_active\":true,\"\
+        goals\":\"\",\"requires_parental_consent\":true,\"profile_image\":{\"image_url_small\"\
+        :\"https://qa.cube.ubuntu.com/static/images/profiles/fake.png\"\
+        ,\"image_url_full\":\"https://qa.cube.ubuntu.com/static/images/profiles/fake.png\"\
+        ,\"image_url_large\":\"https://qa.cube.ubuntu.com/static/images/profiles/fake.png\"\
+        ,\"image_url_medium\":\"https://qa.cube.ubuntu.com/static/images/profiles/fake.png\"\
+        ,\"has_image\":false},\"state\":null,\"username\":\"cube\",\"country\"\
+        :null,\"course_certificates\":null,\"email\":\"cube@canonical.com\"\
+        }]"
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:07 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '1010'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://api.test.badgr.com/o/token
+  response:
+    body:
+      string: '{"access_token": "token"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:08 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c mod_wsgi/4.6.4 Python/3.6
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Vary:
+      - Authorization,Cookie,Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://api.test.badgr.com/v2/issuers/36ZEJnXdTjqobw93BJElog/assertions?recipient=cube@canonical.com
+  response:
+    body:
+      string: '{"status":{"success":true,"description":"ok"},"result":[{"entityType":"Assertion","entityId":"yQUuEITBTVK3GdrGDfD2YQ","openBadgeId":"https://api.test.badgr.com/public/assertions/yQUuEITBTVK3GdrGDfD2YQ","createdAt":"2021-01-14T19:54:03.956331Z","createdBy":"mXJunowbRSaOGoaZQznG4w","badgeclass":"OFLBtlmyQiS1T_fL6IrZGg","badgeclassOpenBadgeId":"https://api.test.badgr.com/public/badges/OFLBtlmyQiS1T_fL6IrZGg","issuer":"36ZEJnXdTjqobw93BJElog","issuerOpenBadgeId":"https://api.test.badgr.com/public/issuers/36ZEJnXdTjqobw93BJElog","image":"https://media.test.badgr.com/uploads/badges/assertion-yQUuEITBTVK3GdrGDfD2YQ.png","recipient":{"identity":"sha256$cec79a94829fe03aa7651ced998e718ec76b5b96700dc02b4866b333a1bbbce2","hashed":true,"type":"email","plaintextIdentity":"cube@canonical.com","salt":"289adbc72609405ba8dc122e8edfe2be"},"issuedOn":"2021-01-14T05:00:00Z","narrative":null,"evidence":[],"revoked":false,"revocationReason":null,"acceptance":"Unaccepted","expires":null,"extensions":{}},{"entityType":"Assertion","entityId":"jnIaXFrnQlOdkmW-z45qzA","openBadgeId":"https://api.test.badgr.com/public/assertions/jnIaXFrnQlOdkmW-z45qzA","createdAt":"2021-01-15T19:43:07.251999Z","createdBy":"mXJunowbRSaOGoaZQznG4w","badgeclass":"cz8Bh5KJQT-0BenVPpn2tQ","badgeclassOpenBadgeId":"https://api.test.badgr.com/public/badges/cz8Bh5KJQT-0BenVPpn2tQ","issuer":"36ZEJnXdTjqobw93BJElog","issuerOpenBadgeId":"https://api.test.badgr.com/public/issuers/36ZEJnXdTjqobw93BJElog","image":"https://media.test.badgr.com/uploads/badges/assertion-jnIaXFrnQlOdkmW-z45qzA.png","recipient":{"identity":"sha256$a0221cce7561a3b377525bfd5b3c8ef0199e7e006ea0b175612cb1c0b2cddda0","hashed":true,"type":"email","plaintextIdentity":"cube@canonical.com","salt":"22917b37d6244c7bb7c9e53ccb148226"},"issuedOn":"2021-01-15T05:00:00Z","narrative":null,"evidence":[],"revoked":false,"revocationReason":null,"acceptance":"Unaccepted","expires":null,"extensions":{}},{"entityType":"Assertion","entityId":"c8tWms4sQm6dngw9j-jInw","openBadgeId":"https://api.test.badgr.com/public/assertions/c8tWms4sQm6dngw9j-jInw","createdAt":"2021-01-20T13:46:51.327859Z","createdBy":"mXJunowbRSaOGoaZQznG4w","badgeclass":"OFLBtlmyQiS1T_fL6IrZGg","badgeclassOpenBadgeId":"https://api.test.badgr.com/public/badges/OFLBtlmyQiS1T_fL6IrZGg","issuer":"36ZEJnXdTjqobw93BJElog","issuerOpenBadgeId":"https://api.test.badgr.com/public/issuers/36ZEJnXdTjqobw93BJElog","image":"https://media.test.badgr.com/uploads/badges/assertion-c8tWms4sQm6dngw9j-jInw.png","recipient":{"identity":"sha256$dfbcd09d04941d532a417cb1e189dbe8433be35b01afde9b6a76e436ae3f1512","hashed":true,"type":"email","plaintextIdentity":"cube@canonical.com","salt":"140e36c1dc914d15ab66457d89740193"},"issuedOn":"2021-01-20T05:00:00Z","narrative":null,"evidence":[],"revoked":false,"revocationReason":null,"acceptance":"Unaccepted","expires":null,"extensions":{}},{"entityType":"Assertion","entityId":"6kbM95L4Tw685eh2t0th0g","openBadgeId":"https://api.test.badgr.com/public/assertions/6kbM95L4Tw685eh2t0th0g","createdAt":"2021-01-20T15:01:35.769493Z","createdBy":"mXJunowbRSaOGoaZQznG4w","badgeclass":"WLnYKUtmRY2N-jpgvcKJRQ","badgeclassOpenBadgeId":"https://api.test.badgr.com/public/badges/WLnYKUtmRY2N-jpgvcKJRQ","issuer":"36ZEJnXdTjqobw93BJElog","issuerOpenBadgeId":"https://api.test.badgr.com/public/issuers/36ZEJnXdTjqobw93BJElog","image":"https://media.test.badgr.com/uploads/badges/assertion-6kbM95L4Tw685eh2t0th0g.png","recipient":{"identity":"sha256$0bccf1266a38561cc537f39f43fb40f9345af1325176604a6f6506d552e40f7e","hashed":true,"type":"email","plaintextIdentity":"cube@canonical.com","salt":"dc2dfc12b17b4e8d852c54225731d361"},"issuedOn":"2021-01-20T05:00:00Z","narrative":null,"evidence":[],"revoked":false,"revocationReason":null,"acceptance":"Unaccepted","expires":null,"extensions":{}},{"entityType":"Assertion","entityId":"Mp--T8d3QnecSwndifpfpQ","openBadgeId":"https://api.test.badgr.com/public/assertions/Mp--T8d3QnecSwndifpfpQ","createdAt":"2021-01-20T15:01:48.290955Z","createdBy":"mXJunowbRSaOGoaZQznG4w","badgeclass":"O818aQFRSqKHmLXoai6Qtw","badgeclassOpenBadgeId":"https://api.test.badgr.com/public/badges/O818aQFRSqKHmLXoai6Qtw","issuer":"36ZEJnXdTjqobw93BJElog","issuerOpenBadgeId":"https://api.test.badgr.com/public/issuers/36ZEJnXdTjqobw93BJElog","image":"https://media.test.badgr.com/uploads/badges/assertion-Mp--T8d3QnecSwndifpfpQ.png","recipient":{"identity":"sha256$eac1e95ef7fba1c2c23d4d47358fd4e63cd3bd3104ac2d91fd69ef0db7f578ce","hashed":true,"type":"email","plaintextIdentity":"cube@canonical.com","salt":"a3e127bc9f864d62945320a69066cd51"},"issuedOn":"2021-01-20T05:00:00Z","narrative":null,"evidence":[],"revoked":false,"revocationReason":null,"acceptance":"Unaccepted","expires":null,"extensions":{}}]}'
+    headers:
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4847'
+      Content-Type:
+      - application/ld+json
+      Date:
+      - Sun, 31 Jan 2021 01:50:08 GMT
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c mod_wsgi/4.6.4 Python/3.6
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Vary:
+      - Accept,Authorization,Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/enrollment/v1/enrollments?username=cube&page_size=100
+  response:
+    body:
+      string: '{"next":null,"previous":null,"results":[{"created":"2021-01-28T23:59:52.101659Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+virtualisation+2020"},{"created":"2021-01-28T23:59:51.796578Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+systemd+2020"},{"created":"2021-01-28T23:59:51.535318Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+sysarch+2020"},{"created":"2021-01-28T23:59:51.263707Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+storage+2020"},{"created":"2021-01-28T23:59:50.978549Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+shellscript+2020"},{"created":"2021-01-28T23:59:50.662015Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+security+2020"},{"created":"2021-01-28T23:59:50.161480Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+package+2020"},{"created":"2021-01-28T23:59:49.888356Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+networking+2020"},{"created":"2021-01-28T23:59:49.580881Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+microk8s+2020"},{"created":"2021-01-28T23:59:49.323557Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+maas+2020"},{"created":"2021-01-28T23:59:49.025720Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+kernel+2020"},{"created":"2021-01-28T23:59:48.706937Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+juju+2020"},{"created":"2021-01-28T23:59:48.367204Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+devices+2020"},{"created":"2021-01-28T23:59:48.106402Z","mode":"honor","is_active":true,"user":"cube","course_id":"course-v1:CUBE+commands+2020"}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:08 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '4514'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+admintasks+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+admintasks+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:09 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '258'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+commands+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+commands+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:09 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '256'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate`
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+devices+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+devices+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:09 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '255'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+juju+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+juju+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:10 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '252'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+kernel+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+kernel+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:10 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '254'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+maas+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+maas+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:10 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '252'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+microk8s+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+microk8s+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:11 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '256'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+networking+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+networking+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:11 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '258'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+package+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[{"id":25,"created":"2021-01-31T03:32:07.880197Z","modified":"2021-01-31T03:32:07.928531Z","user":{"id":289,"username":"cube","email":"cube@canonical.com"},"started_at":"2021-01-31T03:32:07.912549Z","completed_at":"2021-01-31T03:32:07.912549Z","external_id":null,"status":"started","proctored_exam":{"id":124,"course_id":"course-v1:CUBE+security+2020","content_id":"block-v1:CUBE+security+2020+type@sequential+block@exam","external_id":null,"exam_name":"Exam","time_limit_mins":45,"is_proctored":false,"is_practice_exam":false,"is_active":true,"due_date":null,"hide_after_due":false,"backend":"null"},"allowed_time_limit_mins":45,"attempt_code":"6CD5FCAA-A9A7-434E-97EC-4974AD63CB12","is_sample_attempt":false,"taking_as_proctored":false,"last_poll_timestamp":null,"last_poll_ipaddr":null,"review_policy_id":null,"student_name":"","is_status_acknowledged":false}],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+package+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:11 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '255'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+security+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[{"id":25,"created":"2021-01-31T03:32:07.880197Z","modified":"2021-01-31T03:32:07.928531Z","user":{"id":289,"username":"cube","email":"cube@canonical.com"},"started_at":"2021-01-31T03:32:07.912549Z","completed_at":null,"external_id":null,"status":"started","proctored_exam":{"id":124,"course_id":"course-v1:CUBE+security+2020","content_id":"block-v1:CUBE+security+2020+type@sequential+block@exam","external_id":null,"exam_name":"Exam","time_limit_mins":45,"is_proctored":false,"is_practice_exam":false,"is_active":true,"due_date":null,"hide_after_due":false,"backend":"null"},"allowed_time_limit_mins":45,"attempt_code":"6CD5FCAA-A9A7-434E-97EC-4974AD63CB12","is_sample_attempt":false,"taking_as_proctored":false,"last_poll_timestamp":null,"last_poll_ipaddr":null,"review_policy_id":null,"student_name":"","is_status_acknowledged":false}],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+security+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:11 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '256'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+shellscript+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+shellscript+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:12 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '259'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+storage+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+storage+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:12 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '255'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+sysarch+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+sysarch+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:12 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '255'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+systemd+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+systemd+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:12 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '255'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://qa.cube.ubuntu.com/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+virtualisation+2020/search/cube?page_size=100
+  response:
+    body:
+      string: '{"pagination_info":{"has_next":false,"total_pages":1,"current_page":1,"has_previous":false},"proctored_exam_attempts":[],"attempt_url":"/api/edx_proctoring/v1/proctored_exam/attempt/course_id/course-v1:CUBE+virtualisation+2020/search/cube"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 31 Jan 2021 01:50:13 GMT
+      P3P:
+      - CP="Open edX does not have a P3P policy."
+      Server:
+      - nginx
+      Set-Cookie:
+      - openedx-language-preference=""; Domain=cube.ubuntu.com; expires=Thu, 01 Jan
+        1970 00:00:00 GMT; Max-Age=0; Path=/; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Accept-Language, Origin, Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '262'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,0 +1,120 @@
+# Packages
+from flask import template_rendered
+from vcr_unittest import VCRTestCase
+
+# Local
+from webapp.app import app
+
+
+def captured_templates(app, recorded, **extra):
+    def record(sender, template, context):
+        recorded.append((template, context))
+
+    return template_rendered.connected_to(record, app)
+
+
+class TestCube(VCRTestCase):
+    def _get_vcr_kwargs(self):
+        """
+        This removes the authorization header
+        from VCR so we don't record auth parameters
+        """
+        return {
+            "decode_compressed_response": True,
+            "filter_headers": ["Authorization", "Cookie"],
+        }
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+        return super().setUp()
+
+    def test_microcerts_authenticated(self):
+        expected_module = {
+            "course-v1:CUBE+admintasks+2020": "not-enrolled",
+            "course-v1:CUBE+commands+2020": "passed",
+            "course-v1:CUBE+devices+2020": "enrolled",
+            "course-v1:CUBE+juju+2020": "passed",
+            "course-v1:CUBE+kernel+2020": "enrolled",
+            "course-v1:CUBE+maas+2020": "enrolled",
+            "course-v1:CUBE+microk8s+2020": "enrolled",
+            "course-v1:CUBE+networking+2020": "enrolled",
+            "course-v1:CUBE+package+2020": "failed",
+            "course-v1:CUBE+security+2020": "in-progress",
+            "course-v1:CUBE+shellscript+2020": "passed",
+            "course-v1:CUBE+storage+2020": "enrolled",
+            "course-v1:CUBE+sysarch+2020": "enrolled",
+            "course-v1:CUBE+systemd+2020": "enrolled",
+            "course-v1:CUBE+virtualisation+2020": "passed",
+        }
+
+        with self.client.session_transaction() as session:
+            session["authentication_token"] = "test_token"
+            session["openid"] = {
+                "fullname": "Cube Engineer",
+                "email": "cube@canonical.com",
+            }
+
+        templates = []
+        with captured_templates(app, templates):
+            response = self.client.get("/cube/microcerts")
+
+        template, context = templates[0]
+        modules = context["modules"]
+
+        self.assertEqual(template.name, "cube/microcerts.html")
+
+        self.assertEqual(len(modules), 15)
+
+        # Assert all modules have defined topics
+        for module in modules:
+            self.assertGreater(len(module["topics"]), 0)
+            self.assertEqual(module["status"], expected_module[module["id"]])
+            self.assertTrue(
+                module["take_url"].endswith(
+                    f"{module['id']}/courseware/2020/start/?child=first"
+                )
+            )
+            self.assertTrue(
+                module["training_url"].endswith(f"{module['id']}/course")
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("Cache-Control"), "private")
+
+    def test_microcerts_403_authenticated_non_canonical_user(self):
+        with self.client.session_transaction() as session:
+            session["authentication_token"] = "test_token"
+            session["openid"] = {
+                "fullname": "Cube Engineer",
+                "email": "cube@ubuntu.com",
+            }
+
+        response = self.client.get("/cube/microcerts")
+        self.assertEqual(response.status_code, 403)
+
+    def test_home_login_required(self):
+        response = self.client.get("/cube")
+        self.assertEqual(response.status_code, 302)
+
+    def test_home_authenticated(self):
+        with self.client.session_transaction() as session:
+            session["authentication_token"] = "test_token"
+            session["openid"] = {
+                "fullname": "Cube Engineer",
+                "email": "cube@canonical.com",
+            }
+
+        response = self.client.get("/cube")
+        self.assertEqual(response.status_code, 200)
+
+    def test_home_403_non_canonical_user(self):
+        with self.client.session_transaction() as session:
+            session["authentication_token"] = "test_token"
+            session["openid"] = {
+                "fullname": "Cube Engineer",
+                "email": "cube@ubuntu.com",
+            }
+
+        response = self.client.get("/cube")
+        self.assertEqual(response.status_code, 403)

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -98,7 +98,7 @@ class EdxAPI:
         uri = (
             "/api/edx_proctoring/v1/proctored_exam/attempt/course_id/"
             f"{course_id}/search/{username}"
-            "&page_size=100"
+            "?page_size=100"
         )
         return self.make_request(
             "GET",

--- a/webapp/cube/content/cube.yaml
+++ b/webapp/cube/content/cube.yaml
@@ -1,5 +1,5 @@
 -
-  id: course-v1:ubuntu+cubereview+admintasksdev
+  id: course-v1:CUBE+admintasks+2020
   name: Administrative Tasks
   badge:
     class: 5FvYpGQ3S9yPiuJA82SCgg
@@ -11,7 +11,7 @@
     - View and record system utilization.
     - Configure remote logging.
 -
-  id: course-v1:ubuntu+cubereview+commandsdev
+  id: course-v1:CUBE+commands+2020
   name: Commands
   badge:
     class: cz8Bh5KJQT-0BenVPpn2tQ
@@ -21,7 +21,7 @@
     - Process data using the command line
     - Use essential utilities
 -
-  id: course-v1:ubuntu+cubereview+devicesdev
+  id: course-v1:CUBE+devices+2020
   name: Block Devices and Linux Filesystems
   badge:
     class: zIdluAA9RI2tfKb6lEOMQg
@@ -32,7 +32,7 @@
     - Encrypt disks
     - Manage and configure block devices, Device Mapper, and filesystems
 -
-  id: course-v1:ubuntu+cubereview+jujudev
+  id: course-v1:CUBE+juju+2020
   name: Juju
   badge:
     class: OFLBtlmyQiS1T_fL6IrZGg
@@ -42,7 +42,7 @@
     - Everyday Juju usage
     - Juju administration
 -
-  id: course-v1:ubuntu+cubereview+kerneldev
+  id: course-v1:CUBE+kernel+2020
   name: Linux Kernel
   badge:
     class: 04PfU98pSoeOKvmMAy8dZw
@@ -52,7 +52,7 @@
     - Configure kernel and module parameters
     - Configure kernel and module debugging options
 -
-  id: course-v1:ubuntu+cubereview+maasdev
+  id: course-v1:CUBE+maas+2020
   name: MAAS
   badge:
     class: JSQ9YivxTXOZkFa_YGw06g
@@ -62,7 +62,7 @@
     - Everyday MAAS usage
     - MAAS administration
 -
-  id: course-v1:ubuntu+cubereview+microk8sdev
+  id: course-v1:CUBE+microk8s+2020
   name: MicroK8s
   badge:
     class: Y_Iu1ejuRjCi_emy501YlA
@@ -72,7 +72,7 @@
     - MicroK8s configuration
     - Common MicroK8s use cases
 -
-  id: course-v1:ubuntu+cubereview+networkingdev
+  id: course-v1:CUBE+networking+2020
   name: Networking
   badge:
     class: t-_L8-Q5SYCXZRMjr8CLAQ
@@ -82,7 +82,7 @@
     - Configure common networking utilities
     - Verify connectivity and features of remote services
 -
-  id: course-v1:ubuntu+cubereview+packagedev
+  id: course-v1:CUBE+package+2020
   name: Installation and Package Management
   badge:
     class: t63waXMVR0OUXfH_G-ju1g
@@ -93,7 +93,7 @@
     - Manage Debian packages
     - Manage executables with alternatives
 -
-  id: course-v1:ubuntu+cubereview+securitydev
+  id: course-v1:CUBE+security+2020
   name: Security
   badge:
     class: jEBfgLhcQYqzOzCH6KK86g
@@ -104,7 +104,7 @@
     - Solve common security issues
     - Perform basic hardening operations
 -
-  id: course-v1:ubuntu+cubereview+shellscriptdev
+  id: course-v1:CUBE+shellscript+2020
   name: Shell Scripting
   badge:
     class: WLnYKUtmRY2N-jpgvcKJRQ
@@ -115,7 +115,7 @@
     - Monitor and gather information from other systems
     - Automate tasks with loops and conditionals
 -
-  id: course-v1:ubuntu+cubereview+storagedev
+  id: course-v1:CUBE+storage+2020
   name: Storage
   badge:
     class: BkqG388ZTS2rhqD_V2P-Fw
@@ -125,7 +125,7 @@
     - Manage storage lifecycles
     - Test storage capabilities
 -
-  id: course-v1:ubuntu+cubereview+sysarchdev
+  id: course-v1:CUBE+sysarch+2020
   name: System Architecture
   badge:
     class: 9zhR7U8YQbWTForsG9LXPw
@@ -135,7 +135,7 @@
     - Manage kernels and devices
     - Make administrative changes to devices and hardware
 -
-  id: course-v1:ubuntu+cubereview+sysddev
+  id: course-v1:CUBE+systemd+2020
   name: System Services
   badge:
     class: 1UaDxKr_Q-SvaC0xHJ1sKQ
@@ -145,7 +145,7 @@
     - Manage service startup and recovery
     - View and interpret logs using the journaling service
 -
-  id: course-v1:ubuntu+cubereview+virtualizationdev
+  id: course-v1:CUBE+virtualisation+2020
   name: Virtualization
   badge:
     class: O818aQFRSqKHmLXoai6Qtw

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -107,9 +107,11 @@ def cube_microcerts():
         elif course["id"] in enrollments:
             course["status"] = "enrolled"
 
-        course[
-            "test_url"
-        ] = f"{edx_api.base_url}/courses/{course['id']}/course"
+        course["take_url"] = (
+            f"{edx_api.base_url}/courses/{course['id']}"
+            "/courseware/2020/start/?child=first"
+        )
+
         course[
             "training_url"
         ] = f"{edx_api.base_url}/courses/{course['id']}/course"


### PR DESCRIPTION
## Done

- Update mappings file to contain the newly created course IDs
- Update take URLs
- Add test coverage for cube endpoints

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
-  Make sure you see the 15 certifications in the state they should be for your account
