### PR TITLE
Update caching rules with flask-base v0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic==1.5.4
-canonicalwebteam.flask_base==0.7.3
+git+https://github.com/nottrobin/canonicalwebteam.flask-base@caching-headers#egg=canonicalwebteam.flask-base
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic==1.5.4
-git+https://github.com/nottrobin/canonicalwebteam.flask-base@caching-headers#egg=canonicalwebteam.flask-base
+canonicalwebteam.flask-base==0.8.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.3.1
 canonicalwebteam.search==1.0.0

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -84,9 +84,8 @@ class TestCube(VCRTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.headers.get("Cache-Control"),
-            "no-cache, no-store, must-revalidate",
+            "no-store",
         )
-        self.assertEqual(response.headers.get("Pragma"), "no-cache")
 
     def test_microcerts_403_authenticated_non_canonical_user(self):
         with self.client.session_transaction() as session:
@@ -115,9 +114,8 @@ class TestCube(VCRTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.headers.get("Cache-Control"),
-            "no-cache, no-store, must-revalidate",
+            "no-store",
         )
-        self.assertEqual(response.headers.get("Pragma"), "no-cache")
 
     def test_home_403_non_canonical_user(self):
         with self.client.session_transaction() as session:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -396,10 +396,6 @@ def takeovers_json():
     takeovers = get_takeovers()
     response = flask.jsonify(takeovers["active"])
     response.cache_control.max_age = "300"
-    response.cache_control._set_cache_value(
-        "stale-while-revalidate", "360", int
-    )
-    response.cache_control._set_cache_value("stale-if-error", "600", int)
 
     return response
 
@@ -656,27 +652,10 @@ def cache_headers(response):
     Set cache expiry to 60 seconds for homepage and blog page
     """
 
-    if flask.request.path in ["/core/build"]:
-        response.cache_control.private = True
+    disable_cache_on = ("/advantage", "/cube", "/core/build")
 
-    if flask.request.path.startswith("/advantage"):
-        response.cache_control.private = True
-        response.headers[
-            "Cache-Control"
-        ] = "no-cache, no-store, must-revalidate"
-        response.headers["Pragma"] = "no-cache"
-
-    if flask.request.path in ["/", "/blog"]:
-        response.headers[
-            "Cache-Control"
-        ] = "max-age=61, stale-while-revalidate=90"
-
-    if flask.request.path.startswith("/cube"):
-        response.cache_control.private = True
-        response.headers[
-            "Cache-Control"
-        ] = "no-cache, no-store, must-revalidate"
-        response.headers["Pragma"] = "no-cache"
+    if flask.request.path.startswith(disable_cache_on):
+        response.cache_control.no_store = True
 
     return response
 

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -31,7 +31,7 @@ def store_maintenance(func):
 
     @functools.wraps(func)
     def is_store_in_maintenance(*args, **kwargs):
-        if strtobool(os.getenv("STORE_MAINTENANCE")):
+        if strtobool(os.getenv("STORE_MAINTENANCE", "false")):
             return flask.render_template("advantage/maintenance.html")
 
         return func(*args, **kwargs)


### PR DESCRIPTION
Use the [new caching defaults](https://github.com/canonical-web-and-design/canonicalwebteam.flask-base/pull/45) from flask-base 0.8.0, for improved client performance and freshness of content.

Also simplify caching rules as follows:

- For private pages, simply use `cache-control: no-store`, as all the other options (`no-cache`, `must-revalidate`, `Pragma: nocache`, `max-age=0`) are simply less complete ways of doing the same thing.
- Remove the `max-age=61` special cache override for `/` and `/blog`, as the new default is `max-age=60` which is even fresher
  - *Note: The reason it was `61` and not `60` is because we used to use Squid as our proxy cache, and for some bizarre reason Squid wouldn't cache pages with `max-age=60` or less*
 
QA
--

Click around, refresh pages a fair bit, check they also seem to respond quickly. I guess https://ubuntu-com-9425.demos.haus/blog would be a good place to test this.

You can also try hitting the demo with `curl -I`, or use the network tab in the browser tools, to check the `cache-control` headers returned are as expected.

It's particularly important to make sure the private pages aren't going to be cached:

``` bash
$ curl -I https://ubuntu-com-9425.demos.haus/cube
cache-control: no-store

$ curl -I https://ubuntu-com-9425.demos.haus/core/build
cache-control: no-store

$ curl -I https://ubuntu-com-9425.demos.haus/advantage
cache-control: no-store
```