### PR TITLE
CUBE: Add Cache-Control headers to routes starting with '/cube'

### DIFF
--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -82,7 +82,11 @@ class TestCube(VCRTestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers.get("Cache-Control"), "private")
+        self.assertEqual(
+            response.headers.get("Cache-Control"),
+            "no-cache, no-store, must-revalidate",
+        )
+        self.assertEqual(response.headers.get("Pragma"), "no-cache")
 
     def test_microcerts_403_authenticated_non_canonical_user(self):
         with self.client.session_transaction() as session:
@@ -109,6 +113,11 @@ class TestCube(VCRTestCase):
 
         response = self.client.get("/cube")
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get("Cache-Control"),
+            "no-cache, no-store, must-revalidate",
+        )
+        self.assertEqual(response.headers.get("Pragma"), "no-cache")
 
     def test_home_403_non_canonical_user(self):
         with self.client.session_transaction() as session:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -621,6 +621,13 @@ def cache_headers(response):
             "Cache-Control"
         ] = "max-age=61, stale-while-revalidate=90"
 
+    if flask.request.path.startswith("/cube"):
+        response.cache_control.private = True
+        response.headers[
+            "Cache-Control"
+        ] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+
     return response
 
 

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -112,22 +112,18 @@ def cube_microcerts():
             "prepare_url"
         ] = f"{edx_api.base_url}/{CUBE_CONTENT['prepare-course']}/course/"
 
-    response = flask.make_response(
-        flask.render_template(
-            "cube/microcerts.html",
-            **{
-                "user": sso_user,
-                "certified_badge": certified_badge,
-                "modules": courses,
-                "passed_courses": passed_courses,
-                "has_enrollments": len(enrollments) > 0,
-                "has_prepare_material": CUBE_CONTENT["prepare-course"]
-                in enrollments,
-            },
-        )
+    return flask.render_template(
+        "cube/microcerts.html",
+        **{
+            "user": sso_user,
+            "certified_badge": certified_badge,
+            "modules": courses,
+            "passed_courses": passed_courses,
+            "has_enrollments": len(enrollments) > 0,
+            "has_prepare_material": CUBE_CONTENT["prepare-course"]
+            in enrollments,
+        },
     )
-    response.cache_control.private = True
-    return response
 
 
 @login_required


### PR DESCRIPTION
## Done
Make sure all CUBE routes are not cached by setting the correct headers.

## QA

- Go on the demo and check `/cube` and `/cube/microcerts` both set the following headers
  - `"Cache-Control": "no-cache, no-store, must-revalidate"`
  - `"Pragma": "no-cache"`
