### PR TITLE
Build subscription management options into the table

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -122,6 +122,62 @@ export async function postPurchaseData(
   return data;
 }
 
+export async function cancelContract(accountId, previousPurchaseId, productId) {
+  const queryString = window.location.search; // Pass arguments to the flask backend eg. "test=backend=true"
+
+  let response = await fetch(`/advantage/subscribe${queryString}`, {
+    method: "DELETE",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: accountId,
+      product_listings: [{ product_listing: productId }],
+      previous_purchase_id: previousPurchaseId,
+      period: "monthly",
+    }),
+  });
+
+  let data = await response.json();
+  return data;
+}
+
+export async function resizeContract(
+  accountId,
+  previousPurchaseId,
+  productId,
+  quantity
+) {
+  const queryString = window.location.search; // Pass arguments to the flask backend eg. "test=backend=true"
+
+  let response = await fetch(`/advantage/subscribe${queryString}`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: accountId,
+      previous_purchase_id: previousPurchaseId,
+      period: "monthly",
+      products: [
+        {
+          product_listing_id: productId,
+          quantity: quantity,
+        },
+      ],
+    }),
+  });
+
+  let data = await response.json();
+  return data;
+}
+
 export async function postPurchasePreviewData(
   accountID,
   products,

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -160,11 +160,12 @@ function handleChange(e, id, VPSize) {
   const defaultValue = Number.parseInt(e.target.defaultValue);
   let newValue = Number.parseInt(e.target.value);
 
-  const unitPrice = Number.parseFloat(e.target.dataset.unitPrice.split(" ")[0]);
-  const nextPayment = Number.parseFloat(
-    e.target.dataset.nextPayment.split(" ")[0]
-  );
-
+  // const unitPrice = Number.parseFloat(e.target.dataset.unitPrice.split(" ")[0]);
+  // const nextPayment = Number.parseFloat(
+  //   e.target.dataset.nextPayment.split(" ")[0]
+  // );
+  const unitPrice = 10;
+  const nextPayment = 1000;
   const billingPeriod = e.target.dataset.billingPeriod;
 
   const formatter = new Intl.NumberFormat("en-US", {
@@ -194,35 +195,33 @@ function handleChange(e, id, VPSize) {
     e.target.value = max;
   }
 
-  if (newValue !== defaultValue) {
+  const deltaMachines = newValue - defaultValue;
+
+  if (deltaMachines !== 0) {
     resizeSummary.classList.remove("u-hide");
     newPayment.classList.remove("u-hide");
     updateButton.disabled = false;
 
-    if (newValue > defaultValue) {
-      resizeSummary.innerHTML = `Your changes will add UA for ${
-        newValue - defaultValue
-      } machines`;
+    if (deltaMachines > 0) {
+      resizeSummary.innerHTML = `Your changes will add UA for ${deltaMachines} machines`;
       newPayment.innerHTML = `Your ${billingPeriod} payment will be <strong>increased by ${formatter.format(
-        unitPrice * (newValue - defaultValue)
-      )}, to ${formatter.format(
-        unitPrice * (newValue - defaultValue) + nextPayment
-      )} ${
+        unitPrice * deltaMachines
+      )}, to ${formatter.format(unitPrice * deltaMachines + nextPayment)} ${
         billingPeriod === "monthly"
           ? "per month</strong>."
           : `per year</strong>. <br/>A payment of ${formatter.format(
-              unitPrice * (newValue - defaultValue)
+              unitPrice * deltaMachines
             )} will be charged immediately`
       }`;
     } else {
       //Downsizing is only for monthly contracts
       resizeSummary.innerHTML = `Your changes will remove UA for ${
-        defaultValue - newValue
+        deltaMachines * -1
       } machines`;
       newPayment.innerHTML = `Your monthly payment will be <strong>reduced by ${formatter.format(
-        unitPrice * (defaultValue - newValue)
+        unitPrice * (deltaMachines * -1)
       )}, to ${formatter.format(
-        unitPrice * (newValue - defaultValue) + nextPayment
+        unitPrice * deltaMachines + nextPayment
       )} per month</strong>. <br/>Unused credit will be applied to next month’s invoice.`;
     }
   } else {

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -51,6 +51,7 @@ function createModal(id, VPSize) {
   const { contractName, machineCount } = cancelSubscriptionButton.dataset;
 
   const container = document.createElement("div");
+  container.classList.add("p-modal");
 
   const goBackButton = document.createElement("button");
   goBackButton.classList.add("p-button--neutral");
@@ -77,7 +78,6 @@ function createModal(id, VPSize) {
     confirmCancelButton.disabled = e.target.value.toLowerCase() !== "cancel";
   };
 
-  container.classList.add("p-modal");
   const content = `
     <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" style="overflow: auto;">
       <header class="p-modal__header">

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -88,7 +88,7 @@ function createModal(id) {
         </h2>
       </header>
       <div id="modal-description" class="p-modal__body">
-        <p>if you cancel this subscription:</p>
+        <p>If you cancel this subscription:</p>
         <ul>
           <li>No additional charge will be incurred.</li>
           <li>The ${

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -94,7 +94,7 @@ function createModal(id) {
           <li>The ${
             machineCount > 1
               ? `<strong>${machineCount} machines</strong>`
-              : "<strong>machines</strong>"
+              : "<strong>machine</strong>"
           } will stop receiving updates and services at the end of the billing period.</li>
           </ul>
         <p>Want help or advice? <a href="/contact-us">Chat with us</a>.</p>

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -1,13 +1,7 @@
 import { resizeContract, cancelContract } from "./contracts-api.js";
 
-function cancelSubscription(id, VPSize) {
-  const cancelSubscriptionButton = document.querySelector(
-    `#cancel-subscription--${id}[data-viewport="${VPSize}"]`
-  );
-  const { accountId, previousPurchaseId } = cancelSubscriptionButton.dataset;
-  let contractId = id;
-
-  cancelContract(accountId, previousPurchaseId, contractId)
+function handleAPICall(APIFunction, parameters) {
+  APIFunction(...parameters)
     .then((data) => {
       if (data.error) {
         console.error(data.error);
@@ -20,6 +14,16 @@ function cancelSubscription(id, VPSize) {
     });
 }
 
+function cancelSubscription(id, VPSize) {
+  const cancelSubscriptionButton = document.querySelector(
+    `#cancel-subscription--${id}[data-viewport="${VPSize}"]`
+  );
+  const { accountId, previousPurchaseId } = cancelSubscriptionButton.dataset;
+  let contractId = id;
+
+  handleAPICall(cancelContract, [accountId, previousPurchaseId, contractId]);
+}
+
 function handleUpdateClick(id, VPSize) {
   const resizeField = document.querySelector(
     `#resize-input--${id}[data-viewport="${VPSize}"]`
@@ -30,17 +34,12 @@ function handleUpdateClick(id, VPSize) {
   const { accountId, previousPurchaseId } = updateButton.dataset;
   let contractId = id;
 
-  resizeContract(accountId, previousPurchaseId, contractId, resizeField.value)
-    .then((data) => {
-      if (data.error) {
-        console.error(data.error);
-      } else {
-        location.reload();
-      }
-    })
-    .catch((error) => {
-      console.error(error);
-    });
+  handleAPICall(resizeContract, [
+    accountId,
+    previousPurchaseId,
+    contractId,
+    resizeField.value,
+  ]);
 }
 
 function createModal(id, VPSize) {

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -89,7 +89,7 @@ function createModal(id) {
               : "<strong>machines</strong>"
           } will stop receiving updates and services at the end of the billing period.</li>
           </ul>
-        <p>Want help or advice? <a>Chat with us</a>.</p>
+        <p>Want help or advice? <a href="/contact-us">Chat with us</a>.</p>
         <div id="cancel-modal-field-wrapper" class="u-align--right">
           <label for="confirm-cancel">Please type <strong>cancel</strong> to confirm.</label>
         </div>

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -1,17 +1,225 @@
-console.log("whooopwhoopp");
+import { resizeContract, cancelContract } from "./contracts-api.js";
+
+function cancelSubscription(id) {
+  const cancelSubscriptionButton = document.getElementById(
+    `cancel-subscription--${id}`
+  );
+  const { accountId, previousPurchaseId } = cancelSubscriptionButton.dataset;
+
+  cancelContract(accountId, previousPurchaseId, id)
+    .then((data) => {
+      if (data.error) {
+        console.error(data.error);
+      } else {
+        location.reload();
+      }
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+}
+
+function handleUpdateClick(id) {
+  const resizeField = document.getElementById(`resize-input--${id}`);
+  const updateButton = document.getElementById(`save-changes--${id}`);
+  const { accountId, previousPurchaseId } = updateButton.dataset;
+
+  resizeContract(accountId, previousPurchaseId, id, resizeField.value)
+    .then((data) => {
+      if (data.error) {
+        console.error(data.error);
+      } else {
+        location.reload();
+      }
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+}
+
+function createModal(id) {
+  const cancelSubscriptionButton = document.getElementById(
+    `cancel-subscription--${id}`
+  );
+
+  const { contractName, machineCount } = cancelSubscriptionButton.dataset;
+
+  const container = document.createElement("div");
+
+  const goBackButton = document.createElement("button");
+  goBackButton.classList.add("p-button--neutral");
+  goBackButton.textContent = "Go back";
+
+  goBackButton.onclick = () => {
+    document.body.removeChild(container);
+  };
+
+  const confirmCancelButton = document.createElement("button");
+  confirmCancelButton.classList.add("p-button--negative");
+  confirmCancelButton.disabled = true;
+  confirmCancelButton.textContent = "Yes, cancel subscription";
+
+  confirmCancelButton.onclick = () => {
+    cancelSubscription(id);
+  };
+
+  const confirmCancelField = document.createElement("input");
+  confirmCancelField.type = "text";
+  confirmCancelField.name = "confirm-cancel";
+
+  confirmCancelField.oninput = (e) => {
+    confirmCancelButton.disabled = e.target.value.toLowerCase() !== "cancel";
+  };
+
+  container.classList.add("p-modal");
+  const content = `
+    <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" style="overflow: auto;">
+      <header class="p-modal__header">
+        <h2 class="p-modal__title ">
+          Cancel subscription ${contractName}
+        </h2>
+      </header>
+      <div id="modal-description" class="p-modal__body">
+        <p>if you cancel this subscription:</p>
+        <ul>
+          <li>No additional charge will be incurred.</li>
+          <li>The ${
+            machineCount > 1
+              ? `<strong>${machineCount} machines</strong>`
+              : "<strong>machines</strong>"
+          } will stop receiving updates and services at the end of the billing period.</li>
+          </ul>
+        <p>Want help or advice? <a>Chat with us</a>.</p>
+        <div id="cancel-modal-field-wrapper" class="u-align--right">
+          <label for="confirm-cancel">Please type <strong>cancel</strong> to confirm.</label>
+        </div>
+        <div id="cancel-modal-buttons-wrapper" class="u-align--right">
+        </div>
+      </div>
+    </div>
+  `;
+  container.innerHTML = content;
+  document.body.appendChild(container);
+
+  const fieldWrapper = document.getElementById("cancel-modal-field-wrapper");
+  fieldWrapper.appendChild(confirmCancelField);
+
+  const buttonWrapper = document.getElementById("cancel-modal-buttons-wrapper");
+  buttonWrapper.appendChild(goBackButton);
+  buttonWrapper.appendChild(confirmCancelButton);
+}
+
+function handleCancelChangesClick(id) {
+  // Hide edit options
+  const previewSection = document.getElementById(`view-mode--${id}`);
+  const editSection = document.getElementById(`edit-mode--${id}`);
+  previewSection.classList.remove("u-hide");
+  editSection.classList.add("u-hide");
+
+  // Reset input and help text
+  const resizeField = document.getElementById(`resize-input--${id}`);
+  resizeField.oninput = () => {};
+  resizeField.value = resizeField.defaultValue;
+  const resizeSummary = document.getElementById(`resize-summary--${id}`);
+  const newPayment = document.getElementById(`new-payment--${id}`);
+  const updateButton = document.getElementById(`save-changes--${id}`);
+  resizeSummary.classList.add("u-hide");
+  newPayment.classList.add("u-hide");
+  updateButton.disabled = true;
+
+  // Remove buttons handlers
+  const cancelSubscriptionButton = document.getElementById(
+    `cancel-subscription--${id}`
+  );
+  const cancelChangesButton = document.getElementById(`cancel-changes--${id}`);
+  updateButton.onclick = () => {};
+  cancelChangesButton.onclick = () => {};
+  cancelSubscriptionButton.onclick = () => {};
+}
+
+function handleChange(e, id) {
+  const defaultValue = Number.parseInt(e.target.defaultValue);
+  const newValue = Number.parseInt(e.target.value);
+
+  const unitPrice = Number.parseFloat(e.target.dataset.unitPrice.split(" ")[0]);
+  const nextPayment = Number.parseFloat(
+    e.target.dataset.nextPayment.split(" ")[0]
+  );
+
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  });
+
+  const resizeSummary = document.getElementById(`resize-summary--${id}`);
+  const newPayment = document.getElementById(`new-payment--${id}`);
+  const updateButton = document.getElementById(`save-changes--${id}`);
+
+  if (newValue !== defaultValue) {
+    resizeSummary.classList.remove("u-hide");
+    newPayment.classList.remove("u-hide");
+    updateButton.disabled = false;
+
+    if (newValue > defaultValue) {
+      resizeSummary.innerHTML = `Your changes will add UA for ${
+        newValue - defaultValue
+      } machines`;
+      newPayment.innerHTML = `Your monthly payment will be <strong>increased by ${formatter.format(
+        unitPrice * (newValue - defaultValue)
+      )}, to ${formatter.format(
+        unitPrice * (newValue - defaultValue) + nextPayment
+      )} per month</strong>.`;
+    } else {
+      resizeSummary.innerHTML = `Your changes will remove UA for ${
+        defaultValue - newValue
+      } machines`;
+      newPayment.innerHTML = `Your monthly payment will be <strong>reduced by ${formatter.format(
+        unitPrice * (defaultValue - newValue)
+      )}, to ${formatter.format(
+        unitPrice * (newValue - defaultValue) + nextPayment
+      )} per month</strong>. <br/>Unused credit will be applied to next month’s invoice.`;
+    }
+  } else {
+    resizeSummary.classList.add("u-hide");
+    newPayment.classList.add("u-hide");
+    updateButton.disabled = true;
+  }
+}
 
 function handleChangeClick() {
   const id = this.dataset.id;
+  const updateButton = document.getElementById(`save-changes--${id}`);
+  const cancelChangesButton = document.getElementById(`cancel-changes--${id}`);
+  const cancelSubscriptionButton = document.getElementById(
+    `cancel-subscription--${id}`
+  );
+  const resizeField = document.getElementById(`resize-input--${id}`);
+
+  // Show edit options
   const previewSection = document.getElementById(`view-mode--${id}`);
   const editSection = document.getElementById(`edit-mode--${id}`);
-
   previewSection.classList.add("u-hide");
   editSection.classList.remove("u-hide");
+
+  resizeField.oninput = (e) => {
+    handleChange(e, id);
+  };
+
+  cancelChangesButton.onclick = () => {
+    handleCancelChangesClick(id);
+  };
+
+  updateButton.onclick = () => {
+    handleUpdateClick(id);
+  };
+
+  cancelSubscriptionButton.onclick = () => {
+    createModal(id);
+  };
 }
 
 const editButtons = document.querySelectorAll(".js-change-subscription-button");
 
 editButtons.forEach((button) => {
-  console.log(button.dataset.id);
   button.addEventListener("click", handleChangeClick);
 });

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -1,14 +1,11 @@
 import { resizeContract, cancelContract } from "./contracts-api.js";
 
-function cancelSubscription(id) {
-  const cancelSubscriptionButton = document.getElementById(
-    `cancel-subscription--${id}`
+function cancelSubscription(id, VPSize) {
+  const cancelSubscriptionButton = document.querySelector(
+    `#cancel-subscription--${id}[data-viewport="${VPSize}"]`
   );
   const { accountId, previousPurchaseId } = cancelSubscriptionButton.dataset;
   let contractId = id;
-  if (id.includes("--mobile")) {
-    contractId = id.replace("--mobile", "");
-  }
 
   cancelContract(accountId, previousPurchaseId, contractId)
     .then((data) => {
@@ -23,14 +20,15 @@ function cancelSubscription(id) {
     });
 }
 
-function handleUpdateClick(id) {
-  const resizeField = document.getElementById(`resize-input--${id}`);
-  const updateButton = document.getElementById(`save-changes--${id}`);
+function handleUpdateClick(id, VPSize) {
+  const resizeField = document.querySelector(
+    `#resize-input--${id}[data-viewport="${VPSize}"]`
+  );
+  const updateButton = document.querySelector(
+    `#save-changes--${id}[data-viewport="${VPSize}"]`
+  );
   const { accountId, previousPurchaseId } = updateButton.dataset;
   let contractId = id;
-  if (id.includes("--mobile")) {
-    contractId = id.replace("--mobile", "");
-  }
 
   resizeContract(accountId, previousPurchaseId, contractId, resizeField.value)
     .then((data) => {
@@ -45,9 +43,9 @@ function handleUpdateClick(id) {
     });
 }
 
-function createModal(id) {
-  const cancelSubscriptionButton = document.getElementById(
-    `cancel-subscription--${id}`
+function createModal(id, VPSize) {
+  const cancelSubscriptionButton = document.querySelector(
+    `#cancel-subscription--${id}[data-viewport="${VPSize}"]`
   );
 
   const { contractName, machineCount } = cancelSubscriptionButton.dataset;
@@ -68,7 +66,7 @@ function createModal(id) {
   confirmCancelButton.textContent = "Yes, cancel subscription";
 
   confirmCancelButton.onclick = () => {
-    cancelSubscription(id);
+    cancelSubscription(id, VPSize);
   };
 
   const confirmCancelField = document.createElement("input");
@@ -109,43 +107,57 @@ function createModal(id) {
   container.innerHTML = content;
   document.body.appendChild(container);
 
-  const fieldWrapper = document.getElementById("cancel-modal-field-wrapper");
+  const fieldWrapper = document.querySelector("#cancel-modal-field-wrapper");
   fieldWrapper.appendChild(confirmCancelField);
 
-  const buttonWrapper = document.getElementById("cancel-modal-buttons-wrapper");
+  const buttonWrapper = document.querySelector("#cancel-modal-buttons-wrapper");
   buttonWrapper.appendChild(goBackButton);
   buttonWrapper.appendChild(confirmCancelButton);
 }
 
-function handleCancelChangesClick(id) {
+function handleCancelChangesClick(id, VPSize) {
   // Hide edit options
-  const previewSection = document.getElementById(`view-mode--${id}`);
-  const editSection = document.getElementById(`edit-mode--${id}`);
+  const previewSection = document.querySelector(
+    `#view-mode--${id}[data-viewport="${VPSize}"]`
+  );
+  const editSection = document.querySelector(
+    `#edit-mode--${id}[data-viewport="${VPSize}"]`
+  );
   previewSection.classList.remove("u-hide");
   editSection.classList.add("u-hide");
 
   // Reset input and help text
-  const resizeField = document.getElementById(`resize-input--${id}`);
+  const resizeField = document.querySelector(
+    `#resize-input--${id}[data-viewport="${VPSize}"]`
+  );
   resizeField.oninput = () => {};
   resizeField.value = resizeField.defaultValue;
-  const resizeSummary = document.getElementById(`resize-summary--${id}`);
-  const newPayment = document.getElementById(`new-payment--${id}`);
-  const updateButton = document.getElementById(`save-changes--${id}`);
+  const resizeSummary = document.querySelector(
+    `#resize-summary--${id}[data-viewport="${VPSize}"]`
+  );
+  const newPayment = document.querySelector(
+    `#new-payment--${id}[data-viewport="${VPSize}"]`
+  );
+  const updateButton = document.querySelector(
+    `#save-changes--${id}[data-viewport="${VPSize}"]`
+  );
   resizeSummary.classList.add("u-hide");
   newPayment.classList.add("u-hide");
   updateButton.disabled = true;
 
   // Remove buttons handlers
-  const cancelSubscriptionButton = document.getElementById(
-    `cancel-subscription--${id}`
+  const cancelSubscriptionButton = document.querySelector(
+    `#cancel-subscription--${id}[data-viewport="${VPSize}"]`
   );
-  const cancelChangesButton = document.getElementById(`cancel-changes--${id}`);
+  const cancelChangesButton = document.querySelector(
+    `#cancel-changes--${id}[data-viewport="${VPSize}"]`
+  );
   updateButton.onclick = () => {};
   cancelChangesButton.onclick = () => {};
   if (cancelSubscriptionButton) cancelSubscriptionButton.onclick = () => {};
 }
 
-function handleChange(e, id) {
+function handleChange(e, id, VPSize) {
   const defaultValue = Number.parseInt(e.target.defaultValue);
   let newValue = Number.parseInt(e.target.value);
 
@@ -161,9 +173,15 @@ function handleChange(e, id) {
     currency: "USD",
   });
 
-  const resizeSummary = document.getElementById(`resize-summary--${id}`);
-  const newPayment = document.getElementById(`new-payment--${id}`);
-  const updateButton = document.getElementById(`save-changes--${id}`);
+  const resizeSummary = document.querySelector(
+    `#resize-summary--${id}[data-viewport="${VPSize}"]`
+  );
+  const newPayment = document.querySelector(
+    `#new-payment--${id}[data-viewport="${VPSize}"]`
+  );
+  const updateButton = document.querySelector(
+    `#save-changes--${id}[data-viewport="${VPSize}"]`
+  );
 
   const { min, max } = e.target;
 
@@ -217,34 +235,45 @@ function handleChange(e, id) {
 
 function handleChangeClick() {
   const id = this.dataset.id;
-  const updateButton = document.getElementById(`save-changes--${id}`);
-  const cancelChangesButton = document.getElementById(`cancel-changes--${id}`);
-  const cancelSubscriptionButton = document.getElementById(
-    `cancel-subscription--${id}`
+  const VPSize = this.dataset.viewport;
+  const updateButton = document.querySelector(
+    `#save-changes--${id}[data-viewport="${VPSize}"]`
   );
-  const resizeField = document.getElementById(`resize-input--${id}`);
+  const cancelChangesButton = document.querySelector(
+    `#cancel-changes--${id}[data-viewport="${VPSize}"]`
+  );
+  const cancelSubscriptionButton = document.querySelector(
+    `#cancel-subscription--${id}[data-viewport="${VPSize}"]`
+  );
+  const resizeField = document.querySelector(
+    `#resize-input--${id}[data-viewport="${VPSize}"]`
+  );
 
   // Show edit options
-  const previewSection = document.getElementById(`view-mode--${id}`);
-  const editSection = document.getElementById(`edit-mode--${id}`);
+  const previewSection = document.querySelector(
+    `#view-mode--${id}[data-viewport="${VPSize}"]`
+  );
+  const editSection = document.querySelector(
+    `#edit-mode--${id}[data-viewport="${VPSize}"]`
+  );
   previewSection.classList.add("u-hide");
   editSection.classList.remove("u-hide");
 
   resizeField.oninput = (e) => {
-    handleChange(e, id);
+    handleChange(e, id, VPSize);
   };
 
   cancelChangesButton.onclick = () => {
-    handleCancelChangesClick(id);
+    handleCancelChangesClick(id, VPSize);
   };
 
   updateButton.onclick = () => {
-    handleUpdateClick(id);
+    handleUpdateClick(id, VPSize);
   };
 
   if (cancelSubscriptionButton) {
     cancelSubscriptionButton.onclick = () => {
-      createModal(id);
+      createModal(id, VPSize);
     };
   }
 }

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -160,12 +160,10 @@ function handleChange(e, id, VPSize) {
   const defaultValue = Number.parseInt(e.target.defaultValue);
   let newValue = Number.parseInt(e.target.value);
 
-  // const unitPrice = Number.parseFloat(e.target.dataset.unitPrice.split(" ")[0]);
-  // const nextPayment = Number.parseFloat(
-  //   e.target.dataset.nextPayment.split(" ")[0]
-  // );
-  const unitPrice = 10;
-  const nextPayment = 1000;
+  const unitPrice = Number.parseFloat(e.target.dataset.unitPrice.split(" ")[0]);
+  const nextPayment = Number.parseFloat(
+    e.target.dataset.nextPayment.split(" ")[0]
+  );
   const billingPeriod = e.target.dataset.billingPeriod;
 
   const formatter = new Intl.NumberFormat("en-US", {

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -1,0 +1,17 @@
+console.log("whooopwhoopp");
+
+function handleChangeClick() {
+  const id = this.dataset.id;
+  const previewSection = document.getElementById(`view-mode--${id}`);
+  const editSection = document.getElementById(`edit-mode--${id}`);
+
+  previewSection.classList.add("u-hide");
+  editSection.classList.remove("u-hide");
+}
+
+const editButtons = document.querySelectorAll(".js-change-subscription-button");
+
+editButtons.forEach((button) => {
+  console.log(button.dataset.id);
+  button.addEventListener("click", handleChangeClick);
+});

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -139,7 +139,7 @@ function handleCancelChangesClick(id) {
 
 function handleChange(e, id) {
   const defaultValue = Number.parseInt(e.target.defaultValue);
-  const newValue = Number.parseInt(e.target.value);
+  let newValue = Number.parseInt(e.target.value);
 
   const unitPrice = Number.parseFloat(e.target.dataset.unitPrice.split(" ")[0]);
   const nextPayment = Number.parseFloat(
@@ -159,6 +159,16 @@ function handleChange(e, id) {
     resizeSummary.classList.remove("u-hide");
     newPayment.classList.remove("u-hide");
     updateButton.disabled = false;
+
+    if (newValue < 1) {
+      newValue = 1;
+      e.target.value = 1;
+    }
+
+    if (newValue > 999) {
+      newValue = 999;
+      e.target.value = 999;
+    }
 
     if (newValue > defaultValue) {
       resizeSummary.innerHTML = `Your changes will add UA for ${

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -5,8 +5,12 @@ function cancelSubscription(id) {
     `cancel-subscription--${id}`
   );
   const { accountId, previousPurchaseId } = cancelSubscriptionButton.dataset;
+  let contractId = id;
+  if (id.includes("--mobile")) {
+    contractId = id.replace("--mobile", "");
+  }
 
-  cancelContract(accountId, previousPurchaseId, id)
+  cancelContract(accountId, previousPurchaseId, contractId)
     .then((data) => {
       if (data.error) {
         console.error(data.error);
@@ -23,8 +27,12 @@ function handleUpdateClick(id) {
   const resizeField = document.getElementById(`resize-input--${id}`);
   const updateButton = document.getElementById(`save-changes--${id}`);
   const { accountId, previousPurchaseId } = updateButton.dataset;
+  let contractId = id;
+  if (id.includes("--mobile")) {
+    contractId = id.replace("--mobile", "");
+  }
 
-  resizeContract(accountId, previousPurchaseId, id, resizeField.value)
+  resizeContract(accountId, previousPurchaseId, contractId, resizeField.value)
     .then((data) => {
       if (data.error) {
         console.error(data.error);

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -359,7 +359,7 @@ summary {
   border-top-color: $color-mid-x-light;
 
   margin-bottom: 0;
-  padding: 1.5rem !important;
+  padding: 3rem 0 !important;
 
   .change-subscription {
     display: flex;
@@ -368,6 +368,14 @@ summary {
     > button {
       margin-left: 1.2rem;
     }
+
+    > * {
+      margin-bottom: 0;
+    }
+  }
+
+  .buttons-wrapper button {
+    margin-bottom: 0;
   }
 
   .panel-input-wrapper {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -360,6 +360,25 @@ summary {
 
   margin-bottom: 0;
   padding: 1.5rem !important;
+
+  .change-subscription {
+    display: flex;
+    margin-top: 2rem;
+
+    > button {
+      margin-left: 1.2rem;
+    }
+  }
+
+  .panel-input-wrapper {
+    display: flex;
+
+    > input {
+      min-width: 0;
+      width: 4rem;
+      margin-right: 1rem;
+    }
+  }
 }
 
 // Advantage section

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -329,33 +329,15 @@
                       </td>
                       <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
                         <div class="row">
-                          <div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
-                            <p class="col-2 p-muted-text">Created on</p>
-                            <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
-                            <hr />
-                            <p class="col-2 p-muted-text">Ends</p>
-                            <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+                          {% if not contract["period"] == "monthly" %}
 
-                            <div class="change-subscription">
-                              <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-                              <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
-                            </div>
-                          </div>
+                            {% include "advantage/table/_manage-monthly.html" %}
 
-                          <div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
-                            <h5>{{contract['contractInfo']['name']}}</h5>
-                            <hr />
-                            <div class="p-notification--caution">
-                              <p class="p-notification__response" role="status">
-                                <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
-                              </p>
-                            </div>
-                            <p class="p-muted-text">Machines</p>
-                            <div class="panel-input-wrapper"><input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed'] }}"/><p id="resize-summary--{{contract["contractInfo"]["id"]}}" class="u-hidee" >Your changes will remove UA for 5 machines</p></div>
-                            <p id="new-payment--{{contract["contractInfo"]["id"]}}" >Your monthly payment will be <strong>reduced by $42, to $42 per month</strong>. <br/>Unused credit will be applied to next month’s invoice.</p>
-                            <div class="col-6"><button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" class="p-button--negative">Cancel subscription</button></div>
-                            <div class="col-6 u-align--right"><button id="cancel-changes--{{contract["contractInfo"]["id"]}}" class="p-button--neutral">Cancel changes</button> <button id="save-changes--{{contract["contractInfo"]["id"]}}" class="p-button--positive">Save changes</button></div>
-                          </div>
+                          {% else %}
+                          
+                            {% include "advantage/table/_manage-yearly.html" %}
+
+                          {% endif %}
                         </div>
                       </td>
 

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -329,7 +329,7 @@
                       </td>
                       <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
                         <div class="row">
-                          {% if not contract["period"] == "monthly" %}
+                          {% if contract["period"] == "monthly" %}
 
                             {% include "advantage/table/_manage-monthly.html" %}
 

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -328,41 +328,33 @@
                         {% endif %}
                       </td>
                       <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
-                          <div class="row">
-                            <div class="row col-start-large-2 col-10">
-                              <p class="col-2 p-muted-text">Created on</p>
-                              <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
-                              <hr />
-                              <p class="col-2 p-muted-text">Ends</p>
-                              <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+                        <div class="row">
+                          <div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
+                            <p class="col-2 p-muted-text">Created on</p>
+                            <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+                            <hr />
+                            <p class="col-2 p-muted-text">Ends</p>
+                            <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
 
-                              <div class="change-subscription">
-                                <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-                                <button class="p-button--neutral">Change subscription</button>
-                              </div>
-
-                              <hr class="p-separator"/>
-
-                              <h5>{{contract['contractInfo']['name']}}</h5>
-                              <hr />
-                              <div class="p-notification--caution">
-                                <p class="p-notification__response" role="status">
-                                  <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
-                                </p>
-                              </div>
-                              <p class="p-muted-text">Machines</p>
-                              <div class="panel-input-wrapper"><input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed'] }}"/><p id="resize-summary--{{contract["contractInfo"]["id"]}}" class="u-hidee" >Your changes will remove UA for 5 machines</p></div>
-                              <p id="new-payment--{{contract["contractInfo"]["id"]}}" >Your monthly payment will be <strong>reduced by $42, to $42 per month</strong>. <br/>Unused credit will be applied to next month’s invoice.</p>
-                              <div class="col-6"><button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" class="p-button--negative">Cancel subscription</button></div>
-                              <div class="col-6 u-align--right"><button id="cancel-changes--{{contract["contractInfo"]["id"]}}" class="p-button--neutral">Cancel changes</button> <button id="save-changes--{{contract["contractInfo"]["id"]}}" class="p-button--positive">Save changes</button></div>
-
+                            <div class="change-subscription">
+                              <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
+                              <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
                             </div>
-                          <div class="col-12 u-align--center">
-                            <table class="p-table--advantage-contract">
-                              {% if contract["renewal"] %}
-                                {% include "advantage/table/_renewal-actions.html" %}
-                              {% endif %}
-                            </table>
+                          </div>
+
+                          <div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
+                            <h5>{{contract['contractInfo']['name']}}</h5>
+                            <hr />
+                            <div class="p-notification--caution">
+                              <p class="p-notification__response" role="status">
+                                <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
+                              </p>
+                            </div>
+                            <p class="p-muted-text">Machines</p>
+                            <div class="panel-input-wrapper"><input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed'] }}"/><p id="resize-summary--{{contract["contractInfo"]["id"]}}" class="u-hidee" >Your changes will remove UA for 5 machines</p></div>
+                            <p id="new-payment--{{contract["contractInfo"]["id"]}}" >Your monthly payment will be <strong>reduced by $42, to $42 per month</strong>. <br/>Unused credit will be applied to next month’s invoice.</p>
+                            <div class="col-6"><button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" class="p-button--negative">Cancel subscription</button></div>
+                            <div class="col-6 u-align--right"><button id="cancel-changes--{{contract["contractInfo"]["id"]}}" class="p-button--neutral">Cancel changes</button> <button id="save-changes--{{contract["contractInfo"]["id"]}}" class="p-button--positive">Save changes</button></div>
                           </div>
                         </div>
                       </td>
@@ -571,6 +563,7 @@
 </script>
 
 <script src="{{ versioned_static('js/src/advantage/auto-renewal.js') }}" type="module" defer></script>
+<script src="{{ versioned_static('js/src/advantage/manage-subscription.js') }}" type="module" defer></script>
 
 
 {% with first_item="_ua_got_questions", second_item="_ua_legal", third_item="_ua_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -328,18 +328,37 @@
                         {% endif %}
                       </td>
                       <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
-                        <div class="row">
+                          <div class="row">
+                            <div class="row col-start-large-2 col-10">
+                              <p class="col-2 p-muted-text">Created on</p>
+                              <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+                              <hr />
+                              <p class="col-2 p-muted-text">Ends</p>
+                              <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+
+                              <div class="change-subscription">
+                                <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
+                                <button class="p-button--neutral">Change subscription</button>
+                              </div>
+
+                              <hr class="p-separator"/>
+
+                              <h5>{{contract['contractInfo']['name']}}</h5>
+                              <hr />
+                              <div class="p-notification--caution">
+                                <p class="p-notification__response" role="status">
+                                  <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
+                                </p>
+                              </div>
+                              <p class="p-muted-text">Machines</p>
+                              <div class="panel-input-wrapper"><input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed'] }}"/><p id="resize-summary--{{contract["contractInfo"]["id"]}}" class="u-hidee" >Your changes will remove UA for 5 machines</p></div>
+                              <p id="new-payment--{{contract["contractInfo"]["id"]}}" >Your monthly payment will be <strong>reduced by $42, to $42 per month</strong>. <br/>Unused credit will be applied to next month’s invoice.</p>
+                              <div class="col-6"><button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" class="p-button--negative">Cancel subscription</button></div>
+                              <div class="col-6 u-align--right"><button id="cancel-changes--{{contract["contractInfo"]["id"]}}" class="p-button--neutral">Cancel changes</button> <button id="save-changes--{{contract["contractInfo"]["id"]}}" class="p-button--positive">Save changes</button></div>
+
+                            </div>
                           <div class="col-12 u-align--center">
                             <table class="p-table--advantage-contract">
-                              <tr>
-                                <td class="u-align--right">Created on:</td>
-                                <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
-                              </tr>
-
-                              {% if contract['contractInfo']['effectiveTo'] %}
-                                {% include "advantage/table/_expiry-date.html" %}
-                              {% endif %}
-
                               {% if contract["renewal"] %}
                                 {% include "advantage/table/_renewal-actions.html" %}
                               {% endif %}

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -115,6 +115,21 @@
               </div>
               {% endif %}
             </div>
+            <div class="row">
+              {% with mobile="true" %}
+
+                {% if contract["period"] == "monthly" %}
+
+                  {% include "advantage/table/_manage-monthly.html" %}
+
+                {% else %}
+                
+                  {% include "advantage/table/_manage-yearly.html" %}
+
+                {% endif %}
+
+              {% endwith %}
+            </div>
             <div class="row p-card__content">
               <div class="col-small-2 col-medium-3 u-align--right p-muted-text">Created on:</div>
               <div class="col-small-2 col-medium-3 u-align--left">{{ contract['contractInfo']['createdAtFormatted'] }}</div>

--- a/templates/advantage/shared/_certifications-info.html
+++ b/templates/advantage/shared/_certifications-info.html
@@ -1,22 +1,24 @@
-<div class="row" >
-  <div class="col-12" style="text-align: center;">
-    <div  style="display: inline-block; text-align: left;">
-      <strong>FIPS 140-2</strong> Level 1 certified packages use older software versions.<br />
-      Use them only if your organisation requires it.<br /><br />
+<div class="row">
+  <div class="row col-start-large-2 col-10" >
+    <div class="col-12" style="text-align: center;">
+      <div  style="display: inline-block; text-align: left;">
+        <strong>FIPS 140-2</strong> Level 1 certified packages use older software versions.<br />
+        Use them only if your organisation requires it.<br /><br />
 
-      Available on: Ubuntu 16.04 LTS, 18.04 LTS<br />
-      To activate FIPS: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/fips">FIPS setup instructions</a><br /><br />
+        Available on: Ubuntu 16.04 LTS, 18.04 LTS<br />
+        To activate FIPS: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/fips">FIPS setup instructions</a><br /><br />
 
-      <strong>CC-EAL2</strong> certified packages use older software versions<br />
-      Use them only if your organisation requires it.<br /><br />
+        <strong>CC-EAL2</strong> certified packages use older software versions<br />
+        Use them only if your organisation requires it.<br /><br />
 
-      Available on: Ubuntu 16.04 LTS<br />
-      To activate CC-EAL2: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cc-16/">CC-EAL2 setup instructions</a><br /><br />
+        Available on: Ubuntu 16.04 LTS<br />
+        To activate CC-EAL2: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cc-16/">CC-EAL2 setup instructions</a><br /><br />
 
-      <strong>CIS tools</strong> test compliance with the CIS security benchmark.<br /><br />
+        <strong>CIS tools</strong> test compliance with the CIS security benchmark.<br /><br />
 
-      Available on: Ubuntu 16.04 LTS, 18.04 LTS<br />
-      To use the tools: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cis-18-16.html">CIS setup instructions</a>
+        Available on: Ubuntu 16.04 LTS, 18.04 LTS<br />
+        To use the tools: <a class="p-link--external" href="https://docs.ubuntu.com/security-certs/en/cis-18-16.html">CIS setup instructions</a>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/advantage/shared/_esm-info.html
+++ b/templates/advantage/shared/_esm-info.html
@@ -1,59 +1,61 @@
 <div class="row">
-  {% if contract['entitlements']['esm-infra'] == True %}
-  <div class="col-12">
-    <div class="p-notification--information">
-      <p class="p-notification__response">
-        ESM is active by default on any newly-attached Ubuntu 14.04 LTS system.
-      </p>
+  <div class="row col-start-large-2 col-10">
+    {% if contract['entitlements']['esm-infra'] == True %}
+    <div class="col-12">
+      <div class="p-notification--information">
+        <p class="p-notification__response">
+          ESM is active by default on any newly-attached Ubuntu 14.04 LTS system.
+        </p>
+      </div>
     </div>
-  </div>
-  
-  <div class="col-9">
-    <h4>Ubuntu 14.04 ESM</h4>
+    
+    <div class="col-9">
+      <h4>Ubuntu 14.04 ESM</h4>
 
-    <table class="p-table--key-value">
-      <tbody>
-        <tr>
-          <td>To activate ESM Infra:</td>
-          <td><code>sudo ua enable esm-infra</code></td>
-        </tr>
+      <table class="p-table--key-value">
+        <tbody>
+          <tr>
+            <td>To activate ESM Infra:</td>
+            <td><code>sudo ua enable esm-infra</code></td>
+          </tr>
 
-        <tr>
-          <td>To deactivate:</td>
-          <td><code>sudo ua disable esm-infra</code></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-  {% else %}
-  <div class="col-12">
-    <div class="p-notification--information">
-      <p class="p-notification__response">
-        ESM-apps is active by default on any newly-attached Ubuntu 14.04 LTS system.
-      </p>
+          <tr>
+            <td>To deactivate:</td>
+            <td><code>sudo ua disable esm-infra</code></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
+    {% else %}
+    <div class="col-12">
+      <div class="p-notification--information">
+        <p class="p-notification__response">
+          ESM-apps is active by default on any newly-attached Ubuntu 14.04 LTS system.
+        </p>
+      </div>
+    </div>
+
+    <div class="col-9">
+      <h4>Ubuntu 20.04 LTS</h4>
+
+      <table class="p-table--key-value">
+        <tbody>
+          <tr>
+            <td>To activate ESM Apps:</td>
+            <td><code>sudo ua enable esm-apps</code></td>
+          </tr>
+
+          <tr>
+            <td>To deactivate:</td>
+            <td><code>sudo ua disable esm-apps</code></td>
+          </tr>
+        </tbody>
+      </table>
+      
+      <h4>Other Ubuntu versions</h4>
+      
+      <p>ESM Apps is not currently available.</p>
+    </div>
+    {% endif %}
   </div>
-
-  <div class="col-9">
-    <h4>Ubuntu 20.04 LTS</h4>
-
-    <table class="p-table--key-value">
-      <tbody>
-        <tr>
-          <td>To activate ESM Apps:</td>
-          <td><code>sudo ua enable esm-apps</code></td>
-        </tr>
-
-        <tr>
-          <td>To deactivate:</td>
-          <td><code>sudo ua disable esm-apps</code></td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Other Ubuntu versions</h4>
-    
-    <p>ESM Apps is not currently available.</p>
-  </div>
-  {% endif %}
 </div>

--- a/templates/advantage/shared/_livepatch-info.html
+++ b/templates/advantage/shared/_livepatch-info.html
@@ -1,38 +1,40 @@
 <div class="row">
-  <div class="col-9">
-    <h4>Ubuntu 14.04 ESM and 20.04 LTS</h4>
+  <div class="row col-start-large-2 col-10">
+    <div class="col-9">
+      <h4>Ubuntu 14.04 ESM and 20.04 LTS</h4>
 
-    <table class="p-table--key-value">
-      <tbody>
-        <tr>
-          <td>To activate Livepatch:</td>
-          <td><code>ua enable livepatch</code></td>
-        </tr>
+      <table class="p-table--key-value">
+        <tbody>
+          <tr>
+            <td>To activate Livepatch:</td>
+            <td><code>ua enable livepatch</code></td>
+          </tr>
 
-        <tr>
-          <td>To deactivate:</td>
-          <td><code>ua disable livepatch</code></td>
-        </tr>
-      </tbody>
-    </table>
-    
-    <h4>Ubuntu 16.04 LTS and 18.04 LTS</h4>
+          <tr>
+            <td>To deactivate:</td>
+            <td><code>ua disable livepatch</code></td>
+          </tr>
+        </tbody>
+      </table>
+      
+      <h4>Ubuntu 16.04 LTS and 18.04 LTS</h4>
 
-    <table class="p-table--key-value">
-      <tbody>
-        <tr>
-          <td>To activate Livepatch:</td>
-          <td><a class="p-link--external" href="https://auth.livepatch.canonical.com/">Follow the instructions on the Livepatch site</a></td>
-        </tr>
+      <table class="p-table--key-value">
+        <tbody>
+          <tr>
+            <td>To activate Livepatch:</td>
+            <td><a class="p-link--external" href="https://auth.livepatch.canonical.com/">Follow the instructions on the Livepatch site</a></td>
+          </tr>
 
-        <tr>
-          <td>To deactivate:</td>
-          <td><code>sudo canonical-livepatch disable</code></td>
-        </tr>
-      </tbody>
-    </table>
+          <tr>
+            <td>To deactivate:</td>
+            <td><code>sudo canonical-livepatch disable</code></td>
+          </tr>
+        </tbody>
+      </table>
 
-    <h4>Other Ubuntu versions</h4>
-    <p>Livepatch is available only on LTS versions. Consider upgrading to Ubuntu 20.04 LTS.</p>
+      <h4>Other Ubuntu versions</h4>
+      <p>Livepatch is available only on LTS versions. Consider upgrading to Ubuntu 20.04 LTS.</p>
+    </div>
   </div>
 </div>

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -1,4 +1,4 @@
-<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
+<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
   {% if not mobile %}
     <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
     <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
@@ -9,11 +9,11 @@
 
   <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
     <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">Change subscription</button>
+    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">Change subscription</button>
   </div>
 </div>
 
-<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
+<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
   {% if mobile %}
     <hr />
   {% endif %}
@@ -29,7 +29,7 @@
   <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
     <input 
-      id="resize-input--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+      id="resize-input--{{contract["contractInfo"]["id"]}}" 
       type="number" 
       value="{{ contract['machineCount']['allowed']}}" 
       data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
@@ -37,34 +37,38 @@
       min="1" 
       max="999"
       data-billing-period="monthly"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     />
-    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
+    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
   </div>
-  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
+  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
   <div class="col-6 buttons-wrapper">
-    <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+    <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" 
       class="p-button--negative" 
       data-contract-name="{{contract['contractInfo']['name']}}" 
       data-machine-count="{{ contract['machineCount']['allowed']}}" 
       data-account-id="{{contract['accountInfo']['id']}}" 
       data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     >
       Cancel subscription
     </button>
   </div>
   <div class="col-6 u-align--right buttons-wrapper">
     <button 
-      id="cancel-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
       class="p-button--neutral"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     >
       Cancel changes
     </button>
     <button 
-      id="save-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+      id="save-changes--{{contract["contractInfo"]["id"]}}" 
       class="p-button--positive" 
       disabled 
       data-account-id="{{contract['accountInfo']['id']}}" 
       data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     >
       Save changes
     </button>

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -21,7 +21,7 @@
   </div>
   <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
-    <input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed']}}" data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" data-unit-price="{{contract["price_per_unit"]}}" min="1"/>
+    <input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed']}}" data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" data-unit-price="{{contract["price_per_unit"]}}" min="1" max="999"/>
     <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
   </div>
   <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -1,0 +1,56 @@
+<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
+  <p class="col-2 p-muted-text">Created on</p>
+  <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+  <hr />
+  <p class="col-2 p-muted-text">Ends</p>
+  <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+
+  <div class="change-subscription">
+    <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
+    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
+  </div>
+</div>
+
+<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
+  <h5>{{contract['contractInfo']['name']}} (monthly)</h5>
+  <hr />
+  <div class="p-notification--caution">
+    <p class="p-notification__response" role="status">
+      <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
+    </p>
+  </div>
+  <p class="p-muted-text">Machines</p>
+  <div class="panel-input-wrapper">
+    <input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed']}}" data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" data-unit-price="{{contract["price_per_unit"]}}" min="1"/>
+    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
+  </div>
+  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>
+  <div class="col-6">
+    <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" 
+      class="p-button--negative" 
+      data-contract-name="{{contract['contractInfo']['name']}}" 
+      data-machine-count="{{ contract['machineCount']['allowed']}}" 
+      data-account-id="{{contract['accountInfo']['id']}}" 
+      data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+    >
+      Cancel subscription
+    </button>
+  </div>
+  <div class="col-6 u-align--right">
+    <button 
+      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
+      class="p-button--neutral"
+    >
+      Cancel changes
+    </button>
+    <button 
+      id="save-changes--{{contract["contractInfo"]["id"]}}" 
+      class="p-button--positive" 
+      disabled 
+      data-account-id="{{contract['accountInfo']['id']}}" 
+      data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+    >
+      Save changes
+    </button>
+  </div>
+</div>

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -1,76 +1,80 @@
-<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
-  {% if not mobile %}
-    <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
-    <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
-    <hr />
-    <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
-    <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
-  {% endif %}
+<div class="col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
+  <div class="row">
+    {% if not mobile %}
+      <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
+      <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+      <hr />
+      <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
+      <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+    {% endif %}
 
-  <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
-    <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">Change subscription</button>
+    <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
+      <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
+      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">Change subscription</button>
+    </div>
   </div>
 </div>
 
-<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
-  {% if mobile %}
-    <hr />
-  {% endif %}
-  <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (monthly)</h5>
-  {% if not mobile %}
-    <hr />
-  {% endif %}
-  <div class="p-notification--caution">
-    <p class="p-notification__response" role="status">
-      <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
-    </p>
-  </div>
-  <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
-  <div class="panel-input-wrapper">
-    <input 
-      id="resize-input--{{contract["contractInfo"]["id"]}}" 
-      type="number" 
-      value="{{ contract['machineCount']['allowed']}}" 
-      data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
-      data-unit-price="{{contract["price_per_unit"]}}" 
-      min="1" 
-      max="999"
-      data-billing-period="monthly"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    />
-    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
-  </div>
-  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
-  <div class="col-6 buttons-wrapper">
-    <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" 
-      class="p-button--negative" 
-      data-contract-name="{{contract['contractInfo']['name']}}" 
-      data-machine-count="{{ contract['machineCount']['allowed']}}" 
-      data-account-id="{{contract['accountInfo']['id']}}" 
-      data-previous-purchase-id="{{contract['previous_purchase_id']}}"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    >
-      Cancel subscription
-    </button>
-  </div>
-  <div class="col-6 u-align--right buttons-wrapper">
-    <button 
-      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
-      class="p-button--neutral"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    >
-      Cancel changes
-    </button>
-    <button 
-      id="save-changes--{{contract["contractInfo"]["id"]}}" 
-      class="p-button--positive" 
-      disabled 
-      data-account-id="{{contract['accountInfo']['id']}}" 
-      data-previous-purchase-id="{{contract['previous_purchase_id']}}"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    >
-      Save changes
-    </button>
+<div class="col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
+  <div class="row">
+    {% if mobile %}
+      <hr />
+    {% endif %}
+    <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (monthly)</h5>
+    {% if not mobile %}
+      <hr />
+    {% endif %}
+    <div class="p-notification--caution">
+      <p class="p-notification__response" role="status">
+        <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
+      </p>
+    </div>
+    <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
+    <div class="panel-input-wrapper">
+      <input 
+        id="resize-input--{{contract["contractInfo"]["id"]}}" 
+        type="number" 
+        value="{{ contract['machineCount']['allowed']}}" 
+        data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
+        data-unit-price="{{contract["price_per_unit"]}}" 
+        min="1" 
+        max="999"
+        data-billing-period="monthly"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      />
+      <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
+    </div>
+    <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
+    <div class="col-6 buttons-wrapper">
+      <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" 
+        class="p-button--negative" 
+        data-contract-name="{{contract['contractInfo']['name']}}" 
+        data-machine-count="{{ contract['machineCount']['allowed']}}" 
+        data-account-id="{{contract['accountInfo']['id']}}" 
+        data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      >
+        Cancel subscription
+      </button>
+    </div>
+    <div class="col-6 u-align--right buttons-wrapper">
+      <button 
+        id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
+        class="p-button--neutral"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      >
+        Cancel changes
+      </button>
+      <button 
+        id="save-changes--{{contract["contractInfo"]["id"]}}" 
+        class="p-button--positive" 
+        disabled 
+        data-account-id="{{contract['accountInfo']['id']}}" 
+        data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      >
+        Save changes
+      </button>
+    </div>
   </div>
 </div>

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -21,7 +21,16 @@
   </div>
   <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
-    <input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed']}}" data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" data-unit-price="{{contract["price_per_unit"]}}" min="1" max="999"/>
+    <input 
+      id="resize-input--{{contract["contractInfo"]["id"]}}" 
+      type="number" 
+      value="{{ contract['machineCount']['allowed']}}" 
+      data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
+      data-unit-price="{{contract["price_per_unit"]}}" 
+      min="1" 
+      max="999"
+      data-billing-period="monthly"
+    />
     <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
   </div>
   <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -1,19 +1,26 @@
-<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
-  <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
-  <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
-  <hr />
-  <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
-  <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
+  {% if not mobile %}
+    <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
+    <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+    <hr />
+    <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
+    <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+  {% endif %}
 
-  <div class="change-subscription">
+  <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
     <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
+    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">Change subscription</button>
   </div>
 </div>
 
-<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
-  <h5 class="u-no-padding--top" style="margin-bottom: .5rem">{{contract['contractInfo']['name']}} (monthly)</h5>
-  <hr />
+<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
+  {% if mobile %}
+    <hr />
+  {% endif %}
+  <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (monthly)</h5>
+  {% if not mobile %}
+    <hr />
+  {% endif %}
   <div class="p-notification--caution">
     <p class="p-notification__response" role="status">
       <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
@@ -22,7 +29,7 @@
   <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
     <input 
-      id="resize-input--{{contract["contractInfo"]["id"]}}" 
+      id="resize-input--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       type="number" 
       value="{{ contract['machineCount']['allowed']}}" 
       data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
@@ -31,11 +38,11 @@
       max="999"
       data-billing-period="monthly"
     />
-    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
+    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
   </div>
-  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>
+  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
   <div class="col-6 buttons-wrapper">
-    <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" 
+    <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       class="p-button--negative" 
       data-contract-name="{{contract['contractInfo']['name']}}" 
       data-machine-count="{{ contract['machineCount']['allowed']}}" 
@@ -47,13 +54,13 @@
   </div>
   <div class="col-6 u-align--right buttons-wrapper">
     <button 
-      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
+      id="cancel-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       class="p-button--neutral"
     >
       Cancel changes
     </button>
     <button 
-      id="save-changes--{{contract["contractInfo"]["id"]}}" 
+      id="save-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       class="p-button--positive" 
       disabled 
       data-account-id="{{contract['accountInfo']['id']}}" 

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -1,9 +1,9 @@
 <div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
-  <p class="col-2 p-muted-text">Created on</p>
-  <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+  <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
+  <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
   <hr />
-  <p class="col-2 p-muted-text">Ends</p>
-  <p class="col-3 u-no-margin--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+  <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
+  <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
 
   <div class="change-subscription">
     <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
@@ -12,20 +12,20 @@
 </div>
 
 <div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
-  <h5>{{contract['contractInfo']['name']}} (monthly)</h5>
+  <h5 class="u-no-padding--top" style="margin-bottom: .5rem">{{contract['contractInfo']['name']}} (monthly)</h5>
   <hr />
   <div class="p-notification--caution">
     <p class="p-notification__response" role="status">
       <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
     </p>
   </div>
-  <p class="p-muted-text">Machines</p>
+  <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
     <input id="resize-input--{{contract["contractInfo"]["id"]}}" type="number" value="{{ contract['machineCount']['allowed']}}" data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" data-unit-price="{{contract["price_per_unit"]}}" min="1"/>
     <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
   </div>
   <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>
-  <div class="col-6">
+  <div class="col-6 buttons-wrapper">
     <button id="cancel-subscription--{{contract["contractInfo"]["id"]}}" 
       class="p-button--negative" 
       data-contract-name="{{contract['contractInfo']['name']}}" 
@@ -36,7 +36,7 @@
       Cancel subscription
     </button>
   </div>
-  <div class="col-6 u-align--right">
+  <div class="col-6 u-align--right buttons-wrapper">
     <button 
       id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
       class="p-button--neutral"

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -1,19 +1,26 @@
 <div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
-  <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
-  <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
-  <hr />
-  <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
-  <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+  {% if not mobile %}
+    <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
+    <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+    <hr />
+    <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
+    <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+  {% endif %}
 
-  <div class="change-subscription">
-    <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
-  </div>
+    <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
+      <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
+      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
+    </div>
 </div>
 
 <div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
-  <h5 class="u-no-padding--top" style="margin-bottom: .5rem">{{contract['contractInfo']['name']}} (annual)</h5>
-  <hr />
+  {% if mobile %}
+    <hr />
+  {% endif %}
+  <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (annual)</h5>
+  {% if not mobile %}
+    <hr />
+  {% endif %}
   <div class="p-notification--information">
     <p class="p-notification__response" role="status">
       <span class="p-notification__status">You can add machines to your annual subscription, but not remove machines until the end of your agreed term.</span><a href="/contact-us">Contact us</a> for further information or to amend your subscription.

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -1,4 +1,4 @@
-<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
+<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
   {% if not mobile %}
     <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
     <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
@@ -9,11 +9,11 @@
 
     <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
       <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">Change subscription</button>
+      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">Change subscription</button>
     </div>
 </div>
 
-<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
+<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
   {% if mobile %}
     <hr />
   {% endif %}
@@ -29,7 +29,7 @@
   <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
     <input 
-      id="resize-input--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+      id="resize-input--{{contract["contractInfo"]["id"]}}" 
       type="number" 
       value="{{ contract['machineCount']['allowed']}}" 
       data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
@@ -37,23 +37,26 @@
       min="{{ contract['machineCount']['allowed']}}" 
       max="999"
       data-billing-period="yearly"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     />
-    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
+    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}"></p>
   </div>
-  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
+  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
   <div class="col-12 u-align--right buttons-wrapper">
     <button 
-      id="cancel-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
       class="p-button--neutral"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     >
       Cancel changes
     </button>
     <button 
-      id="save-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
+      id="save-changes--{{contract["contractInfo"]["id"]}}" 
       class="p-button--positive" 
       disabled 
       data-account-id="{{contract['accountInfo']['id']}}" 
       data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
     >
       Save changes
     </button>

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -1,4 +1,4 @@
-<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
+<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
   {% if not mobile %}
     <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
     <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
@@ -9,11 +9,11 @@
 
     <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
       <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
+      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">Change subscription</button>
     </div>
 </div>
 
-<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
+<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}">
   {% if mobile %}
     <hr />
   {% endif %}
@@ -29,7 +29,7 @@
   <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
   <div class="panel-input-wrapper">
     <input 
-      id="resize-input--{{contract["contractInfo"]["id"]}}" 
+      id="resize-input--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       type="number" 
       value="{{ contract['machineCount']['allowed']}}" 
       data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
@@ -38,18 +38,18 @@
       max="999"
       data-billing-period="yearly"
     />
-    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
+    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
   </div>
-  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>
+  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" ></p>
   <div class="col-12 u-align--right buttons-wrapper">
     <button 
-      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
+      id="cancel-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       class="p-button--neutral"
     >
       Cancel changes
     </button>
     <button 
-      id="save-changes--{{contract["contractInfo"]["id"]}}" 
+      id="save-changes--{{contract["contractInfo"]["id"]}}{% if mobile %}--mobile{% endif %}" 
       class="p-button--positive" 
       disabled 
       data-account-id="{{contract['accountInfo']['id']}}" 

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -1,64 +1,68 @@
-<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
-  {% if not mobile %}
-    <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
-    <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
-    <hr />
-    <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
-    <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
-  {% endif %}
+<div class="col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
+  <div class="row">
+    {% if not mobile %}
+      <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
+      <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+      <hr />
+      <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
+      <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+    {% endif %}
 
     <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
       <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
       <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">Change subscription</button>
     </div>
+  </div>
 </div>
 
-<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
-  {% if mobile %}
-    <hr />
-  {% endif %}
-  <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (annual)</h5>
-  {% if not mobile %}
-    <hr />
-  {% endif %}
-  <div class="p-notification--information">
-    <p class="p-notification__response" role="status">
-      <span class="p-notification__status">You can add machines to your annual subscription, but not remove machines until the end of your agreed term.</span><a href="/contact-us">Contact us</a> for further information or to amend your subscription.
-    </p>
-  </div>
-  <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
-  <div class="panel-input-wrapper">
-    <input 
-      id="resize-input--{{contract["contractInfo"]["id"]}}" 
-      type="number" 
-      value="{{ contract['machineCount']['allowed']}}" 
-      data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
-      data-unit-price="{{contract["price_per_unit"]}}" 
-      min="{{ contract['machineCount']['allowed']}}" 
-      max="999"
-      data-billing-period="yearly"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    />
-    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}"></p>
-  </div>
-  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
-  <div class="col-12 u-align--right buttons-wrapper">
-    <button 
-      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
-      class="p-button--neutral"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    >
-      Cancel changes
-    </button>
-    <button 
-      id="save-changes--{{contract["contractInfo"]["id"]}}" 
-      class="p-button--positive" 
-      disabled 
-      data-account-id="{{contract['accountInfo']['id']}}" 
-      data-previous-purchase-id="{{contract['previous_purchase_id']}}"
-      data-viewport="{% if mobile %}small{% else %}large{% endif %}"
-    >
-      Save changes
-    </button>
+<div class="col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
+  <div class="row">
+    {% if mobile %}
+      <hr />
+    {% endif %}
+    <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (annual)</h5>
+    {% if not mobile %}
+      <hr />
+    {% endif %}
+    <div class="p-notification--information">
+      <p class="p-notification__response" role="status">
+        <span class="p-notification__status">You can add machines to your annual subscription, but not remove machines until the end of your agreed term.</span><a href="/contact-us">Contact us</a> for further information or to amend your subscription.
+      </p>
+    </div>
+    <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
+    <div class="panel-input-wrapper">
+      <input 
+        id="resize-input--{{contract["contractInfo"]["id"]}}" 
+        type="number" 
+        value="{{ contract['machineCount']['allowed']}}" 
+        data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
+        data-unit-price="{{contract["price_per_unit"]}}" 
+        min="{{ contract['machineCount']['allowed']}}" 
+        max="999"
+        data-billing-period="yearly"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      />
+      <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}"></p>
+    </div>
+    <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" data-viewport="{% if mobile %}small{% else %}large{% endif %}" ></p>
+    <div class="col-12 u-align--right buttons-wrapper">
+      <button 
+        id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
+        class="p-button--neutral"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      >
+        Cancel changes
+      </button>
+      <button 
+        id="save-changes--{{contract["contractInfo"]["id"]}}" 
+        class="p-button--positive" 
+        disabled 
+        data-account-id="{{contract['accountInfo']['id']}}" 
+        data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+        data-viewport="{% if mobile %}small{% else %}large{% endif %}"
+      >
+        Save changes
+      </button>
+    </div>
   </div>
 </div>

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -1,0 +1,54 @@
+<div class="row col-start-large-2 col-10" id="view-mode--{{contract["contractInfo"]["id"]}}">
+  <p class="col-2 p-muted-text" style="margin-bottom: .5rem">Created on</p>
+  <p class="col-3 u-no-margin--top" style="margin-bottom: .5rem">{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+  <hr />
+  <p class="col-2 p-muted-text u-no-padding--top">Ends</p>
+  <p class="col-3 u-no-margin--top u-no-padding--top">{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+
+  <div class="change-subscription">
+    <p>Auto-renewal {% if subscriptions['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
+    <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}">Change subscription</button>
+  </div>
+</div>
+
+<div class="row col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}">
+  <h5 class="u-no-padding--top" style="margin-bottom: .5rem">{{contract['contractInfo']['name']}} (annual)</h5>
+  <hr />
+  <div class="p-notification--information">
+    <p class="p-notification__response" role="status">
+      <span class="p-notification__status">You can add machines to your annual subscription, but not remove machines until the end of your agreed term.</span><a href="/contact-us">Contact us</a> for further information or to amend your subscription.
+    </p>
+  </div>
+  <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
+  <div class="panel-input-wrapper">
+    <input 
+      id="resize-input--{{contract["contractInfo"]["id"]}}" 
+      type="number" 
+      value="{{ contract['machineCount']['allowed']}}" 
+      data-next-payment="{{subscriptions["next_payment"]["ammount"]}}" 
+      data-unit-price="{{contract["price_per_unit"]}}" 
+      min="{{ contract['machineCount']['allowed']}}" 
+      max="999"
+      data-billing-period="yearly"
+    />
+    <p class="u-hide" id="resize-summary--{{contract["contractInfo"]["id"]}}" ></p>
+  </div>
+  <p class="u-hide "id="new-payment--{{contract["contractInfo"]["id"]}}" ></p>
+  <div class="col-12 u-align--right buttons-wrapper">
+    <button 
+      id="cancel-changes--{{contract["contractInfo"]["id"]}}" 
+      class="p-button--neutral"
+    >
+      Cancel changes
+    </button>
+    <button 
+      id="save-changes--{{contract["contractInfo"]["id"]}}" 
+      class="p-button--positive" 
+      disabled 
+      data-account-id="{{contract['accountInfo']['id']}}" 
+      data-previous-purchase-id="{{contract['previous_purchase_id']}}"
+    >
+      Save changes
+    </button>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Added options to resize or cancel monthly contracts from the table

## To do

- Build the view for yearly subscriptions

- [x] Mobile view
- [x] Yearly view
- [x] Correct link in cancel modal
- [x] check for minimum / maximum values before sending

## Known issues

Trying to cancel returns a `405 (METHOD NOT ALLOWED)`

Trying to resize throws an error about `product_listing_id` being a number instead of a string


## QA

- go to https://ubuntu-com-9315.demos.haus/advantage?test_backend=true
- login
- expand one of your subscriptions and try the different settings


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3787

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/109184733-92b07a80-778f-11eb-9237-f133375e180c.png)

![image](https://user-images.githubusercontent.com/11927929/109184797-9e9c3c80-778f-11eb-8ba0-40a8841dc197.png)

![image](https://user-images.githubusercontent.com/11927929/109184829-a65be100-778f-11eb-852f-ffe5d958747e.png)

![image](https://user-images.githubusercontent.com/11927929/109987671-1f66b580-7d07-11eb-827d-9527b9626df3.png)
