### PR TITLE
CUBE: refactor code and add meta data

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1496,7 +1496,7 @@ cube:
   children:
     - title: Overview
       path: /cube
-    - title: MicroCerts
+    - title: Microcerts
       path: /cube/microcerts
 
     - title: Contact us

--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,5 +1,5 @@
 function toggleMenu(element, show) {
-  const dropdown = element.nextElementSibling;
+  const dropdown = element.getAttribute("aria-controls");
 
   element.setAttribute("aria-expanded", show);
   dropdown.setAttribute("aria-hidden", !show);

--- a/static/sass/_pattern_cube-progression.scss
+++ b/static/sass/_pattern_cube-progression.scss
@@ -28,14 +28,34 @@
       width: map-get($rhombusSize, "width") * 1px;
     }
 
+    %is-faded {
+      background-color: rgba(255, 255, 255, 0.1);
+      clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+      opacity: 0.5;
+
+      &--right {
+        @extend %is-faded;
+
+        clip-path: polygon(0% 34%, 100% 0%, 100% 66.6%, 0% 100%);
+      }
+
+      &--left {
+        @extend %is-faded;
+
+        clip-path: polygon(0% 0%, 100% 34%, 100% 100%, 0% 66.6%);
+      }
+    }
+
     &.is-architecture {
       @extend %diamond-badge;
+      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/8b175afd-Architecture.svg);
     }
 
     &.is-bash {
       @extend %rhombus-badge;
+      @extend %is-faded--right;
 
       background: url(https://assets.ubuntu.com/v1/4b2c2de2-bash.svg);
       transform: translate(
@@ -46,6 +66,7 @@
 
     &.is-devices {
       @extend %rhombus-badge;
+      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/9ba960cc-devices+and+files.svg);
       transform: translate(0, map-get($diamondSize, "height") * 0.5px);
@@ -53,6 +74,7 @@
 
     &.is-packages {
       @extend %diamond-badge;
+      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/eb3be63d-Packages.svg);
       transform: translate(map-get($diamondSize, "width") * 1px, 0);
@@ -60,6 +82,7 @@
 
     &.is-services {
       @extend %rhombus-badge;
+      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/74e5c92e-Services.svg);
       transform: translate(
@@ -70,6 +93,7 @@
 
     &.is-admin {
       @extend %rhombus-badge;
+      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/0a374de7-Admin.svg);
       transform: translate(
@@ -80,6 +104,7 @@
 
     &.is-commands {
       @extend %diamond-badge;
+      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/5e068487-Commands.svg);
       transform: translate(map-get($diamondSize, "width") * 2px, 0);
@@ -87,6 +112,7 @@
 
     &.is-security {
       @extend %rhombus-badge;
+      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/d9074c81-Security.svg);
       transform: translate(
@@ -97,6 +123,7 @@
 
     &.is-networking {
       @extend %rhombus-badge;
+      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/3f3f2687-Networking.svg);
       transform: translate(
@@ -107,6 +134,7 @@
 
     &.is-kernel {
       @extend %diamond-badge;
+      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/7b4466fe-Kernel.svg);
       transform: translate(
@@ -117,6 +145,7 @@
 
     &.is-microk8s {
       @extend %rhombus-badge;
+      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/c26080a5-Microk8s.svg);
       transform: translate(
@@ -128,6 +157,7 @@
 
     &.is-virtualisation {
       @extend %rhombus-badge;
+      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/4f1c55a5-Virtualisation.svg);
       transform: translate(
@@ -139,6 +169,7 @@
 
     &.is-storage {
       @extend %diamond-badge;
+      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/090ef9e2-Storage.svg);
       transform: translate(
@@ -149,6 +180,7 @@
 
     &.is-juju {
       @extend %rhombus-badge;
+      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/ce96b82f-Juju.svg);
       transform: translate(
@@ -160,6 +192,7 @@
 
     &.is-maas {
       @extend %rhombus-badge;
+      @extend %is-faded--left;
 
       background: url(https://assets.ubuntu.com/v1/711b3e71-MAAS.svg);
       transform: translate(
@@ -167,35 +200,6 @@
         (map-get($rhombusSize, "height") * 1px) +
           (map-get($diamondSize, "height") * 0.5px)
       );
-    }
-
-    &.is-tag {
-      @extend %diamond-badge;
-
-      background-image: $color-accent;
-      clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-      transform: translate(
-        map-get($diamondSize, "width") * -0.5px,
-        map-get($rhombusSize, "height") * 1px
-      );
-    }
-
-    .is-faded {
-      background-color: rgba(255, 255, 255, 0.1);
-      clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-      opacity: 0.5;
-
-      &--right {
-        @extend .is-faded;
-
-        clip-path: polygon(0% 34%, 100% 0%, 100% 66.6%, 0% 100%);
-      }
-
-      &--left {
-        @extend .is-faded;
-
-        clip-path: polygon(0% 0%, 100% 34%, 100% 100%, 0% 66.6%);
-      }
     }
   }
 }

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -1,8 +1,8 @@
 {% extends "cube/base_cube.html" %}
 
-{% block title %}CUBE{% endblock %}
+{% block title %}The Certified Ubuntu Engineer (CUBE){% endblock %}
 
-{% block meta_description %}This is the CUBE landing page{% endblock meta_description %}
+{% block meta_description %}The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. It consists of 15 microcertifications to complete.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -1,8 +1,8 @@
 {% extends "cube/base_cube.html" %}
 
-{% block title %}The Certified Ubuntu Engineer (CUBE){% endblock %}
+{% block title %}Certified Ubuntu Engineer (CUBE){% endblock %}
 
-{% block meta_description %}The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. It consists of 15 microcertifications to complete.{% endblock meta_description %}
+{% block meta_description %}The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. It consists of 15 microcertifications.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -1,15 +1,15 @@
 {% extends "cube/base_cube.html" %}
 
-{% block title %} Microcerts | CUBE {% endblock %}
+{% block title %} Microcertifications | CUBE {% endblock %}
 
-{% block meta_description %}This is the CUBE Microcerts page{% endblock meta_description %}
+{% block meta_description %}The path to certification is clear and convenient. Complete 15 microcerts to attain CUBE.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1IHmr2SIxcEKVNN2sA-z_32PV0fCXi38pmeVP7k7O1mM/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
-<section class="p-strip--square-suru has-cube is-dark is-slanted--bottom-left">
+<section class="p-strip--square-suru has-cube is-dark is-slanted--bottom-left js-cube-hero">
   <div class="row u-equal-height u-vertically-center">
-    <div id="hero-content" class="col-6">
+    <div class="col-6 js-hero-content">
       {% if certified_badge %}
 
         <h1>CUBE 2020 complete</h1>
@@ -343,15 +343,15 @@ const myObserver = new ResizeObserver((entries) => {
     const width = Math.floor(entry.contentRect.width);
     if (width < 1035) {
       entry.target.classList.remove("is-shallow");
-      document.getElementById("hero-content").style.marginTop = "2rem";
+      document.querySelector(".js-hero-content").style.marginTop = "2rem";
     } else {
       entry.target.classList.add("is-shallow");
-      document.getElementById("hero-content").style.marginTop = "-2rem";
+      document.querySelector(".js-hero-content").style.marginTop = "-2rem";
     }
   });
 });
 
-const strip = document.querySelector(".p-strip--square-suru");
+const strip = document.querySelector(".js-cube-hero");
 myObserver.observe(strip);
 
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -2,7 +2,7 @@
 
 {% block title %} Microcertifications | CUBE {% endblock %}
 
-{% block meta_description %}The path to certification is clear and convenient. Complete 15 microcerts to attain CUBE.{% endblock meta_description %}
+{% block meta_description %}Follow the path to certification - complete the 15 microcerts to attain CUBE.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1IHmr2SIxcEKVNN2sA-z_32PV0fCXi38pmeVP7k7O1mM/edit{% endblock meta_copydoc %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- Fix typo in nav
- Revert to using `getAttribute` not `nextElementSibling` to be more specific when targeting share menu
- Make the `.is-faded` styling a placeholder which is then extended instead of extending a class
- Add meta descriptions 
- Add `js-` prefix to class

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube and http://0.0.0.0:8001/cube/microcerts
- Check (update?) meta descriptions and titles
- Check points raised in this this [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/8990) have been addressed
- Check refactored code

## Issue / Card

Fixes #9308 

