### PR TITLE
CUBE: Copy update 

### DIFF
--- a/templates/cube/base_cube.html
+++ b/templates/cube/base_cube.html
@@ -1,6 +1,6 @@
 {% extends "templates/base.html" %}
 
-{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1XqlPwl4su8nwIjbnhbfTpG5vJOl8JLxI{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -10,9 +10,9 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
-      <p class="p-heading--4">Certified Ubuntu Engineer (CUBE) designation is Canonical&rsquo;s professional endorsement indicating mastery of Ubuntu. CUBE candidates must earn 15 microcertifications across relevant subject areas.</p>
+      <p class="p-heading--4">The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. You need to pass 15 microcerts to earn your CUBE qualification.</p>
       <p>
-        <a href="/cube/microcerts" class="p-button--positive">View MicroCerts</a>
+        <a href="/cube/microcerts" class="p-button--positive">View the microCerts</a>
       </p>
     </div>
     <div class="col-5 col-start-large-8 u-hide--small p-cube-animation">
@@ -29,9 +29,9 @@
 <section class="p-strip">
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2>What are Microcertifications?</h2>
+      <h2>Certification at your convenience</h2>
       <p class="p-heading--four">Earn your qualification one topic at a time, at your own pace, in any order.</p>
-      <p class="u-sv3">The CUBE curriculum is perfectly portioned to accomodate your busy schedule. It consists of 15 separate microcertifications, each covering a specific subject area, that can be taken in any order and at any time.</p>
+      <p class="u-sv3">The CUBE curriculum is perfectly portioned to accommodate your busy schedule. It consists of 15 separate microcerts, each covering a specific subject area, that can be taken in any order and at any time.</p>
     </div>
     <div class="col-4 col-start-large-9 u-hide--small">
       {{ image (
@@ -66,8 +66,8 @@
 <section class="p-strip--light is-slanted--top-right">
   <div class="row">
     <div class="col-6">
-      <h2 class="u-no-margin--bottom">Crystalise Your Expertise</h2>
-      <p><strong>You know a lot. Prove it.</strong></p>
+      <h2 class="u-no-margin--bottom">Crystallise your expertise</h2>
+      <p><strong>Prove what you know</strong></p>
     </div>
     <div class="col-6">
       <p>Test your abilities through Canonical&rsquo;s meticulously curated exams. Canonical-backed professional credentials are awarded for passing marks.</p>
@@ -76,8 +76,8 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2 class="u-no-margin--bottom">Upgrade Your Career</h2>
-      <p><strong>Onwards and upwards.</strong></p>
+      <h2 class="u-no-margin--bottom">Upgrade your career</h2>
+      <p><strong>Onwards and upwards</strong></p>
     </div>
     <div class="col-6">
       <p>Show current and prospective employers how you stand out from the rest. Individualised CUBE badges can be shared on social media, meaning that your successes will always remain visible and tied to you.</p>    
@@ -86,18 +86,18 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2 class="u-no-margin--bottom">Highlight Your Practical Skills</h2>
-      <p><strong>Real-world expertise for real-world problems.</strong></p>
+      <h2 class="u-no-margin--bottom">Highlight your practical skills</h2>
+      <p><strong>Real-world expertise for real-world problems</strong></p>
     </div>
     <div class="col-6">
-      <p>Canonical&rsquo;s exams focus on useful applications of the topics at hand, ensuring that anyone with CUBE designation is well-equipped for the modern workplace.</p>
+      <p>Canonical&rsquo;s exams focus on useful applications of the topics at hand, ensuring that anyone with CUBE designation is well-equipped for the modern workplace. </p>
     </div>
     <hr class="p-separator">
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2 class="u-no-margin--bottom">Stay Relevant</h2>
-      <p><strong>Cutting-edge credentials.</strong></p>
+      <h2 class="u-no-margin--bottom">Stay relevant</h2>
+      <p><strong>Cutting&ndash;edge credentials</strong></p>
     </div>
     <div class="col-6">
       <p>CUBE certification demonstrates mastery of the latest Canonical offerings, assuring your competency in the Ubuntu ecosystem and beyond.</p>
@@ -123,7 +123,7 @@
 
 <section class="p-strip u-image-position is-grid-pinned" id="syllabus">
   <div class="u-fixed-width">
-  <h2 class="u-sv2">Complete CUBE Syllabus - at a Glance</h2>
+  <h2 class="u-sv2">Complete CUBE Syllabus - at a glance</h2>
     <ul class="p-matrix">
       <li class="p-matrix__item">
           {{ 
@@ -159,7 +159,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Packages</h3>
           <div class="p-matrix__desc">
-            <p>Control and customize installations.</p>
+            <p>Control and customise installations.</p>
           </div>
         </div>
       </li>
@@ -230,7 +230,7 @@
           }}
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Admin</h3>
-          <p class="p-matrix__desc">Master useful tasks for working with shared and individual systems.</p>
+          <p class="p-matrix__desc">Useful tasks for working with shared and individual systems.</p>
         </div>
       </li>
       <li class="p-matrix__item">
@@ -248,7 +248,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Services</h3>
           <div class="p-matrix__desc">
-            <p>Fine-tune systems for optimal performance.</p>
+            <p>Control system services for optimal performance.</p>
           </div>
         </div>
       </li>
@@ -267,7 +267,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Networking</h3>
           <div class="p-matrix__desc">
-            <p>Link machines to perform advanced tasks.</p>
+            <p>Configure networking for Ubuntu systems.</p>
           </div>
         </div>
       </li>
@@ -286,7 +286,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Security</h3>
           <div class="p-matrix__desc">
-            <p>Protect systems and servers from unwelcome intrusions.</p>
+            <p>Protect systems and servers against intrusions.</p>
           </div>
         </div>
       </li>

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -3,6 +3,7 @@
 {% block title %}CUBE{% endblock %}
 
 {% block meta_description %}This is the CUBE landing page{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -3,6 +3,7 @@
 {% block title %} Microcerts | CUBE {% endblock %}
 
 {% block meta_description %}This is the CUBE Microcerts page{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1IHmr2SIxcEKVNN2sA-z_32PV0fCXi38pmeVP7k7O1mM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -100,7 +100,7 @@
         </a>
         </li>
       </ul>
-      <p>You can <a href="https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=CUBE 2020&organizationName=Canonical&certUrl={{ certified_badge.image }}">add this badge</a> to the Certification section of your LinkedIn profile</p>
+      <p>You can <a href="https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=CUBE 2020&organizationName=Canonical&certUrl={{ certified_badge.image }}">add this badge</a> to the Certification section of your LinkedIn profile.</p>
       <p class="u-no-padding--top"><small>{{ certified_badge.image }}</small></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Copy update on `/cube` and `/cube/microcerts`
- Add copy doc links to pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube and http://0.0.0.0:8001/cube/microcerts
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check pages against [copy docs](https://drive.google.com/drive/folders/1XqlPwl4su8nwIjbnhbfTpG5vJOl8JLxI)

