### PR TITLE
Update for the 20.04.2.0 desktop respin

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -11,6 +11,7 @@ lts:
   name: "Focal Fossa"
   short_version: "20.04"
   full_version: "20.04.2"
+  full_version_desktop: "20.04.2.0"
   release_date: "April 2020"
   eol: "April 2025"
 openstack_lts:
@@ -29,7 +30,7 @@ previous_previous_lts:
 checksums:
   desktop:
     "20.10": "3ef833828009fb69d5c584f3701d6946f89fa304757b7947e792f9491caa270e *ubuntu-20.10-desktop-amd64.iso"
-    "20.04.2": "e2ce1771e352b04cfdef5bf6583f6a7d62b1f2967903fae512506d18d251a434 *ubuntu-20.04.2-desktop-amd64.iso"
+    "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
   live-server:
     "20.10": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45 *ubuntu-20.10-live-server-amd64.iso"
     "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -50,7 +50,7 @@
     <div class="col-4">
       <h3 class="p-heading--four"><span>Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.lts.full_version }} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version_desktop }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.lts.full_version }} Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu Server {{ releases.lts.full_version }} LTS</a></li>
       </ul>
     </div>

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -50,7 +50,7 @@
     <div class="col-4">
       <h3 class="p-heading--four"><span>Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></span></h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version_desktop }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.lts.full_version }} Desktop (64-bit)</a></li>
+        <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version_desktop }}-desktop-amd64.iso.torrent">Ubuntu {{ releases.lts.full_version_desktop }} Desktop (64-bit)</a></li>
         <li class="p-list__item"><a class="download-torrent" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu Server {{ releases.lts.full_version }} LTS</a></li>
       </ul>
     </div>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -13,7 +13,7 @@
 </section>
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+    <h2>Ubuntu {{ releases.lts.full_version_desktop }} LTS</h2>
     <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
       <div class="col-8 p-divider__block">
         <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
@@ -29,7 +29,7 @@
       </div>
       <div class="col-4">
         <p>
-          <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download</a>
+          <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.lts.full_version_desktop }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download</a>
           <script>performance.mark("Download (Desktop) button rendered")</script>
         </p>
         <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors, and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>

--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -5,7 +5,7 @@
         <div class="col-3">
           <h4 class="p-heading-four is-dense"><a href='/download/desktop'>Ubuntu Desktop&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Download Ubuntu desktop and replace your current operating system whether it's Windows or Mac OS, or, run Ubuntu alongside it.</p>
-          <a class="p-button--positive p-button--small" href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">{{ releases.lts.short_version }} LTS</a>
+          <a class="p-button--positive p-button--small" href="/download/desktop/thank-you?version={{ releases.lts.full_version_desktop }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">{{ releases.lts.short_version }} LTS</a>
           {% if releases.latest.short_version > releases.lts.short_version %}<a class="p-button--neutral p-button--small" href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">{{ releases.latest.short_version }}</a>{% endif %}
         </div>
         <div class="col-3">


### PR DESCRIPTION
## Done

- Update for the 20.04.2.0 desktop respin
- Added a variable for this
- **note, the file isn't in place, so it will not download**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop and http://0.0.0.0:8001/download/alternative-downloads
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it points to the 20.04.2.0 download

