### PR TITLE
Update Core 18 with Core 20 on /robotics

### DIFF
--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -487,13 +487,13 @@
   <div class="row p-divider u-no-padding--left u-no-padding--right">
     <div class="col-4 p-divider__block">
       <h3>Download Ubuntu Core</h3>
-      <p>Try Ubuntu Core 18 on one of several popular development boards</p>
-      <p><a href="http://docs.ubuntu.com/core/en/guides/build-device/image-building?from=corepage">Download and install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+      <p>Try Ubuntu Core 20 on one of several popular development boards</p>
+      <p><a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current">Download and install Ubuntu Core 20</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Make your own Ubuntu Core device</h3>
       <p>Walk through the steps to build an image for a device</p>
-      <p><a href="http://docs.ubuntu.com/core/en/guides/build-device/image-building?from=corepage">Build a custom Ubuntu Core image&nbsp;&rsaquo;</a></p>
+      <p><a href="/core/docs/image-building">Build a custom Ubuntu Core image&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3>Let's work together</h3>


### PR DESCRIPTION
## Done

- Update Core 18 with Core 20 on /robotics

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the section at the bottom points to core 20 and the new docs for 'Build a custom Ubuntu Core image' link


## Issue / Card

Fixes [#3794](https://github.com/canonical-web-and-design/web-squad/issues/3704)

## Screenshots
![image](https://user-images.githubusercontent.com/441217/106587712-d96cd500-6541-11eb-9612-4d6533e6003f.png)


