### PR TITLE
Rebuild /openstack page 

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -2,21 +2,21 @@
 
 {% block title %}OpenStack private cloud - a cost-effective extension to public clouds{% endblock %}
 
-{% block meta_description %}Canonical’s Charmed OpenStack ensures the best price-performance of a private cloud, providing full automation around OpenStack deployments and operations. Together with Ubuntu, it meets the highest security, stability and quality standards in the industry. Run with confidence: supported or fully-managed.{% endblock meta_description %}
+{% block meta_description %}Canonical's Charmed OpenStack ensures the best price-performance of a private cloud, providing full automation around OpenStack deployments and operations. Together with Ubuntu, it meets the highest security, stability and quality standards in the industry. Run with confidence: supported or fully-managed.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-deep">
+<section class="p-strip--suru-bottomed">
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>OpenStack private cloud</h1>
-      <p>Multi-cloud operations are more cost-effective with a private cloud.</p>
-      <p>Private cloud is more cost-effective with Canonical’s Charmed OpenStack.</p>
+      <p>Multi&ndash;cloud operations are more cost-effective with a private cloud. Private cloud is more cost&ndash;effective with Canonical's Charmed OpenStack.</p>
+      <p>Save up to 60% with Charmed OpenStack.</p>
       <p>
         <a class="p-button--positive js-invoke-modal" href="/openstack/contact-us?product=openstack">
           Get in touch
-        </a> to save up to 60% with Charmed OpenStack
+        </a>
       </p>
       <p>
         <a href="/engage/redhat-openstack-comparison-whitepaper">
@@ -24,30 +24,28 @@
         </a>
       </p>
     </div>
-    <div class="col-4 u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/669390e0-openstack-cloud.svg",
-          alt="Canonical OpenStack",
-          height="184",
-          width="323",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "u-hide--small"},
+    <div class="col-4 u-vertically-center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/346134cb-Openstack-cost-effective.svg",
+        alt="",
+        width="313",
+        height="180",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <p class="p-muted-heading u-align--center">Proven record of success</p>
     <ul class="p-inline-images">
       <li class="p-inline-images__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
-          alt="",
+          alt="AT&T",
           width="1000",
           height="411",
           hi_def=True,
@@ -232,20 +230,20 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-6">
-      <h2>Engineered for best price-performance</h2>
+      <h2>Engineered for best price&ndash;performance</h2>
       <h3 class="p-heading--5">Designed to be economical in every way</h3>
       <p>Smart operations, optimal architecture, better pricing. All of this to ensure TCO reduction of your cloud, while expanding your budget for innovation.</p>
       <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/9faeb5af-Openstack+illustration_3.png",
+        url="https://assets.ubuntu.com/v1/8468f4b4-Openstack-price-performance.svg",
         alt="",
-        width="1600",
-        height="979",
+        width="446",
+        height="270",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -254,14 +252,14 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-6">
+<section class="p-strip">
+  <div class="row u-vertically-center">
+    <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/9faeb5af-Openstack+illustration_3.png",
+        url="https://assets.ubuntu.com/v1/ba7bf5ff-Openstack-cloud-optimisation.svg",
         alt="",
-        width="1600",
-        height="979",
+        width="390",
+        height="174",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -272,12 +270,12 @@
       <h3 class="p-heading--5">Run your workloads where it makes the most sense from an economical point of view</h3>
       <p>The future of infrastructure is multi-cloud.</p>
       <p>Using private and public cloud infrastructure at the same time allows you to optimise your CapEx and OpEx costs.</p>
-      <a class="p-link--external" href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf?_ga=2.41518498.1083732777.1610363777-647098137.1594061070">Download datasheet</a>
+      <button class="p-link--external p-button--neutral" href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf?_ga=2.41518498.1083732777.1610363777-647098137.1594061070">Download datasheet</button>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-6">
       <h2>Cheaper VMs</h2>
@@ -386,18 +384,18 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row u-vertically-center">
     <div class="col-6">
       <h2>We bring infrastructure costs down</h2>
       <p class="u-sv3">Read how Charmed OpenStack helped SBI Group to optimise their CapEx and OpEx costs</p>
       <blockquote class="p-pull-quote">
-        <p class="p-pull-quote__quote">Canonical’s solution was a third of the price of the other proposals we’d received. The solution is also proving to be highly cost-effective, both from CAPEX and OPEX perspectives.</p>
+        <p class="p-pull-quote__quote">Canonical's solution was a third of the price of the other proposals we'd received. The solution is also proving to be highly cost-effective, both from CAPEX and OPEX perspectives.</p>
         <cite class="p-pull-quote__citation">Georgi Georgiev, CIO at SBI BITS</cite>
       </blockquote>
-      <a href="/engage/sbi-casestudy" class="p-button--neutral">Download casestudy</a>
+      <button href="/engage/sbi-casestudy" class="p-button--neutral">Download casestudy</button>
     </div>
-    <div class="col-6">
+    <div class="col-6 u-hide--small">
       <a href="/engage/sbi-casestudy">
       {{ image (
         url="https://assets.ubuntu.com/v1/0cf02c9e-SBI-info.png",
@@ -413,7 +411,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Fixed-price delivery</h2>
     <p class="p-heading--5">Consulting packages tailored to your needs</p>
@@ -446,7 +444,7 @@
       <div class="p-card__content">
         <p>$150,000 fixed price</p>
         <p>Design and deployment of a carrier-grade, feature-rich OpenStack cloud based on a custom architecture.</p>
-        <p>What’s included: *</p>
+        <p>What's included: *</p>
         <p>Everything in the Private Cloud Build, plus:</p>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Custom architecture</li>
@@ -466,14 +464,14 @@
   </div>
   <div class="u-fixed-width">
     <p>* Additional features, functionality and integrations are available via add-ons</p>
-    <button href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">Download datasheet</button>
+    <button href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral p-link--external">Download datasheet</button>
     <p>
       <a href="/openstack/consulting">Learn more about our consulting packages&nbsp;&rsaquo;</a>
     </p>
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row u-vertically-center">
     <div class="col-6">
       <h2>Total bottom-up automation</h2>
@@ -496,14 +494,14 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/e02f9f2e-Open-infrastructure-stack.png",
+        url="https://assets.ubuntu.com/v1/a21ceaf9-Openstack-extendable-containers-layers.svg",
         alt="",
-        width="619",
-        height="555",
+        width="387",
+        height="330",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -518,7 +516,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row u-vertically-center">
     <div class="col-6">
       <h2>Product interoperability</h2>
@@ -529,9 +527,9 @@
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/25c42877-simplified-software-management-2.svg",
+        url="https://assets.ubuntu.com/v1/0678b279-Openstack-puzzle.svg",
         alt="",
-        width="300",
+        width="262",
         height="300",
         hi_def=True,
         loading="lazy"
@@ -541,7 +539,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
@@ -572,7 +570,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <p class="p-muted-heading u-align--center u-sv3">
       Endorsed by customers, globally
@@ -614,7 +612,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2 class="u-sv3">Security maintenance and support</h2>
     {% with no_desktop="true" %}{% include "shared/pricing/_ua-for-infrastructure.html" %}{% endwith %}
@@ -626,7 +624,7 @@
 </section>
 
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>Fully-managed OpenStack</h2>
@@ -655,13 +653,13 @@
       </div>
       <button href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf?_ga=2.108619394.1083732777.1610363777-647098137.1594061070" class="p-button--neutral p-link--external">Download datasheet</button>
       <p>
-        <a href="/openstack/managed">I want fully-managed OpenStack&nbsp;&rsaquo;</a>
+        <a href="/openstack/managed">I want fully&ndash;managed OpenStack&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-6">
       <h2>Long-term community member</h2>
@@ -686,7 +684,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row u-vertically-center">
     <div class="col-5 u-hide--small u-align--center">
       {{ image (
@@ -701,7 +699,7 @@
     </div>
     <div class="col-7">
       <h2>Get in touch</h2>
-      <p>Tell us your story and let’s work together on expanding the benefits of using Charmed OpenStack in your organisation.</p>
+      <p>Tell us your story and let's work together on expanding the benefits of using Charmed OpenStack in your organisation.</p>
       <button href="/openstack/contact-us?product=openstack" class="p-button--positive js-invoke-modal">Get in touch</button>
     </div>
   </div>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -234,7 +234,7 @@
   <div class="row">
     <div class="col-6">
       <h2>Engineered for best price&ndash;performance</h2>
-      <h3 class="p-heading--5">Designed to be economical in every way</h3>
+      <h3 class="p-heading--4">Designed to be economical in every way</h3>
       <p>Smart operations, optimal architecture, better pricing. All of this to ensure TCO reduction of your cloud, while expanding your budget for innovation.</p>
       <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
     </div>
@@ -267,7 +267,7 @@
     </div>
     <div class="col-6">
       <h2>Maximum multi-cloud cost optimisation</h2>
-      <h3 class="p-heading--5">Run your workloads where it makes the most sense from an economical point of view</h3>
+      <h3 class="p-heading--4">Run your workloads where it makes the most sense from an economical point of view</h3>
       <p>The future of infrastructure is multi-cloud.</p>
       <p>Using private and public cloud infrastructure at the same time allows you to optimise your CapEx and OpEx costs.</p>
       <button class="p-link--external p-button--neutral" href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf?_ga=2.41518498.1083732777.1610363777-647098137.1594061070">Download datasheet</button>
@@ -279,10 +279,10 @@
   <div class="row">
     <div class="col-6">
       <h2>Cheaper VMs</h2>
-      <h3 class="p-heading--5">Machines cost less if they run in a private cloud</h3>
+      <h3 class="p-heading--4">Machines cost less if they run in a private cloud</h3>
       <p>Compare the prices of sample VMs running on a baseline Charmed OpenStack cloud over a three-year period. The calculations include hardware costs, typical hosting charges and <a href="/openstack/managed">fully-managed service</a>*.</p>
       <a class="u-sv2" href="/openstack/tco-calculator">Check pricing for other VMs&nbsp;&rsaquo;</a>
-      <p>* - Exact prices may vary depending on the used hardware, cloud configuration, local hosting charges and salary costs.</p>
+      <p>* Exact prices may vary depending on the used hardware, cloud configuration, local hosting charges and salary costs.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       <table aria-label="Comparison table for pricing of VMs">
@@ -384,86 +384,103 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <h2>We bring infrastructure costs down</h2>
-      <p class="u-sv3">Read how Charmed OpenStack helped SBI Group to optimise their CapEx and OpEx costs</p>
-      <blockquote class="p-pull-quote">
-        <p class="p-pull-quote__quote">Canonical's solution was a third of the price of the other proposals we'd received. The solution is also proving to be highly cost-effective, both from CAPEX and OPEX perspectives.</p>
-        <cite class="p-pull-quote__citation">Georgi Georgiev, CIO at SBI BITS</cite>
-      </blockquote>
-      <button href="/engage/sbi-casestudy" class="p-button--neutral">Download casestudy</button>
-    </div>
-    <div class="col-6 u-hide--small">
-      <a href="/engage/sbi-casestudy">
+<section class="p-strip--suru-accent is-dark">
+  <div class="row">
+    <div class="col-3 p-card u-hide--small u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/0cf02c9e-SBI-info.png",
-        alt="",
-        width="792",
-        height="920",
+        url="https://assets.ubuntu.com/v1/91fb9ca2-SBI-BITS_logo.svg",
+        alt="SBI Bits",
+        width="292",
+        height="85",
         hi_def=True,
         loading="lazy"
         ) | safe
       }}
-      </a>
     </div>
+    <div class="col-8 col-start-large-5">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/fc781c43-Case+study+-+white.svg",
+            alt="",
+            width="32",
+            height="32",
+            hi_def=True,
+            attrs={"class":"p-heading-icon__img"},
+            loading="lazy"
+            ) | safe
+          }}
+          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">Case study</p>
+        </div>
+        <h2 class="p-heading--4">We bring infrastructure costs down</h2>
+        <p>Read how Charmed OpenStack helped SBI Group to optimise their CapEx and OpEx costs</p>
+        <p><a href="/engage/sbi-casestudy" class="p-button--neutral">Read the case study</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <blockquote class="p-pull-quote">
+      <p class="p-pull-quote__quote">Canonical's solution was a third of the price of the other proposals we'd received. The solution is also proving to be highly cost-effective, both from CAPEX and OPEX perspectives.</p>
+      <cite class="p-pull-quote__citation">Georgi Georgiev, CIO at SBI BITS</cite>
+    </blockquote>
   </div>
 </section>
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Fixed-price delivery</h2>
-    <p class="p-heading--5">Consulting packages tailored to your needs</p>
-    <p>No hidden costs. No surprises. Everything is clear from the beginning.</p>
-    <p>We design the cloud. We build the cloud.</p>
+    <p class="p-heading--4">Consulting packages tailored to your needs</p>
+    <p>No hidden costs. No surprises. Everything is clear from the beginning. We design the cloud. We build the cloud.</p>
     <p>Choose your package:</p>
   </div>
   <div class="row">
-    <div class="p-card col-6">
-      <h3 class="p-card__title">Private Cloud Build</h3>
-      <div class="p-card__content">
-        <p>$75,000 fixed price</p>
-        <p>Design and deployment of a baseline OpenStack cloud based on the reference architecture.</p>
-        <p>What’s included: *</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
-          <li class="p-list__item is-ticked">Reference architecture</li>
-          <li class="p-list__item is-ticked">Simplified networking</li>
-          <li class="p-list__item is-ticked">Hyper-converged or Converged</li>
-          <li class="p-list__item is-ticked">Containerised control plane</li>
-          <li class="p-list__item is-ticked">Observability stack</li>
-          <li class="p-list__item is-ticked">Block and object storage</li>
-          <li class="p-list__item is-ticked">High availability</li>
-        </ul>
-        <p>Design and delivery on certified hardware.</p>
-      </div>
+    <div class="col-6 p-card">
+      <h2 class="p-heading--four">Private Cloud Build</h2>
+      <p><span class="p-heading--two">$75,000</span> fixed price</p>
+      <hr class="u-sv1">
+      <p>Design and deployment of a baseline OpenStack cloud based on the reference architecture.</p>
+      <p>What’s included: <sup><a href="#os-footnote">*</a></sup></p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
+        <li class="p-list__item is-ticked">Reference architecture</li>
+        <li class="p-list__item is-ticked">Simplified networking</li>
+        <li class="p-list__item is-ticked">Hyper-converged or Converged</li>
+        <li class="p-list__item is-ticked">Containerised control plane</li>
+        <li class="p-list__item is-ticked">Observability stack</li>
+        <li class="p-list__item is-ticked">Block and object storage</li>
+        <li class="p-list__item is-ticked">High availability</li>
+      </ul>
+      <p>Design and delivery on certified hardware.</p>
+      <p><a href="/openstack/consulting">Get OpenStack&nbsp;›</a></p>
     </div>
-    <div class="p-card col-6">
-      <h3 class="p-card__title">Private Cloud Build Plus</h3>
-      <div class="p-card__content">
-        <p>$150,000 fixed price</p>
-        <p>Design and deployment of a carrier-grade, feature-rich OpenStack cloud based on a custom architecture.</p>
-        <p>What's included: *</p>
-        <p>Everything in the Private Cloud Build, plus:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Custom architecture</li>
-          <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
-          <li class="p-list__item is-ticked">Complex networking</li>
-          <li class="p-list__item is-ticked">LDAP or Active Directory integration</li>
-          <li class="p-list__item is-ticked">Regulatory compliance</li>
-          <li class="p-list__item is-ticked">Encryption in flight and at rest</li>
-          <li class="p-list__item is-ticked">EPA tuning options</li>
-          <li class="p-list__item is-ticked">Block, object and file storage</li>
-          <li class="p-list__item is-ticked">Layer-7 load balancer</li>
-          <li class="p-list__item is-ticked">Secrets management</li>
-        </ul>
-        <p>Workshops determine the optimal architecture for your workloads and integration requirements.</p>
-      </div>
+    <div class="col-6 p-card">
+      <h2 class="p-heading--four">Private Cloud Build Plus</h2>
+      <p><span class="p-heading--two">$150,000</span> fixed price</p>
+      <hr class="u-sv1">
+      <p>Design and deployment of a carrier-grade, feature-rich OpenStack cloud based on a custom architecture.</p>
+      <p>What’s included: <sup><a href="#os-footnote">*</a></sup></p>
+      <p>Everything in Private Cloud Build, plus:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Custom architecture</li>
+        <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
+        <li class="p-list__item is-ticked">Complex networking</li>
+        <li class="p-list__item is-ticked">LDAP or Active Directory integration</li>
+        <li class="p-list__item is-ticked">Regulatory compliance</li>
+        <li class="p-list__item is-ticked">Encryption in flight and at rest</li>
+        <li class="p-list__item is-ticked">EPA tuning options</li>
+        <li class="p-list__item is-ticked">Block, object and file storage</li>
+        <li class="p-list__item is-ticked">Layer&ndash;7 load balancer</li>
+        <li class="p-list__item is-ticked">Secrets management</li>
+      </ul>
+      <p>Workshops determine the optimal architecture for your workloads and integration requirements.</p>
+      <p><a href="/openstack/consulting">Migrate from VMware&nbsp;›</a></p>
     </div>
   </div>
   <div class="u-fixed-width">
-    <p>* Additional features, functionality and integrations are available via add-ons</p>
+    <p id="os-footnote">* Additional features, functionality and integrations are available via add-ons</p>
     <button href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral p-link--external">Download datasheet</button>
     <p>
       <a href="/openstack/consulting">Learn more about our consulting packages&nbsp;&rsaquo;</a>
@@ -475,7 +492,7 @@
   <div class="row u-vertically-center">
     <div class="col-6">
       <h2>Total bottom-up automation</h2>
-      <p class="p-heading--5">Fully automated OpenStack deployment and operations</p>
+      <h3 class="p-heading--4">Fully automated OpenStack deployment and operations</h3>
       <p>From bare metal to cloud control plane, Charmed OpenStack uses automation everywhere.</p>
       <p>Save time and money by moving to the only OpenStack platform on the market that uses operators for OpenStack automation.</p>
       <a href="/engage/openstack-deployment-guide">Read how to deploy and operate OpenStack effectively&nbsp;&rsaquo;</a>
@@ -509,7 +526,7 @@
     </div>
     <div class="col-6">
       <h2>Extendable containers layer</h2>
-      <p class="p-heading--5">Run both containers and VMs on the same platform</p>
+      <h3 class="p-heading--4">Run both containers and VMs on the same platform</h3>
       <p>Extend your cloud with a <a href="/kubernetes">Kubernetes</a> layer running on top of it and benefit from a unified approach to both containers and legacy workloads management.</p>
       <p>The entire stack is supported under the same <a href="/advantage">subscription</a>.</p>
     </div>
@@ -520,7 +537,7 @@
   <div class="row u-vertically-center">
     <div class="col-6">
       <h2>Product interoperability</h2>
-      <p class="p-heading--5">Servers, SDN controllers, storage platforms and more</p>
+      <h3 class="p-heading--4">Servers, SDN controllers, storage platforms and more</h3>
       <p>We partner with leading semiconductor companies, hardware vendors, network equipment providers and open source communities to ensure the best bread of technology choices.</p>
       <p>All of that to design the optimal architecture and ensure the best price-performance all of the time.</p>
       <a href="/openstack/features">Read about supported options&nbsp;&rsaquo;</a>
@@ -554,7 +571,7 @@
     </div>
     <div class="col-6">
       <h2>100 Gbps OpenStack</h2>
-      <p class="p-heading--5">For telcos, for HPC, for AI/ML</p>
+      <h3 class="p-heading--4">For telcos, for HPC, for AI/ML</h3>
       <p>All necessary performance extensions for running NFVI/VIM and other advanced cloud architectures:</p>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">OVS hardware offloading</li>
@@ -572,38 +589,20 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
-    <p class="p-muted-heading u-align--center u-sv3">
-      Endorsed by customers, globally
-    </p>
+    <h2 class="u-sv2">Endorsed by customers, globally</h2>
   </div>
   <div class="row">
     <div class="col-6">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/d2bfbb2b-MTS_logo_%282016%29.svg",
-        alt="",
-        width="130",
-        height="50",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-      <blockquote class="p-pull-quote">
+      <blockquote class="p-pull-quote has-image">
+        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/d2bfbb2b-MTS_logo_%282016%29.svg" alt="MTS">
         <p class="p-pull-quote__quote">Building an ecosystem based on OpenStack will speed up our technology adoption, lay a foundation for future 5G rollout, and enable us to improve virtualization cost effectiveness.</p>
         <cite class="p-pull-quote__citation">Victor Belov, CTO at MTS</cite>
       </blockquote>
       <a href="/blog/mts-selects-openstack-and-canonical-for-next-generation-cloud-infrastructure">Read the announement&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/7c97efb0-BT_logo.svg",
-        alt="",
-        width="50",
-        height="50",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-      <blockquote class="p-pull-quote">
+      <blockquote class="p-pull-quote has-image">
+        <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/7c97efb0-BT_logo.svg" alt="BT">
         <p class="p-pull-quote__quote">Canonical is providing us with the ‘cloud-native’ foundation that enables us to create a smart and fully converged network.</p>
         <cite class="p-pull-quote__citation">Neil J. McRae, Group Chief Architect at BT</cite>
       </blockquote>
@@ -614,7 +613,10 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <h2 class="u-sv3">Security maintenance and support</h2>
+    <h2 class="u-sv3">Full-stack enterprise support</h2>
+    <h3 class="p-heading--4">Multiple products, single subscription</h3>
+    <p>Manage your cloud with confidence with commercial support from Canonical.</p>
+    <p class="u-sv3">Choose the plan that suits you the best:</p>
     {% with no_desktop="true" %}{% include "shared/pricing/_ua-for-infrastructure.html" %}{% endwith %}
     <button href="https://assets.ubuntu.com/v1/b0b42477-Ubuntu_Advantage_+Datasheet-2019.pdf" class="p-button--neutral p-link--external">Download datasheet</button>
     <p>
@@ -625,17 +627,19 @@
 
 
 <section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Fully-managed OpenStack</h2>
+    <h3 class="p-heading--4">We manage the cloud for you</h3>
+    <p>Just like a public cloud, but running on your premises or in one of our partner data centres.</p>
+  </div>
   <div class="row">
-    <div class="col-8">
-      <h2>Fully-managed OpenStack</h2>
-      <p class="p-heading--5">We manage the cloud for you</p>
-      <p>Just like a public cloud, but running on your premises or in one of our partner data centres.</p>
+    <div class="col-6">
       <div class="p-card">
-        <h3 class="p-card__title">Managed OpenStack</h3>
-        <div class="p-card__content">
-          <p>$15 per server per day</p>
-          <p>Full remote operations of your Charmed OpenStack cloud.</p>
-          <p>What’s included:</p>
+        <h2 class="p-heading--four">Managed OpenStack</h2>
+        <p><span class="p-heading--two">$15</span> per server per day</p>
+        <hr class="u-sv1">
+        <p>Full remote operations of your Charmed OpenStack cloud.</p>
+        <p>What’s included: <sup><a href="#os-footnote">*</a></sup></p>
           <ul class="p-list">
             <li class="p-list__item is-ticked">Logging, monitoring and alerting</li>
             <li class="p-list__item is-ticked">24/7 operations with fully staffed NOC</li>
@@ -648,13 +652,12 @@
             <li class="p-list__item is-ticked">EU and US regulatory compliance options</li>
             <li class="p-list__item is-ticked">Training and transfer options</li>
           </ul>
-          <p>The most straightforward way to accelerate your time to market.</p>
-        </div>
+        <p>The most straightforward way to accelerate your time to market.</p>
+        <button href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf?_ga=2.108619394.1083732777.1610363777-647098137.1594061070" class="p-button--neutral p-link--external">Download datasheet</button>
+        <p>
+          <a href="/openstack/managed">I want fully&ndash;managed OpenStack&nbsp;&rsaquo;</a>
+        </p>
       </div>
-      <button href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf?_ga=2.108619394.1083732777.1610363777-647098137.1594061070" class="p-button--neutral p-link--external">Download datasheet</button>
-      <p>
-        <a href="/openstack/managed">I want fully&ndash;managed OpenStack&nbsp;&rsaquo;</a>
-      </p>
     </div>
   </div>
 </section>
@@ -662,22 +665,22 @@
 <section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2>Long-term community member</h2>
+      <h2 class="p-heading--4">Long-term community member</h2>
       <p>Open source comes through contribution and community collaboration. Canonical is a long-term member of the OpenStack community, <a href="https://www.stackalytics.com/?metric=loc&release=all" class="p-link--external">one of the top contributors</a> to the OpenStack code and Gold Member of the <a href="https://openinfra.dev/" class="p-link--external">Open Infrastructure Foundation</a>. Together with other leaders we constantly drive the evolution of OpenStack towards new challenges.</p>
     </div>
     <div class="col-6">
-      <h2>The most popular open source cloud platform</h2>
+      <h2 class="p-heading--4">The most popular open source cloud platform</h2>
       <p><a href="https://www.statista.com/statistics/511526/worldwide-survey-private-coud-services-running-application/" class="p-link--external">OpenStack adoption continues to grow</a> every year. Its combined market size worldwide is approaching $8,000,000,000. OpenStack is supported by leading industry players, and successfully used by thousands of organisations all over the world. The popularity of OpenStack comes from its better economics, stability and openness of the code.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2>From VMware to OpenStack</h2>
+      <h2 class="p-heading--4">From VMware to OpenStack</h2>
       <p>VMware costs increasing? Do not worry. Charmed OpenStack significantly decreases the TCO of infrastructure maintenance. Our team of cloud experts will help you to migrate from VMware to Charmed OpenStack and take control over your budget back.</p>
       <a href="engage/vmware-to-charmed-openstack">Explore how to perform a live migration&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6">
-      <h2>Install OpenStack yourself</h2>
+      <h2 class="p-heading--4">Install OpenStack yourself</h2>
       <p>Looking for the most straightforward installation instructions for OpenStacK? <a href="https://microstack.run" class="p-link--external">MicroStack</a> allows you to install a fully functional OpenStack on your workstation in just two commands. The entire process takes around twenty minutes.</p>
       <a href="/openstack/install">Get started with OpenStack today&nbsp;&rsaquo;</a>
     </div>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -235,7 +235,8 @@
     <div class="col-6">
       <h2>Engineered for best price&ndash;performance</h2>
       <h3 class="p-heading--4">Designed to be economical in every way</h3>
-      <p>Smart operations, optimal architecture, better pricing. All of this to ensure TCO reduction of your cloud, while expanding your budget for innovation.</p>
+      <p>Smart operations, optimal architecture, better pricing.</p>
+      <p>All of this to ensure TCO reduction of your cloud, while expanding your budget for innovation.</p>
       <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6 u-hide--small u-align--center">
@@ -302,7 +303,7 @@
                     <div role="heading" aria-level="3" class="p-accordion__heading">
                       <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="false">c1.small</button>
                     </div>
-                    <section class="p-accordion__panel" id="tab1-section" aria-hidden="true" aria-labelledby="tab1">
+                    <section class="p-accordion__panel" style="padding-left: 1rem;" id="tab1-section" aria-hidden="true" aria-labelledby="tab1">
                       <p>vCPUs: 1</p>
                       <p>RAM: 4 GB</p>
                       <p>Ephemeral storage: 8 GB</p>
@@ -323,7 +324,7 @@
                     <div role="heading" aria-level="3" class="p-accordion__heading">
                       <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">c2.medium</button>
                     </div>
-                    <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
+                    <section class="p-accordion__panel" style="padding-left: 1rem;" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
                       <p>vCPUs: 2</p>
                       <p>RAM: 8 GB</p>
                       <p>Ephemeral storage: 8 GB</p>
@@ -344,7 +345,7 @@
                     <div role="heading" aria-level="3" class="p-accordion__heading">
                       <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">c3.large</button>
                     </div>
-                    <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
+                    <section class="p-accordion__panel" style="padding-left: 1rem;" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
                       <p>vCPUs: 4</p>
                       <p>RAM: 16 GB</p>
                       <p>Ephemeral storage: 8 GB</p>
@@ -365,7 +366,7 @@
                     <div role="heading" aria-level="4" class="p-accordion__heading">
                       <button type="button" class="p-accordion__tab" id="tab4" aria-controls="tab4-section" aria-expanded="false">c4.xlarge</button>
                     </div>
-                    <section class="p-accordion__panel" id="tab4-section" aria-hidden="true" aria-labelledby="tab4">
+                    <section class="p-accordion__panel" style="padding-left: 1rem;" id="tab4-section" aria-hidden="true" aria-labelledby="tab4">
                       <p>vCPUs: 8</p>
                       <p>RAM: 32 GB</p>
                       <p>Ephemeral storage: 8 GB</p>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -1,22 +1,22 @@
 {% extends "openstack/_base_openstack.html" %}
 
-{% block title %}OpenStack on Ubuntu is your scalable private cloud, by Canonical{% endblock %}
+{% block title %}OpenStack private cloud - a cost-effective extension to public clouds{% endblock %}
 
-{% block meta_description %}Ubuntu OpenStack is the most trusted and economical way to build your private OpenStack cloud. Supported or fully managed by Canonical.{% endblock meta_description %}
+{% block meta_description %}Canonical’s Charmed OpenStack ensures the best price-performance of a private cloud, providing full automation around OpenStack deployments and operations. Together with Ubuntu, it meets the highest security, stability and quality standards in the industry. Run with confidence: supported or fully-managed.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-deep is-bordered">
+<section class="p-strip--suru-topped is-deep">
   <div class="row u-equal-height">
     <div class="col-8">
-      <h1>OpenStack, delivered</h1>
-      <p>Canonical designs, builds, operates and supports OpenStack private clouds on Ubuntu. We understand the importance of certainty, stability, performance and economic efficiency for private cloud infrastructure.</p>
-      <p>Ready to move from proprietary virtualisation to OpenStack?</p>
+      <h1>OpenStack private cloud</h1>
+      <p>Multi-cloud operations are more cost-effective with a private cloud.</p>
+      <p>Private cloud is more cost-effective with Canonical’s Charmed OpenStack.</p>
       <p>
         <a class="p-button--positive js-invoke-modal" href="/openstack/contact-us?product=openstack">
-          Move to OpenStack today
-        </a>
+          Get in touch
+        </a> to save up to 60% with Charmed OpenStack
       </p>
       <p>
         <a href="/engage/redhat-openstack-comparison-whitepaper">
@@ -41,329 +41,673 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2>Fully managed OpenStack to maintain your business focus</h2>
+  <div class="u-fixed-width">
+    <p class="p-muted-heading u-align--center">Proven record of success</p>
+    <ul class="p-inline-images">
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
+          alt="",
+          width="1000",
+          height="411",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/2616b34f-ACI-Universal-Payments.svg",
+          alt="ACI universal payments",
+          width="118",
+          height="54",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg",
+          alt="Cisco",
+          width="125",
+          height="65",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/8442024b-Gendarmerie_nationale_logo.svg.png",
+          alt="Gendarmerie nationale",
+          width="894",
+          height="768",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/7538babd-Bloomberg_logo.svg",
+          alt="Bloomberg",
+          width="130",
+          height="26",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/7c97efb0-BT_logo.svg",
+          alt="BT",
+          width="90",
+          height="90",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/40b42dd2-bnp-paribas_logo.svg",
+          alt="BNP Paribas",
+          width="165",
+          height="40",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/d3959703-T-SYSTEMS-LOGO2013.svg",
+          alt="T-systems",
+          width="225",
+          height="43",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/cf1920c8-1200px-University_of_Cape_Town_logo.svg.png",
+          alt="University of capetown",
+          width="130",
+          height="131",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/2ee0e692-1200px-DaimlerLogo.svg.png",
+          alt="Daimer",
+          width="240",
+          height="30",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/d2bfbb2b-MTS_logo_%282016%29.svg",
+          alt="MTS",
+          width="266",
+          height="98",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg",
+          alt="Rabobank",
+          width="250",
+          height="45",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/df4150e2-nec-logo.svg",
+          alt="NEC",
+          width="132",
+          height="36",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/1d34393a-best-buy_logo.svg",
+          alt="Best Buy",
+          width="100",
+          height="73",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/27819db8-spectrum-health-logo.png",
+          alt="Spectrum health",
+          width="300",
+          height="120",
+          hi_def=True,
+          attrs={"class": "p-inline-images__logo"},
+          loading="auto"
+          ) | safe
+        }}
+      </li>
+    </ul>
+    <div>
+      <p class="u-align--center">Telcos, financial institutions, hardware manufacturers, government institutions, enterprises.</p>
+      <p class="u-align--center">OpenStack and Ubuntu help you optimise infrastructure costs across all market sectors all over the world.</p>
     </div>
   </div>
+</section>
+
+<section class="p-strip">
   <div class="row">
-    <div class="col-7">
-      <p>Canonical operates many private OpenStack clouds on behalf of customers, enabling them to get the benefits of OpenStack while focusing their team on business workloads rather than infrastructure.</p>
-      <p>This is the fast way to validate the economic case for OpenStack; you don't need new staff or skills, just allocate the hardware and engage with Canonical to manage your OpenStack. Once you have proven the economics of private cloud, you can invest in the skills and time to operate it yourself.</p>
-      <p>Fully managed OpenStack is a 'build, operate, transfer, support' service that allows you to take control of your own cloud at any time. All Openstack and operational components deployed are open source.</p>
+    <div class="col-6">
+      <h2>Engineered for best price-performance</h2>
+      <h3 class="p-heading--5">Designed to be economical in every way</h3>
+      <p>Smart operations, optimal architecture, better pricing. All of this to ensure TCO reduction of your cloud, while expanding your budget for innovation.</p>
+      <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-5 u-hide--small">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg",
-          alt="",
-          height="247",
-          width="413",
-          hi_def=True,
-          loading="lazy",
+    <div class="col-6 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/9faeb5af-Openstack+illustration_3.png",
+        alt="",
+        width="1600",
+        height="979",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-bordered u-no-padding--top">
-  <div class="u-fixed-width">
-    <ul class="p-list is-split">
-      <li class="p-list__item is-ticked">Jointly shape the OpenStack architecture</li>
-      <li class="p-list__item is-ticked">We help you plan your cloud hardware requirements</li>
-      <li class="p-list__item is-ticked">We build OpenStack in your data centre</li>
-      <li class="p-list__item is-ticked">We operate the cloud to an SLA</li>
-      <li class="p-list__item is-ticked">Transparent audit, logging, monitoring and management</li>
-      <li class="p-list__item is-ticked">When your team is ready, we hand over the keys</li>
-    </ul>
-    <p>
-      <a class="p-button--positive" href="/openstack/managed">
-        Learn about Managed OpenStack
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/9faeb5af-Openstack+illustration_3.png",
+        alt="",
+        width="1600",
+        height="979",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h2>Maximum multi-cloud cost optimisation</h2>
+      <h3 class="p-heading--5">Run your workloads where it makes the most sense from an economical point of view</h3>
+      <p>The future of infrastructure is multi-cloud.</p>
+      <p>Using private and public cloud infrastructure at the same time allows you to optimise your CapEx and OpEx costs.</p>
+      <a class="p-link--external" href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf?_ga=2.41518498.1083732777.1610363777-647098137.1594061070">Download datasheet</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2>Cheaper VMs</h2>
+      <h3 class="p-heading--5">Machines cost less if they run in a private cloud</h3>
+      <p>Compare the prices of sample VMs running on a baseline Charmed OpenStack cloud over a three-year period. The calculations include hardware costs, typical hosting charges and <a href="/openstack/managed">fully-managed service</a>*.</p>
+      <a class="u-sv2" href="/openstack/tco-calculator">Check pricing for other VMs&nbsp;&rsaquo;</a>
+      <p>* - Exact prices may vary depending on the used hardware, cloud configuration, local hosting charges and salary costs.</p>
+    </div>
+    <div class="col-6 u-hide--small u-align--center">
+      <table aria-label="Comparison table for pricing of VMs">
+        <thead>
+          <tr>
+            <th>VM flavour</th>
+            <th class="u-align--right">Number of VMs</th>
+            <th class="u-align--right">Price per hour</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <aside class="p-accordion">
+                <ul class="p-accordion__list">
+                  <li class="p-accordion__group">
+                    <div role="heading" aria-level="3" class="p-accordion__heading">
+                      <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="false">c1.small</button>
+                    </div>
+                    <section class="p-accordion__panel" id="tab1-section" aria-hidden="true" aria-labelledby="tab1">
+                      <p>vCPUs: 1</p>
+                      <p>RAM: 4 GB</p>
+                      <p>Ephemeral storage: 8 GB</p>
+                      <p>Persistent storage: 40 GB</p>
+                    </section>
+                  </li>
+                </ul>
+              </aside>
+            </td>
+            <td class="u-align--right">3078</td>
+            <td class="u-align--right">$0.0145</td>
+          </tr>
+          <tr>
+            <td>
+              <aside class="p-accordion">
+                <ul class="p-accordion__list">
+                  <li class="p-accordion__group">
+                    <div role="heading" aria-level="3" class="p-accordion__heading">
+                      <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">c2.medium</button>
+                    </div>
+                    <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
+                      <p>vCPUs: 2</p>
+                      <p>RAM: 8 GB</p>
+                      <p>Ephemeral storage: 8 GB</p>
+                      <p>Persistent storage: 80 GB</p>
+                    </section>
+                  </li>
+                </ul>
+              </aside>
+            </td>
+            <td class="u-align--right">1539</td>
+            <td class="u-align--right">$0.0290</td>
+          </tr>
+          <tr>
+            <td>
+              <aside class="p-accordion">
+                <ul class="p-accordion__list">
+                  <li class="p-accordion__group">
+                    <div role="heading" aria-level="3" class="p-accordion__heading">
+                      <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">c3.large</button>
+                    </div>
+                    <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
+                      <p>vCPUs: 4</p>
+                      <p>RAM: 16 GB</p>
+                      <p>Ephemeral storage: 8 GB</p>
+                      <p>Persistent storage: 160 GB</p>
+                    </section>
+                  </li>
+                </ul>
+              </aside>
+            </td>
+            <td class="u-align--right">769</td>
+            <td class="u-align--right">$0.0580</td>
+          </tr>
+          <tr>
+            <td>
+              <aside class="p-accordion">
+                <ul class="p-accordion__list">
+                  <li class="p-accordion__group">
+                    <div role="heading" aria-level="4" class="p-accordion__heading">
+                      <button type="button" class="p-accordion__tab" id="tab4" aria-controls="tab4-section" aria-expanded="false">c4.xlarge</button>
+                    </div>
+                    <section class="p-accordion__panel" id="tab4-section" aria-hidden="true" aria-labelledby="tab4">
+                      <p>vCPUs: 8</p>
+                      <p>RAM: 32 GB</p>
+                      <p>Ephemeral storage: 8 GB</p>
+                      <p>Persistent storage: 320 GB</p>
+                    </section>
+                  </li>
+                </ul>
+              </aside>
+            </td>
+            <td class="u-align--right">384</td>
+            <td class="u-align--right">$0.1161</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-6">
+      <h2>We bring infrastructure costs down</h2>
+      <p class="u-sv3">Read how Charmed OpenStack helped SBI Group to optimise their CapEx and OpEx costs</p>
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">Canonical’s solution was a third of the price of the other proposals we’d received. The solution is also proving to be highly cost-effective, both from CAPEX and OPEX perspectives.</p>
+        <cite class="p-pull-quote__citation">Georgi Georgiev, CIO at SBI BITS</cite>
+      </blockquote>
+      <a href="/engage/sbi-casestudy" class="p-button--neutral">Download casestudy</a>
+    </div>
+    <div class="col-6">
+      <a href="/engage/sbi-casestudy">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/0cf02c9e-SBI-info.png",
+        alt="",
+        width="792",
+        height="920",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
       </a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Fixed-price delivery</h2>
+    <p class="p-heading--5">Consulting packages tailored to your needs</p>
+    <p>No hidden costs. No surprises. Everything is clear from the beginning.</p>
+    <p>We design the cloud. We build the cloud.</p>
+    <p>Choose your package:</p>
+  </div>
+  <div class="row">
+    <div class="p-card col-6">
+      <h3 class="p-card__title">Private Cloud Build</h3>
+      <div class="p-card__content">
+        <p>$75,000 fixed price</p>
+        <p>Design and deployment of a baseline OpenStack cloud based on the reference architecture.</p>
+        <p>What’s included: *</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
+          <li class="p-list__item is-ticked">Reference architecture</li>
+          <li class="p-list__item is-ticked">Simplified networking</li>
+          <li class="p-list__item is-ticked">Hyper-converged or Converged</li>
+          <li class="p-list__item is-ticked">Containerised control plane</li>
+          <li class="p-list__item is-ticked">Observability stack</li>
+          <li class="p-list__item is-ticked">Block and object storage</li>
+          <li class="p-list__item is-ticked">High availability</li>
+        </ul>
+        <p>Design and delivery on certified hardware.</p>
+      </div>
+    </div>
+    <div class="p-card col-6">
+      <h3 class="p-card__title">Private Cloud Build Plus</h3>
+      <div class="p-card__content">
+        <p>$150,000 fixed price</p>
+        <p>Design and deployment of a carrier-grade, feature-rich OpenStack cloud based on a custom architecture.</p>
+        <p>What’s included: *</p>
+        <p>Everything in the Private Cloud Build, plus:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Custom architecture</li>
+          <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
+          <li class="p-list__item is-ticked">Complex networking</li>
+          <li class="p-list__item is-ticked">LDAP or Active Directory integration</li>
+          <li class="p-list__item is-ticked">Regulatory compliance</li>
+          <li class="p-list__item is-ticked">Encryption in flight and at rest</li>
+          <li class="p-list__item is-ticked">EPA tuning options</li>
+          <li class="p-list__item is-ticked">Block, object and file storage</li>
+          <li class="p-list__item is-ticked">Layer-7 load balancer</li>
+          <li class="p-list__item is-ticked">Secrets management</li>
+        </ul>
+        <p>Workshops determine the optimal architecture for your workloads and integration requirements.</p>
+      </div>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <p>* Additional features, functionality and integrations are available via add-ons</p>
+    <button href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">Download datasheet</button>
+    <p>
+      <a href="/openstack/consulting">Learn more about our consulting packages&nbsp;&rsaquo;</a>
     </p>
   </div>
 </section>
 
-<section class="p-strip is-bordered">
-  <div class="u-fixed-width">
-    <h2>Choose your OpenStack package</h2>
-  </div>
-  {% with columns=3 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
-</section>
-
 <section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-8">
-      <h2>Migrate from VMware to OpenStack with Canonical</h2>
-      <p>Fully open source and automated infrastructure as a service delivers dramatic cost and agility improvements for private data centers. Canonical manages the complexity to deliver OpenStack on rails &mdash; automated operations, flexible architectures and the world's most popular cloud operating system, Ubuntu.</p>
-      <p>
-        <a href="/engage/vmware-to-charmed-openstack" class="p-button--positive">
-          Move from VMware to OpenStack
-        </a>
-      </p>
+  <div class="row u-vertically-center">
+    <div class="col-6">
+      <h2>Total bottom-up automation</h2>
+      <p class="p-heading--5">Fully automated OpenStack deployment and operations</p>
+      <p>From bare metal to cloud control plane, Charmed OpenStack uses automation everywhere.</p>
+      <p>Save time and money by moving to the only OpenStack platform on the market that uses operators for OpenStack automation.</p>
+      <a href="/engage/openstack-deployment-guide">Read how to deploy and operate OpenStack effectively&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/b8c1c0e2-halfcostgraph-white.svg",
-          alt="VMware cost savings",
-          height="235",
-          width="250",
-          hi_def=True,
-          loading="lazy",
+    <div class="col-6 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c4596e41-openstack-charm-diagram.png",
+        alt="OpenStack charm diagram",
+        width="422",
+        height="333",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>
   </div>
 </section>
 
-<section class="p-strip--light u-no-padding--top is-bordered">
-  <div class="u-fixed-width">
-    <ul class="p-list is-split">
-      <li class="p-list__item is-ticked">Save 50% with fully Managed OpenStack compared to VMWare</li>
-      <li class="p-list__item is-ticked">Cloud infrastructure provides developer self-service agility</li>
-      <li class="p-list__item is-ticked">Architecture flexibility supports wide range of sector needs</li>
-      <li class="p-list__item is-ticked">Ubuntu is the infrastructure leader for large-scale Linux operations</li>
-      <li class="p-list__item is-ticked">Workload analysis, migration plan and automation</li>
-      <li class="p-list__item is-ticked">GPU and FPGA pass-through for workload acceleration</li>
-      <li class="p-list__item is-ticked">Integrated Kubernetes offering for modern application ops</li>
-      <li class="p-list__item is-ticked">Integrated data protection for backup and recovery</li>
-      <li class="p-list__item is-ticked">Optimised KVM for high performance and security</li>
-      <li class="p-list__item is-ticked">Scale from one to hundreds of racks</li>
-    </ul>
-    <p><a href="/engage/vmware-to-charmed-openstack">Move from VMware to OpenStack&nbsp;&rsaquo;</a></p>
-  </div>
-</section>
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-10">
-      <h2 style="max-width: none;">Your multi-cloud, our expertise</h2>
+<section class="p-strip">
+  <div class="row u-vertically-center">
+    <div class="col-6 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/e02f9f2e-Open-infrastructure-stack.png",
+        alt="",
+        width="619",
+        height="555",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
     </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-5 u-vertically-center u-hide--small">
-      <div>
-        <div class="u-align--center u-sv2">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/95212c08-OpenStack_Logo_2016.svg",
-              alt="",
-              height="106",
-              width="220",
-              hi_def=True,
-              loading="lazy",
-            ) | safe
-          }}
-        </div>
-        <cite>Canonical drives down the cost of OpenStack with fully managed private cloud services.</cite>
-      </div>
-    </div>
-    <div class="col-7">
-      <p>Your multi-cloud strategy depends on having competing public clouds and a cost-effective private cloud. Ubuntu is an essential ingredient of any successful multi-cloud strategy.</p>
-      <p>Our deep relationships with all major public cloud vendors ensure that Ubuntu is the most optimised OS on all public clouds. Ubuntu is also the number one operating system used for OpenStack deployments. That makes it a perfect platform for multi-cloud operations.</p>
-      <p>Analysts found that Canonical delivers the <a href="/engage/cloud-economics">most efficient infrastructure as a service on-premise</a>. This, together with neutral public cloud expertise, makes us the right partner for the move to cloud computing. We provide consulting, training, support and fully managed private cloud services for many of the world's leading companies.</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light is-bordered">
-  {% with heading="A SELECTION OF OUR OPENSTACK CLIENTS" %}{% include "openstack/shared/_openstack_clients.html" %}{% endwith %}
-</section>
-
-<section class="p-strip u-no-padding--bottom">
-  <div class="row u-equal-height">
     <div class="col-6">
-      <h2>Real architectural flexibility, full automation</h2>
-      <p>Every business is different, and every sector faces unique constraints. That creates real reasons to have your own OpenStack architecture. At the same time, reinventing all of the operations for a large open source codebase makes no sense. Canonical encodes operations in a way that is shared across all our customers, while retaining the ability to craft the most efficient architecture for a particular deployment. This is why Canonical can consistently and repeatedly outperform the competition on delivery and flexibility for OpenStack, and why Canonical leads on day-2 operations such as upgrades and scaling for the private cloud.</p>
-    </div>
-    <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
-      {{  image(      url="https://assets.ubuntu.com/v1/c4596e41-openstack-charm-diagram.png",      alt="",      width="422",      height="333",      hi_def=True,      loading="lazy",   ) | safe}}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-bordered u-no-padding--top">
-  <div class="row">
-    <div class="col-7">
-      <h3 class="p-heading--four">Charmed OpenStack is uniquely flexible and enjoys the widest ecosystem support of any OpenStack offering</h3>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Flexible placement of services across the cluster</li>
-        <li class="p-list__item is-ticked">Multiple high availability strategies for different scenarios</li>
-        <li class="p-list__item is-ticked">Operations, such as upgrades, are independent of architecture</li>
-        <li class="p-list__item is-ticked">Common operations code across all customer deployments</li>
-        <li class="p-list__item is-ticked">Containerised Control Plane or isolated services, your choice</li>
-        <li class="p-list__item is-ticked">Optional hyper-converged storage and compute</li>
-        <li class="p-list__item is-ticked">Fully automated, repeatable deployment and operations</li>
-        <li class="p-list__item is-ticked">OpenStack integrated data protection for backup and recovery</li>
-        <li class="p-list__item is-ticked">Ceph or iSCSI storage built-in</li>
-        <li class="p-list__item is-ticked">OVN, OVS, and open source SDNs</li>
-        <li class="p-list__item is-ticked">Juniper Contrail and Cisco ACI available as third-party options</li>
-        <li class="p-list__item is-ticked">CI/CD for cloud infrastructure operations</li>
-        <li class="p-list__item is-ticked">Wide range of certified hardware</li>
-        <li class="p-list__item is-ticked">Hardware recommendations for efficient procurement</li>
-        <li class="p-list__item is-ticked">Training, consulting and operations capabilities and services</li>
-        <li class="p-list__item is-ticked">Ubuntu Advantage for infrastructure &mdash; predictable per-node support and security</li>
-        <li class="p-list__item is-ticked">Managed services available for both OpenStack and Kubernetes</li>
-      </ul>
-      <p><a href="/openstack/features" class="p-button--positive">Learn about Canonical OpenStack features</a></p>
+      <h2>Extendable containers layer</h2>
+      <p class="p-heading--5">Run both containers and VMs on the same platform</p>
+      <p>Extend your cloud with a <a href="/kubernetes">Kubernetes</a> layer running on top of it and benefit from a unified approach to both containers and legacy workloads management.</p>
+      <p>The entire stack is supported under the same <a href="/advantage">subscription</a>.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-7">
-      <h2>We deliver OpenStack</h2>
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-6">
+      <h2>Product interoperability</h2>
+      <p class="p-heading--5">Servers, SDN controllers, storage platforms and more</p>
+      <p>We partner with leading semiconductor companies, hardware vendors, network equipment providers and open source communities to ensure the best bread of technology choices.</p>
+      <p>All of that to design the optimal architecture and ensure the best price-performance all of the time.</p>
+      <a href="/openstack/features">Read about supported options&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-6 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/25c42877-simplified-software-management-2.svg",
+        alt="",
+        width="300",
+        height="300",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
-  <div class="row">
-    <div class="col-7">
-      <p>Canonical's cloud build service delivers production OpenStack clouds with an efficient reference architecture. Featuring a containerised control plane, optional hyper-converged architecture, model-driven operations and upgrades to future OpenStack releases guaranteed, the OpenStack cloud from Canonical is the fast track to private cloud success. Optional consulting is available to tailor the architecture to your specific requirements.</p>
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">SLAs and support services</li>
-        <li class="p-list__item is-ticked">On-site engineering and support</li>
-        <li class="p-list__item is-ticked">Reference architecture available</li>
-        <li class="p-list__item is-ticked">OpenStack feature development as needed</li>
-        <li class="p-list__item is-ticked">Customised architecture service placement</li>
-        <li class="p-list__item is-ticked">Repeatable, automated deployment</li>
-        <li class="p-list__item is-ticked">Hardware guidance</li>
-      </ul>
-      <p><a href="/openstack/contact-us?product=foundation-cloud" class="p-button--positive js-invoke-modal">Contact us for custom OpenStack engineering</a></p>
-      <p><a href="/openstack/consulting">Learn more about Private Cloud Build&nbsp;&rsaquo;</a></p>
+</section>
+
+<section class="p-strip">
+  <div class="row u-vertically-center">
+    <div class="col-6 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/58e11dd2-delta+updates.svg",
+        alt="",
+        width="341",
+        height="195",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
     </div>
-    <div class="col-4 col-start-large-9">
+    <div class="col-6">
+      <h2>100 Gbps OpenStack</h2>
+      <p class="p-heading--5">For telcos, for HPC, for AI/ML</p>
+      <p>All necessary performance extensions for running NFVI/VIM and other advanced cloud architectures:</p>
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">OVS hardware offloading</li>
+        <li class="p-list__item is-ticked">SR-IOV</li>
+        <li class="p-list__item is-ticked">DPDK</li>
+        <li class="p-list__item is-ticked">CPU pinning</li>
+        <li class="p-list__item is-ticked">NUMA topology</li>
+        <li class="p-list__item is-ticked">Hugepages</li>
+        <li class="p-list__item is-ticked">PCI passthrough</li>
+        <li class="p-list__item is-ticked">GPU passthrough</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <p class="p-muted-heading u-align--center u-sv3">
+      Endorsed by customers, globally
+    </p>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/d2bfbb2b-MTS_logo_%282016%29.svg",
+        alt="",
+        width="130",
+        height="50",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
       <blockquote class="p-pull-quote">
-        <p class="p-pull-quote__quote">The support has been fabulous. The whole team stepped up and helped us work through issues.</p>
-        <cite class="p-pull-quote__citation">Director of Web Engineering, Best Buy Corp</cite>
+        <p class="p-pull-quote__quote">Building an ecosystem based on OpenStack will speed up our technology adoption, lay a foundation for future 5G rollout, and enable us to improve virtualization cost effectiveness.</p>
+        <cite class="p-pull-quote__citation">Victor Belov, CTO at MTS</cite>
       </blockquote>
+      <a href="/blog/mts-selects-openstack-and-canonical-for-next-generation-cloud-infrastructure">Read the announement&nbsp;&rsaquo;</a>
     </div>
-  </div>
-</section>
-
-
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>The number one cloud and container operating system, by far</h2>
-    </div>
-  </div>
-  <div class="row">
     <div class="col-6">
-      <p>Ubuntu is the #1 platform for OpenStack and the #1 platform for public cloud operations on AWS, Azure and Google Cloud, too.</p>
-      <p>Canonical delivers OpenStack on rails, with consulting, training, enterprise support and managed operations to help you focus on what matters most &mdash; your applications, not the infrastructure.</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">We are a founding member of OpenStack</li>
-        <li class="p-list__item is-ticked">The most widely used distribution of OpenStack</li>
-        <li class="p-list__item is-ticked">The largest OpenStack operators consistently pick Ubuntu - AT&amp;T, Bloomberg, PayPal, eBay, Walmart and many more build OpenStack with Canonical</li>
-        <li class="p-list__item is-ticked">The Intel reference platform for telco OpenStack</li>
-        <li class="p-list__item is-ticked">Operations, such as upgrading OpenStack, are included</li>
-        <li class="p-list__item is-ticked">Canonical's reference architecture optimises utilisation</li>
-        <li class="p-list__item is-ticked">Design, architecture, support, operations and training in one package by Canonical</li>
-        <li class="p-list__item is-ticked">Dell, HP, Lenovo, Supermicro, Quanta servers</li>
-        <li class="p-list__item is-ticked">Multi-cloud AWS, Azure, Google, IBM, Oracle, OpenStack</li>
-        <li class="p-list__item is-ticked">Container friendly kernel makes Ubuntu #1 for Kubernetes, Docker and Linux system containers</li>
-      </ul>
-      <p><a href="/openstack/features" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Openstack', 'eventLabel' : 'Features of Canonical OpenStack on Ubuntu', 'eventValue' : undefined });">Features of Canonical OpenStack on Ubuntu</a></p>
-    </div>
-    <div class="col-4 col-start-large-8">
-      {% include "openstack/shared/_openstack-pie-chart.html" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/7c97efb0-BT_logo.svg",
+        alt="",
+        width="50",
+        height="50",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">Canonical is providing us with the ‘cloud-native’ foundation that enables us to create a smart and fully converged network.</p>
+        <cite class="p-pull-quote__citation">Neil J. McRae, Group Chief Architect at BT</cite>
+      </blockquote>
+      <a href="/blog/bt-turns-to-canonical-ubuntu-to-enable-next-generation-5g-cloud-core">Read the announement&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-deep is-bordered">
-  {% include "shared/_resources_openstack.html"%}
-</section>
-
-<section class="p-strip is-bordered">
+<section class="p-strip">
   <div class="u-fixed-width">
-    <div class="p-matrix u-clearfix">
-      <div class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Fully managed private OpenStack cloud</h3>
-          <div class="p-matrix__desc">
-            <p>Start your private cloud journey with a low-risk managed OpenStack by Canonical. We help you design, deliver and operate your cloud, enabling you to focus on your apps while proving the business case for OpenStack.</p>
-            <p><a href="/openstack/managed">Learn about managed services&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </div>
-      <div class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Consulting packages</h3>
-          <div class="p-matrix__desc">
-            <p>We offer workshops, application requirements assessment, hardware recommendations and our on-rails Private Cloud Build, a fixed-price OpenStack deployment service.</p>
-            <p><a href="/openstack/consulting">Learn about our OpenStack consulting services&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </div>
-      <div class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Install now</h3>
-          <div class="p-matrix__desc">
-            <p>Deploy OpenStack on a single laptop or across many racks using Ubuntu, the most widely used cloud OS. Canonical is the most popular provider of OpenStack globally.</p>
-            <p><a href="/openstack/install">Deploy OpenStack on Ubuntu&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </div>
-      <div class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Automate server provisioning</h3>
-          <div class="p-matrix__desc">
-            <p>Turn your data center into a physical cloud with MAAS bare metal provisioning. Open source IPAM and SDDC with enterprise support.</p>
-            <p><a class="p-link--external" href="https://maas.io">Learn about MAAS</a></p>
-          </div>
-        </div>
-      </div>
-      <div class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Use Ubuntu on all major public clouds</h3>
-          <div class="p-matrix__desc">
-            <p>Ubuntu is the leading enterprise cloud OS, running most workloads in public clouds today. From container hosts to AI and machine learning, Ubuntu is the choice of Silicon Valley and beyond.</p>
-            <p><a href="/download/cloud">Get started with Ubuntu server&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </div>
-      <div class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Model-driven operations</h3>
-          <div class="p-matrix__desc">
-            <p>Simplify your multi-cloud operations with Juju, an open source model driven operations system. Share operations code as open source, dramatically reducing the cost of complexity.</p>
-            <p><a class="p-link--external" href="https://jujucharms.com">Get started with Juju</a></p>
-          </div>
-        </div>
-      </div>
-    </div>
+    <h2 class="u-sv3">Security maintenance and support</h2>
+    {% with no_desktop="true" %}{% include "shared/pricing/_ua-for-infrastructure.html" %}{% endwith %}
+    <button href="https://assets.ubuntu.com/v1/b0b42477-Ubuntu_Advantage_+Datasheet-2019.pdf" class="p-button--neutral p-link--external">Download datasheet</button>
+    <p>
+      <a href="/advantage">Learn more about our support plans&nbsp;&rsaquo;</a>
+    </p>
   </div>
 </section>
 
-{% with type="OpenStack" %}{% include "shared/_training.html" %}{% endwith %}
 
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2>Install OpenStack yourself &mdash; developer edition or production cluster</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-6">
-      <p>OpenStack developers looking to dig into the heart of a complex running OpenStack can <a href="/openstack/install#workstation-deployment">follow our workstation install instructions</a> for a single-node OpenStack deployment in multiple containers. For production environments, the same operational stack can be used at scale to <a href="/openstack/install#cluster-deployment">deploy a full OpenStack cluster</a> on bare metal servers. This Ubuntu reference OpenStack architecture uses <a class="p-link--external" href="https://maas.io">MAAS</a> and <a class="p-link--external" href="https://linuxcontainers.org/">Linux Containers</a> to operate efficiently on racks of bare metal.</p>
-    </div>
-    <div class="col-6">
-      <p class="p-heading--four">Watch a Canonical Openstack deployment on Ubuntu</p>
-      <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" src="https://player.vimeo.com/video/202448226?color=ffffff&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+      <h2>Fully-managed OpenStack</h2>
+      <p class="p-heading--5">We manage the cloud for you</p>
+      <p>Just like a public cloud, but running on your premises or in one of our partner data centres.</p>
+      <div class="p-card">
+        <h3 class="p-card__title">Managed OpenStack</h3>
+        <div class="p-card__content">
+          <p>$15 per server per day</p>
+          <p>Full remote operations of your Charmed OpenStack cloud.</p>
+          <p>What’s included:</p>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">Logging, monitoring and alerting</li>
+            <li class="p-list__item is-ticked">24/7 operations with fully staffed NOC</li>
+            <li class="p-list__item is-ticked">Proactive cloud management</li>
+            <li class="p-list__item is-ticked">Incident and problem resolution</li>
+            <li class="p-list__item is-ticked">Software updates and OpenStack upgrades</li>
+            <li class="p-list__item is-ticked">SLA and regular independent audits</li>
+            <li class="p-list__item is-ticked">Most cost-effective approach up to 200 nodes</li>
+            <li class="p-list__item is-ticked">Optional Managed Kubernetes service on top</li>
+            <li class="p-list__item is-ticked">EU and US regulatory compliance options</li>
+            <li class="p-list__item is-ticked">Training and transfer options</li>
+          </ul>
+          <p>The most straightforward way to accelerate your time to market.</p>
+        </div>
       </div>
+      <button href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf?_ga=2.108619394.1083732777.1610363777-647098137.1594061070" class="p-button--neutral p-link--external">Download datasheet</button>
+      <p>
+        <a href="/openstack/managed">I want fully-managed OpenStack&nbsp;&rsaquo;</a>
+      </p>
     </div>
   </div>
 </section>
 
-{% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h2>Long-term community member</h2>
+      <p>Open source comes through contribution and community collaboration. Canonical is a long-term member of the OpenStack community, <a href="https://www.stackalytics.com/?metric=loc&release=all" class="p-link--external">one of the top contributors</a> to the OpenStack code and Gold Member of the <a href="https://openinfra.dev/" class="p-link--external">Open Infrastructure Foundation</a>. Together with other leaders we constantly drive the evolution of OpenStack towards new challenges.</p>
+    </div>
+    <div class="col-6">
+      <h2>The most popular open source cloud platform</h2>
+      <p><a href="https://www.statista.com/statistics/511526/worldwide-survey-private-coud-services-running-application/" class="p-link--external">OpenStack adoption continues to grow</a> every year. Its combined market size worldwide is approaching $8,000,000,000. OpenStack is supported by leading industry players, and successfully used by thousands of organisations all over the world. The popularity of OpenStack comes from its better economics, stability and openness of the code.</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h2>From VMware to OpenStack</h2>
+      <p>VMware costs increasing? Do not worry. Charmed OpenStack significantly decreases the TCO of infrastructure maintenance. Our team of cloud experts will help you to migrate from VMware to Charmed OpenStack and take control over your budget back.</p>
+      <a href="engage/vmware-to-charmed-openstack">Explore how to perform a live migration&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-6">
+      <h2>Install OpenStack yourself</h2>
+      <p>Looking for the most straightforward installation instructions for OpenStacK? <a href="https://microstack.run" class="p-link--external">MicroStack</a> allows you to install a fully functional OpenStack on your workstation in just two commands. The entire process takes around twenty minutes.</p>
+      <a href="/openstack/install">Get started with OpenStack today&nbsp;&rsaquo;</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-5 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
+        alt="",
+        width="240",
+        height="171",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>Get in touch</h2>
+      <p>Tell us your story and let’s work together on expanding the benefits of using Charmed OpenStack in your organisation.</p>
+      <button href="/openstack/contact-us?product=openstack" class="p-button--positive js-invoke-modal">Get in touch</button>
+    </div>
+  </div>
+</section>
+
+{% with first_item="_openstack_next_step", second_item="_cloud_newsletter", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/shared/contextual_footers/_openstack_next_step.html
+++ b/templates/shared/contextual_footers/_openstack_next_step.html
@@ -1,0 +1,8 @@
+<div class="col-4 p-divider__block">
+  <h3 class="p-heading--four">Ready for the next step?</h3>
+  <p>Looking for a cost-effective extension to your public cloud infrastructure?</p>
+  <p>Want to migrate from VMware to OpenStack?</p>
+  <p>Trying to deploy a telco cloud?</p>
+  <p>Canonical’s team of cloud experts can deploy and operate OpenStack for you.</p>
+  <p><a class="p-button" href="/openstack/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'BootStack', 'eventLabel' : 'Ready for the next step?', 'eventValue' : undefined });">Contact us</a></p>
+</div>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -25,12 +25,14 @@
           <td class="u-align--center">$250</td>
           <td class="u-align--center">$500</td>
         </tr>
+        {% if no_desktop != "true" %}
         <tr>
           <td>Desktop</td>
           <td class="u-align--center">$25</td>
           <td class="u-align--center">$150</td>
           <td class="u-align--center">$300</td>
         </tr>
+        {% endif %}
       </tbody>
       <thead>
         <tr>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -8,8 +8,8 @@
           <th width="200" class="u-align--center">Standard</th>
           <th width="200" class="u-align--center">Advanced</th>
         </tr>
-        <tr>
-          <th colspan="4" style="background-color: #f7f7f7; padding: .75rem;"><strong>Price per year</strong></th>
+        <tr style="background: #E5E5E5;">
+          <th colspan="4" style="padding: .75rem 0 .75rem .5rem;"><strong>Price per year</strong></th>
         </tr>
       </thead>
       <tbody>
@@ -35,8 +35,8 @@
         {% endif %}
       </tbody>
       <thead>
-        <tr>
-          <th colspan="4" style="background-color: #f7f7f7; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>Service level</strong></th>
+        <tr style="background: #E5E5E5;">
+          <th colspan="4" style="border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem 0 .75rem .5rem;"><strong>Service level</strong></th>
         </tr>
       </thead>
       <tbody>
@@ -72,8 +72,8 @@
         </tr>
         </tbody>
         <thead>
-          <tr>
-            <th colspan="4" style="background-color: #f7f7f7; border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem;"><strong>What's included</strong></th>
+          <tr style="background: #E5E5E5;">
+            <th colspan="4" style="border-top: 1px solid rgba(0,0,0,0.1); padding: .75rem 0 .75rem 0.5rem;"><strong>What's included</strong></th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Done

- Rebuild page at `/openstack`


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page against [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#). I've suggested a change to the hero text to keep it more inline with the rest of ubuntu.com. 
- The graph mentioned with the slider will be done as a separate [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/9524) as this will take some time. 

## Issue / Card

Fixes [#3821](https://github.com/canonical-web-and-design/web-squad/issues/3821)

