### PR TITLE
Update CUBE contact us form

### DIFF
--- a/templates/cube/contact-us.html
+++ b/templates/cube/contact-us.html
@@ -4,11 +4,11 @@
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}
-{% with h1="Contact us about CUBE Beta",
+{% with h1="Contact us about CUBE beta",
   intro_text="Fill in your details below and a member of our team will be in touch.",
   formid="3801",
   lpId="7140",
   returnURL="https://ubuntu.com/cube/thank-you" %}
-  {% include "shared/_cloud-contact-us-form.html" %}
+  {% include "shared/_cube-contact-us-form.html" %}
 {% endwith %}
 {% endblock content %}

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -1,0 +1,69 @@
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>{{h1}}</h1>
+      <p class="p-heading--four">{{intro_text}}</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{formid}}">
+        <fieldset class="u-no-margin--bottom">
+          <h3>About you</h3>
+          <ul class="p-list">
+            <li class="mktFormReq mktField p-list__item">
+              <label for="FirstName" class="mktoLabel">First name:</label>
+              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="LastName" class="mktoLabel">Last name:</label>
+              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            </li>
+            <li class="mktFormReq mktField p-list__item">
+              <label for="Email" class="mktoLabel">Email address:</label>
+              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+            </li>
+          </ul>
+        </fieldset>
+        <fieldset class="u-no-margin--bottom">
+          <ul class="p-list">
+            <li class="mktField p-list__item">
+              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+            </li>
+            <li class="p-list__item">
+              In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+            </li>
+          </ul>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
+            </li>
+          </ul>
+          <ul class="p-list">
+            <li class="mktField p-list__item">
+              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+            </li>
+          </ul>
+          <!-- hidden fields -->
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{lpId}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        </fieldset>
+      </form>
+    </div>
+  </section>
+
+  <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -61,7 +61,7 @@
             </div>
 
             <div class="pagination">
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Join the beta</button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Done

- Create a bespoke static contact us form for CUBE
- Update submit button on contact us modal

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube and check the pop up modal when you select 'Apply for access' now says 'Join the beta'
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/contact-us and check the form has only first name, last name, and email address fields and there are no phone numbers visible. 
- Points addressed from this [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/9202)

## Issue / Card

Fixes #9202 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/107052739-ec8fd700-67c5-11eb-954f-91b8e5d7e2da.png)

