### PR TITLE
Update the agreement file downloads to use assets

### DIFF
--- a/templates/legal/contributors/agreement.html
+++ b/templates/legal/contributors/agreement.html
@@ -277,7 +277,7 @@ defer>
                         <p style="margin-bottom: 0cm;">the assignment, that third party must agree in writing to abide by all the rights and obligations in the Agreement.</p>
                         <p>6.4 The failure of either party to require performance by the other party of any provision of this Agreement in one situation shall not affect the right of a party to require such performance at any time in the future. A waiver of performance under a provision in one situation shall not be considered a waiver of the performance of the provision in the future or a waiver of the provision in its entirety.</p>
                         <p>6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.</p>
-                        <p>To <a href="http://www.canonical.com/sites/default/files/active/images/Canonical-HA-CLA-ANY-I.pdf">download as a PDF</a>
+                        <p>To <a href="https://assets.ubuntu.com/v1/869aa215-Canonical-HA-CLA-ANY-I.pdf">download as a PDF</a>
                         </p>
                       </div>
                     </div>
@@ -332,7 +332,7 @@ defer>
                       <p>6.3 If You or We assign the rights or obligations received through this Agreement to a third party, as a condition of the assignment, that third party must agree in writing to abide by all the rights and obligations in the Agreement.</p>
                       <p>6.4 The failure of either party to require performance by the other party of any provision of this Agreement in one situation shall not affect the right of a party to require such performance at any time in the future. A waiver of performance under a provision in one situation shall not be considered a waiver of the performance of the provision in the future or a waiver of the provision in its entirety.</p>
                       <p>6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.</p>
-                      <p>To <a href="http://www.canonical.com/sites/default/files/active/images/Canonical-HA-CLA-ANY-E.pdf">download as a PDF</a>
+                      <p>To <a href="https://assets.ubuntu.com/v1/4dadfc6b-Canonical-HA-CLA-ANY-E.pdf">download as a PDF</a>
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Done
Update the agreement file downloads to use assets

## QA
- Go to /legal/contributors/agreement
- Check that the two "download as a PDF" links work from assets

## Issue / Card
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/367

