### PR TITLE
Update the Modern Slavery legal pages

### DIFF
--- a/templates/legal/index.html
+++ b/templates/legal/index.html
@@ -71,7 +71,7 @@
     </div>
     <div class="col-6 p-card">
       <h3>
-        <a href="https://assets.ubuntu.com/v1/47d72a70-Modern+Slavery+Statement+2019.pdf" class="p-link--external">Modern slavery statement</a>
+        <a href="/legal/modern-slavery-statement">Modern slavery statement</a>
       </h3>
       <p>This is Canonical's modern slavery statement.</p>
     </div>

--- a/templates/legal/modern-slavery-statement/_base_markdown.html
+++ b/templates/legal/modern-slavery-statement/_base_markdown.html
@@ -1,0 +1,33 @@
+{% extends "templates/base.html" %}
+{% block title %}{{ title }}{% endblock title %}
+{% block meta_description %}{{ description }}{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/16q1jDEr_ArWdCnWzEVuXmC66deXeCnuEHy2G_jX0hqE/edit{% endblock meta_copydoc %}
+
+{% block outer_content %}
+
+    {% block content %}
+    <div class="p-strip is-deep">
+      <div class="row" id="service-description">
+        <div class="col-8 l-legal-pages">
+{{ content | safe }}
+        </div>
+        <div class="col-4">
+          <nav>
+            <div class="p-card">
+              <h3>Download versions</h3>
+              <ul class="p-list">
+                <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/3f0a32b5-Modern+Slavery+Statement+2021.pdf" class="p-link--external">Modern Slavery Statement 2021</a></li>
+                <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/dfd6376f-Modern+Slavery+Statement+2020.pdf" class="p-link--external">Modern Slavery Statement 2020</a></li>
+                <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/47d72a70-Modern+Slavery+Statement+2019.pdf" class="p-link--external">Modern Slavery Statement 2019</a></li>
+                <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/505a21c3-Canonicals+Modern+Slavery+Statement+2018.pdf" class="p-link--external">Modern Slavery Statement 2018</a></li>
+              </ul>
+            </div>
+          </nav>
+        </nav>
+      </div>
+    </div>
+
+    {% endblock %}
+
+{% endblock %}

--- a/templates/legal/modern-slavery-statement/index.md
+++ b/templates/legal/modern-slavery-statement/index.md
@@ -1,0 +1,59 @@
+---
+wrapper_template: "legal/modern-slavery-statement/_base_markdown.html"
+context:
+  title: "Modern Slavery Statement"
+  description: "Ubuntu and Canonical Legal - Modern Slavery Statement"
+  copydoc: https://assets.ubuntu.com/v1/3f0a32b5-Modern+Slavery+Statement+2021.pdf
+---
+
+# Modern Slavery Statement - 2021
+
+## What is modern slavery?
+
+Modern slavery is the illegal exploitation of people for personal or commercial gain, often in horrendous conditions which the victim cannot escape. It includes human trafficking.
+
+This statement sets out the steps Canonical has taken during its financial year to ensure that slavery and human trafficking is not taking place in its supply chain. This statement is made pursuant to section 54 of the Modern Slavery Act 2015.
+
+## Who we are-our structure and supply chains
+
+650+ personnel and 7 offices.
+
+Canonical is the company behind the Ubuntu open source operating system. Canonical’s mission is to make open source software available to people everywhere. Canonical delivers services which include, software development and support.
+
+As an organisation Canonical’s internal activities include engineering, support, project management and commercial operation services -legal, finance, HR and sales and business operations.
+
+Canonical procures services from a number of external third parties to support its activities and services.
+
+Canonical Group Limited and Canonical UK Limited are English subsidiaries of Canonical Holdings Limited and a number of affiliated entities provide services. A full list of Canonical entities can be found at [https://www.ubuntu.com/legal/companies](https://www.ubuntu.com/legal/companies). This statement relates to Canonical Group Limited and Canonical UK Limited.
+
+## Our procedures
+
+Canonical does not tolerate modern slavery. Canonical will never knowingly engage with customers, suppliers, personnel or other business partners who are in any way connected with the use of forced labour or human trafficking.
+
+Canonical holds itself and its supply chain accountable for compliance with the Modern Slavery Act 2015.
+
+Canonical has a number of procedures in place to ensure that modern slavery does not occur in its business or supply chain.
+
+**Personnel** - Robust recruitment processes, including identity checks (and background checks where required) and contracts of employment. Market standard pay and rewards. Canonical supports employee engagement and dialogue. Training of relevant staff.
+
+**Suppliers** - Due diligence on suppliers. Contractual agreements in place with suppliers requiring compliance with law and adherence to Canonical processes, procedures and instructions (where applicable). Canonical builds long standing relationships with its suppliers.
+
+Canonical recognises that modern slavery is a complex supply chain issue and continues to work in partnership with its suppliers. Canonical conducts periodic reviews of all of its policies and procedures. We will continue to review our procurement process and how we engage with our suppliers.
+
+## Financial Year
+
+Canonical’s financial year end is 31st December.
+
+This statement covers the financial year ending 31st December 2020.
+
+## Approval
+
+This statement is signed by the director of Canonical Group Limited and Canonical UK Limited.
+
+**Neil French**<br />
+**Canonical**<br />
+**March 2021**
+
+<div class="p-top">
+  <a href="#" class="p-top__link">Back to top</a>
+</div>


### PR DESCRIPTION
## Done
- Build a Modern Slavery landing page using the content from the latest statement
- Added links to all version to download in PDF form
- Updated the link on the legal main page to link to the page instead of the PDF

## QA
- Open the demo and go to /legal/modern-slavery-statement
- Check the content matches [the copy](https://docs.google.com/document/d/16q1jDEr_ArWdCnWzEVuXmC66deXeCnuEHy2G_jX0hqE/edit#)
- Ensure the PDF downloads all work

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9453
