### PR TITLE
Copy the beta programme for Ubuntu Pro form to advantage page

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -20,6 +20,16 @@
 
     <div class="row">
       <div class="col-12">
+        <div class="p-notification">
+          <p class="p-notification__response" role="status">
+            Are you using Ubuntu in production? <a href="/support/contact-us" class="p-notification__action js-invoke-modal">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
 
         <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})
@@ -403,6 +413,17 @@
 
 {% else %}
   <section class="p-strip--suru-topped">
+
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification">
+          <p class="p-notification__response" role="status">
+            Are you using Ubuntu in production? <a href="/support/contact-us" class="p-notification__action js-invoke-modal">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>


### PR DESCRIPTION
## Done
Copy the beta programme for Ubuntu Pro form to advantage page

## QA
- Go to /advantage and see there is a call-out at the top to fill in the form for the beta.
- Click the link and ensure that the modal form appears
- Check it is present in both logged in and logged out versions.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3956
