### PR TITLE
Correct links to CUBE prepare material

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -116,7 +116,7 @@
       <p><strong>Be prepared for every exam</strong></p>
       <p class="u-sv2">Brush up on your Ubuntu skills with preparatory materials that cover every microcert.</p>
       {% if has_prepare_material %}
-      <a href="https://qa.cube.ubuntu.com/courses/course-v1:ubuntu+cubereview+coursecommandsdev/course/" class="p-button--positive">Prepare</a>
+      <a href="{{ prepare_material_url }}" class="p-button--positive">Prepare</a>
       {% else %}
       <a href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Apply for access</a>
       {% endif %}

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -108,9 +108,15 @@ def cube_microcerts():
             "/courseware/2020/start/?child=first"
         )
 
-        course[
-            "prepare_url"
-        ] = f"{edx_api.base_url}/{CUBE_CONTENT['prepare-course']}/course/"
+        course["prepare_url"] = (
+            f"{edx_api.base_url}/courses/"
+            f"{CUBE_CONTENT['prepare-course']}/course/"
+        )
+
+    has_prepare_material = CUBE_CONTENT["prepare-course"] in enrollments
+    prepare_material_url = (
+        f"{edx_api.base_url}/courses/{CUBE_CONTENT['prepare-course']}/course/"
+    )
 
     return flask.render_template(
         "cube/microcerts.html",
@@ -120,8 +126,8 @@ def cube_microcerts():
             "modules": courses,
             "passed_courses": passed_courses,
             "has_enrollments": len(enrollments) > 0,
-            "has_prepare_material": CUBE_CONTENT["prepare-course"]
-            in enrollments,
+            "has_prepare_material": has_prepare_material,
+            "prepare_material_url": prepare_material_url,
         },
     )
 


### PR DESCRIPTION
## Done

- Correct the links to access the preparation material for cube.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- Check when you click the prepare buttons you are redirected to the right link
- https://cube.ubuntu.com/courses/course-v1:CUBE+study_labs_2020+alpha/course/

