### PR TITLE
Updated button in sub heading

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -12,7 +12,7 @@
       <h1>Secure embedded devices</h1>
       <p class="p-heading--four u-sv3">Give your device its own app store</p>
       <p>
-        <a class="p-button--positive" href="/core/smartstart">Get to market faster</a>
+        <a class="p-button--positive" href="/engage/ubuntu-core-20-webinar">Watch the webinar</a>
       </p>
       <p class="u-sv3">
         <a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/b2c770ea-Ubuntu+Core20+Datasheet.pdf">Read the Ubuntu Core datasheet</a>


### PR DESCRIPTION
## Done

Updated button in the sub heading to "watch the webinar" linking to “https://ubuntu.com/smartstart” with “https://ubuntu.com/engage/ubuntu-core-20-webinar”

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the changes against the [copy doc](https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit?ts=602e6dca#) and accept the correct changes

Fixes [#3838](https://github.com/canonical-web-and-design/web-squad/issues/3838)