### PR TITLE
Fix the side-nav ref in kubernetes docs

### DIFF
--- a/templates/kubernetes/docs/charm-reference.md
+++ b/templates/kubernetes/docs/charm-reference.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: "templates/docs/markdown.html"
 markdown_includes:
-  nav: "kubernetes/docs/shared/_side-navigation(/kubernetes/docs/)"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Charm reference"
   description: Detailed configuration and usage for the Charmed Kubernetes charms


### PR DESCRIPTION
## Done
Fix the typo in the nav include for k8s docs.

## QA
- Go to /kubernetes/docs/charm-reference
- check it does not 500 like on live

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9285
