### PR TITLE
Add links to features page

### DIFF
--- a/templates/core/features/index.html
+++ b/templates/core/features/index.html
@@ -128,6 +128,9 @@
         <li class="p-list__item is-ticked">If an improper or unsigned component is detected, the boot process is stopped</li>
         <li class="p-list__item is-ticked">Supports for both hardware and software Root of Trust</li>
       </ul>
+      <p>
+        <a href="/core/features/secure-boot">Learn more about secure boot&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
         {{ image (
@@ -153,6 +156,9 @@
         <li class="p-list__item is-ticked">Private keys for hardware, TPM and other secure layers are securely stored</li>
         <li class="p-list__item is-ticked">Symmetric key encryption enabled by use of specialised software-enabled stores</li>
       </ul>
+      <p>
+        <a href="/core/features/full-disk-encryption">Learn more about full disk encryption&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
         {{ image (
@@ -177,6 +183,9 @@
         <li class="p-list__item is-ticked">A graphical user interface to manage recovery options</li>
         <li class="p-list__item is-ticked">Snapshots of configuration settings and software bills of materials are backed up in the recovery system</li>
       </ul>
+      <p>
+        <a href="/core/features/recovery">Learn more about recovery&nbsp;&rsaquo;</a>
+      </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
         {{ image (


### PR DESCRIPTION
## Done

- Add links to `/core/features/secure-boot`,  `/core/features/full-disk-encryption` and `/core/features/recovery` to `/core/features` page. 
- Will add OTA link once page is built 

## QA

- View page at:

OR

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core/features
- Check secure-boot, full disk encryption and recovery links are correct 



