### PR TITLE
Copy update - Add video to hero on managed

### DIFF
--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru-bottomed">
+<section class="p-strip--suru">
   <div class="row u-vertically-center">
     <div class="col-6">
       <h1>Performant open source with Managed Apps</h1>
@@ -17,17 +17,8 @@
         <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Free deployment assessment</a>
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
-        alt="",
-        width="225",
-        height="225",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}
+    <div class="col-6 u-embedded-media u-hide--small u-align--center">
+      <iframe title="Why managed open source?" class="u-embedded-media__element" src="https://player.vimeo.com/video/505174501" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen=""></iframe>
     </div>
   </div>
 </section>

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -17,7 +17,7 @@
         <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Free deployment assessment</a>
       </p>
     </div>
-    <div class="col-6 u-embedded-media u-hide--small u-align--center">
+    <div class="col-6 u-embedded-media u-align--center">
       <iframe title="Why managed open source?" class="u-embedded-media__element" src="https://player.vimeo.com/video/505174501" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen=""></iframe>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Add Video to hero section
- Change background to suru so video can be seen 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed
- Or view page at: https://ubuntu-com-9192.demos.haus/managed
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1fLRWW-Gtslaia2ypSrLJVBxZVHo5FY5Q84o97Gs2-w4/edit?ts=60114f22) comment 


## Issue / Card

Fixes #9172 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/106924931-804e9e00-6707-11eb-9c3f-5481a1debbb0.png)

