### PR TITLE
Make empty POST show step 1, instead of 500

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -90,21 +90,18 @@ def download_server_steps():
         "download": "download/server/download.html",
     }
     context = {}
-    step = "step1"
+    step = flask.request.form.get("next-step") or "step1"
 
-    if flask.request.method == "POST":
-        if step not in templates:
+    if step not in templates:
+        flask.abort(400)
+
+    if step == "download":
+        version = flask.request.form.get("version")
+
+        if not version:
             flask.abort(400)
 
-        step = flask.request.form.get("next-step")
-
-        if step == "download":
-            version = flask.request.form.get("version")
-
-            if not version:
-                flask.abort(400)
-
-            context = {"version": version, "mirror_list": _build_mirror_list()}
+        context = {"version": version, "mirror_list": _build_mirror_list()}
 
     return flask.render_template(templates[step], **context)
 


### PR DESCRIPTION
Fixes #9275

I don't know how [the error](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/12076/events/a0274d47ecc34e66b68e758a17875e2e/) is happening *exactly8, but it looks like it happens when people load the form with `POST`, but without a `next-step`. Maybe this is because the user refreshes the page, and the browser resubmits the post request but doesn't include the form data for some reason?

Anyway, this should fix it - if you submit an empty `POST` request for `/download/server`, you should now see step 1.

QA
--

First, reproduce the error:

```
$ curl -I -X POST https://ubuntu.com/download/server
HTTP/2 500 
```

Now try on my branch:

```
$ curl -I -X POST https://ubuntu-com-9336.demos.haus/download/server
HTTP/2 200 
```

Rejoice!
```