### PR TITLE
Start trial

### DIFF
--- a/webapp/advantage/api.py
+++ b/webapp/advantage/api.py
@@ -138,7 +138,13 @@ class UAContractsAPI:
             )
         except HTTPError as error:
             if error.response.status_code == 401:
-                raise UAContractsAPIAuthError(error)
+                if self.is_for_view:
+                    raise UAContractsAPIAuthErrorView(error)
+                else:
+                    raise UAContractsAPIAuthError(error)
+
+            if self.is_for_view:
+                raise UAContractsAPIErrorView(error)
 
             raise UAContractsAPIError(error)
 
@@ -413,6 +419,28 @@ class UAContractsAPI:
             raise UAContractsAPIError(error)
 
         return response.json() if response.status_code != 200 else None
+
+    def post_marketplace_trial(
+        self, marketplace: str, trial_request: dict
+    ) -> dict:
+        try:
+            response = self._request(
+                method="post",
+                path=f"v1/marketplace/{marketplace}/trial",
+                json=trial_request,
+            )
+        except HTTPError as error:
+            if error.response.status_code == 401:
+                if self.is_for_view:
+                    raise UAContractsAPIAuthErrorView(error)
+                raise UAContractsAPIAuthError(error)
+
+            if self.is_for_view:
+                raise UAContractsAPIErrorView(error)
+
+            raise UAContractsAPIError(error)
+
+        return response.json()
 
 
 class UnauthorizedError(Exception):

--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -68,3 +68,18 @@ ensure_purchase_account = {
     "account_name": String(),
     "payment_method_id": String(),
 }
+
+post_guest_trial = {
+    "email": String(),
+    "account_name": String(),
+    "name": String(),
+    "address": Nested(AddressSchema),
+    "products": List(Nested(ProductSchema), required=True),
+}
+
+post_trial = {
+    "account_id": String(required=True),
+    "products": List(Nested(ProductSchema), required=True),
+    "name": String(required=True),
+    "address": Nested(AddressSchema, required=True),
+}

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -19,6 +19,8 @@ from webapp.advantage.api import (
     UnauthorizedError,
     UAContractsUserHasNoAccount,
     UAContractsAPIError,
+    UAContractsAPIAuthErrorView,
+    UAContractsAPIErrorView,
 )
 
 from webapp.advantage.schemas import (
@@ -28,18 +30,26 @@ from webapp.advantage.schemas import (
     post_customer_info,
     ensure_purchase_account,
     post_payment_method,
+    post_trial,
+    post_guest_trial,
 )
 
 
 session = talisker.requests.get_session()
 
 
-@advantage_checks(check_list=["is_maintenance", "view_need_user"])
+@advantage_checks(
+    check_list=[
+        "is_maintenance",
+        "view_need_user",
+        "check_for_guest_trials",
+    ]
+)
 @use_kwargs({"subscription": String(), "email": String()}, location="query")
 def advantage_view(**kwargs):
     is_test_backend = kwargs.get("test_backend")
     api_url = kwargs.get("api_url")
-    stripe_publishable_key = kwargs["stripe_publishable_key"]
+    stripe_publishable_key = kwargs.get("stripe_publishable_key")
     token = kwargs.get("token")
     open_subscription = kwargs.get("subscription", None)
 
@@ -704,6 +714,111 @@ def accept_renewal(renewal_id, **kwargs):
     advantage = UAContractsAPI(session, token, api_url=api_url)
 
     return advantage.accept_renewal(renewal_id)
+
+
+@advantage_checks(check_list=["need_user"])
+@use_kwargs(post_trial, location="json")
+def post_trial(**kwargs):
+    api_url = kwargs.get("api_url")
+    token = kwargs.get("token")
+    account_id = kwargs.get("account_id")
+    products = kwargs.get("products")
+    name = kwargs.get("name")
+    address = kwargs.get("address")
+
+    advantage = UAContractsAPI(session, token, api_url=api_url)
+
+    trial = advantage.post_marketplace_trial(
+        marketplace="canonical-ua",
+        trial_request={
+            "accountID": account_id,
+            "items": [
+                {
+                    "productListingID": product["product_listing_id"],
+                    "value": product["quantity"],
+                }
+                for product in products
+            ],
+            "customerInfo": {
+                "name": name,
+                "address": address,
+            },
+        },
+    )
+
+    return flask.jsonify(trial), 200
+
+
+@advantage_checks()
+@use_kwargs(post_guest_trial, location="json")
+def post_guest_trial(**kwargs):
+    flask.session["guest_trial"] = {
+        "is_test_backend": kwargs.get("is_test_backend"),
+        "api_url": kwargs.get("api_url"),
+        "email": kwargs.get("email"),
+        "account_name": kwargs.get("account_name"),
+        "name": kwargs.get("name"),
+        "address": kwargs.get("address"),
+        "products": kwargs.get("products"),
+    }
+
+    return flask.jsonify({"message": "guest trial stored"})
+
+
+@advantage_checks(check_list=["view_need_user", "need_guest_trial"])
+def save_guest_trial(**kwargs):
+    token = kwargs.get("token")
+    session_values = flask.session.get("guest_trial")
+    is_test_backend = session_values.get("test_backend")
+    api_url = session_values.get("api_url")
+    email = session_values.get("email")
+    account_name = session_values.get("account_name")
+    name = session_values.get("name")
+    address = session_values.get("address")
+    products = session_values.get("products")
+
+    flask.session.pop("guest_trial")
+
+    advantage = UAContractsAPI(
+        session, token, api_url=api_url, is_for_view=True
+    )
+
+    try:
+        account = advantage.ensure_purchase_account(
+            email=email, account_name=account_name
+        )
+    except (UnauthorizedError, HTTPError) as error:
+        if error.response.status_code == 401:
+            raise UAContractsAPIAuthErrorView(error)
+
+        raise UAContractsAPIErrorView
+
+    advantage.put_customer_info(
+        account.get("accountID"), None, address, name, None
+    )
+
+    advantage.post_marketplace_trial(
+        marketplace="canonical-ua",
+        trial_request={
+            "accountID": account.get("accountID"),
+            "items": [
+                {
+                    "productListingID": product["product_listing_id"],
+                    "value": product["quantity"],
+                }
+                for product in products
+            ],
+            "customerInfo": {
+                "name": name,
+                "address": address,
+            },
+        },
+    )
+
+    if is_test_backend:
+        return flask.redirect("/advantage?test_backend=true")
+
+    return flask.redirect("/advantage")
 
 
 def _prepare_monthly_info(monthly_info, subscription, advantage):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -82,6 +82,9 @@ from webapp.advantage.views import (
     post_customer_info,
     post_stripe_invoice_id,
     cancel_advantage_subscriptions,
+    post_guest_trial,
+    save_guest_trial,
+    post_trial,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -336,6 +339,24 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/renewals/<renewal_id>/process-payment",
     view_func=accept_renewal,
+    methods=["POST"],
+)
+
+app.add_url_rule(
+    "/advantage/post-guest-trial",
+    view_func=post_guest_trial,
+    methods=["POST"],
+)
+
+app.add_url_rule(
+    "/advantage/save-guest-trial",
+    view_func=save_guest_trial,
+    methods=["GET"],
+)
+
+app.add_url_rule(
+    "/advantage/post-trial",
+    view_func=post_trial,
     methods=["POST"],
 )
 


### PR DESCRIPTION
`POST /advantage/post-guest-trial` with
```
email: string
acount_name: string
name: string
address: {
  city: string
  country: string
  line1: string
  postal_code: string
  state: string
}
products: [
  {
    product_listing_id: string
    quantity: int
  }
]
```
It will store the info of the purchase in the session. Once the user
logs in and arrives on `/advantage` it will trigger the
`GET /advantage/save-guest-trial` endpoint with that data.
This second endpoint will fetch an `account_id` for the user(using email and
account_name), update the customer info(using name and address) and then
make the trial (using account_id and products).

`POST /advantage/post-trial` with
```
acount_id: string
products: [
  {
    product_listing_id: string
    quantity: int
  }
],
name: string,
address: {
  city: string
  country: string
  line1: string
  postal_code: string
  state: string
}
```
For logged in users, we use their current `account_id` and we create a
trial immediately with the info in `products`.

## Done

- [List of work items including drive-bys.]

## QA

- We QA when the front-end is ready.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/3948
