### PR TITLE
Redirect /blog/topic to prevent 500

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -866,3 +866,7 @@ download/server/thank-you: /download/server
 
 # Server guide
 server/guide: /server/docs
+
+# Blog redirects to fix 500s
+blog/topic/(?P<path>.*): /blog/topics/{path}
+blog/topic: /blog


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9279

# QA

Go to `/blog/topic` and `/blog/topic/design` in the demo. Check you're redirected to the working page in both cases.