### PR TITLE
Badgr API: Authenticate and retry request after HTTP 401

### DIFF
--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -17,16 +17,20 @@ class BadgrAPI:
         path: str,
         headers: dict = {},
         data: dict = {},
+        retry: bool = True,
     ):
-        if not self.token:
-            self._authenticate()
-
         uri = f"{self.base_url}{path}"
         headers["Authorization"] = f"Bearer {self.token}"
 
         response = self.session.request(
             method, uri, data=data, headers=headers
         )
+
+        if retry and response.status_code == 401:
+            self._authenticate()
+            response = self.make_request(
+                method, path, data=data, headers=headers, retry=False
+            )
 
         return response
 


### PR DESCRIPTION
## Done

Badgr API: Authenticate and retry request after HTTP 401

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- Make sure the page renders fine
