### PR TITLE
Capture error response in sentry when posting to contracts API

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -685,9 +685,12 @@ def post_advantage_subscriptions(preview):
             purchase = advantage.preview_purchase_from_marketplace(
                 marketplace="canonical-ua", purchase_request=purchase_request
             )
-    except HTTPError:
+    except HTTPError as http_error:
         flask.current_app.extensions["sentry"].captureException(
-            extra={"purchase_request": purchase_request}
+            extra={
+                "purchase_request": purchase_request,
+                "api_response": http_error.response.json(),
+            }
         )
         return (
             flask.jsonify({"error": "could not complete this purchase"}),


### PR DESCRIPTION
## Done

Related to but doesn't fix #9109 - when a user submits a payment, we currently capture the purchase request in Sentry if there is an error, but nothing else. This adds the error response from the API, so we have more visibility over the issue.

## QA

- Check the code, see that it looks OK
- Tricky to actually QA, we can't reproduce the issue in #9109 yet, so this is more to help us debug that issue if it happens again in production while we're investigating it.
