### PR TITLE
9488: IOT index copy change

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -147,8 +147,8 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2>Private App Store included</h2>
-      <p>Turn on your app store, and build on the huge Ubuntu app portfolio. Ubuntu is the developer platform, with the largest pool of talent and the best developer tools.</p>
+      <h2>IoT App Store</h2>
+      <p>A private, custom, dedicated app store. Enterprise-ready for efficient software distribution. Utilise our huge range of existing apps or build your own. Included in the SMART START package.</p>
     </div>
   </div>
   <div class="u-fixed-width u-hide--small">
@@ -162,7 +162,7 @@
         attrs={"class":"p-image--shadowed"},
       ) | safe
     }}
-    <p><a href="http://snapcraft.io/store" class="p-link--external">Visit the Snap Store</a></p>
+    <p><a href="/internet-of-things/appstore">Learn more&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Update IOT index page copy according to #9488.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the copy matches the proposed changes and mark them as resolved in the document

## Issue / Card

Fixes #9488
