### PR TITLE
add 1.20 release to k8s chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1287,7 +1287,7 @@ export var kubernetesReleases = [
     startDate: new Date("2020-01-07T00:00:00"),
     endDate: new Date("2020-12-07T00:00:00"),
     taskName: "Kubernetes 1.17",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2020-03-24T00:00:00"),
@@ -1297,8 +1297,14 @@ export var kubernetesReleases = [
   },
   {
     startDate: new Date("2020-08-16T00:00:00"),
-    endDate: new Date("2021-06-16T00:00:00"),
+    endDate: new Date("2021-08-16T00:00:00"),
     taskName: "Kubernetes 1.19",
+    status: "CHARMED_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2020-12-08T00:00:00"),
+    endDate: new Date("2021-12-08T00:00:00"),
+    taskName: "Kubernetes 1.20",
     status: "CHARMED_KUBERNETES_SUPPORT",
   },
 ];
@@ -1518,6 +1524,7 @@ export var openStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.20",
   "Kubernetes 1.19",
   "Kubernetes 1.18",
   "Kubernetes 1.17",

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1291,7 +1291,7 @@ export var kubernetesReleases = [
   },
   {
     startDate: new Date("2020-03-24T00:00:00"),
-    endDate: new Date("2021-02-23T00:00:00"),
+    endDate: new Date("2021-04-08T00:00:00"),
     taskName: "Kubernetes 1.18",
     status: "CHARMED_KUBERNETES_SUPPORT",
   },

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -585,14 +585,19 @@
           </thead>
           <tbody>
             <tr>
+              <td><strong>Kubernetes 1.20</strong></td>
+              <td align='right'>Dec 2020</td>
+              <td align='right'>Dec 2021</td>
+            </tr>
+            <tr>
               <td><strong>Kubernetes 1.19</strong></td>
               <td align='right'>Aug 2020</td>
-              <td align='right'>Jun 2021</td>
+              <td align='right'>Aug 2021</td>
             </tr>
             <tr>
               <td><strong>Kubernetes 1.18</strong></td>
               <td align='right'>Mar 2020</td>
-              <td align='right'>Feb 2021</td>
+              <td align='right'>Apr 2021</td>
             </tr>
             <tr>
               <td><strong>Kubernetes 1.17</strong></td>


### PR DESCRIPTION
## Done

- Add dates for 1.20 k8s to release-cycle chart

N.B. The length of support has changed due to upstream changes. There will be changes to the chart in future to indicate a 'security patch support' period, though this is currently waiting approval (at which point I will update the text also).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the chart at <http://0.0.0.0:8001/about/release-cycle#charmed-kubernetes-release-cycle> renders correctly

## Screenshots

![image](https://user-images.githubusercontent.com/115290/110659804-d4dbb200-81ba-11eb-9f8d-ffcebeb18c94.png)

