### PR TITLE
Redirect K8s 1.21 release blog post to a better URL

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -832,8 +832,8 @@ blog/home/?: /
 # specific article redirects
 blog/event/mobile-world-congress-2018/?:  /blog/nvidia-gtc-2018
 blog/(2019/02/05/)?ubuntu-14-04-trusty-tahr-end-of-life/?: /blog/ubuntu-14-04-trusty-tahr
-blog/kubernetes-1-19-available-from-canonical%25EF%25BB%25BF: /blog/kubernetes-1-19-available-from-canonical
-blog/kubernetes-1-21-available-from-canonical%25EF%25BB%25BF: /blog/kubernetes-1-21-available-from-canonical
+blog/kubernetes-1-19-available-from-canonical\%EF\%BB\%BF: /blog/kubernetes-1-19-available-from-canonical
+blog/kubernetes-1-21-available-from-canonical\%EF\%BB\%BF: /blog/kubernetes-1-21-available-from-canonical
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -832,8 +832,8 @@ blog/home/?: /
 # specific article redirects
 blog/event/mobile-world-congress-2018/?:  /blog/nvidia-gtc-2018
 blog/(2019/02/05/)?ubuntu-14-04-trusty-tahr-end-of-life/?: /blog/ubuntu-14-04-trusty-tahr
-blog/kubernetes-1-19-available-from-canonical%EF%BB%BF: /blog/kubernetes-1-19-available-from-canonical
-blog/kubernetes-1-21-available-from-canonical%EF%BB%BF: /blog/kubernetes-1-21-available-from-canonical
+blog/kubernetes-1-19-available-from-canonical%25EF%25BB%25BF: /blog/kubernetes-1-19-available-from-canonical
+blog/kubernetes-1-21-available-from-canonical%25EF%25BB%25BF: /blog/kubernetes-1-21-available-from-canonical
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -832,8 +832,8 @@ blog/home/?: /
 # specific article redirects
 blog/event/mobile-world-congress-2018/?:  /blog/nvidia-gtc-2018
 blog/(2019/02/05/)?ubuntu-14-04-trusty-tahr-end-of-life/?: /blog/ubuntu-14-04-trusty-tahr
-blog/kubernetes-1-19-available-from-canonical.*: /blog/kubernetes-1-19-available-from-canonical
-blog/kubernetes-1-21-available-from-canonical.*: /blog/kubernetes-1-21-available-from-canonical
+blog/kubernetes-1-19-available-from-canonical..*: /blog/kubernetes-1-19-available-from-canonical
+blog/kubernetes-1-21-available-from-canonical..*: /blog/kubernetes-1-21-available-from-canonical
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -833,6 +833,7 @@ blog/home/?: /
 blog/event/mobile-world-congress-2018/?:  /blog/nvidia-gtc-2018
 blog/(2019/02/05/)?ubuntu-14-04-trusty-tahr-end-of-life/?: /blog/ubuntu-14-04-trusty-tahr
 blog/kubernetes-1-19-available-from-canonical%EF%BB%BF: /blog/kubernetes-1-19-available-from-canonical
+blog/kubernetes-1-21-available-from-canonical%EF%BB%BF: /blog/kubernetes-1-21-available-from-canonical
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -832,8 +832,8 @@ blog/home/?: /
 # specific article redirects
 blog/event/mobile-world-congress-2018/?:  /blog/nvidia-gtc-2018
 blog/(2019/02/05/)?ubuntu-14-04-trusty-tahr-end-of-life/?: /blog/ubuntu-14-04-trusty-tahr
-blog/kubernetes-1-19-available-from-canonical\%EF\%BB\%BF: /blog/kubernetes-1-19-available-from-canonical
-blog/kubernetes-1-21-available-from-canonical\%EF\%BB\%BF: /blog/kubernetes-1-21-available-from-canonical
+blog/kubernetes-1-19-available-from-canonical.*: /blog/kubernetes-1-19-available-from-canonical
+blog/kubernetes-1-21-available-from-canonical.*: /blog/kubernetes-1-21-available-from-canonical
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 


### PR DESCRIPTION
## Done

- Blog article redirect

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure https://ubuntu.com/blog/kubernetes-1-21-available-from-canonical exists before merging
