### PR TITLE
UA: bug fixes

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -173,7 +173,7 @@ function attachCTAevents() {
 
       checkoutEvent(analyticsFriendlyProducts(), 1);
       setOrderInformation(cartItems, modal);
-      checkVAT();
+      checkVATdebounce();
     }
 
     if (isRenewalCTA || isShopCTA) {
@@ -246,7 +246,7 @@ function attachFormEvents() {
 
   countryDropdown.addEventListener("change", () => {
     handleCountryInput();
-    checkVAT();
+    checkVATdebounce();
   });
 
   // these elements aren't rendered on the renewal form
@@ -343,9 +343,7 @@ function checkVAT() {
   applyTotals();
 }
 
-const checkVATdebounce = debounce(() => {
-  checkVAT();
-}, 500);
+const checkVATdebounce = debounce(checkVAT, 500);
 
 function applyTotals() {
   // Clear any existing totals
@@ -462,7 +460,6 @@ function setFormElements() {
   if (address) {
     form.elements["Country"].value = address.country;
     handleCountryInput();
-    checkVAT();
     form.elements["address"].value = address.line1;
     form.elements["city"].value = address.city;
     form.elements["postal_code"].value = address.postal_code;

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -593,6 +593,12 @@ def cache_headers(response):
     if flask.request.path in ["/core/build", "/advantage"]:
         response.cache_control.private = True
 
+    if flask.request.path in ["/advantage/subscribe"]:
+        response.headers[
+            "Cache-Control"
+        ] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+
     if flask.request.path in ["/", "/blog"]:
         response.headers[
             "Cache-Control"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -749,8 +749,8 @@ def advantage_shop_view():
 
                 return flask.render_template(
                     "advantage/subscribe/index.html",
-                    account=account,
-                    previous_purchase_id=previous_purchase_id,
+                    account=None,
+                    previous_purchase_id=None,
                     product_listings=[],
                     stripe_publishable_key=stripe_publishable_key,
                     is_test_backend=is_test_backend,


### PR DESCRIPTION
## Done

- Reduce the amount of calls we're making to the purchase preview endpoint, previously it would happen twice when launching the payment modal on /subscribe
- Explicitly set account and previous_purchase_id as `None` if we know the user isn't logged in
- Disable caching on /advantage/subscribe

## QA

- Check the [demo](https://ubuntu-com-9175.demos.haus/advantage/subscribe?test_backend=true)
- While not logged in, inspect the page source for "accountID" and "previousPurchaseID" variables, see that both values are empty strings.
- Log in
- Open network panel in dev tools
- Select a product, add it to cart, then click "Buy Now"
- Fill out the form, select "United Kingdom" as your country
  - Card details: 4242 4242 4242 4242 / CVC: 242 / Expiry: 04/24 / Zip: 42424
- Click "Pay"
- In the network panel, you should see only one request to "preview"
