### PR TITLE
Downgrade Vanilla to 2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "date-fns": "2.17.0",
     "smartquotes": "2.3.2",
     "url-search-params-polyfill": "8.1.0",
-    "vanilla-framework": "2.24.0"
+    "vanilla-framework": "2.23.0"
   },
   "resolutions": {
     "lodash": "4.17.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8298,10 +8298,10 @@ vanilla-framework@2.19.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
   integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
-vanilla-framework@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.24.0.tgz#e5f667473165cf48476cc955fe91c5bda894f198"
-  integrity sha512-tgHdu11XzWH7VIygKRSfcQm0b2HZX7TIlmHYChtJtAbKQGvyrErw9mEzg/KGK2ox8JYLNXvRR+WTlN9CRTi71Q==
+vanilla-framework@2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.23.0.tgz#fb57f8feca3f3ce429668577e65388eebe1f6e18"
+  integrity sha512-6f0DuORalazRoMH1Smmtn9hX4qZuUxRoHHtMLq61JtsXSCn9TSWog/dZJHUZ/b85MUcnly+ZsD78/8ix2czYxA==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- /advantage/subscribe .p-card--radio were 100% @ big media screens for some reason, so I am downgrading the version for now.

## QA

- Check https://staging.ubuntu.com/advantage/subscribe look at the cards from the **What are you setting up?** section. They should be aligned on one row, but instead they are full row width.
- Check https://ubuntu-com-9258.demos.haus/advantage/subscribe
- Are the 4 cards on one row? 
