### PR TITLE
Add discourse module for openstack charms docs

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -583,6 +583,18 @@ core_als_autils_docs = Docs(
 )
 core_als_autils_docs.init_app(app)
 
+openstack_docs = Docs(
+    parser=DocParser(
+        api=discourse_api,
+        index_topic_id=20998,
+        url_prefix="/openstack/docs",
+    ),
+    document_template="/templates/docs/discourse.html",
+    url_prefix="/openstack/docs",
+    blueprint_name="openstack-docs",
+)
+openstack_docs.init_app(app)
+
 
 @app.after_request
 def cache_headers(response):


### PR DESCRIPTION
## Done

Add discourse module for Openstack charms docs

## QA

- Check https://ubuntu-com-9251.demos.haus/openstack/docs
- Check discourse https://discourse.ubuntu.com/t/openstack-charms-introduction/20998

## Issue / Card

Fixes #9247 #9246
