### PR TITLE
Update purchase to subscription matching

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -114,6 +114,7 @@ export async function postPurchaseData(
       account_id: accountID,
       products: products,
       previous_purchase_id: previousPurchaseId,
+      period: "yearly",
     }),
   });
 
@@ -140,6 +141,7 @@ export async function postPurchasePreviewData(
       account_id: accountID,
       products: products,
       previous_purchase_id: previousPurchaseId,
+      period: "yearly",
     }),
   });
 

--- a/static/js/src/ua-product-selector.js
+++ b/static/js/src/ua-product-selector.js
@@ -86,6 +86,8 @@ function productSelector() {
       }
     });
 
+    const previous_purchase_id = window.previousPurchaseIds["yearly"];
+
     return `<div class="row">
       <div class="col-12">
         <h2>Your subscription so far</h2>
@@ -111,13 +113,17 @@ function productSelector() {
       </div>
 
       <div class="col-2 u-align--right">
-        <button class="p-button--positive js-ua-shop-cta ${
-          subtotal === 0 ? "u-disable" : ""
-        }" data-cart='${JSON.stringify(cartData)}' data-account-id="${
-      window.accountId
-    }" data-subtotal='${subtotalUnits}' data-previous-purchase-id="${
-      window.previousPurchaseId
-    }">Buy now</button>
+        <button 
+          class="p-button--positive js-ua-shop-cta ${
+            subtotal === 0 ? "u-disable" : ""
+          }" 
+          data-cart='${JSON.stringify(cartData)}' 
+          data-account-id="${window.accountId}" 
+          data-subtotal='${subtotalUnits}' 
+          data-previous-purchase-id="${previous_purchase_id}"
+        >
+          Buy now
+        </button>
       </div>
     </div>
     `;

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -217,7 +217,11 @@
 
     var accountId = "{% if account %}{{ account.id }}{% endif %}";
     var accountName = "{% if account %}{{ account.name }}{% endif %}";
-    var previousPurchaseId = "{{ previous_purchase_id or ''}}"
+    var previousPurchaseIds = {
+      {% for period, id in previous_purchase_ids.items() %}
+        "{{ period }}": "{{ id }}",
+      {% endfor %}
+    }
   </script>
 
 {% endblock %}

--- a/webapp/advantage.py
+++ b/webapp/advantage.py
@@ -144,14 +144,19 @@ class AdvantageContracts:
         return response.json()
 
     def get_account_subscriptions_for_marketplace(
-        self, account_id: str, marketplace: str
+        self, account_id: str, marketplace: str, filters=None
     ) -> dict:
+        if filters:
+            filters = "&".join(
+                "{}={}".format(key, value) for key, value in filters.items()
+            )
+
         response = self._request(
             method="get",
             path=(
                 f"v1/accounts/{account_id}"
                 f"/marketplace/{marketplace}"
-                f"/subscriptions?status=active"
+                f"/subscriptions?{filters}"
             ),
         )
         return response.json()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -226,6 +226,7 @@ app.add_url_rule(
     view_func=accept_renewal,
     methods=["POST"],
 )
+
 app.add_url_rule(
     (
         "/download"


### PR DESCRIPTION
## Done

- The way a new contract gets attached to a subscription had to be updated. 
- Before you could always make the assumption that from all the subscriptions you get from that account, the first one (and the only one) is the right subscription to attach the new contract to it
- Now that users can have up to two subscriptions (yearly and monthly), we can no longer rely on that assumption. 
- The purchase form had to be adapted to cover the new situations.

## QA

- Go to https://ubuntu-com-9252.demos.haus/advantage?backend_testing=true make a purchase. It should work.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/3833