### PR TITLE
Fix nested strips on financial services page

### DIFF
--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -22,7 +22,7 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="u-fixed-width">
+  <div class="row">
     <h2 class="p-muted-heading u-align--center">INNOVATING ON UBUNTU WITH CANONICAL</h2>
     <ul class="p-inline-images u-no-margin">
       <li class="p-inline-images__item">
@@ -32,7 +32,7 @@
             width="167",
             height="37",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy"
             ) | safe
           }}
       </li>
@@ -43,7 +43,7 @@
           width="130",
           height="23",
           hi_def=True,
-          loading="auto|lazy"
+          loading="lazy"
           ) | safe
         }}
       </li>
@@ -54,7 +54,7 @@
           width="65",
           height="78",
           hi_def=True,
-          loading="auto|lazy"
+          loading="lazy"
           ) | safe
         }}
       </li>
@@ -78,7 +78,7 @@
           width="160",
           height="49",
           hi_def=True,
-          loading="auto|lazy"
+          loading="lazy"
           ) | safe
         }}
       </li>
@@ -86,473 +86,505 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
-  <div class="u-fixed-width">
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Drive business agility</h2>
-        <h4>A better multi-cloud strategy</h4>
-        <p>You need two public clouds and an efficient private cloud. Ubuntu is optimised on AWS, Azure, Google, IBM and Oracle, with seamless portability. For on-premise IAAS, the <a href="/engage/cloud-economics">451 Research Cloud Price Index</a> shows Canonical delivers the best value.</p>
-        <p>
-          <a href="/public-cloud">Public cloud&nbsp;&rsaquo;</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="/openstack">Private cloud&nbsp;&rsaquo;</a>
-        </p>
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/a6517959-451-research-vector-logo.svg",
-              alt="Research 451",
-              width="86",
-              height="32",
-              hi_def=True,
-              loading="auto|lazy",
-              attrs={"style": "margin-right: 1rem"}
-              ) | safe
-            }}
-            <div class="p-heading-icon__title u-no-margin">
-              <a href="/engage/finserv-multi-cloud">Find out why 60% of financial services turn to multi-cloud</a>
-            </div>
+<section class="p-strip">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Drive business agility</h2>
+      <h4>A better multi-cloud strategy</h4>
+      <p>You need two public clouds and an efficient private cloud. Ubuntu is optimised on AWS, Azure, Google, IBM and Oracle, with seamless portability. For on-premise IAAS, the <a href="/engage/cloud-economics">451 Research Cloud Price Index</a> shows Canonical delivers the best value.</p>
+      <p>
+        <a href="/public-cloud">Public cloud&nbsp;&rsaquo;</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="/openstack">Private cloud&nbsp;&rsaquo;</a>
+      </p>
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/a6517959-451-research-vector-logo.svg",
+            alt="Research 451",
+            width="86",
+            height="32",
+            hi_def=True,
+            loading="lazy",
+            attrs={"style": "margin-right: 1rem"}
+            ) | safe
+          }}
+          <div class="p-heading-icon__title u-no-margin">
+            <a href="/engage/finserv-multi-cloud">Find out why 60% of financial services turn to multi-cloud</a>
           </div>
         </div>
       </div>
-      <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <ul class="p-inline-images u-no-margin">
-          <li class="p-inline-images__item">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png",
-            alt="BNP Paribas",
-            width="167",
-            height="37",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-            }}
-          </li>
-        </ul>
-        <ul class="p-inline-images u-no-margin">
-          <li class="p-inline-images__item">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/80d895b6-Rabobank.png",
-            alt="Robobank",
-            width="60",
-            height="72",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/b41ec3f5-SBI-Bits_logo.png",
-            alt="SBI Bits",
-            width="130",
-            height="39",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-            }}
-          </li>
-        </ul>
-      </div>
     </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Faster innovation, lower cost</h2>
-        <h4>Second-source Linux with Ubuntu</h4>
-        <p>Ubuntu is the leading cloud and container platform, and the best platform for devsecops, AI/ML and blockchain, with <a href="/support">enterprise support</a> and <a href="/esm">extended security maintenance</a> by Canonical.</p>
-        <p>Financial institutions choose Ubuntu to scale innovation and drive down open source operating costs.</p>
-        <p><a class="p-button--neutral" href="/contact-us">Contact Canonical</a></p>
-      </div>
-      <div class="col-4 u-align--right u-vertically-center u-hide--small">
+    <div class="col-4 u-align--center u-hide--small">
+      <ul class="p-inline-images u-no-margin">
+        <li class="p-inline-images__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/73232a96-Innovation+in+banking.png",
-            alt="",
-            width="250",
-            height="251",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+          url="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png",
+          alt="BNP Paribas",
+          width="167",
+          height="37",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
           }}
-      </div>
-    </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Better Kubernetes</h2>
-        <h4>EKS, AKS, GKE, VMware and bare metal</h4>
-        <p>Canonical works with each major cloud provider to optimise their Kubernetes. All major providers choose Ubuntu, for seamless portability across clouds and on-premise infrastructure. Experience cloud-native operations without lock-in.</p>
-        <p>Read our whitepaper on five strategies to accelerate Kubernetes deployment in the enterprise.</p>
-        <p><a href="/engage/kubernetes-deployment-enterprise-whitepaper">Download the whitepaper</a></p>
-      </div>
-      <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/91154a9f-Managed+Kubernetes.svg",
-            alt="Managed Kubernetes",
-            width="250",
-            height="172",
-            hi_def=True,
-            loading="lazy",
-          ) | safe
-        }}
-      </div>
-    </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Reduce IT operations cost</h2>
-        <h4>Model driven operators</h4>
-        <p>Canonical leads multi-cloud application management with the <a class="p-link--external"
-          href="https://juju.is/mission">universal operator pattern</a> to speed up operations and drive down the cost of integration.</p>
-        <p>The legacy application estate is an enormous cost burden for financial institutions. In addition, the need to containerize and move to the cloud creates a new wave of complexity for IT. Choose Canonical  to address both, and transform the quality, cost and speed of software operations.</p>
-      </div>
-      <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/d399db60-save-money.svg",
-            alt="Save Money",
-            width="250",
-            height="253",
-            hi_def=True,
-            loading="lazy",
-          ) | safe
-        }}
-      </div>
-    </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Secure and compliant</h2>
-        <h4>FIPS, GDPR, CCPA, PCI-DSS ready</h4>
-        <p>Ubuntu meets certification requirements for the finance sector and is
-          <a href="/security/certifications">FIPS certified and CIS compliant</a>, with 10 years
-          <a href="/security">security</a> maintenance and <a href="/support">support</a>. Ubuntu ranks first for speed and quality of security fixes across the widest range of open source applications and infrastructure.</p>
-      </div>
-      <div class="col-4 u-align--right u-vertically-center u-hide--small">
-        <ul class="p-inline-images u-no-margin">
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/ff9e7377-disa-logo.svg",
-              alt="Disa",
-              width="130",
-              height="48",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-        </ul>
-        <ul class="p-inline-images u-no-margin">
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg",
-              alt="CSEC",
-              width="80",
-              height="91",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg",
-              alt="CIS",
-              width="100",
-              height="100",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-        </ul>
-      </div>
-    </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Redefine customer experience</h2>
-        <h4>Crisp, clean cloud-native innovation</h4>
-        <p>Your software-defined success depends on productive developers. Get to market faster with innovative products and services on cloud-native technologies and Kubernetes.
-          <a href="/kubernetes/features">Kubernetes on Ubuntu</a> gives you perfect portability across all infrastructures, from the data centre to the public cloud. Focus on your business while Canonical
-          <a href="/kubernetes/managed">builds and manages your Kubernetes clusters</a>.</p>
-      </div>
-      <div class="col-4 u-align--center u-vertically-center u-hide--small">
+        </li>
+      </ul>
+      <ul class="p-inline-images u-no-margin">
+        <li class="p-inline-images__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/6e444e74-ACI.png",
-            alt="ACI",
-            width="300",
-            height="192",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+          url="https://assets.ubuntu.com/v1/80d895b6-Rabobank.png",
+          alt="Robobank",
+          width="60",
+          height="72",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
           }}
-      </div>
+        </li>
+        <li class="p-inline-images__item">
+          {{ image (
+          url="https://assets.ubuntu.com/v1/b41ec3f5-SBI-Bits_logo.png",
+          alt="SBI Bits",
+          width="130",
+          height="39",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+          }}
+        </li>
+      </ul>
     </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-12">
-        <h2>Regain focus on business priorities</h2>
-        <h4>Managed apps, simplified</h4>
-        <p>Canonical offers <a href="/managed">fully managed open source</a> with a disruptive business model - priced per host or VM, not by the hour or per application. Maintain business focus and reduce costs, and offload the complexity of deploying and managing open source components to our specialist team.</p>
-      </div>
-      <div class="col-12 u-align--center u-vertically-center u-hide--small">
-        <ul class="p-inline-images u-no-margin">
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/82e5d34c-MySQL.png",
-              alt="MySQL",
-              width="90",
-              height="47",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/382e801d-postgresql-logo.png",
-              alt="Postgresql",
-              width="90",
-              height="67",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/c530ca79-Cassandra_logo.svg",
-              alt="Cassandra",
-              width="90",
-              height="60",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/5ee6eb7b-influxdb.svg",
-              alt="Influx",
-              width="130",
-              height="30",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/0f2d8f49-prometheus-logo.png",
-              alt="Prometheus",
-              width="130",
-              height="33",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/0a3ecbb7-elasticsearch.png",
-              alt="Elasticsearch",
-              width="130",
-              height="23",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/ec2d171f-grafanahero.jpg",
-              alt="Grafana",
-              width="130",
-              height="35",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/bd33839a-graylog.svg",
-              alt="Graylog",
-              width="130",
-              height="37",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/b0541732-2018-logo-open-source-mano.png",
-              alt="Source mano",
-              width="120",
-              height="45",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/c2a4ebd4-Kafka.svg",
-              alt="Kafka",
-              width="120",
-              height="55",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
-              alt="Kubeflow",
-              width="130",
-              height="30",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-        </ul>
-      </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Faster innovation, lower cost</h2>
+      <h4>Second-source Linux with Ubuntu</h4>
+      <p>Ubuntu is the leading cloud and container platform, and the best platform for devsecops, AI/ML and blockchain, with <a href="/support">enterprise support</a> and <a href="/esm">extended security maintenance</a> by Canonical.</p>
+      <p>Financial institutions choose Ubuntu to scale innovation and drive down open source operating costs.</p>
+      <p><a class="p-button--neutral" href="/contact-us">Contact Canonical</a></p>
     </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Enhance business resilience</h2>
-        <h4>Data centre of the future</h4>
-        <p>Future-proof your data centres for hybrid cloud and cloud-native applications.
-          <a href="/server">Ubuntu server</a> brings economic and technical scalability to your data centre. Turn your data centre into a bare metal cloud with
-          <a class="p-link--external" href="https://maas.io/">MAAS</a>, an automated and optimised provisioning system for your production hardware.</p>
-      </div>
-      <div class="col-4 u-align--center u-vertically-center u-hide--small">
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
         {{ image (
-          url="https://assets.ubuntu.com/v1/af1a572f-barclays_logo.svg",
-          alt="Barclays",
-          width="260",
-          height="46",
+          url="https://assets.ubuntu.com/v1/73232a96-Innovation+in+banking.png",
+          alt="",
+          width="250",
+          height="251",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Better Kubernetes</h2>
+      <h4>EKS, AKS, GKE, VMware and bare metal</h4>
+      <p>Canonical works with each major cloud provider to optimise their Kubernetes. All major providers choose Ubuntu, for seamless portability across clouds and on-premise infrastructure. Experience cloud-native operations without lock-in.</p>
+      <p>Read our whitepaper on five strategies to accelerate Kubernetes deployment in the enterprise.</p>
+      <p><a href="/engage/kubernetes-deployment-enterprise-whitepaper">Download the whitepaper</a></p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/91154a9f-Managed+Kubernetes.svg",
+          alt="Managed Kubernetes",
+          width="250",
+          height="172",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Reduce IT operations cost</h2>
+      <h4>Model driven operators</h4>
+      <p>Canonical leads multi-cloud application management with the <a class="p-link--external"
+        href="https://juju.is/mission">universal operator pattern</a> to speed up operations and drive down the cost of integration.</p>
+      <p>The legacy application estate is an enormous cost burden for financial institutions. In addition, the need to containerize and move to the cloud creates a new wave of complexity for IT. Choose Canonical  to address both, and transform the quality, cost and speed of software operations.</p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d399db60-save-money.svg",
+          alt="Save Money",
+          width="250",
+          height="253",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Secure and compliant</h2>
+      <h4>FIPS, GDPR, CCPA, PCI-DSS ready</h4>
+      <p>Ubuntu meets certification requirements for the finance sector and is
+        <a href="/security/certifications">FIPS certified and CIS compliant</a>, with 10 years
+        <a href="/security">security</a> maintenance and <a href="/support">support</a>. Ubuntu ranks first for speed and quality of security fixes across the widest range of open source applications and infrastructure.</p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      <ul class="p-inline-images u-no-margin">
+        <li class="p-inline-images__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/ff9e7377-disa-logo.svg",
+            alt="Disa",
+            width="130",
+            height="48",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </li>
+      </ul>
+      <ul class="p-inline-images u-no-margin">
+        <li class="p-inline-images__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/905104b8-csec-logo.jpg",
+            alt="CSEC",
+            width="80",
+            height="91",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </li>
+        <li class="p-inline-images__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/1acf78b2-cis-logo.jpg",
+            alt="CIS",
+            width="100",
+            height="100",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Redefine customer experience</h2>
+      <h4>Crisp, clean cloud-native innovation</h4>
+      <p>Your software-defined success depends on productive developers. Get to market faster with innovative products and services on cloud-native technologies and Kubernetes.
+        <a href="/kubernetes/features">Kubernetes on Ubuntu</a> gives you perfect portability across all infrastructures, from the data centre to the public cloud. Focus on your business while Canonical
+        <a href="/kubernetes/managed">builds and manages your Kubernetes clusters</a>.</p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/6e444e74-ACI.png",
+          alt="ACI",
+          width="300",
+          height="192",
           hi_def=True,
           loading="auto|lazy"
           ) | safe
         }}
-      </div>
     </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Intelligent finance</h2>
-        <h4>Platform to power your AI/ML needs</h4>
-        <p>Combat financial crime with the leading AI/ ML tools, powered by Ubuntu on-prem or on cloud. Radically reshape customer experience. Create industrial-scale
-          <a href="/kubeflow">machine learning processes with Kubeflow</a>. With  Ubuntu, you benefit from perfect multi-cloud portability of AI/ML workloads.</p>
-      </div>
-      <div class="col-4 u-align--center u-vertically-center u-hide--small">
-        <ul class="p-inline-images u-no-margin">
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
-              alt="Nvidia",
-              width="90",
-              height="66",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-          <li class="p-inline-images__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/c346c103-openai.png",
-              alt="OpenAI",
-              width="90",
-              height="62",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
-          </li>
-        </ul>
-      </div>
-    </div>
-    <hr />
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-8">
-        <h2>Increase developer productivity</h2>
-        <h4>Ubuntu workstations for engineering</h4>
-        <p>An <a href="/desktop">Ubuntu workstation</a> is the <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">professional developer’s preference</a>. Highly secure, reliable and with low cost of ownership, Ubuntu workstations are widely adopted by application engineering teams at financial institutions.</p>
-        <p>Canonical provides 24x7 support and <a class="p-link--external" href="https://landscape.canonical.com/">management tools</a> for monitoring, managing, patching and compliance reporting on all your Ubuntu workstations.</p>
-        <p>
-          <a class="p-link--external" href="https://buy.ubuntu.com/?_ga=2.170240736.1542483846.1604916464-1912709568.1604434903">Learn about Ubuntu Advantage</a>
-        </p>
-      </div>
-      <div class="col-4 u-align--center u-vertically-center u-hide--small">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
-          alt="Bloomberg",
-          width="200",
-          height="39",
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height">
+    <h2>Regain focus on business priorities</h2>
+    <h4>Managed apps, simplified</h4>
+    <p>Canonical offers <a href="/managed">fully managed open source</a> with a disruptive business model - priced per host or VM, not by the hour or per application. Maintain business focus and reduce costs, and offload the complexity of deploying and managing open source components to our specialist team.</p>
+  </div>
+  <div class="row u-align--center u-vertically-center u-hide--small">
+    <ul class="p-inline-images u-no-margin">
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/82e5d34c-MySQL.png",
+          alt="MySQL",
+          width="90",
+          height="47",
           hi_def=True,
-          loading="lazy",
+          loading="auto|lazy"
           ) | safe
         }}
-      </div>
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/382e801d-postgresql-logo.png",
+          alt="Postgresql",
+          width="90",
+          height="67",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/c530ca79-Cassandra_logo.svg",
+          alt="Cassandra",
+          width="90",
+          height="60",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/5ee6eb7b-influxdb.svg",
+          alt="Influx",
+          width="130",
+          height="30",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/0f2d8f49-prometheus-logo.png",
+          alt="Prometheus",
+          width="130",
+          height="33",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/0a3ecbb7-elasticsearch.png",
+          alt="Elasticsearch",
+          width="130",
+          height="23",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/ec2d171f-grafanahero.jpg",
+          alt="Grafana",
+          width="130",
+          height="35",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/bd33839a-graylog.svg",
+          alt="Graylog",
+          width="130",
+          height="37",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/b0541732-2018-logo-open-source-mano.png",
+          alt="Source mano",
+          width="120",
+          height="45",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/c2a4ebd4-Kafka.svg",
+          alt="Kafka",
+          width="120",
+          height="55",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
+          alt="Kubeflow",
+          width="130",
+          height="30",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+    </ul>
+  </div>
+    
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Enhance business resilience</h2>
+      <h4>Data centre of the future</h4>
+      <p>Future-proof your data centres for hybrid cloud and cloud-native applications.
+        <a href="/server">Ubuntu server</a> brings economic and technical scalability to your data centre. Turn your data centre into a bare metal cloud with
+        <a class="p-link--external" href="https://maas.io/">MAAS</a>, an automated and optimised provisioning system for your production hardware.</p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/af1a572f-barclays_logo.svg",
+        alt="Barclays",
+        width="260",
+        height="46",
+        hi_def=True,
+        loading="auto|lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+    
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h2>Intelligent finance</h2>
+      <h4>Platform to power your AI/ML needs</h4>
+      <p>Combat financial crime with the leading AI/ ML tools, powered by Ubuntu on-prem or on cloud. Radically reshape customer experience. Create industrial-scale
+        <a href="/kubeflow">machine learning processes with Kubeflow</a>. With  Ubuntu, you benefit from perfect multi-cloud portability of AI/ML workloads.</p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      <ul class="p-inline-images u-no-margin">
+        <li class="p-inline-images__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
+            alt="Nvidia",
+            width="90",
+            height="66",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </li>
+        <li class="p-inline-images__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/c346c103-openai.png",
+            alt="OpenAI",
+            width="90",
+            height="62",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h2>Increase developer productivity</h2>
+      <h4>Ubuntu workstations for engineering</h4>
+      <p>An <a href="/desktop">Ubuntu workstation</a> is the <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">professional developer’s preference</a>. Highly secure, reliable and with low cost of ownership, Ubuntu workstations are widely adopted by application engineering teams at financial institutions.</p>
+      <p>Canonical provides 24x7 support and <a class="p-link--external" href="https://landscape.canonical.com/">management tools</a> for monitoring, managing, patching and compliance reporting on all your Ubuntu workstations.</p>
+      <p>
+        <a class="p-link--external" href="https://buy.ubuntu.com/?_ga=2.170240736.1542483846.1604916464-1912709568.1604434903">Learn about Ubuntu Advantage</a>
+      </p>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+        alt="Bloomberg",
+        width="200",
+        height="39",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
 
-<section class="p-strip bg--light">
+<section class="p-strip--light">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <h2>Software strategy acceleration</h2>
+      <h3>Trusted by executives. Loved by leaders.</h3>
+      <p>The <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">best developers choose Ubuntu</a>.</p>
+      <p>The biggest pool of open source talent. The broadest range of tools. The community that counts.</p>
+      <p>One company stands behind it all - Canonical.</p>
+    </div>
+    <div class="col-6 u-align--center u-hide--small">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg",
+      alt="Ubuntu",
+      width="350",
+      height="79",
+      hi_def=True,
+      loading="lazy",
+      ) | safe
+      }}
+    </div>
+  </div>
+
   <div class="u-fixed-width">
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-6">
-        <h2>Software strategy acceleration</h2>
-        <h3>Trusted by executives. Loved by leaders.</h3>
-        <p>The <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">best developers choose Ubuntu</a>.</p>
-        <p>The biggest pool of open source talent. The broadest range of tools. The community that counts.</p>
-        <p>One company stands behind it all - Canonical.</p>
-      </div>
-      <div class="col-6 u-align--center u-vertically-center u-hide--small">
-        {{
-        image(
-        url="https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg",
-        alt="Ubuntu",
-        width="350",
-        height="79",
-        hi_def=True,
-        loading="lazy",
-        ) | safe
-        }}
-      </div>
+    <hr class="p-separator">
+  </div>
+
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <h2>Innovate with Canonical</h2>
+      <p>The experts in open source operations, from cloud to desktop to devices. The publishers of Ubuntu.</p>
+      <p>Get to market faster</p>
+      <p>Drive down IT costs</p>
+      <p>Accelerate innovation</p>
+      <br>
+      <p><a class="p-button--positive" href="#get-in-touch">Get in touch</a></p>
     </div>
-    <div class="u-fixed-width">
-      <hr class="p-separator">
-    </div>
-    <div class="p-strip is-shallow row u-equal-height u-no-padding--left u-no-padding--right">
-      <div class="col-6">
-        <h2>Innovate with Canonical</h2>
-        <p>The experts in open source operations, from cloud to desktop to devices. The publishers of Ubuntu.</p>
-        <p>Get to market faster</p>
-        <p>Drive down IT costs</p>
-        <p>Accelerate innovation</p>
-        <br>
-        <p><a href="#get-in-touch">Get in touch&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-6 u-align--center u-vertically-center u-hide--small">
-        {{
-        image(
-        url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
-        alt="Canonical",
-        width="350",
-        height="47",
-        hi_def=True,
-        loading="lazy",
-        ) | safe
-        }}
-      </div>
+    <div class="col-6 u-align--center u-hide--small">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
+      alt="Canonical",
+      width="350",
+      height="47",
+      hi_def=True,
+      loading="lazy",
+      ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Fix nested `p-strip` class on `/financial-services`
- See explanation of issue [here](https://github.com/canonical-web-and-design/ubuntu.com/pull/9110#discussion_r566778918)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/financial-services
- Check layout on desktop and mobile view
- Check the code - implementation of strip classes, rows and cols

## Issue / Card

Fixes #9168 
