### PR TITLE
Changed 20.04 to 18.04 and updated links

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -122,7 +122,7 @@
           <li class="p-list__item is-ticked">Updates mirrored and images published in all Azure regions worldwide</li>
           <li class="p-list__item is-ticked">5-year lifetime</li>
         </ul>
-        <p>Run Ubuntu 20.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview" class="p-link--external">Standard</a></p>
+        <p>Run Ubuntu 18.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/Canonical.UbuntuServer1804LTS?tab=Overview" class="p-link--external">Standard</a></p>
       </div>
     </div>
     <div class="col-6 p-card">
@@ -138,7 +138,7 @@
           <li class="p-list__item is-ticked">Integration with Azure security and compliance features</li>
           <li class="p-list__item is-ticked">10-year lifetime</li>
         </ul>
-        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 20.04 LTS</span></a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS</span></a></p>
         <p><a href="/azure/pro">More about Ubuntu Pro for Azure&nbsp;&rsaquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Changed 20.04 to 18.04 and updated links

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare the changes against the [copy doc](https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit?ts=602ea235#) and accept the correct ones.


## Issue / Card

Fixes [#3839](https://github.com/canonical-web-and-design/web-squad/issues/3839)

