### PR TITLE
Add country to ensurePurchaseAccount

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -15,7 +15,8 @@ export async function getPurchase(purchaseID) {
 export async function ensurePurchaseAccount(
   email,
   accountName,
-  paymentMethodID
+  paymentMethodID,
+  country
 ) {
   const queryString = window.location.search; // Pass arguments to the flask backend eg. "test=backend=true"
 
@@ -31,6 +32,7 @@ export async function ensurePurchaseAccount(
       email: email,
       account_name: accountName,
       payment_method_id: paymentMethodID,
+      country: country,
     }),
   });
 

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -749,7 +749,8 @@ function handleGuestPaymentMethodResponse(data) {
   ensurePurchaseAccount(
     customerInfo.email,
     customerInfo.accountName,
-    paymentMethod.id
+    paymentMethod.id,
+    customerInfo.address.country
   ).then((data) => {
     if (data.code) {
       // an error was returned, most likely cause

--- a/tests/test_advantage.py
+++ b/tests/test_advantage.py
@@ -112,6 +112,7 @@ class TestEnsurePurchaseAccount(unittest.TestCase):
             email="picard@enterprise",
             account_name="jeanluc",
             payment_method_id="pmid",
+            country="BR",
         )
         self.assertEqual(resp, {"ok": True})
         self.assertEqual(
@@ -122,6 +123,7 @@ class TestEnsurePurchaseAccount(unittest.TestCase):
                     "defaultPaymentMethod": {"Id": "pmid"},
                     "email": "picard@enterprise",
                     "name": "jeanluc",
+                    "address": {"country": "BR"},
                 },
                 "method": "post",
                 "params": None,
@@ -143,6 +145,7 @@ class TestEnsurePurchaseAccount(unittest.TestCase):
                     "defaultPaymentMethod": {"Id": ""},
                     "email": "",
                     "name": "",
+                    "address": {"country": ""},
                 },
                 "method": "post",
                 "params": None,

--- a/webapp/advantage/api.py
+++ b/webapp/advantage/api.py
@@ -298,6 +298,7 @@ class UAContractsAPI:
         email: str = "",
         account_name: str = "",
         payment_method_id: str = "",
+        country: str = "",
     ) -> dict:
         try:
             response = self._request(
@@ -307,6 +308,7 @@ class UAContractsAPI:
                     "email": email,
                     "name": account_name,
                     "defaultPaymentMethod": {"Id": payment_method_id},
+                    "address": {"country": country},
                 },
             )
         except HTTPError as err:


### PR DESCRIPTION
We will soon introduce a requirement in ua-contracts so that all endpoints sending us shop customer information must always include both the name and the country. This is to ensure we don't create invalid entries in Stripe and Salesforce.

It seems this requirement is currently respected everywhere here, except in `ensurePurchaseAccount` (which is fine, it never required such field). Including this field in the request now before we make it mandatory should have no harmful effects: it will just be ignored for now.

## QA

- Go to https://ubuntu-com-9534.demos.haus/advantage/subscribe?test_backend=true
- Try to make a guest purchase in the UA shop; it should still succeed, and both the Flask app and ua-contracts should be receiving the country.