### PR TITLE
Capitalise FIPS on aws secondary nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -119,7 +119,7 @@ aws:
       path: /aws/pro
     - title: Outposts
       path: /aws/outposts
-    - title: Fips
+    - title: FIPS
       path: /aws/fips
     - title: Contact us
       path: /aws/contact-us


### PR DESCRIPTION
## Done

- Capitalise FIPS on aws secondary nav

## QA

- View page at: https://ubuntu-com-9193.demos.haus/aws
- Check that FIPS in the secondary nav is capitalised as requested [here](https://github.com/canonical-web-and-design/ubuntu.com/issues/9124#issue-796812323) 


## Issue / Card

Fixes #9124 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/106926585-2222ba80-6709-11eb-9ca9-2158ab0312e3.png)

