### PR TITLE
advantage: implement view as functionality

### DIFF
--- a/webapp/advantage/api.py
+++ b/webapp/advantage/api.py
@@ -21,7 +21,7 @@ class UAContractsAPI:
         self.api_url = api_url.rstrip("/")
         self.is_for_view = is_for_view
 
-    def _request(self, method, path, json=None):
+    def _request(self, method, path, json=None, params=None):
         headers = {
             "Authorization": (
                 f"{self.token_type} " f"{self.authentication_token}"
@@ -33,14 +33,18 @@ class UAContractsAPI:
             url=f"{self.api_url}/{path}",
             json=json,
             headers=headers,
+            params=params,
         )
         response.raise_for_status()
 
         return response
 
-    def get_accounts(self):
+    def get_accounts(self, email=""):
+        params = {"email": email} if email else None
         try:
-            response = self._request(method="get", path="v1/accounts")
+            response = self._request(
+                method="get", path="v1/accounts", params=params
+            )
         except HTTPError as error:
             if error.response.status_code == 401:
                 if self.is_for_view:


### PR DESCRIPTION
## Done

advantage: implement view as functionality.

This will allow admins to view /advantage as a specific user by providing the `email` query.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8001/advantage?test_backend=true , log in and check that you see your contracts as usual.
- Now, assuming you have the contract ACL in ua-contracts staging, go to http://0.0.0.0:8001/advantage?test_backend=true&email=allan.vidal@canonical.com and you should see Allan's contracts.
