### PR TITLE
Build model details page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1545,3 +1545,11 @@ certification:
   children:
     - title: Overview
       path: /certification
+    - title: Desktops
+      path: /certification?form=Desktop
+    - title: Servers
+      path: /certification?form=Server
+    - title: IoT
+      path: /certification?form=Ubuntu%20Core
+    - title: SoCs
+      path: /certification?form=Server%20SoC

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1541,6 +1541,7 @@ ubuntu1604:
 certification:
   title: Hardware
   path: /certification
+  persist: True
 
   children:
     - title: Overview

--- a/static/sass/_pattern_component-table.scss
+++ b/static/sass/_pattern_component-table.scss
@@ -2,7 +2,7 @@
   th,
   td {
     &:nth-child(1) {
-      width: 30%;
+      width: 35%;
     }
 
     &:nth-child(2) {
@@ -38,7 +38,7 @@
     }
 
     &:nth-child(6) {
-      width: 30%;
+      width: 25%;
     }
   }
 }

--- a/static/sass/_pattern_component-table.scss
+++ b/static/sass/_pattern_component-table.scss
@@ -1,0 +1,44 @@
+.p-table--devices {
+  th,
+  td {
+    &:nth-child(1) {
+      width: 30%;
+    }
+
+    &:nth-child(2) {
+      width: 10%;
+      @media only screen and (min-width: $breakpoint-medium) {
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    &:nth-child(3) {
+      width: 10%;
+      @media only screen and (min-width: $breakpoint-medium) {
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    &:nth-child(4) {
+      width: 10%;
+      @media only screen and (min-width: $breakpoint-medium) {
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    &:nth-child(5) {
+      width: 10%;
+      @media only screen and (min-width: $breakpoint-medium) {
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    &:nth-child(6) {
+      width: 30%;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -42,6 +42,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_card";
 @import "pattern_certification-results";
 @import "pattern_chart";
+@import "pattern_component-table";
 @import "pattern_contact-modal";
 @import "pattern_contextual-footer";
 @import "pattern_cube-animation";

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -71,8 +71,25 @@
               <button type="button" class="p-accordion__tab" style="background-position: top 1.25rem left 1rem;"id="tab{{ loop.index }}" aria-controls="tab{{ loop.index }}-section" aria-expanded="{% if release_details['releases']|length == 1 %}true{% else %}false{% endif %}"><h3 class="u-no-margin--bottom">{{ release.name }}</h3></button>
             </div>
             <section class="p-accordion__panel" id="tab{{ loop.index }}-section" aria-hidden="{% if release_details['releases']|length == 1 %}false{% else %}true{% endif %}" aria-labelledby="tab{{ loop.index }}">
-              <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system’s hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
-              <p></p>
+              {% if release.level == "Enabled" %}
+                <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system’s hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
+              {% elif release.level == "Certified" %}
+                <p>The {{ vendor }} {{ name }} development board with the components described below has been awarded the status of certified for Ubuntu.</p>
+                <p class="u-no-margin--bottom">
+                  {% if category == "Desktop" or category == "Laptop" %}
+                  <a href="/download/desktop" class="p-button--neutral">Download</a>
+                  {% endif%}
+                  {% if category == "Ubuntu Core" %}
+                  <a href="/download/iot" class="p-button--neutral">Download</a>
+                  {% endif%}
+                  {% if category == "Server" %}
+                  <a href="/download/server" class="p-button--neutral">Download</a>
+                  {% endif%}
+                  {% if category == "Server SoC" %}
+                  <a href="/download/server/arm" class="p-button--neutral">Download</a>
+                  {% endif%}
+                </p>
+              {% endif %}
               {% if release.kernel %}
               <h4 class="u-no-margin--bottom">Kernel</h4>
               <p>{{ release.kernel }}</p>
@@ -88,16 +105,16 @@
                 <tbody>
                 {% for hardware_subtitle, values in release_details["components"].items() %}
                   <tr>
-                    <th colspan="3" class="p-muted-text">{{ hardware_subtitle }}</th>
-                    <td colspan="9">{% for value in values %} 
-                      <p style="margin-bottom: 0.5rem;"><a href="#">{{ value.name }} {{ value.bus }}</a> ({{ value.identifier }})</p>
+                    <th colspan="2" class="p-muted-text">{{ hardware_subtitle }}</th>
+                    <td colspan="8">{% for value in values %} 
+                      <p style="margin-bottom: 0.5rem;">{{ value.name }} {{ value.bus }}({{ value.identifier }})</p>
                       {% endfor %}
                     </td>
                   </tr>
                 {% endfor%}
                 </tbody>
               </table>
-              <p>
+              <p class="u-sv3">
                 <a href="/certification/{{ canonical_id }}/{{ release.version }}">Hardware details&nbsp;&rsaquo;</a>
               </p>
             </section>

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -101,7 +101,7 @@
               {% endfor %}
               {% endif %}
               <h4>Hardware</h4>
-              <table aria-label="Hardware">
+              <table aria-label="Hardware" class="u-no-margin--bottom">
                 <tbody>
                 {% for hardware_subtitle, values in release_details["components"].items() %}
                   <tr>
@@ -239,11 +239,14 @@
         {% endfor %}
     </table>
     <ul class="p-inline-list" style="margin-left:0.5rem;">
-      <li class="p-inline-list__item"><i class="p-icon--success"></i> Supported</li>
       <li class="p-inline-list__item">
-          <img src="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg" alt=""> May require 3rd-party driver
+        <i class="p-icon--success"></i> <small class="p-">Supported</small></li>
+      <li class="p-inline-list__item">
+          <img src="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg" alt=""> <small>May require 3rd-party driver</small>
       </li>
-      <li class="p-inline-list__item"><i class="p-icon--help"></i> In progress</li>
+      <li class="p-inline-list__item">
+        <i class="p-icon--help"></i> <small>In progress</small>
+      </li>
     </ul>
   </div>
 </section>

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -1,37 +1,235 @@
-<h1>This is the models details page</h1>
+{% extends "certification/base_certification.html" %}
 
-<h2>ID (Canonical ID)</h2>
-{{canonical_id}}
+{% block title %}Model details | Ubuntu{% endblock %}
 
-<h2>Name:</h2>
-{{ name }}
+{% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
-<h2>Category/Form</h2>
-{{ category }}
+{% block content %}
 
-<h2>form_factor</h2>
-{{ form_factor }}
-
-<h2>vendor</h2>
-{{ vendor }}
-
-<h2>major release</h2>
-{{ major_release }}
-
-<h2>Release details</h2>
-<p>This contains data for all elements in the table </p>
-<ul>
-    <li>release.name</li>
-    <li>ubuntu image or not (release.level)</li>
-    <li>release.kernel</li>
-    <li>release.notes</li>
-    <li>whole hardware details page, but you need to filter the amount of data accordingly</li>
-</ul>
-<p>Links need to be built in the for of /certification/{model-id}/{release} to link to the corresponding hardware details page</p>
-{{ release_details }}
-
-<h2>Processor, network, video are contained within release.components</h2>
+<section class="p-strip--suru-topped">
+  <div class="row u-sv3">
+    <div class="col-7">
+      <h1>{{ vendor }} {{ name }}</h1>
+      <p class="p-heading--4"> {{ category }} system certified with Ubuntu</p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {% if category == "Desktop" or category == "Laptop" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
+        alt="",
+        width="132",
+        height="77",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+      {% if category == "Server" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
+        alt="Server",
+        width="80",
+        height="96",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+      {% if category == "Ubuntu Core" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
+        alt="Gateway",
+        width="96",
+        height="100",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+      {% if category == "Server SoC" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
+        alt="Chip",
+        width="84",
+        height="100",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <h2>Releases</h2>
+      <aside class="p-accordion">
+        <ul class="p-accordion__list">
+          {% for release in release_details["releases"] %}
+          <li class="p-accordion__group">
+            <div role="heading" aria-level="3" class="p-accordion__heading">
+              <button type="button" class="p-accordion__tab" style="background-position: top 1.25rem left 1rem;"id="tab{{ loop.index }}" aria-controls="tab{{ loop.index }}-section" aria-expanded="{% if release_details['releases']|length == 1 %}true{% else %}false{% endif %}"><h3 class="u-no-margin--bottom">{{ release.name }}</h3></button>
+            </div>
+            <section class="p-accordion__panel" id="tab{{ loop.index }}-section" aria-hidden="{% if release_details['releases']|length == 1 %}false{% else %}true{% endif %}" aria-labelledby="tab{{ loop.index }}">
+              <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system’s hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
+              <p></p>
+              {% if release.kernel %}
+              <h4 class="u-no-margin--bottom">Kernel</h4>
+              <p>{{ release.kernel }}</p>
+              {% endif %}
+              {% if release.notes %}
+              <h4 class="u-no-margin--bottom">Notes</h4>
+              {% for note in release.notes %}
+              <p>{{ note.comment }}</p>
+              {% endfor %}
+              {% endif %}
+              <h4>Hardware</h4>
+              <table aria-label="Hardware">
+                <tbody>
+                {% for release_subtitle, values in release_details["components"].items() %}
+                  <tr>
+                    <th colspan="3" class="p-muted-text">{{ release_subtitle }}</th>
+                    <td colspan="9">{% for value in values %} 
+                      <p style="margin-bottom: 0.5rem;"><a href="#">{{ value.name }} {{ value.bus }}</a> ({{ value.identifier }})</p>
+                      {% endfor %}
+                    </td>
+                  </tr>
+                {% endfor%}
+                </tbody>
+              </table>
+              <p>
+                <a href="/certification/{{ canonical_id }}/{{ release.version }}">Hardware details&nbsp;&rsaquo;</a>
+              </p>
+            </section>
+          </li>
+          {% endfor %}
+        </ul>
+      </aside>
+    </div>
+  </div>
+</section>
 
 {% if components %}
-<p>{{ components }}</p>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2 class="u-sv2">Components certified with this system</h2>
+    <table class="p-table--mobile-card p-table--devices" aria-label="Component Devices table">
+      <thead>
+        <tr>
+          <th>Component</th>
+          <th class="u-align--center">14.04 ESM</th>
+          <th class="u-align--center">16.04 LTS</th>
+          <th class="u-align--center">18.04 LTS</th>
+          <th class="u-align--center">20.04 LTS</th>
+          <th>Comments</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for component in components%}
+        <tr>
+          <th aria-label="Component"><a href="/certification/component/{{ canonical_id }}">{{ component.vendor_name }} {{ component.model}}</a></th>
+          {% for lts_release, details in component.lts_releases.items() %}
+            {% if lts_release == '14.04 ESM' %}
+              {% if details[0].third_party_driver == True %}
+              <td aria-label="14.04 ESM">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
+                  alt="May require third-party driver",
+                  width="21",
+                  height="14",
+                  hi_def=True,
+                  loading="lazy"
+                  ) | safe
+                }}
+              </td>
+              {% elif details[0].status == 'inprogress' %}
+              <td aria-label="14.04 ESM"><i class="p-icon--help">In progress</i></td>
+              {% elif details[0].status == 'certified' %}
+              <td aria-label="14.04 ESM"><i class="p-icon--success">Supported</i></td>
+              {% endif %}
+            {% else %}
+             <td aria-label="14.04 ESM"></td>
+            {% endif %}
+            {% if lts_release == '16.04 LTS' %}
+              {% if details[0].third_party_driver == True %}
+              <td aria-label="16.04 LTS">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
+                  alt="May require third-party driver",
+                  width="21",
+                  height="14",
+                  hi_def=True,
+                  attrs={"style":"margin-left: 0.45rem;"},
+                  loading="lazy"
+                  ) | safe
+                }}
+              </td>
+              {% elif details[0].status == 'inprogress' %}
+              <td aria-label="16.04 ESM"><i class="p-icon--help">In progress</i></td>
+              {% elif details[0].status == 'certified'%}
+              <td aria-label="16.04 LTS"><i class="p-icon--success">Supported</i></td>
+              {% endif %}
+            {% else %}
+             <td aria-label="16.04 LTS"></td>
+            {% endif %}
+            {% if lts_release == '18.04 LTS' %}
+              {% if details[0].third_party_driver == True %}
+              <td aria-label="18.04 LTS">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
+                  alt="May require third-party driver",
+                  width="21",
+                  height="14",
+                  hi_def=True,
+                  attrs={"style":"margin-left: 0.45rem;"},
+                  loading="lazy"
+                  ) | safe
+                }}
+              </td>
+              {% elif details[0].status == 'inprogress' %}
+              <td aria-label="18.04 ESM"><i class="p-icon--help">In progress</i></td>
+              {% elif details[0].status == 'certified'%}
+              <td aria-label="18.04 LTS"><i class="p-icon--success">Supported</i></td>
+              {% endif %}
+            {% else %}
+             <td aria-label="18.04 LTS"></td>
+            {% endif %}
+            {% if lts_release == '20.04 LTS' %}
+              {% if details[0].third_party_driver == True %}
+              <td aria-label="20.04 LTS">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
+                  alt="May require third-party driver",
+                  width="21",
+                  height="14",
+                  hi_def=True,
+                  attrs={"style":"margin-left: 0.45rem;"},
+                  loading="lazy"
+                  ) | safe
+                }}
+              </td>
+              {% elif details[0].status == 'inprogress' %}
+              <td aria-label="20.04 ESM"><i class="p-icon--help">In progress</i></td>
+              {% elif details[0].status == 'certified' %}
+              <td aria-label="20.04 LTS"><i class="p-icon--success">Supported</i></td>
+              {% endif %}
+            {% else %}
+             <td aria-label="20.04 LTS"></td>
+            {% endif %}
+          {% endfor %}
+          <td aria-label="Comments" >{{ component.note }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <ul class="p-inline-list" style="margin-left:0.5rem;">
+      <li class="p-inline-list__item"><i class="p-icon--success"></i> Supported</li>
+      <li class="p-inline-list__item">
+          <img src="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg" alt=""> May require 3rd-party driver
+      </li>
+      <li class="p-inline-list__item"><i class="p-icon--help"></i> In progress</li>
+    </ul>
+  </div>
+</section>
 {% endif %}
+
+{% endblock content %}

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -86,9 +86,9 @@
               <h4>Hardware</h4>
               <table aria-label="Hardware">
                 <tbody>
-                {% for release_subtitle, values in release_details["components"].items() %}
+                {% for hardware_subtitle, values in release_details["components"].items() %}
                   <tr>
-                    <th colspan="3" class="p-muted-text">{{ release_subtitle }}</th>
+                    <th colspan="3" class="p-muted-text">{{ hardware_subtitle }}</th>
                     <td colspan="9">{% for value in values %} 
                       <p style="margin-bottom: 0.5rem;"><a href="#">{{ value.name }} {{ value.bus }}</a> ({{ value.identifier }})</p>
                       {% endfor %}

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -120,7 +120,7 @@
         <tbody>
           {% for result in results %}
           <tr>
-          <td><a href="/certification/{{ canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
+          <td><a href="/certification/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
           <td>{{ result.category }}</td>
           </tr>
           {% endfor %}


### PR DESCRIPTION
## Done

- Added page to show model details
- Page is at `/certification/<canonical_id>`

## QA

Check the following views:
- 1 release with no component devices: https://ubuntu-com-9537.demos.haus/certification/201612-25300
- 4 releases with no component devices: https://ubuntu-com-9537.demos.haus/certification/201911-27455
- 1 release with component devices including third party driver: https://ubuntu-com-9537.demos.haus/certification/202004-27860
- 2 releases with component devices including in progress status: https://ubuntu-com-9537.demos.haus/certification/202005-27924


## Issue / Card

Fixes [#154](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/154)
