### PR TITLE
Add is_hidden column to usn

### DIFF
--- a/webapp/security/alembic/versions/8008e46e6ea8_add_is_hidden_column_for_notices.py
+++ b/webapp/security/alembic/versions/8008e46e6ea8_add_is_hidden_column_for_notices.py
@@ -1,0 +1,32 @@
+"""add_is_hidden_column_for_notices
+
+Revision ID: 8008e46e6ea8
+Revises: 3e0a3f15abb9
+Create Date: 2021-02-19 12:39:11.459139
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8008e46e6ea8"
+down_revision = "3e0a3f15abb9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "notice",
+        sa.Column(
+            "is_hidden",
+            sa.Boolean(),
+            nullable=False,
+            server_default="False",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("notice", "is_hidden")

--- a/webapp/security/database.py
+++ b/webapp/security/database.py
@@ -1,12 +1,17 @@
-# Standard library
 import os
 
-# Packages
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
+
+from webapp.security.models import BaseFilterQuery
 
 
 db_engine = create_engine(os.environ["DATABASE_URL"])
 db_session = scoped_session(
-    sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+    sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=db_engine,
+        query_cls=BaseFilterQuery,
+    )
 )

--- a/webapp/security/models.py
+++ b/webapp/security/models.py
@@ -147,6 +147,7 @@ class Notice(Base):
     release_packages = Column(JSON)
     cves = relationship("CVE", secondary=notice_cves, back_populates="notices")
     references = Column(JSON)
+    is_hidden = Column(Boolean)
     releases = relationship(
         "Release",
         secondary=notice_releases,

--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -92,6 +92,7 @@ class NoticeSchema(Schema):
     cves = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
     published = ParsedDateTime(required=True)
     description = String(allow_none=True)
+    is_hidden = Boolean(required=False)
     release_packages = Dict(
         keys=ReleaseCodename(),
         values=List(Nested(NoticePackage), required=True),

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -249,6 +249,10 @@ def _update_notice_object(notice, data):
     notice.published = data["published"]
     notice.references = data["references"]
     notice.instructions = data["instructions"]
+
+    if "is_hidden" in data:
+        notice.is_hidden = data["is_hidden"]
+
     notice.releases = [
         db_session.query(Release).get(codename)
         for codename in data["release_packages"].keys()


### PR DESCRIPTION
## Done

- Add new column to usn table
- add BaseFilterQuery class is overriding the default Query class and applies a default filtering based on the set rules of the Model set inside the `_base_filters`.
   
If we wish to bypass this default filtering, we would call
    `without_default_filtering` on the query:

`usn = db_session.query(Notice).without_default_filters().get(notice_id)`


## QA

- Have a database
- Do not fetch changes
- `docker-compose up -d` and `dotrun`
- Browse to http://0.0.0.0:8001/security/notices/USN-4417-2 # can be any id.
- You should get a 200
- Let's make USN-4417-2 private:
```sql
docker exec -it db psql -U postgres
select id,is_hidden from notice where id='USN-4417-2'; -- you will see the is_hidden value is set to false
update notice set is_hidden=True where id='USN-4417-2'; -- set is_hidden value to true
select id,is_hidden from notice where id='USN-4417-2'; -- you will see the is_hidden value is set to true 
```
- Browse to http://0.0.0.0:8001/security/notices/USN-4417-2
- You will get a 404


## Issue / Card

Fixes #9263 