### PR TITLE
Upgrade to canonicalwebteam.search v1 to use default session

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build stage: Install python dependencies
 # ===
 FROM ubuntu:focal AS python-dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools python3-wheel build-essential
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools python3-wheel build-essential git ca-certificates
 ADD requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ alembic==1.5.4
 canonicalwebteam.flask_base==0.7.3
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.3.1
-# canonicalwebteam.search==0.2.1
-git+https://github.com/nottrobin/canonicalwebteam.search@v1-remove-http#egg=canonicalwebteam.search
+canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.flask_base==0.7.3
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.3.1
 # canonicalwebteam.search==0.2.1
-git+git://github.com/nottrobin/canonicalwebteam.search@v1-remove-http#egg=canonicalwebteam.search
+git+https://github.com/nottrobin/canonicalwebteam.search@v1-remove-http#egg=canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ alembic==1.5.4
 canonicalwebteam.flask_base==0.7.3
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.3.1
-canonicalwebteam.search==0.2.1
+# canonicalwebteam.search==0.2.1
+git+git://github.com/nottrobin/canonicalwebteam.search@v1-remove-http#egg=canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==2.1.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -240,7 +240,9 @@ app.add_url_rule(
 
 app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)
 app.add_url_rule(
-    "/search", "search", build_search_view(template_path="search.html")
+    "/search",
+    "search",
+    build_search_view(session=session, template_path="search.html"),
 )
 app.add_url_rule(
     (


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9274

This switches over to using the default talisker session, without such aggressive timeouts.

At present it points to the branch behind this PR: https://github.com/canonical-web-and-design/canonicalwebteam.search/pull/8

QA
--

Check e.g. https://ubuntu-com-9287.demos.haus/search?q=ubuntu works