### PR TITLE
Canonical url to juju.is for article with tag 4059 (juju.is)

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -7,7 +7,7 @@
 {# Change canonical URL for "snapcraft.io" articles (2996 is the ID of the "snapcraft.io" tag) #}
 
 {% block body_class %}blog-article{% endblock %}
-{% block canonical_url %}{% if 2996 in article.tags %}https://snapcraft.io/blog/{{ article.slug }}{% else %}{{ super() }}{% endif %}{% endblock canonical_url %}
+{% block canonical_url %}{% if 2996 in article.tags %}https://snapcraft.io/blog/{{ article.slug }}{% elif 4059 in article.tags %}https://juju.is/blog/{{ article.slug }}{% else %}{{ super() }}{% endif %}{% endblock canonical_url %}
 
 {% block content %}
 <article>


### PR DESCRIPTION
## Done

- juju.is is getting its own blog
- To appear there the articles should have the tag 4059 (juju.is)
- To make sure we are indexing juju.is and not ubuntu we replace the canonical url with juju.is  (like snapcraft)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- http://0.0.0.0:8001/blog/kubernetes-operators
-  Make sure the canonical url is https://juju.is/blog/kubernetes-operators
- Try another blog post. The canonical url should be ubuntu.com