### PR TITLE
Typo on /compare

### DIFF
--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -199,7 +199,7 @@
           <td aria-label="Rancher">
             <div class="u-align--center">
               <span class="p-rating p-rating--4 is-half">4.5 out of 5</span>
-              <p>GlusterFS, NFS, GlusterFS, vSphere, Longhorn</p>
+              <p>GlusterFS, NFS, vSphere, Longhorn</p>
             </div>
           </td>
         </tr>


### PR DESCRIPTION

## Done

Removed the second GlusterFS on / compare

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check and accept correct copy changes in the [copy doc](https://docs.google.com/document/d/1JngYmRhohPo62yU72V1xpzCCILI21SmHKKttBxHjPog/edit?ts=602a7fd3)

## Issue / Card 

Fixes #3837
