### PR TITLE
Fix the contextual menu functionality in Chrome

### DIFF
--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,5 +1,6 @@
 function toggleMenu(element, show) {
-  const dropdown = element.getAttribute("aria-controls");
+  const dropdownControl = element.getAttribute("aria-controls");
+  const dropdown = document.querySelector(dropdownControl);
 
   element.setAttribute("aria-expanded", show);
   dropdown.setAttribute("aria-hidden", !show);
@@ -65,13 +66,14 @@ function setupContextualMenuListeners(contextualMenuToggleSelector) {
   document.addEventListener("click", (e) => {
     toggles.forEach((toggle) => {
       const contextualMenu = document.querySelector(".p-contextual-menu");
+      if (contextualMenu) {
+        const clickOutside = !(
+          toggle.contains(e.target) || contextualMenu.contains(e.target)
+        );
 
-      const clickOutside = !(
-        toggle.contains(e.target) || contextualMenu.contains(e.target)
-      );
-
-      if (clickOutside) {
-        toggleMenu(toggle, false);
+        if (clickOutside) {
+          toggleMenu(toggle, false);
+        }
       }
     });
   });


### PR DESCRIPTION
## Done
Fix the contextual menu functionality in Chrome

## QA
- Go to /advantage
- Login and scroll to the Free personal token section
- Click the reveal button both on Chrome/Chromium and Firefox
- Check the token is revealed
- Click of the panel and see there is now no console errors