### PR TITLE
Add DFI logo to /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -195,6 +195,17 @@
         ) | safe
       }}
     </li>
+    <li class="p-inline-images__item">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/24bd5aaf-dfi-logo.png",
+        alt="DFI",
+        width="80",
+        height="40",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </li>
   </ul>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Add DFI logo to page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the logo is there

## Issue / Card

Fixes #9347

## Screenshots

![image](https://user-images.githubusercontent.com/441217/109931418-bf4d2080-7cc0-11eb-8e58-9592904e0c56.png)

