### PR TITLE
Add dynamic content to the 16.04 page

### DIFF
--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -43,6 +43,48 @@
 </section>
 
 <section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-12">
+      <h2>Ubuntu 16.04 LTS security updates</h2>
+      <p>The Ubuntu Security Team continues its dedication to providing security updates for Ubuntu 16.04 LTS beyond the five-year standard support with Extended Security Maintenance (ESM).</p>
+    </div>
+  </div>
+  <div class="row" style="margin-top: 1rem">
+    <div class="col-4">
+      <span id="total-patches-applied" style="font-size: 3rem; line-height: 4rem">-</span>
+      <hr>
+      <span class="p-muted-heading">16.04 LTS ESM <br>PATCHES APPLIED</span>
+    </div>
+    <div class="col-4">
+      <span id="total-notices-issued" style="font-size: 3rem; line-height: 4rem">-</span>
+      <hr>
+      <span class="p-muted-heading">USNS ISSUED</span>
+    </div>
+    <div class="col-4">
+      <span id="total-cves-issued" style="font-size: 3rem; line-height: 4rem">-</span>
+      <hr>
+      <span class="p-muted-heading">CVES ADDRESSED</span>
+    </div>
+  </div>
+  <div class="row" id="notice-feed" style="margin-top: 3rem">
+    Loading notices feed...
+  </div>
+  <div class="row" style="margin-top: 2rem">
+    <a href="/security/notices?release=xenial">View the full list&nbsp;&rsaquo;</a>
+  </div>
+  <template id="notice-row-template" style="display:none">
+    <hr>
+    <div class="col-6">
+      <strong><span><a class="notice-title"></a></span></strong><br>
+      <span class="p-muted-heading notice-date"></span><br><br>
+    </div>
+    <div class="col-6">
+      <p class="notice-summary"></p>
+    </div>
+  </template>
+</section>
+
+<section class="p-strip">
   <div class="row">
     <div class="col-6">
       <h2>Ubuntu 16.04 LTS Extended Security Maintenance (ESM)</h2>
@@ -268,4 +310,84 @@ hwe-16.04</code></pre>
     text-align: left;
   }
 </style>
+
+<script async>
+  function formatDate(date) {
+    let parsedDate = new Date(date);
+    let monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+    return parsedDate.getDate() + " " + monthNames[parsedDate.getMonth()] + " " + parsedDate.getFullYear();
+  }
+
+  function getTemplate(selector) {
+    let fragment;
+    let template = document.querySelector(selector);
+
+    if ("content" in template) {
+      fragment = document.importNode(template.content, true);
+    } else {
+      fragment = document.createDocumentFragment();
+
+      for (let i = 0; i < template.childNodes.length; i++) {
+        fragment.appendChild(template.childNodes[i].cloneNode(true));
+      }
+    }
+
+    return fragment
+  }
+
+  total_patches_applied = document.querySelector("#total-patches-applied");
+  total_patches_applied.innerHTML = "69"; /** will be hard-coded for now **/
+
+  fetch(`https://ubuntu.com/security/notices.json?release=xenial`)
+    .then((res) => {
+      if (res.ok) return res.json()
+
+      throw new Error(`${res.status} Failed Fetch`);
+    })
+    .then((results) => {
+      let total_notices_issued = document.querySelector("#total-notices-issued");
+      total_notices_issued.innerHTML = results["total_results"].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+    })
+
+  fetch(`https://ubuntu.com/security/cves.json?version=xenial&status=released`)
+    .then((res) => {
+      if (res.ok) return res.json()
+
+      throw new Error(`${res.status} Failed Fetch`);
+    })
+    .then((results) => {
+      let total_cves_issued = document.querySelector("#total-cves-issued");
+      total_cves_issued.innerHTML = results["total_results"].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")    })
+
+
+  fetch(`https://ubuntu.com/security/notices.json?release=xenial&limit=5`)
+    .then((res) => {
+      if (res.ok) return res.json()
+
+      throw new Error(`${res.status} Failed Fetch`);
+    })
+    .then((results) => {
+      let notice_feed = document.querySelector("#notice-feed");
+      notice_feed.innerHTML = "";
+
+      results["notices"].forEach((notice) => {
+        let template = getTemplate("#notice-row-template")
+        let notice_title = template.querySelector(".notice-title");
+        let notice_date = template.querySelector(".notice-date");
+        let notice_summary = template.querySelector(".notice-summary");
+
+        notice_title.href = "https://ubuntu.com/security/notices/" + notice["id"]
+        notice_title.innerHTML = notice["title"] + "&nbsp;&rsaquo;"
+        notice_date.innerText = formatDate(notice["published"]);
+        notice_summary.innerHTML = notice["summary"]
+
+        notice_feed.appendChild(template);
+      })
+    })
+    .catch((error) => {
+      throw new Error(error);
+    });
+</script>
+
 {% endblock content %}

--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -51,37 +51,36 @@
   </div>
   <div class="row" style="margin-top: 1rem">
     <div class="col-4">
-      <span id="total-patches-applied" style="font-size: 3rem; line-height: 4rem">-</span>
+      <span style="font-size: 3rem; line-height: 4rem">{{ total_patches_applied }}</span>
       <hr>
       <span class="p-muted-heading">16.04 LTS ESM <br>PATCHES APPLIED</span>
     </div>
     <div class="col-4">
-      <span id="total-notices-issued" style="font-size: 3rem; line-height: 4rem">-</span>
+      <span style="font-size: 3rem; line-height: 4rem">{{ total_notices_issued }}</span>
       <hr>
       <span class="p-muted-heading">USNS ISSUED</span>
     </div>
     <div class="col-4">
-      <span id="total-cves-issued" style="font-size: 3rem; line-height: 4rem">-</span>
+      <span style="font-size: 3rem; line-height: 4rem">{{ total_cves_issued }}</span>
       <hr>
       <span class="p-muted-heading">CVES ADDRESSED</span>
     </div>
   </div>
   <div class="row" id="notice-feed" style="margin-top: 3rem">
-    Loading notices feed...
+    {% for notice in latest_notices %}
+      <hr>
+      <div class="col-6">
+        <strong><span><a>{{ notice.title }}</a></span></strong><br>
+        <span class="p-muted-heading">{{ notice.date }}</span><br><br>
+      </div>
+      <div class="col-6">
+        <p>{{ notice.summary }}</p>
+      </div>
+    {% endfor %}
   </div>
   <div class="row" style="margin-top: 2rem">
     <a href="/security/notices?release=xenial">View the full list&nbsp;&rsaquo;</a>
   </div>
-  <template id="notice-row-template" style="display:none">
-    <hr>
-    <div class="col-6">
-      <strong><span><a class="notice-title"></a></span></strong><br>
-      <span class="p-muted-heading notice-date"></span><br><br>
-    </div>
-    <div class="col-6">
-      <p class="notice-summary"></p>
-    </div>
-  </template>
 </section>
 
 <section class="p-strip">
@@ -310,84 +309,5 @@ hwe-16.04</code></pre>
     text-align: left;
   }
 </style>
-
-<script async>
-  function formatDate(date) {
-    let parsedDate = new Date(date);
-    let monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-
-    return parsedDate.getDate() + " " + monthNames[parsedDate.getMonth()] + " " + parsedDate.getFullYear();
-  }
-
-  function getTemplate(selector) {
-    let fragment;
-    let template = document.querySelector(selector);
-
-    if ("content" in template) {
-      fragment = document.importNode(template.content, true);
-    } else {
-      fragment = document.createDocumentFragment();
-
-      for (let i = 0; i < template.childNodes.length; i++) {
-        fragment.appendChild(template.childNodes[i].cloneNode(true));
-      }
-    }
-
-    return fragment
-  }
-
-  total_patches_applied = document.querySelector("#total-patches-applied");
-  total_patches_applied.innerHTML = "69"; /** will be hard-coded for now **/
-
-  fetch(`https://ubuntu.com/security/notices.json?release=xenial`)
-    .then((res) => {
-      if (res.ok) return res.json()
-
-      throw new Error(`${res.status} Failed Fetch`);
-    })
-    .then((results) => {
-      let total_notices_issued = document.querySelector("#total-notices-issued");
-      total_notices_issued.innerHTML = results["total_results"].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
-    })
-
-  fetch(`https://ubuntu.com/security/cves.json?version=xenial&status=released`)
-    .then((res) => {
-      if (res.ok) return res.json()
-
-      throw new Error(`${res.status} Failed Fetch`);
-    })
-    .then((results) => {
-      let total_cves_issued = document.querySelector("#total-cves-issued");
-      total_cves_issued.innerHTML = results["total_results"].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")    })
-
-
-  fetch(`https://ubuntu.com/security/notices.json?release=xenial&limit=5`)
-    .then((res) => {
-      if (res.ok) return res.json()
-
-      throw new Error(`${res.status} Failed Fetch`);
-    })
-    .then((results) => {
-      let notice_feed = document.querySelector("#notice-feed");
-      notice_feed.innerHTML = "";
-
-      results["notices"].forEach((notice) => {
-        let template = getTemplate("#notice-row-template")
-        let notice_title = template.querySelector(".notice-title");
-        let notice_date = template.querySelector(".notice-date");
-        let notice_summary = template.querySelector(".notice-summary");
-
-        notice_title.href = "https://ubuntu.com/security/notices/" + notice["id"]
-        notice_title.innerHTML = notice["title"] + "&nbsp;&rsaquo;"
-        notice_date.innerText = formatDate(notice["published"]);
-        notice_summary.innerHTML = notice["summary"]
-
-        notice_feed.appendChild(template);
-      })
-    })
-    .catch((error) => {
-      throw new Error(error);
-    });
-</script>
 
 {% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -69,6 +69,7 @@ from webapp.views import (
     build_engage_index,
     engage_thank_you,
     sitemap_index,
+    sixteen_zero_four,
 )
 from webapp.login import login_handler, logout, user_info
 from webapp.security.database import db_session
@@ -411,6 +412,7 @@ def takeovers_index():
     )
 
 
+app.add_url_rule("/16-04", view_func=sixteen_zero_four)
 app.add_url_rule("/takeovers.json", view_func=takeovers_json)
 app.add_url_rule("/takeovers", view_func=takeovers_index)
 engage_pages.init_app(app)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -79,7 +79,7 @@ def sixteen_zero_four():
     try:
         response = session.request(
             method="GET",
-            url=f"{host}/security/notices.json?release=xenial",
+            url=f"{host}/security/notices.json?release=xenial&limit=1",
         )
 
         total_notices_issued = response.json().get("total_results")
@@ -89,7 +89,10 @@ def sixteen_zero_four():
     try:
         response = session.request(
             method="GET",
-            url=f"{host}/security/cves.json?version=xenial&status=released",
+            url=(
+                f"{host}/security/cves.json"
+                f"?version=xenial&status=released&limit=1"
+            ),
         )
 
         total_cves_issued = response.json().get("total_results")

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -70,6 +70,61 @@ def _build_mirror_list():
     return mirror_list
 
 
+def sixteen_zero_four():
+    host = "https://ubuntu.com"
+    total_notices_issued = "-"
+    total_cves_issued = "-"
+    latest_notices = []
+
+    try:
+        response = session.request(
+            method="GET",
+            url=f"{host}/security/notices.json?release=xenial",
+        )
+
+        total_notices_issued = response.json().get("total_results")
+    except HTTPError:
+        flask.current_app.extensions["sentry"].captureException()
+
+    try:
+        response = session.request(
+            method="GET",
+            url=f"{host}/security/cves.json?version=xenial&status=released",
+        )
+
+        total_cves_issued = response.json().get("total_results")
+    except HTTPError:
+        flask.current_app.extensions["sentry"].captureException()
+
+    try:
+        response = session.request(
+            method="GET",
+            url=f"{host}/security/notices.json?release=xenial&limit=5",
+        )
+
+        latest_notices = [
+            {
+                "title": notice.get("title"),
+                "date": dateutil.parser.parse(
+                    notice.get("published")
+                ).strftime("%d %B %Y"),
+                "summary": notice.get("summary"),
+            }
+            for notice in response.json().get("notices")
+        ]
+    except HTTPError:
+        flask.current_app.extensions["sentry"].captureException()
+
+    context = {
+        "total_patches_applied": 69,  # hard-coded for now
+        "total_notices_issued": f"{total_notices_issued:,}",
+        "total_cves_issued": f"{total_cves_issued:,}",
+        "latest_notices": latest_notices,
+    }
+
+    return flask.render_template("16-04/index.html", **context)
+
+
 def show_template(filename):
     try:
         template_content = flask.render_template(f"templates/{filename}.html")


### PR DESCRIPTION
We need 3 dynamic values:
1) Number of patches applied to version 16.04. Number of LSNs released on 16.04.
Will have to be hard coded for now, until all LSNs reach prod.

2) Number of USNs applied to version 16.04. Number of USNs that have affected 16.04.
https://ubuntu.com/security/notices.json?release=xenial

3) Number of CVEs addressed by 16.04.  Number of CVEs that have the status "released" on 16.04.
https://ubuntu.com/security/cves.json?version=xenial&status=released

We also need the latest 5 USNs released that affected 16.04 for the feed.
https://ubuntu.com/security/notices.json?release=xenial&limit=5

## QA

- QA won't be possible (easily) due to CORS errors.

## Issue / Card

Fixes #9410