### PR TITLE
Cube alpha fixes

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -293,7 +293,11 @@
             </div>
           </td>
           {% elif module.status == "in-progress" %}
-          <td></td>
+          <td>
+            <div class="p-table--cube__contents u-align--right">
+              <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.take_url }}">Resume</a>
+            </div>
+          </td>
           {% endif %}
         </tr>
       {% endfor %}

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -14,7 +14,7 @@
         <h1>CUBE 2020 complete</h1>
         <p class="p-heading--4">You have completed all 15 microcerts, proving your Ubuntu expertise. You are now a Certified Ubuntu Engineer.</p>
 
-      {% elif has_enrollment %}
+      {% elif has_enrollments %}
 
       <h1>Your road to CUBE</h1>
         {% if passed_courses > 0 %}
@@ -106,7 +106,7 @@
   </div>
 </section>
 
-{% elif has_enrollment %}
+{% elif has_enrollments %}
 
 <section class="p-strip--light is-slanted--top-right is-shallow">
   <div class="row">
@@ -114,7 +114,11 @@
       <h2>Refresh your knowledge</h2>
       <p><strong>Be prepared for every exam</strong></p>
       <p class="u-sv2">Brush up on your Ubuntu skills with preparatory materials that cover every microcert.</p>
-      <a href="https://qa.cube.ubuntu.com/" class="p-button--positive">Prepare</a>
+      {% if has_prepare_material %}
+      <a href="https://qa.cube.ubuntu.com/courses/course-v1:ubuntu+cubereview+coursecommandsdev/course/" class="p-button--positive">Prepare</a>
+      {% else %}
+      <a href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Get preparatory materials</a>
+      {% endif %}
     </div>
   </div>
 </section>
@@ -187,7 +191,7 @@
           <th></th>
           <th>Module</th>
           <th>Topics</th>
-          {% if has_enrollment %}
+          {% if has_enrollments %}
           <th class="p-table__cell--icon-placeholder">Status</th>
           <th class="u-align--right">Action</th>
           {% else %}
@@ -274,7 +278,9 @@
           {% elif module.status == "enrolled" %}
           <td>
             <div class="p-table--cube__contents u-align--right">
-              <a class="p-button--neutral u-no-margin--right" href="{{ module.training_url }}">Prepare</a>
+              {% if has_prepare_material %}
+              <a class="p-button--neutral u-no-margin--right" href="{{ module.prepare_url }}">Prepare</a>
+              {% endif %}
               <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.take_url }}">Take</a>
             </div>
           </td>
@@ -297,7 +303,7 @@
 </section>
 {% endif %}
 
-{% if has_enrollment %}
+{% if has_enrollments %}
 
 <section class="p-strip--square-suru has-cube is-slanted--top-right">
   <div class="u-fixed-width">

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -285,7 +285,11 @@
             </div>
           </td>
           {% elif module.status == "failed" %}
-          <td></td>
+          <td>
+            <div class="p-table--cube__contents u-align--right">
+              <a class="p-button--neutral u-no-margin--right" href="https://support.canonical.com">Request retry</a>
+            </div>
+          </td>          
           {% elif module.status == "not-enrolled" %}
           <td>
             <div class="p-table--cube__contents u-align--right">

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -76,7 +76,9 @@ class TestCube(VCRTestCase):
                 )
             )
             self.assertTrue(
-                module["training_url"].endswith(f"{module['id']}/course")
+                module["prepare_url"].endswith(
+                    "/course-v1:ubuntu+cubereview+coursecommandsdev/course/"
+                )
             )
 
         self.assertEqual(response.status_code, 200)

--- a/webapp/cube/content/cube.yaml
+++ b/webapp/cube/content/cube.yaml
@@ -146,7 +146,7 @@
     - View and interpret logs using the journaling service
 -
   id: course-v1:CUBE+virtualisation+2020
-  name: Virtualization
+  name: Virtualisation
   badge:
     class: O818aQFRSqKHmLXoai6Qtw
     url: https://assets.ubuntu.com/v1/64422ff3-Virtualisation.svg

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -17,6 +17,8 @@ COURSES = yaml.load(
     Path("webapp/cube/content/cube.yaml").read_text(), Loader=yaml.Loader
 )
 
+PREPARE_COURSE_ID = "course-v1:ubuntu+cubereview+coursecommandsdev"
+
 BADGR_ISSUER = "36ZEJnXdTjqobw93BJElog"
 BADGR_CERTIFIED_BADGE_CLASS = "x9kzmcNhSSyqYhZcQGz0qg"
 
@@ -113,9 +115,10 @@ def cube_microcerts():
             "/courseware/2020/start/?child=first"
         )
 
-        course[
-            "training_url"
-        ] = f"{edx_api.base_url}/courses/{course['id']}/course"
+        course["prepare_url"] = (
+            "https://qa.cube.ubuntu.com/courses"
+            f"/{PREPARE_COURSE_ID}/course/"
+        )
 
     response = flask.make_response(
         flask.render_template(
@@ -125,7 +128,8 @@ def cube_microcerts():
                 "certified_badge": certified_badge,
                 "modules": courses,
                 "passed_courses": passed_courses,
-                "has_enrollment": len(enrollments) > 0,
+                "has_enrollments": len(enrollments) > 0,
+                "has_prepare_material": PREPARE_COURSE_ID in enrollments,
             },
         )
     )


### PR DESCRIPTION
## Done
Some fixes for issue found while QAing the `cube` branch.

- “Prepare” Button
  - IF the customer has not purchased the Study Labs; THEN “Prepare” will be a link to purchase (or request enrollment for the purposes of Alpha/Beta testing). Table prepare links are hidden if you don't have the material.
  - ELSE all “Prepare”  buttons should direct to: https://qa.cube.ubuntu.com/courses/course-v1:ubuntu+cubereview+coursecommandsdev/course/

- Failed Exams
  - IF the user has failed an exam; THEN display a button the links to https://support.canonical.com:

- Resume button

  - IF the user has left the exam tab, accidentally or otherwise AND there is still time left on the running exam; THEN ‘Resume’ should send them right back to the same link as ‘Take’

- Change ‘Virtualization’ to ‘Virtualisation’  in the course mappings

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


