### PR TITLE
Remove logos section and update number

### DIFF
--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -34,55 +34,6 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-12">
-      <h2 class="p-muted-heading u-align--center">UBUNTU ON Google Cloud POWERS CLOUD LEADERS LIKE</h2>
-      <ul class="p-inline-images u-no-margin--bottom">
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
-              alt="Walmart",
-              height=60,
-              width=200,
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/2400d5a7-Spotify_logo_with_text.svg",
-              alt="Spotify",
-              height=60,
-              width=200,
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/1d3f5d21-Netflix_2015_logo.svg",
-              alt="Netflix",
-              height=43,
-              width=200,
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
@@ -109,7 +60,7 @@
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--four">Ubuntu Pro for Google Cloud <span class="p-label--new u-float-right">Launching soon</span></h3>
-      <p class="p-heading--two">3-4.5% of instance cost</p>
+      <p class="p-heading--two">3-6% of instance cost</p>
       <hr class="u-sv1">
       <div class="p-card__content">
         <ul class="p-list">

--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -34,6 +34,8 @@
   </div>
 </section>
 
+<hr class="u-sv3">
+
 <section class="p-strip">
   <div class="row">
     <div class="col-6">


### PR DESCRIPTION
## Done

- Removed Walmart, Spotify, and Netflix logos
- Changed  "3-4.5%" to "3-6%" 

## QA

- go to https://ubuntu-com-9438.demos.haus/gcp
- Check that the logos are gone and the numbers updated correctly


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9437

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/112168170-5981f380-8bf1-11eb-9bc2-7a8a5e03b01c.png)
