### PR TITLE
Adapt tutorials search for new module version

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -461,7 +461,7 @@ tutorials_docs = Tutorials(
     blueprint_name="tutorials",
 )
 app.add_url_rule(
-    tutorials_path, view_func=build_tutorials_index(tutorials_docs)
+    tutorials_path, view_func=build_tutorials_index(session, tutorials_docs)
 )
 tutorials_docs.init_app(app)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1124,7 +1124,7 @@ def accept_renewal(renewal_id):
         return flask.jsonify({"error": "authentication required"}), 401
 
 
-def build_tutorials_index(tutorials_docs):
+def build_tutorials_index(session, tutorials_docs):
     def tutorials_index():
         page = flask.request.args.get("page", default=1, type=int)
         topic = flask.request.args.get("topic", default=None, type=str)
@@ -1149,6 +1149,7 @@ def build_tutorials_index(tutorials_docs):
 
         if query:
             results = get_search_results(
+                session=session,
                 api_key=search_api_key,
                 search_engine_id=search_engine_id,
                 siteSearch="ubuntu.com/tutorials",


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9346

Fix 500 error by updating tutorials search to use the new interface for canonicalwebteam.search v1.0.0.

QA
--

Search here: https://ubuntu-com-9351.demos.haus/tutorials. Check it works. E.g.: https://ubuntu-com-9351.demos.haus/tutorials?q=ubuntu