### PR TITLE
Add engage pages errors to /engage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==4.0.5
+canonicalwebteam.discourse==4.0.6
 python-dateutil==2.8.1
 pytz==2020.5
 maxminddb-geolite2==2018.703

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -77,7 +77,16 @@
 </section>
 
 <section class="p-strip is-shallow" id="posts-list">
-  {% if metadata | length > 0 %}
+{% if metadata | length > 0 %}
+  <!-- Engage page errors -->
+  {% if errors|length > 0 %}
+  <div class="row u-equal-height">
+    {% for error in errors %}
+      <p>{{ error }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+
   <div class="row u-equal-height">
     {% for item in metadata %}
       {% with 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -371,6 +371,7 @@ def build_engage_index(engage_docs):
         posts_per_page = 15
         engage_docs.parser.parse()
         metadata = engage_docs.parser.metadata
+        errors = engage_docs.parser.metadata_errors
 
         resource_types = []
         tags_list = set()
@@ -433,6 +434,7 @@ def build_engage_index(engage_docs):
             tags=tags_list,
             posts_per_page=posts_per_page,
             total_pages=total_pages,
+            errors=errors,
         )
 
     return engage_index


### PR DESCRIPTION
## Done

- Update to discourse v 4.0.6
- Include the new feature that shows errors

## QA
1. Checkout this branch
2. Add [Sentry DSN](https://sentry.is.canonical.com/settings/canonical/projects/test/keys/) to your `.env.local`. This will use the Test sentry project to avoid spamming our main ubuntu.com one.
3. Run `dotrun clean && dotrun` to make sure you are getting the latest discourse module version.
4. Go to line 552 and change the `index_topic_id ` to `18033`. This changes to a bunch of discourse topics that contain errors.
5. go to `/engage`. This will output errors in Sentry and on the page
6. https://sentry.is.canonical.com/canonical/test/ should show the errors too
7. Revert the `index_topic_id` and go to /engage and check that there are no errors.

### Additional checks if you have more time
7. Check "/tutorials" work
8. Check "/server/docs" work

## issues
Fixes https://github.com/canonical-web-and-design/canonicalwebteam.discourse/issues/75