### PR TITLE
CUBE: Update module titles

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -13,7 +13,7 @@
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
       <p class="p-heading--4">The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. You need to pass 15 microcerts to earn your CUBE qualification.</p>
       <p>
-        <a href="/cube/microcerts" class="p-button--positive">View the microCerts</a>
+        <a href="/cube/microcerts" class="p-button--positive">View the microcerts</a>
       </p>
     </div>
     <div class="col-5 col-start-large-8 u-hide--small p-cube-animation">

--- a/webapp/cube/content/cube-qa.yaml
+++ b/webapp/cube/content/cube-qa.yaml
@@ -9,7 +9,7 @@ prepare-course: "course-v1:ubuntu+cubereview+coursecommandsdev"
 courses:
   -
     id: course-v1:CUBE+admintasks+2020
-    name: Administrative Tasks
+    name: Performing Administrative Tasks
     badge:
       class: 5FvYpGQ3S9yPiuJA82SCgg
       url: https://assets.ubuntu.com/v1/7bf909cc-Admin.svg
@@ -21,7 +21,7 @@ courses:
       - Configure remote logging.
   -
     id: course-v1:CUBE+commands+2020
-    name: Commands
+    name: Using Command Line Tools
     badge:
       class: cz8Bh5KJQT-0BenVPpn2tQ
       url: https://assets.ubuntu.com/v1/43f7d2a3-Commands.svg
@@ -31,7 +31,7 @@ courses:
       - Use essential utilities
   -
     id: course-v1:CUBE+devices+2020
-    name: Block Devices and Linux Filesystems
+    name: Linux Devices and Filesystems
     badge:
       class: zIdluAA9RI2tfKb6lEOMQg
       url: https://assets.ubuntu.com/v1/093b57b6-Devices+%26+files.svg
@@ -52,7 +52,7 @@ courses:
       - Juju administration
   -
     id: course-v1:CUBE+kernel+2020
-    name: Linux Kernel
+    name: Ubuntu Kernels
     badge:
       class: 04PfU98pSoeOKvmMAy8dZw
       url: https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg
@@ -82,7 +82,7 @@ courses:
       - Common MicroK8s use cases
   -
     id: course-v1:CUBE+networking+2020
-    name: Networking
+    name: Networking on Ubuntu
     badge:
       class: t-_L8-Q5SYCXZRMjr8CLAQ
       url: https://assets.ubuntu.com/v1/f59674b7-Networking.svg
@@ -92,7 +92,7 @@ courses:
       - Verify connectivity and features of remote services
   -
     id: course-v1:CUBE+package+2020
-    name: Installation and Package Management
+    name: Managing Packages in Ubuntu
     badge:
       class: t63waXMVR0OUXfH_G-ju1g
       url: https://assets.ubuntu.com/v1/c19e9931-Packages.svg
@@ -103,7 +103,7 @@ courses:
       - Manage executables with alternatives
   -
     id: course-v1:CUBE+security+2020
-    name: Security
+    name: Securing Ubuntu
     badge:
       class: jEBfgLhcQYqzOzCH6KK86g
       url: https://assets.ubuntu.com/v1/2291952a-Security.svg
@@ -114,7 +114,7 @@ courses:
       - Perform basic hardening operations
   -
     id: course-v1:CUBE+shellscript+2020
-    name: Shell Scripting
+    name: Bash Shell Scripting
     badge:
       class: WLnYKUtmRY2N-jpgvcKJRQ
       url: https://assets.ubuntu.com/v1/30af430c-bash.svg
@@ -125,7 +125,7 @@ courses:
       - Automate tasks with loops and conditionals
   -
     id: course-v1:CUBE+storage+2020
-    name: Storage
+    name: Configuring Enterprise Storage
     badge:
       class: BkqG388ZTS2rhqD_V2P-Fw
       url: https://assets.ubuntu.com/v1/cd7785d1-Storage.svg
@@ -135,7 +135,7 @@ courses:
       - Test storage capabilities
   -
     id: course-v1:CUBE+sysarch+2020
-    name: System Architecture
+    name: Ubuntu System Architecture
     badge:
       class: 9zhR7U8YQbWTForsG9LXPw
       url: https://assets.ubuntu.com/v1/9ef4a092-Architecture.svg
@@ -145,7 +145,7 @@ courses:
       - Make administrative changes to devices and hardware
   -
     id: course-v1:CUBE+systemd+2020
-    name: System Services
+    name: Managing System Services
     badge:
       class: 1UaDxKr_Q-SvaC0xHJ1sKQ
       url: https://assets.ubuntu.com/v1/09d0b73a-Services.svg

--- a/webapp/cube/content/cube.yaml
+++ b/webapp/cube/content/cube.yaml
@@ -9,7 +9,7 @@ prepare-course: "course-v1:CUBE+study_labs_2020+alpha"
 courses:
   -
     id: course-v1:CUBE+admintasks+2020
-    name: Administrative Tasks
+    name: Performing Administrative Tasks
     badge:
       class: czAAvvs2SJCH1py9Y7i3wQ
       url: https://assets.ubuntu.com/v1/7bf909cc-Admin.svg
@@ -21,7 +21,7 @@ courses:
       - Configure remote logging.
   -
     id: course-v1:CUBE+commands+2020
-    name: Commands
+    name: Using Command Line Tools
     badge:
       class: Yjz2TbTASeajywVHtNtcnA
       url: https://assets.ubuntu.com/v1/43f7d2a3-Commands.svg
@@ -52,7 +52,7 @@ courses:
       - Juju administration
   -
     id: course-v1:CUBE+kernel+2020
-    name: Linux Kernel
+    name: Ubuntu Kernels
     badge:
       class: TRfJwsr6R-a-iU-Vi7wkQQ
       url: https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg
@@ -82,7 +82,7 @@ courses:
       - Common MicroK8s use cases
   -
     id: course-v1:CUBE+networking+2020
-    name: Networking
+    name: Networking on Ubuntu
     badge:
       class: 5871A52aRE6TnUlMuThXYQ
       url: https://assets.ubuntu.com/v1/f59674b7-Networking.svg
@@ -92,7 +92,7 @@ courses:
       - Verify connectivity and features of remote services
   -
     id: course-v1:CUBE+package+2020
-    name: Installation and Package Management
+    name: Managing Packages in Ubuntu
     badge:
       class: n_lXbWCdTfifAiWcj9D_ZQ
       url: https://assets.ubuntu.com/v1/c19e9931-Packages.svg
@@ -103,7 +103,7 @@ courses:
       - Manage executables with alternatives
   -
     id: course-v1:CUBE+security+2020
-    name: Security
+    name: Securing Ubuntu
     badge:
       class: MIpdhnR1TjmeK4eYUCkN9A
       url: https://assets.ubuntu.com/v1/2291952a-Security.svg
@@ -114,7 +114,7 @@ courses:
       - Perform basic hardening operations
   -
     id: course-v1:CUBE+shellscript+2020
-    name: Shell Scripting
+    name: Bash Shell Scripting
     badge:
       class: 3MpPyZTISEqlgyG9gjN2mQ
       url: https://assets.ubuntu.com/v1/30af430c-bash.svg
@@ -125,7 +125,7 @@ courses:
       - Automate tasks with loops and conditionals
   -
     id: course-v1:CUBE+storage+2020
-    name: Storage
+    name: Configuring Enterprise Storage
     badge:
       class: tEAG-zVjRMKeUsR6tKefgA
       url: https://assets.ubuntu.com/v1/cd7785d1-Storage.svg
@@ -135,7 +135,7 @@ courses:
       - Test storage capabilities
   -
     id: course-v1:CUBE+sysarch+2020
-    name: System Architecture
+    name: Ubuntu System Architecture
     badge:
       class: KafTCFzVSHecbUPcjkVA-Q
       url: https://assets.ubuntu.com/v1/9ef4a092-Architecture.svg
@@ -145,7 +145,7 @@ courses:
       - Make administrative changes to devices and hardware
   -
     id: course-v1:CUBE+systemd+2020
-    name: System Services
+    name: Managing System Services
     badge:
       class: GQwSj8y5R3yYpO9togXGbQ
       url: https://assets.ubuntu.com/v1/09d0b73a-Services.svg


### PR DESCRIPTION
## Done

- Fix typo on view microcerts button on `/cube`
- Update module titles in table on `/cube/microcerts`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube and http://0.0.0.0:8001/cube/microcerts
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check titles of modules on the microcerts table match updated titles seen [here](https://docs.google.com/document/d/1a8GvqITokFmAZvhDCQCq8tc3urSfDGW0GxeLDFGDda0/edit) 
- Check View Microcerts button against [copy doc](https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit?ts=6037ec8b#heading=h.pldvznbtjgmu) on `/cube`


## Issue / Card

Fixes #9320 

