### PR TITLE
9447: Add new datasheet link Ubuntu Pro Azure

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -13,7 +13,7 @@
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for Azure is a premium image delivering the most comprehensive security and compliance features. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations — no contract necessary.</p>
         <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on Azure</span></a></p>
-        <p><a href="https://assets.ubuntu.com/v1/27a386bc-Ubuntu_Pro_Azure_03.04.20.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
+        <p><a href="https://assets.ubuntu.com/v1/26408fa0-UbuntuPro_Azure_Datasheet_21.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{


### PR DESCRIPTION
## Done
Add new datasheet link in `/azure/pro`.

## QA
- wait for the demo.
- got to `/azure/pro` and make sure we are linking to the new datasheet as described in #9447.
