### PR TITLE
Cube alpha copy changes

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -117,7 +117,7 @@
       {% if has_prepare_material %}
       <a href="https://qa.cube.ubuntu.com/courses/course-v1:ubuntu+cubereview+coursecommandsdev/course/" class="p-button--positive">Prepare</a>
       {% else %}
-      <a href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Get preparatory materials</a>
+      <a href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Apply for access</a>
       {% endif %}
     </div>
   </div>

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -19,7 +19,7 @@
                 <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
+                <label for="Email" class="mktoLabel">Email:</label>
                 <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">


### PR DESCRIPTION
## Done

- Change the contact form email field label to be just `Email:`.
- Use `Apply for access` as the button text for getting preparatory material.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Check the copy changes are there.