### PR TITLE
9487: Change IOT app stores contact-us copy

### DIFF
--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -38,7 +38,7 @@
     {% elif product == 'appstore' %}
 
 {% with h1="Contact us about app stores",
-  intro_text="If you would like to know more about Ubuntu for your IoT app store, please fill in your details below and a member of our team will get in touch.",
+  intro_text="Enhance your software distribution with a custom, dedicated app store. Fill in your details below and a member of our team will be in touch.",
   formid="2639",
   lpId="5811",
   returnURL="https://ubuntu.com/internet-of-things/thank-you?product=appstore" %}


### PR DESCRIPTION
## Done
Changed copy according to #9487

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the copy matches what is on the doc on `/iot/contact-us?product=appstore`
- 


## Issue / Card

Fixes #9487 
