### PR TITLE
Fix repeated get customer info calls bug

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -135,7 +135,7 @@ function attachCTAevents() {
       }
     }
 
-    if (currentTransaction.accountId && !isCustomerInfoSet) {
+    if (currentTransaction.accountId && !isCustomerInfoSet && !guestPurchase) {
       fetchCustomerInfo(currentTransaction.accountId);
     }
 


### PR DESCRIPTION
- Given I am a guest user and I want to make a purchase.
- When I go to the modal after selecting my product.
- And I insert all my info and press submit to trigger the purchase
preview.
- After that every time you make a click on the modal and even after
closing the modal everywhere on the website we trigger a request.

- This request is not necessary for guest users. It's only useful for
  existing users when we try to prefill their contact info.

## QA

- Go to https://ubuntu-com-9508.demos.haus/advantage/subscribe?test_backend=true
- Open the Network tab
- Start making a guest purchase
- Insert your info and press the green button to preview purchase
- Click anywhere on the modal it should NOT make get requests to customer-info endpoint on click
- Start making a purchase as a logged in user
- When you reach the modal you will still have your customer info prefilled as it is expected


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/3951
