### PR TITLE
Move Certification Api requests

### DIFF
--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -1,0 +1,26 @@
+# Packages
+from vcr_unittest import VCRTestCase
+
+# Local
+from webapp.app import app
+
+
+class TestCertification(VCRTestCase):
+    def _get_vcr_kwargs(self):
+        """
+        This removes the authorization header
+        from VCR so we don't record auth parameters
+        """
+        return {
+            "decode_compressed_response": True,
+            "filter_headers": ["Authorization", "Cookie"],
+        }
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+        return super().setUp()
+
+    def test_certification_home(self):
+        response = self.client.get("/certification")
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -229,10 +229,6 @@ class TestRoutes(VCRTestCase):
             soup.find("meta", {"name": "robots", "content": "nofollow"})
         )
 
-    def test_certification_home(self):
-        response = self.client.get("/certification")
-        self.assertEqual(response.status_code, 200)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/certification/api.py
+++ b/webapp/certification/api.py
@@ -1,5 +1,6 @@
 from requests import Session
 
+
 class CertificationAPI:
     """
     Method names and properties to describe and map directly
@@ -12,7 +13,7 @@ class CertificationAPI:
         self.base_url = base_url
         self.session = session
 
-    def _get(self, path: str, params: dict={}):
+    def _get(self, path: str, params: dict = {}):
         # Remove "None" values from params
         params = {
             key: value for key, value in params.items() if value is not None
@@ -28,7 +29,7 @@ class CertificationAPI:
 
         return response
 
-    def certifiedmakes(
+    def certified_makes(
         self,
         limit=None,
         offset=None,
@@ -51,7 +52,7 @@ class CertificationAPI:
             },
         ).json()
 
-    def certifiedmodels(
+    def certified_models(
         self,
         limit=None,
         offset=None,
@@ -95,7 +96,7 @@ class CertificationAPI:
 
         return response.json()
 
-    def certifiedmodeldetails(
+    def certified_model_details(
         self, limit=None, offset=None, canonical_id=None
     ):
         return self._get(
@@ -107,7 +108,7 @@ class CertificationAPI:
             },
         ).json()
 
-    def certifiedmodeldevices(
+    def certified_model_devices(
         self,
         limit=None,
         offset=None,
@@ -128,7 +129,7 @@ class CertificationAPI:
             },
         ).json()
 
-    def certifiedreleases(
+    def certified_releases(
         self, limit=None, offset=None, smart_core__gte=None, soc__gte=None
     ):
         return self._get(
@@ -141,7 +142,7 @@ class CertificationAPI:
             },
         ).json()
 
-    def componentsummaries(
+    def component_summaries(
         self,
         limit=None,
         offset=None,
@@ -162,10 +163,10 @@ class CertificationAPI:
             },
         ).json()
 
-    def componentsummary(self, id):
+    def component_summary(self, id):
         return self._get(f"componentsummaries/{id}").json()
 
-    def devicecategories(self, limit=None, offset=None):
+    def device_categories(self, limit=None, offset=None):
         return self._get(
             "devicecategories", params={"limit": limit, "offset": offset}
         ).json()
@@ -175,7 +176,7 @@ class CertificationAPI:
             "releases", params={"limit": limit, "offset": offset}
         ).json()
 
-    def vendorsummaries_server(self, limit=None, offset=None):
+    def vendor_summaries_server(self, limit=None, offset=None):
         return self._get(
             "vendorsummaries/server", params={"limit": limit, "offset": offset}
         ).json()

--- a/webapp/certification/api.py
+++ b/webapp/certification/api.py
@@ -1,0 +1,181 @@
+from requests import Session
+
+class CertificationAPI:
+    """
+    Method names and properties to describe and map directly
+    onto the Certification API
+    (at the time of writing, this API is available at
+    https://certification.canonical.com/api/v1)
+    """
+
+    def __init__(self, base_url: str, session: Session):
+        self.base_url = base_url
+        self.session = session
+
+    def _get(self, path: str, params: dict={}):
+        # Remove "None" values from params
+        params = {
+            key: value for key, value in params.items() if value is not None
+        }
+
+        # Get the JSON data
+        response = self.session.get(
+            f"{self.base_url}/{path.strip('/')}/?format=json", params=params
+        )
+
+        # Raise any HTTP errors
+        response.raise_for_status()
+
+        return response
+
+    def certifiedmakes(
+        self,
+        limit=None,
+        offset=None,
+        desktops__gte=None,
+        laptops__gte=None,
+        smart_core__gte=None,
+        soc__gte=None,
+        make__iexact=None,
+    ):
+        return self._get(
+            "certifiedmakes",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "desktops__gte": desktops__gte,
+                "laptops__gte": laptops__gte,
+                "smart_core__gte": smart_core__gte,
+                "soc__gte": soc__gte,
+                "make__iexact": make__iexact,
+            },
+        ).json()
+
+    def certifiedmodels(
+        self,
+        limit=None,
+        offset=None,
+        level=None,
+        category=None,
+        canonical_id=None,
+        canonical_id__in=None,
+        major_release__in=None,
+        vendor=None,
+        make__iexact=None,
+        query=None,
+        category__in=None,
+        order_by=None,
+        device_identifier=None,
+        device_bus=None,
+        device_subsystem=None,
+        device_vendor_id=None,
+    ):
+        response = self._get(
+            "certifiedmodels",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "level": level,
+                "major_release__in": major_release__in,
+                "vendor": vendor,
+                "make__iexact": make__iexact,
+                "query": query,
+                "canonical_id": canonical_id,
+                "canonical_id__in": canonical_id__in,
+                "category": category,
+                "category__in": category__in,
+                "order_by": order_by,
+                "device_identifier": device_identifier,
+                "device_bus": device_bus,
+                "device_subsystem": device_subsystem,
+                "device_vendor_id": device_vendor_id,
+            },
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    def certifiedmodeldetails(
+        self, limit=None, offset=None, canonical_id=None
+    ):
+        return self._get(
+            "certifiedmodeldetails",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "canonical_id": canonical_id,
+            },
+        ).json()
+
+    def certifiedmodeldevices(
+        self,
+        limit=None,
+        offset=None,
+        query=None,
+        canonical_id=None,
+        identifier=None,
+        subsystem=None,
+    ):
+        return self._get(
+            "certifiedmodeldevices",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "query": query,
+                "canonical_id": canonical_id,
+                "identifier": identifier,
+                "subsystem": subsystem,
+            },
+        ).json()
+
+    def certifiedreleases(
+        self, limit=None, offset=None, smart_core__gte=None, soc__gte=None
+    ):
+        return self._get(
+            "certifiedreleases",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "smart_core__gte": smart_core__gte,
+                "soc__gte": soc__gte,
+            },
+        ).json()
+
+    def componentsummaries(
+        self,
+        limit=None,
+        offset=None,
+        id=None,
+        canonical_id=None,
+        query=None,
+        make=None,
+    ):
+        return self._get(
+            "componentsummaries",
+            params={
+                "limit": limit,
+                "offset": offset,
+                "id": id,
+                "canonical_id": canonical_id,
+                "query": query,
+                "make": make,
+            },
+        ).json()
+
+    def componentsummary(self, id):
+        return self._get(f"componentsummaries/{id}").json()
+
+    def devicecategories(self, limit=None, offset=None):
+        return self._get(
+            "devicecategories", params={"limit": limit, "offset": offset}
+        ).json()
+
+    def releases(self, limit=None, offset=None):
+        return self._get(
+            "releases", params={"limit": limit, "offset": offset}
+        ).json()
+
+    def vendorsummaries_server(self, limit=None, offset=None):
+        return self._get(
+            "vendorsummaries/server", params={"limit": limit, "offset": offset}
+        ).json()

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -1,4 +1,14 @@
 import flask
+import talisker.requests
+import talisker.sentry
+from requests import Session
+from webapp.certification.api import CertificationAPI
+
+session = Session()
+talisker.requests.configure(session)
+api = CertificationAPI(
+    base_url="https://certification.canonical.com/api/v1", session=session
+)
 
 
 def certification_home():


### PR DESCRIPTION
## Done

- Move certification Api requests
- Add tests
- Cleanup names

## QA

- https://ubuntu-com-9434.demos.haus/certification should still work
- Check that tests pass
- Check that code matches https://github.com/canonical-web-and-design/certification.ubuntu.com/blob/master/webapp/api.py


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/166

