### PR TITLE
Copy update - Ubuntu components table /azure/fips

### DIFF
--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -210,6 +210,13 @@
             <td class="u-align--right" aria-label="Version">5.6.2</td>
             <td class="u-align--right" aria-label="CMVP Certificate">3648</td>
           </tr>
+          <tr>
+            <td class="u-align--right" aria-label="Ubuntu LTS">18.04</td>
+            <td aria-label="FIPS certified component">Libgcrypt</td>
+            <td aria-label="Description">The GNUPG cryptographic general purpose library (provides fully certified full disk encryption)</td>
+            <td class="u-align--right" aria-label="Version">1.8.1</td>
+            <td class="u-align--right" aria-label="CMVP Certificate">3748</td>
+          </tr>
         </tbody>
       </table>
       <br>


### PR DESCRIPTION
## Done

- Update Ubuntu components table on `/azure/fips`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure/fips
- Check table has new row as per [copy doc](https://docs.google.com/document/d/1Djxdzjy78bau8ELM4-MNGoM2YRa_QjpN1xJ4H4GjFyw/edit?ts=603d1978#heading=h.nnv3rdrfhrzr) and resolve comment on copy doc 


## Issue / Card

Fixes [#3899](https://github.com/canonical-web-and-design/web-squad/issues/3899)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/109976261-7ebaca80-7cf3-11eb-8b0a-ea6ab677d0ae.png)

