### PR TITLE
Fix tax_id parameter

### DIFF
--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -25,6 +25,11 @@ class AddressSchema(Schema):
     state = String()
 
 
+class TaxIdSchema(Schema):
+    type = String()
+    value = String()
+
+
 post_advantage_subscriptions = {
     "account_id": String(required=True),
     "period": String(enum=["monthly", "yearly"], required=True),
@@ -42,7 +47,7 @@ cancel_advantage_subscriptions = {
 post_anonymised_customer_info = {
     "account_id": String(required=True),
     "address": Nested(AddressSchema, required=True),
-    "tax_id": String(allow_none=True),
+    "tax_id": Nested(TaxIdSchema, allow_none=True),
 }
 
 post_payment_method = {
@@ -54,7 +59,7 @@ post_customer_info = {
     "payment_method_id": String(required=True),
     "account_id": String(required=True),
     "name": String(),
-    "tax_id": String(allow_none=True),
+    "tax_id": Nested(TaxIdSchema, allow_none=True),
     "address": Nested(AddressSchema),
 }
 


### PR DESCRIPTION
I assumed tax_id would be a string. It turns out it's a dictionary. I
updated the validation to expect a dictionary instead.

## QA

- Go to https://ubuntu-com-9443.demos.haus/advantage/subscribe?test_backend=true
- Select and item and get to the modal
- Open the network tab
- Insert a VAT number: 123 you should get an error (correctly, as it's an invalid number) from the calls: `POST /advantage/customer-info` and `POST /advantage/customer-info-anon` will fail
- Insert GB 123 123 123 it should work this time then finish the payment
