### PR TITLE
Update /download/kvm and /download/raspberry-pi-core to use core 20

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -122,7 +122,7 @@
     <div class="row p-divider">
       <div class="col-3">
         <img src="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg" width="168" height="45" alt="Raspberry Pi">
-        <p><a href="/download/raspberry-pi-core">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+        <p><a href="/download/raspberry-pi-core">Install Ubuntu Core 20&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
           <img src="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg" width="120" height="45" alt="Intel NUC">

--- a/templates/download/kvm.html
+++ b/templates/download/kvm.html
@@ -15,7 +15,7 @@
       <div class="u-equal-height row p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
-          <p>We will walk you through the steps of installing Ubuntu Core 18 on your Linux desktop in a virtual machine.</p>
+          <p>We will walk you through the steps of installing Ubuntu Core 20 on your Linux desktop in a virtual machine.</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
@@ -41,11 +41,11 @@
         </h3>
         <div class="p-stepped-list__content">
           <ul class="u-no-margin--left">
-		  <li>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-amd64.img.xz">Ubuntu Core 18 image for amd64</a>.</li>
-            <li>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
+		  <li>Download the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/ubuntu-core-20-amd64.img.xz">Ubuntu Core 20 image for amd64</a>.</li>
+            <li>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</li>
             <li>
               <p>Uncompress the image with the following command:</p>
-              <pre><code>unxz ubuntu-core-18-amd64.img.xz</code></pre>
+              <pre><code>unxz ubuntu-core-20-amd64.img.xz</code></pre>
             </li>
           </ul>
         </div>
@@ -81,7 +81,7 @@ KVM acceleration can be used</code></pre>
         </h3>
         <div class="p-stepped-list__content">
           <p>You can now launch a virtual machine with KVM, using the following command:</p>
-          <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-18-amd64.img,format=raw</code></pre>
+          <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-20-amd64.img,format=raw</code></pre>
           <p>
             Note: this command sets up port redirections:
             <ul>

--- a/templates/download/raspberry-pi-core.html
+++ b/templates/download/raspberry-pi-core.html
@@ -44,8 +44,8 @@
           Download Ubuntu Core
         </h3>
         <div class="p-stepped-list__content">
-          <p>Download <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/ubuntu-core-18-armhf+raspi.img.xz">Ubuntu Core 18 image for Raspberry Pi</a>.</p>
-          <p>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</p>
+          <p>Download <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/ubuntu-core-20-armhf+raspi.img.xz">Ubuntu Core 20 image for Raspberry Pi</a>.</p>
+          <p>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</p>
         </div>
       </li>
       {% with card="microSD card" %}{% include "download/iot/_flash-image.html" %}{% endwith %}


### PR DESCRIPTION
## Done

- Update /download/kvm and /download/raspberry-pi-core to use core 20
- Updated the copy docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/kvm and http://0.0.0.0:8001/download/raspberry-pi-core
- Or http://ubuntu-com-9165.demos.haus/download/kvm http://ubuntu-com-9165.demos.haus/download/raspberry-pi-core
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it used UC 20 and the links work

