### PR TITLE
Change cancel contract

### DIFF
--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -36,7 +36,7 @@ post_advantage_subscriptions = {
 cancel_advantage_subscriptions = {
     "account_id": String(required=True),
     "previous_purchase_id": String(required=True),
-    "product_listings": String(required=True),
+    "product_listing_id": String(required=True),
 }
 
 post_anonymised_customer_info = {

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -431,7 +431,7 @@ def cancel_advantage_subscriptions(**kwargs):
     token = kwargs.get("token")
     account_id = kwargs.get("account_id")
     previous_purchase_id = kwargs.get("previous_purchase_id")
-    product_listings = kwargs.get("product_listings")
+    product_listing_id = kwargs.get("product_listing_id")
 
     advantage = UAContractsAPI(session, token, api_url=api_url)
 
@@ -450,12 +450,11 @@ def cancel_advantage_subscriptions(**kwargs):
         "accountID": account_id,
         "purchaseItems": [
             {
-                "productListingID": product_listing,
+                "productListingID": product_listing_id,
                 "metric": "active-machines",
                 "value": 0,
                 "delete": True,
             }
-            for product_listing in product_listings
         ],
         "previousPurchaseID": previous_purchase_id,
     }


### PR DESCRIPTION
## Done

- Change cancel contract to only accept one `product_listing_id`. Before it was accepting a list of ids, but we only ever cancel one product at a time, so it's pointless.
