### PR TITLE
Add a null check for the login menu when logged out

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -273,22 +273,24 @@ if (accountContainer && accountContainerSmall) {
       function setupAllContextualMenus(contextualMenuToggleSelector) {
         // Setup all menu toggles on the page.
         var userToggle = document.querySelector(contextualMenuToggleSelector);
-        setupContextualMenu(userToggle);
+        if (userToggle) {
+          setupContextualMenu(userToggle);
 
-        // Add handler for clicking outside the menu.
-        document.addEventListener("click", function (event) {
-          var contextualMenu = document.getElementById(
-            userToggle.getAttribute("aria-controls")
-          );
-          var clickOutside = !(
-            userToggle.contains(event.target) ||
-            contextualMenu.contains(event.target)
-          );
+          // Add handler for clicking outside the menu.
+          document.addEventListener("click", function (event) {
+            var contextualMenu = document.getElementById(
+              userToggle.getAttribute("aria-controls")
+            );
+            var clickOutside = !(
+              userToggle.contains(event.target) ||
+              contextualMenu.contains(event.target)
+            );
 
-          if (clickOutside) {
-            toggleMenu(userToggle, false);
-          }
-        });
+            if (clickOutside) {
+              toggleMenu(userToggle, false);
+            }
+          });
+        }
       }
 
       setupAllContextualMenus(".p-navigation__link-anchor.p-subnav__toggle");


### PR DESCRIPTION
## Done
Add a null check for the login menu when logged out

## QA
- Open the demo and login
- Check there is no error in the console
- Check the login menu works 
- Open the demo in a private window with the console open
- Check there is no error in the console
