### PR TITLE
Fix IoT link in smart use cases section

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -255,7 +255,7 @@
       <p class="p-heading--4 u-sv2"><a href="/embedded">Embedded&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/networking">IoT&nbsp;&rsaquo;</a></p>
+      <p class="p-heading--4 u-sv2"><a href="/internet-of-things">IoT&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
## Done

- Fix IoT link on `/core` to point to `/internet-of-things` not `/internet-of-things/networking`

## QA

- View page at: https://ubuntu-com-9233.demos.haus/core
- Check the IoT link in the 'For smart use cases' section points to `/internet-of-things`


## Issue / Card

Fixes #9200 
