### PR TITLE
Extend the search when activated

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -109,6 +109,12 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
       display: flex;
       margin-right: 0;
       width: 100%;
+
+      &.has-active-search {
+        .p-navigation__items {
+          display: none;
+        }
+      }
     }
 
     & &__link-anchor {
@@ -342,6 +348,23 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
       @media (max-width: $breakpoint-x-small - 1) {
         padding-left: $grid-margin-width / 4 !important;
         padding-right: $grid-margin-width / 4 !important;
+      }
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      .p-search-box {
+        max-width: none;
+        margin-left: 1rem;
+
+        .p-search-box__button {
+          display: none;
+        }
+
+        .p-search-box__input:not(:valid) ~ .p-search-box__reset {
+          display: inherit;
+          margin-top: 0.3rem;
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -111,8 +111,10 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
       width: 100%;
 
       &.has-active-search {
-        .p-navigation__items {
-          display: none;
+        @media (min-width: $breakpoint-navigation-threshold) {
+          .p-navigation__items {
+            display: none;
+          }
         }
       }
     }

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -177,19 +177,27 @@
 
   function openSearch(e) {
     e.preventDefault();
+    var navigation = document.querySelector('.p-navigation__nav');
+    var dropdownWindowOverlay = document.querySelector(".dropdown-window-overlay");
     var searchButton = document.querySelector('.js-search-button');
     var search = document.querySelector('.p-navigation__search');
     var searchInput = document.querySelector('.p-search-box__input');
     var searchActive = !search.classList.contains('u-hide');
     search.classList.remove('u-hide');
     searchButton.classList.add('u-hide');
+    dropdownWindowOverlay.classList.remove("fade-animation");
+    navigation.classList.add('has-active-search');
     searchInput.focus();
   }
 
   function closeSearch(e) {
+    var navigation = document.querySelector('.p-navigation__nav');
+    var dropdownWindowOverlay = document.querySelector(".dropdown-window-overlay");
     var searchButton = document.querySelector('.js-search-button');
     var search = document.querySelector('.p-navigation__search');
     search.classList.add('u-hide');
+    dropdownWindowOverlay.classList.add("fade-animation");
+    navigation.classList.remove('has-active-search');
     searchButton.classList.remove('u-hide');
   }
 </script>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -188,6 +188,7 @@
     dropdownWindowOverlay.classList.remove("fade-animation");
     navigation.classList.add('has-active-search');
     searchInput.focus();
+    dropdownWindowOverlay.addEventListener('click', closeSearch);
     document.addEventListener('keyup', keyPressHandler);
   }
 
@@ -201,6 +202,7 @@
     navigation.classList.remove('has-active-search');
     searchButton.classList.remove('u-hide');
     document.removeEventListener('keyup', keyPressHandler);
+    dropdownWindowOverlay.removeEventListener('click', closeSearch);
   }
 
   function keyPressHandler (e) {

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -188,9 +188,10 @@
     dropdownWindowOverlay.classList.remove("fade-animation");
     navigation.classList.add('has-active-search');
     searchInput.focus();
+    document.addEventListener('keyup', keyPressHandler);
   }
 
-  function closeSearch(e) {
+  function closeSearch() {
     var navigation = document.querySelector('.p-navigation__nav');
     var dropdownWindowOverlay = document.querySelector(".dropdown-window-overlay");
     var searchButton = document.querySelector('.js-search-button');
@@ -199,5 +200,13 @@
     dropdownWindowOverlay.classList.add("fade-animation");
     navigation.classList.remove('has-active-search');
     searchButton.classList.remove('u-hide');
+    document.removeEventListener('keyup', keyPressHandler);
+  }
+
+  function keyPressHandler (e) {
+    console.log(e);
+    if (e.key === "Escape") {
+      closeSearch();
+    }
   }
 </script>


### PR DESCRIPTION
## Done
Extend the search input full width to match the [design](https://app.zeplin.io/project/5ffdb21a3714151de9cf750c/screen/5fff03c52885841ced879a74)

## QA
- Check out the demo
- Activate the search
- See that it extends across the entire navigation
- Click the X and see that closes
- Check small screens work as before

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9291

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/112387447-afd25d80-8ce9-11eb-86ce-f84daa0e5271.png)

