### PR TITLE
Update to UC20 on /download/iot page

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -139,7 +139,7 @@
       </div>
       <div class="u-fixed-width" style="margin-top: 2rem;">
         <p>
-          <a class="p-button--neutral" href="https://cdimage.ubuntu.com/ubuntu-core/18/stable/current/">
+          <a class="p-button--neutral" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">
             <span class="p-link--external">Browse all supported images</span>
           </a>
         </p>


### PR DESCRIPTION
## Done

- Update to UC20 on /download/iot page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the 'Browse all supported images' links points to https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/


## Issue / Card

Fixes [#3781](https://github.com/canonical-web-and-design/web-squad/issues/3781)

