### PR TITLE
K8s1.20+ck1

### DIFF
--- a/templates/kubernetes/docs/1.20/upgrading.md
+++ b/templates/kubernetes/docs/1.20/upgrading.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "kubernetes/docs/base_docs.html"
+wrapper_template: "templates/docs/markdown.html"
 markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:

--- a/templates/kubernetes/docs/1.20/upgrading.md
+++ b/templates/kubernetes/docs/1.20/upgrading.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "templates/docs/markdown.html"
+wrapper_template: "kubernetes/docs/base_docs.html"
 markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
@@ -292,10 +292,10 @@ juju upgrade-charm kubernetes-master
 Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.19 version of **Kubernetes**, you would enter:
 
 ```bash
-juju config kubernetes-master channel=1.18/stable
+juju config kubernetes-master channel=1.20/stable
 ```
 
-If you wanted to try a release candidate for 1.20, the channel would be `1.20/candidate`.
+If you wanted to try a release candidate for 1.21, the channel would be `1.21/candidate`.
 
 <div class="p-notification--caution">
   <p markdown="1" class="p-notification__response">

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -6,33 +6,30 @@ context:
   title: "Private Docker Registry"
   description: How to use a private Docker registry to serve Docker images to your Kubernetes cluster components.
 keywords: juju, docker, registry
-tags: [operating]
+tags: [operating, registry]
 sidebar: k8smain-sidebar
 permalink: docker-registry.html
 layout: [base, ubuntu-com]
 toc: False
 ---
 
-The [docker-registry][registry-charm] charm facilitates the storage and
-distribution of container images. Include this in a **Kubernetes**
-deployment to provide images to cluster components without requiring
-access to public registries.
-See [https://docs.docker.com/registry/][upstream-registry] for
-details.
+The [docker-registry][registry-charm] charm deploys a local image registry 
+for your cluster, taking care of the storage and distribution of 
+container images. There are a few reasons why this may be a useful option
+for your cluster:
 
-<div class="p-notification--information">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-    Currently, when using a custom private registry, Charmed Kubernetes
-    requires <strong>ALL</strong> the required images to be served from
-    that registry. The list of images used by Charmed Kubernetes itself
-    can be found in the
-    <a href="https://github.com/charmed-kubernetes/bundle/blob/master/container-images.txt">bundle repository </a>.
-  </p>
-</div>
+-  Providing the images required by Charmed Kubernetes without requiring
+   access to a public registry (e.g. in environments where network access
+   is controlled, expensive or otherwise problematic).
+-  Providing images required by workloads running on the cluster.
 
+When deployed and related to the cluster as described below, this 
+registry will be checked first for any image requests, so it can be used
+in addition to public registries. For more details of the mechanics of 
+the Docker Registry, see the
+[upstream documentation at https://docs.docker.com/registry][upstream-registry].
 
-## Deploy
+## Deploying
 
 The registry is deployed as a stand-alone application. Many deployment
 scenarios are described in the [charm readme][registry-charm]. The most common
@@ -145,7 +142,10 @@ A list of images that may be used by **Charmed Kubernetes** can be found in
 the [container-images.txt][container-images-txt] document. This is a
 comprehensive list sorted by release; not all images are required for all
 deployments. Take note of the images required by your deployment that will
-need to be hosted in your private registry.
+need to be hosted in your private registry. A list of images required by
+a specific release is also included on the 'components' page in the 
+documentation, for example, the list for the 1.20 release is located on the
+[1.20 components page][1.20]
 
 ## Hosting images
 
@@ -186,6 +186,7 @@ juju config kubernetes-master image-registry=$REGISTRY
 [quickstart]: /kubernetes/docs/quickstart
 [container-runtime]: /kubernetes/docs/container-runtime
 [container-images-txt]: https://github.com/charmed-kubernetes/bundle/blob/master/container-images.txt
+[1.20]: /kubernetes/docs/1.20/components#images
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.20.x    | [charmed-kubernetes-559](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-559/archive/bundle.yaml) |
+| 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
 | 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |
 | 1.17.x    | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -34,7 +34,7 @@ Kubernetes cluster running on the cloud of your choice in minutes!
   - [Rackspace][cloud-rackspace]
 
 <div class="p-notification--positive"><p markdown="1" class="p-notification__response">
-<span class="p-notification__status">Note:</span> If you don't meet these requirements, there are additional ways of installing the <emphasis>Charmed Distribution of Kubernetes<sup>&reg;</sup></emphasis>, including additional OS support and an entirely local deploy. Please see the more general <a href="/kubernetes/docs/install-manual">Installing Charmed Kubernetes</a> page for details. </p></div>
+<span class="p-notification__status">Note:</span> If you don't meet these requirements, there are additional ways of installing <emphasis>Charmed Kubernetes<sup>&reg;</sup></emphasis>, including additional OS support and an entirely local deploy. Please see the more general <a href="/kubernetes/docs/install-manual">Installing Charmed Kubernetes</a> page for details. </p></div>
 
 
 <section class="p-strip--light is-bordered">

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,34 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.20+ck1 Bugfix release
+
+### February 23rd, 2021 - [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.20+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.20+ck1).
+
+## Notes / Known Issues
+
+- Secret names
+
+[LP 1906732](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1906732)
+highlighted an issue where `kubernetes-worker` units would overwrite existing
+secrets when deployed as different application names. This lead to some worker
+units losing the ability to authenticate with the cluster. This has be resolved
+by ensuring new secrets are uniquely named in the form: `auth-$username-$random`.
+
+- Juju and GCP
+
+[LP 1761838](https://bugs.launchpad.net/juju/+bug/1761838) describes an issue
+with Juju and Google cloud where deployments may fail due to FAN networking.
+Workaround this by disabling FAN configuration for Google cloud models:
+
+`juju model-config -m <model_name> fan-config="" container-networking-method=""`
+
+
 
 # 1.20
 

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -57,7 +57,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.20.x    | [charmed-kubernetes-559](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-559/archive/bundle.yaml) |
+| 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
 | 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |
 | 1.17.x    | [charmed-kubernetes-410](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-410/archive/bundle.yaml) |

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -22,7 +22,7 @@ any of the intervening steps.
 ## Upgrades to all versions deployed to Juju's `localhost` LXD based cloud
 
 There is a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
-with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#charms-deployed-to-lxd-containers-fail-after-upgradereboot)
+with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#charms-deployed-to-lxd-containers-fail-after-upgradereboot).
 
 <a  id="1.19"> </a>
 

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -22,7 +22,7 @@ any of the intervening steps.
 ## Upgrades to all versions deployed to Juju's `localhost` LXD based cloud
 
 There is a known issue ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
-with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#charms-deployed-to-lxd-containers-fail-after-upgradereboot).
+with container profiles not surviving an upgrade in clouds running on LXD. If your container-based applications fail to work properly after an upgrade, please see this [topic on the troubleshooting page](/kubernetes/docs/troubleshooting#charms-deployed-to-lxd-containers-fail-after-upgradereboot)
 
 <a  id="1.19"> </a>
 

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -60,6 +60,14 @@ You should also make sure:
 -   Your cluster is running normally
 -   You read the [Upgrade notes][notes] to see if any caveats apply to the versions you are upgrading to/from
 -   You read the [Release notes][release-notes] for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster
+-   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.19 which may impact your workloads.
+
+It is also important to understand that **Charmed Kubernetes** will only upgrade
+and if necessary migrate, components relating specifically to elements of
+Kubernetes installed and configured as part of Charmed Kubernetes.
+This may not include any customised configuration of Kubernetes, or user
+generated objects (e.g. storage classes) or deployments which rely on
+deprecated APIs.
 
 ## Infrastructure updates
 
@@ -280,7 +288,7 @@ juju upgrade-charm kubernetes-master
 Once the charm has been upgraded, it can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.19 version of **Kubernetes**, you would enter:
 
 ```bash
-juju config kubernetes-master channel=1.18/stable
+juju config kubernetes-master channel=1.19/stable
 ```
 
 If you wanted to try a release candidate for 1.20, the channel would be `1.20/candidate`.


### PR DESCRIPTION
## Done
 - update bundle revisions
 - update release notes
 - add docker-registry clarifications

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
