### PR TITLE
CUBE: Authorize specific users

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -64,6 +64,12 @@ env:
       key: client-secret
       name: cube-edx
 
+  - name: CUBE_AUTHORIZED_USERS
+    configMapKeyRef:
+      key: cube-authorized-users
+      name: ubuntu-com
+      optional: true
+
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
@@ -158,6 +164,12 @@ production:
           secretKeyRef:
             key: client-secret
             name: cube-edx
+
+        - name: CUBE_AUTHORIZED_USERS
+          configMapKeyRef:
+            key: cube-authorized-users
+            name: ubuntu-com
+            optional: true
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -311,6 +323,12 @@ staging:
           secretKeyRef:
             key: client-secret
             name: cube-edx
+
+        - name: CUBE_AUTHORIZED_USERS
+          configMapKeyRef:
+            key: cube-authorized-users
+            name: ubuntu-com
+            optional: true
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -17,6 +17,12 @@ CUBE_CONTENT = yaml.load(
     Path("webapp/cube/content/cube.yaml").read_text(), Loader=yaml.Loader
 )
 
+AUTHORIZED_USERS = (
+    os.getenv("CUBE_AUTHORIZED_USERS").strip(" ,").split(",")
+    if os.getenv("CUBE_AUTHORIZED_USERS")
+    else []
+)
+
 badgr_session = Session()
 talisker.requests.configure(badgr_session),
 badgr_api = BadgrAPI(
@@ -46,7 +52,10 @@ edx_api = EdxAPI(
 
 def is_authorized(user):
     email_domain = user["email"].split("@")[1]
-    return email_domain.lower() == "canonical.com"
+    return (
+        email_domain.lower() == "canonical.com"
+        or user["email"].lower() in AUTHORIZED_USERS
+    )
 
 
 @login_required


### PR DESCRIPTION
## Done
Add the possibility of allowing non canonical e-mail addresses to access the CUBE beta.

## QA

I will ask one of the users the change is intended for to test in the demo to see if they can access it.

