### PR TITLE
Extend the no-cache to include the entire all advantage endpoints

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -590,10 +590,11 @@ def cache_headers(response):
     Set cache expiry to 60 seconds for homepage and blog page
     """
 
-    if flask.request.path in ["/core/build", "/advantage"]:
+    if flask.request.path in ["/core/build"]:
         response.cache_control.private = True
 
-    if flask.request.path in ["/advantage/subscribe"]:
+    if flask.request.path.startswith("/advantage"):
+        response.cache_control.private = True
         response.headers[
             "Cache-Control"
         ] = "no-cache, no-store, must-revalidate"


### PR DESCRIPTION
## Done
Extend the no-cache to include the entire all advantage endpoints

## QA
- Go to the demo
- Go to advantage
- See the page request has no-cache headers
- Check the paths after /advantage such as "/advantage/subscribe", "/advantage/customer-info", "/advantage/subscribe/preview", etc all have no-cache headers.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9256