### PR TITLE
Refactor search results page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1553,4 +1553,4 @@ certification:
     - title: IoT
       path: /certification?form=Ubuntu%20Core
     - title: SoCs
-      path: /certification?form=Server%20SoC
+      path: /certification?form=SoC

--- a/templates/certification/index.html
+++ b/templates/certification/index.html
@@ -74,7 +74,7 @@
       <ul class="p-inline-list" style="margin-bottom: 0.5rem;">
         {% for desktop_vendor in desktop_vendors %}
         <li class="p-inline-list__item">
-          <a href="{{ desktop_vendor.path }}">{{ desktop_vendor.make }}&nbsp;({{ desktop_vendor.total }})</a>
+          <a href="/certification?form=Desktop&vendor={{ desktop_vendor.make }}&filters=True">{{ desktop_vendor.make }}&nbsp;({{ desktop_vendor.total }})</a>
         </li>
         {% endfor %}
       </ul>
@@ -82,7 +82,7 @@
       <ul class="p-inline-list">
         {% for desktop_release in desktop_releases %}
         <li class="p-inline-list__item">
-          <a href="{{ desktop_release.path }}">{{ desktop_release.release }}&nbsp;({{ desktop_release.desktops + desktop_release.laptops + desktop_release.servers + desktop_release.smart_core + desktop_release.soc }})</a>
+          <a href="/certification?form=Desktop&release={{ desktop_release.release }}&filters=True">{{ desktop_release.release }}&nbsp;({{ desktop_release.desktops + desktop_release.laptops + desktop_release.servers + desktop_release.smart_core + desktop_release.soc }})</a>
         </li>
         {% endfor %}
       </ul>
@@ -105,7 +105,7 @@
       <ul class="p-inline-list">
         {% for server_release, total in server_releases.items() %}
         <li class="p-inline-list__item">
-          <a href="/certification?form=Server&release={{ server_release }}">{{ server_release }}&nbsp;({{ total }})</a>
+          <a href="/certification?form=Server&release={{ server_release }}&filters=True">{{ server_release }}&nbsp;({{ total }})</a>
         </li>
         {% endfor %}
       </ul>
@@ -130,7 +130,7 @@
       <ul class="p-inline-list">
         {% for iot_vendor in iot_vendors %}
         <li class="p-inline-list__item">
-          <a href="{{ iot_vendor.path }}">{{ iot_vendor.make }}&nbsp;({{ iot_vendor.total }})</a>
+          <a href="{{ iot_vendor.path }}&filters=True">{{ iot_vendor.make }}&nbsp;({{ iot_vendor.total }})</a>
         </li>
         {% endfor %}
       </ul>
@@ -153,7 +153,7 @@
       <ul class="p-inline-list">
         {% for soc_vendor in soc_vendors %}
         <li class="p-inline-list__item">
-          <a href="{{ soc_vendor.path }}">{{ soc_vendor.make }} ({{ soc_vendor.total }})</a>
+          <a href="{{ soc_vendor.path }}&filters=True">{{ soc_vendor.make }} ({{ soc_vendor.total }})</a>
         </li>
         {% endfor %}
       </ul>

--- a/templates/certification/index.html
+++ b/templates/certification/index.html
@@ -38,7 +38,7 @@
           <option value="Laptop">Laptops</option>
           <option value="Server">Servers</option>
           <option value="Ubuntu Core">IoT</option>
-          <option value="Server SoC">SoC</option>
+          <option value="SoC">SoC</option>
         </select>
         <input hidden id="filters" value="True" name="filters">
       </div>

--- a/templates/certification/index.html
+++ b/templates/certification/index.html
@@ -37,9 +37,10 @@
           <option value="Desktop">Desktops</option>
           <option value="Laptop">Laptops</option>
           <option value="Server">Servers</option>
-          <option value='Ubuntu Core'>IoT</option>
-          <option value='Server SoC'>SoC</option>
+          <option value="Ubuntu Core">IoT</option>
+          <option value="Server SoC">SoC</option>
         </select>
+        <input hidden id="filters" value="True" name="filters">
       </div>
     </div>
     <div class="col-8" style="margin-top: 1rem;">

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -76,18 +76,7 @@
               {% elif release.level == "Certified" %}
                 <p>The {{ vendor }} {{ name }} development board with the components described below has been awarded the status of certified for Ubuntu.</p>
                 <p class="u-no-margin--bottom">
-                  {% if category == "Desktop" or category == "Laptop" %}
-                  <a href="/download/desktop" class="p-button--neutral">Download</a>
-                  {% endif%}
-                  {% if category == "Ubuntu Core" %}
-                  <a href="/download/iot" class="p-button--neutral">Download</a>
-                  {% endif%}
-                  {% if category == "Server" %}
-                  <a href="/download/server" class="p-button--neutral">Download</a>
-                  {% endif%}
-                  {% if category == "Server SoC" %}
-                  <a href="/download/server/arm" class="p-button--neutral">Download</a>
-                  {% endif%}
+                  <a href="{{ release.download_url }}" class="p-button--neutral">Download</a>
                 </p>
               {% endif %}
               {% if release.kernel %}

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -8,138 +8,211 @@
 {% block content %}
 
 <form class="form">
-<section class="p-strip--suru-topped">
-  <div class="row">
-    <div class="col-12">
-      {{ filters }}
+  <section class="p-strip--suru-topped">
+    {% if filters != True%}
       {% if form == "Desktop" %}
-        <h1>Ubuntu Certified desktop hardware</h1>
-        <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
+      <div class="row">
+        <div class="col-7">
+          <h1>Ubuntu Certified desktop hardware</h1>
+          <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
+        </div>
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
+            alt="",
+            width="132",
+            height="77",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+      </div>
       {% elif form == "Server" %}
-        <h1>Ubuntu Certified server hardware</h1>
-        <p>Ubuntu Server gives you the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
-        <p class="u-sv3">Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-centre environments.</p>
+      <div class="row">
+        <div class="col-7">
+          <h1>Ubuntu Certified server hardware</h1>
+          <p>Ubuntu Server gives you the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
+          <p class="u-sv3">Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-centre environments.</p>
+        </div>
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
+            alt="Server",
+            width="80",
+            height="96",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+      </div>
       {% elif form == "Ubuntu Core" %}
-        <h1>Ubuntu Certified IoT hardware</h1>
-        <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
-        <p class="u-sv3">Canonical's certification program offers you peace of mind that all your Internet of Things devices will remain secure and regularly updated over the long term.</p>
+      <div class="row">
+        <div class="col-7">
+          <h1>Ubuntu Certified IoT hardware</h1>
+          <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
+          <p class="u-sv3">Canonical's certification program offers you peace of mind that all your Internet of Things devices will remain secure and regularly updated over the long term.</p>
+        </div>
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
+            alt="Gateway",
+            width="96",
+            height="100",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+      </div>
       {% elif form == "Server SoC" %}
-        <h1>Ubuntu Certified SoC hardware</h1>
-        <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
-        <p class="u-sv3">Canonical's certification program offers manufacturers a selection of SoCs officially supported and maintained in Ubuntu.</p>
-      {% else %}
-        <h1 class="u-sv3">Ubuntu Certified hardware search</h1>
-      {% endif %}
+      <div class="row">
+        <div class="col-7">
+          <h1>Ubuntu Certified SoC hardware</h1>
+          <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
+          <p class="u-sv3">Canonical's certification program offers manufacturers a selection of SoCs officially supported and maintained in Ubuntu.</p>
+        </div>
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
+            alt="Chip",
+            width="84",
+            height="100",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+      </div>
+    {% endif %}
+    {% else %}
+    <div class="u-fixed-width">
+      <h1 class="u-sv3">Ubuntu Certified hardware search</h1>
+    </div>
+    {% endif %}
+    <div class="u-fixed-width">
       <div class="p-search-box">
         <input class="p-search-box__input" type="text" name="text" value="{{ query or '' }}">
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-3 p-side-navigation" id="drawer">
-      <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-      <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-      <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-        <div class="p-side-navigation__drawer-header">
-          <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-            Toggle filters
-          </a>
-        </div>
-        <div>
-          <aside class="p-accordion">
-          <ul class="p-accordion__list">
-            <li class="p-accordion__group">
-              <div role="heading" aria-level="2" class="p-accordion__heading">
-                <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Show</button>
-              </div>
-              <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
-                  {% for form_filter, total in form_filters.items() %}
-                  <label class="p-checkbox">
-                    <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form_filter in form %}checked{% endif %}>
-                    <div class="p-checkbox__label" id="{{ form_filter }}">
-                      <span>{{ form_filter }}</span>
-                    </div>
-                  </label>
-                  {% endfor %}
-              </section>
-            </li>
-            <li class="p-accordion__group">
-              <div role="heading" aria-level="2" class="p-accordion__heading">
-                <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Certified for Ubuntu</button>
-              </div>
-              <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab2">
-                {% for release_filter, total in release_filters.items() %}
-                <label class="p-checkbox">
-                  <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}">
-                  <div class="p-checkbox__label" id="{{ release_filter }}">
-                    <span>{{ release_filter }}</span>
+    <div class="row">
+      <div class="col-3 p-side-navigation" id="drawer">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
+          <div class="p-side-navigation__drawer-header">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle filters
+            </a>
+          </div>
+          <div>
+            <aside class="p-accordion">
+              <ul class="p-accordion__list">
+                <li class="p-accordion__group">
+                  <div role="heading" aria-level="2" class="p-accordion__heading">
+                    <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Show</button>
                   </div>
-                </label>
-                {% endfor %}
-              </section>
-            </li>
-            <li class="p-accordion__group">
-              <div role="heading" aria-level="2" class="p-accordion__heading">
-                <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
-              </div>
-              <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
-                {% for vendor_filter, total in vendor_filters.items() %}
-                <label class="p-checkbox">
-                  <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendors" value="{{ vendor_filter }}" {% if vendor_filter|lower in query|lower %}checked{% endif %}>
-                  <div class="p-checkbox__label" id="{{ vendor_filter }}">
-                    <span>{{ vendor_filter }}</span>
+                  <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
+                    {% for form_filter, total in form_filters.items() %}
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form %}checked{% endif %}>
+                      <div class="p-checkbox__label" id="{{ form_filter }}">
+                        <span>{{ form_filter }}</span>
+                      </div>
+                    </label>
+                    {% endfor %}
+                  </section>
+                </li>
+                <li class="p-accordion__group">
+                  <div role="heading" aria-level="2" class="p-accordion__heading">
+                    <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Certified for Ubuntu</button>
                   </div>
-                </label>
-                {% endfor %}
-              </section>
-            </li>
-          </ul>
-        </aside>
-          <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
-        </div>
-      </nav>
-    </div>
-    <div class="col-9">
+                  <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab2">
+                    {% for release_filter, total in release_filters.items() %}
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
+                      <div class="p-checkbox__label" id="{{ release_filter }}">
+                        <span>{{ release_filter }}</span>
+                      </div>
+                    </label>
+                    {% endfor %}
+                  </section>
+                </li>
+                <li class="p-accordion__group">
+                  <div role="heading" aria-level="2" class="p-accordion__heading">
+                    <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
+                  </div>
+                  <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
+                    {% for vendor_filter, total in vendor_filters.items() %}
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendors" value="{{ vendor_filter }}" {% if query and vendor_filter|lower in query|lower %}checked{% endif %}>
+                      <div class="p-checkbox__label" id="{{ vendor_filter }}">
+                        <span>{{ vendor_filter }}</span>
+                      </div>
+                    </label>
+                    {% endfor %}
+                  </section>
+                </li>
+              </ul>
+            </aside>
+            <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
+            <input hidden id="filters" value="True" name="filters">
+          </div>
+        </nav>
+      </div>
       {% if total_results > 0 %}
-      <table class="p-certification-results">
-        <thead>
-          <tr>
-            <th>
-              {% if total_results and total_results > 1 %}
-                {{ offset + 1 }}
-                &ndash;
-                {% if offset + limit > total_results %}
-                  {{ total_results }}
-                {% else %}
-                  {{ offset + limit }}
+      <div class="col-9">
+        <table class="p-certification-results">
+          <thead>
+            <tr>
+              <th>
+                {% if total_results and total_results > 1 %}
+                  {{ offset + 1 }}
+                  &ndash;
+                  {% if offset + limit > total_results %}
+                    {{ total_results }}
+                  {% else %}
+                    {{ offset + limit }}
+                  {% endif %}
+                  of
                 {% endif %}
-                of
-              {% endif %}
-              {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-            </th>
-            <th>type</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for result in results %}
-          <tr>
-          <td><a href="/certification/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-          <td>{{ result.category }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+                {{ total_results }} result{% if total_results != 1 %}s{% endif %}
+              </th>
+              <th>type</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for result in results %}
+            <tr>
+            <td><a href="/certification/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
+            <td>{{ result.category }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
         {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
         {% include "security/cve/_pagination.html" %}
         {% endwith %}
-  
-       {% else %}
-       <p>There are no results to show</p>
-       {% endif %}
+      </div>
+      {% else %}
+      <div class="col-5">
+        <h3>Why not try widening your search?</h3>
+        <p>You can do this by:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked u-sv1">
+            Adding alternative words or phrases
+          </li>
+          <li class="p-list__item is-ticked  u-sv1">
+            Using individual words instead of phrases
+          </li>
+          <li class="p-list__item is-ticked">Trying a different spelling</li>
+        </ul>
+      </div>
+      {% endif %}
     </div>
-  </div>
-</section>
+  </section>
 </form>
 
 <script>
@@ -178,23 +251,6 @@ function setupSideNavigations(sideNavigationSelector) {
 }
 
 setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
-
-
-(function () {
-  const updateButton = document.querySelector(".p-update-results");
-
-  let currentUrl = location.href
-
-  updateButton.addEventListener("click", (e) => {
-    if(!currentUrl.includes("filters")) {
-      console.log("before prevent default", currentUrl)
-      e.preventDefault()
-      currentUrl += '&filters=True';
-      window.location = currentUrl;
-    }
-    console.log("After click", currentUrl)
-  })
-})();
 
 </script>
 

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -7,11 +7,29 @@
 
 {% block content %}
 
-<form>
+<form class="form">
 <section class="p-strip--suru-topped">
   <div class="row">
     <div class="col-12">
-      <h1 class="u-sv3">Ubuntu Certified hardware search</h1>
+      {{ filters }}
+      {% if form == "Desktop" %}
+        <h1>Ubuntu Certified desktop hardware</h1>
+        <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
+      {% elif form == "Server" %}
+        <h1>Ubuntu Certified server hardware</h1>
+        <p>Ubuntu Server gives you the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
+        <p class="u-sv3">Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-centre environments.</p>
+      {% elif form == "Ubuntu Core" %}
+        <h1>Ubuntu Certified IoT hardware</h1>
+        <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
+        <p class="u-sv3">Canonical's certification program offers you peace of mind that all your Internet of Things devices will remain secure and regularly updated over the long term.</p>
+      {% elif form == "Server SoC" %}
+        <h1>Ubuntu Certified SoC hardware</h1>
+        <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
+        <p class="u-sv3">Canonical's certification program offers manufacturers a selection of SoCs officially supported and maintained in Ubuntu.</p>
+      {% else %}
+        <h1 class="u-sv3">Ubuntu Certified hardware search</h1>
+      {% endif %}
       <div class="p-search-box">
         <input class="p-search-box__input" type="text" name="text" value="{{ query or '' }}">
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
@@ -29,69 +47,55 @@
           </a>
         </div>
         <div>
-          <table aria-label="show">
-            <thead>
-              <tr>
-                <th style="color: #111;">Show</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
+          <aside class="p-accordion">
+          <ul class="p-accordion__list">
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="2" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Show</button>
+              </div>
+              <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
                   {% for form_filter, total in form_filters.items() %}
                   <label class="p-checkbox">
-                    <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" name="form" value="{{ form_filter }}" {% if form == form_filter or form == "Desktops,Laptops,Ubuntu Core,Server,Server SoC" %}checked{% endif %}>
+                    <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form_filter in form %}checked{% endif %}>
                     <div class="p-checkbox__label" id="{{ form_filter }}">
                       <span>{{ form_filter }}</span>
                     </div>
                   </label>
                   {% endfor %}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <table aria-label="show">
-            <thead>
-              <tr>
-                <th style="color: #111;">Certified for Ubuntu</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  {% for release_filter, total in release_filters.items() %}
-                  <label class="p-checkbox">
-                    <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" name="release" value="{{ release_filter }}" {% if releases == release_filter %}checked{% endif %}>
-                    <div class="p-checkbox__label" id="{{ release_filter }}">
-                      <span>{{ release_filter }}</span>
-                    </div>
-                  </label>
-                  {% endfor %}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <table aria-label="show">
-            <thead>
-              <tr>
-                <th style="color: #111;">Vendor</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  {% for vendor_filter, total in vendor_filters.items() %}
-                  <label class="p-checkbox">
-                    <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" name="vendors" value="{{ vendor_filter }}" {% if vendor == vendor_filter %}checked{% endif %}>
-                    <div class="p-checkbox__label" id="{{ vendor_filter }}">
-                      <span>{{ vendor_filter }}</span>
-                    </div>
-                  </label>
-                  {% endfor %}
-                </td>
-              </tr>
-            </tbody>
-          </table>
+              </section>
+            </li>
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="2" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Certified for Ubuntu</button>
+              </div>
+              <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab2">
+                {% for release_filter, total in release_filters.items() %}
+                <label class="p-checkbox">
+                  <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}">
+                  <div class="p-checkbox__label" id="{{ release_filter }}">
+                    <span>{{ release_filter }}</span>
+                  </div>
+                </label>
+                {% endfor %}
+              </section>
+            </li>
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="2" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
+              </div>
+              <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
+                {% for vendor_filter, total in vendor_filters.items() %}
+                <label class="p-checkbox">
+                  <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendors" value="{{ vendor_filter }}" {% if vendor_filter|lower in query|lower %}checked{% endif %}>
+                  <div class="p-checkbox__label" id="{{ vendor_filter }}">
+                    <span>{{ vendor_filter }}</span>
+                  </div>
+                </label>
+                {% endfor %}
+              </section>
+            </li>
+          </ul>
+        </aside>
           <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
         </div>
       </nav>
@@ -174,6 +178,24 @@ function setupSideNavigations(sideNavigationSelector) {
 }
 
 setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
+
+
+(function () {
+  const updateButton = document.querySelector(".p-update-results");
+
+  let currentUrl = location.href
+
+  updateButton.addEventListener("click", (e) => {
+    if(!currentUrl.includes("filters")) {
+      console.log("before prevent default", currentUrl)
+      e.preventDefault()
+      currentUrl += '&filters=True';
+      window.location = currentUrl;
+    }
+    console.log("After click", currentUrl)
+  })
+})();
+
 </script>
 
 {% endblock content %}

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -66,7 +66,7 @@
           }}
         </div>
       </div>
-      {% elif form == "Server SoC" %}
+      {% elif form == "SoC" %}
       <div class="row">
         <div class="col-8">
           <h1>Ubuntu Certified SoC hardware</h1>

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -147,9 +147,10 @@
                   <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
                     {% for vendor_filter, total in vendor_filters.items() %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if query and vendor_filter|lower in query|lower or vendors and vendor_filter|lower in vendors|lower %}checked{% endif %}>
+                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
                       <div class="p-checkbox__label" id="{{ vendor_filter }}">
                         <span>{{ vendor_filter }}</span>
+                        </p>
                       </div>
                     </label>
                     {% endfor %}

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -117,7 +117,7 @@
                   <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
                     {% for form_filter, total in form_filters.items() %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form %}checked{% endif %}>
+                      <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form or form == "Models" %}checked{% endif %}>
                       <div class="p-checkbox__label" id="{{ form_filter }}">
                         <span>{{ form_filter }}</span>
                       </div>

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -12,11 +12,11 @@
     {% if filters != True%}
       {% if form == "Desktop" %}
       <div class="row">
-        <div class="col-7">
+        <div class="col-8">
           <h1>Ubuntu Certified desktop hardware</h1>
           <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
         </div>
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+        <div class="col-4 u-align--center u-vertically-center u-hide--small">
           {{ image (
             url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
             alt="",
@@ -30,12 +30,12 @@
       </div>
       {% elif form == "Server" %}
       <div class="row">
-        <div class="col-7">
+        <div class="col-8">
           <h1>Ubuntu Certified server hardware</h1>
           <p>Ubuntu Server gives you the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
           <p class="u-sv3">Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-centre environments.</p>
         </div>
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+        <div class="col-4 u-align--center u-vertically-center u-hide--small">
           {{ image (
             url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
             alt="Server",
@@ -49,12 +49,12 @@
       </div>
       {% elif form == "Ubuntu Core" %}
       <div class="row">
-        <div class="col-7">
+        <div class="col-8">
           <h1>Ubuntu Certified IoT hardware</h1>
           <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
           <p class="u-sv3">Canonical's certification program offers you peace of mind that all your Internet of Things devices will remain secure and regularly updated over the long term.</p>
         </div>
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+        <div class="col-4 u-align--center u-vertically-center u-hide--small">
           {{ image (
             url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
             alt="Gateway",
@@ -68,12 +68,12 @@
       </div>
       {% elif form == "Server SoC" %}
       <div class="row">
-        <div class="col-7">
+        <div class="col-8">
           <h1>Ubuntu Certified SoC hardware</h1>
           <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
           <p class="u-sv3">Canonical's certification program offers manufacturers a selection of SoCs officially supported and maintained in Ubuntu.</p>
         </div>
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+        <div class="col-4 u-align--center u-vertically-center u-hide--small">
           {{ image (
             url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
             alt="Chip",
@@ -147,7 +147,7 @@
                   <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
                     {% for vendor_filter, total in vendor_filters.items() %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendors" value="{{ vendor_filter }}" {% if query and vendor_filter|lower in query|lower %}checked{% endif %}>
+                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if query and vendor_filter|lower in query|lower or vendors and vendor_filter|lower in vendors|lower %}checked{% endif %}>
                       <div class="p-checkbox__label" id="{{ vendor_filter }}">
                         <span>{{ vendor_filter }}</span>
                       </div>

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -136,7 +136,9 @@ def certification_home():
             iot_releases.append(release)
 
         if int(release["soc"] > 1):
-            release["path"] = f"/certification?form=SoC&release={version}"
+            release[
+                "path"
+            ] = f"/certification?form=Server%20SoC&release={version}"
             soc_releases.append(release)
 
     for vendor in certified_makes:
@@ -180,7 +182,7 @@ def certification_home():
             if request.args.getlist("form")
             else None
         )
-        if "Models" in forms:
+        if forms and "Models" in forms:
             forms = ",".join(
                 ["Desktops", "Laptops", "Ubuntu Core", "Server", "Server SoC"]
             )

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -177,15 +177,18 @@ def certification_home():
         offset = request.args.get("offset", default=0, type=int)
         filters = request.args.get("filters", default=False, type=bool)
 
+        selected_forms = request.args.getlist("form")
+        if "SoC" in selected_forms:
+            selected_forms.remove("SoC")
+            selected_forms.append("Server SoC")
+
         forms = (
-            ",".join(request.args.getlist("form"))
-            if request.args.getlist("form")
+            ",".join(selected_forms)
+            if selected_forms
             else None
         )
         if forms and "Models" in forms:
-            forms = ",".join(
-                ["Desktops", "Laptops", "Ubuntu Core", "Server", "Server SoC"]
-            )
+            forms = None
         releases = (
             ",".join(request.args.getlist("release"))
             if request.args.getlist("release")
@@ -211,7 +214,7 @@ def certification_home():
             "Desktop": 0,
             "Ubuntu Core": 0,
             "Server": 0,
-            "Server SoC": 0,
+            "SoC": 0,
         }
         release_filters = defaultdict(lambda: 0)
         for release in all_releases:
@@ -225,7 +228,10 @@ def certification_home():
 
         # Populate filter numbers
         for model in results:
-            form_filters[model["category"]] += 1
+            if model["category"] == "Server SoC":
+                form_filters["SoC"] += 1
+            else:
+                form_filters[model["category"]] += 1
             release_filters[model["release"]] += 1
             vendor_filters[model["make"]] += 1
 
@@ -236,7 +242,7 @@ def certification_home():
             "certification/search-results.html",
             results=results,
             query=query,
-            form=forms,
+            form=",".join(request.args.getlist("form")),
             releases=releases,
             form_filters=form_filters,
             release_filters=release_filters,

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -173,6 +173,7 @@ def certification_home():
         query = request.args.get("text", default=None, type=str)
         limit = request.args.get("limit", default=20, type=int)
         offset = request.args.get("offset", default=0, type=int)
+        filters = request.args.get("filters", default=False, type=bool)
 
         forms = (
             ",".join(request.args.getlist("form"))
@@ -243,6 +244,7 @@ def certification_home():
             total_pages=math.ceil(total_results / limit),
             offset=offset,
             limit=limit,
+            filters=filters,
         )
 
     else:

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -182,11 +182,7 @@ def certification_home():
             selected_forms.remove("SoC")
             selected_forms.append("Server SoC")
 
-        forms = (
-            ",".join(selected_forms)
-            if selected_forms
-            else None
-        )
+        forms = ",".join(selected_forms) if selected_forms else None
         if forms and "Models" in forms:
             forms = None
         releases = (


### PR DESCRIPTION
## Done

- Add form factor headers only if user selects form factor from secondary nav, or selects the "All ubuntu certified <form> hardware" link from the overview page. If user selects filters and clicks `update` the header should now be the standard search results header.
- Fix SoC path in `/certification/views.py`
- Fix error by null checking `forms` in `/certification/views.py`
- Add `filters=True` flag to URL to be able to differentiate between form factor view and search results view. 

## QA

- Start here: https://ubuntu-com-9551.demos.haus/certification
- Click through to the search results from the "All ubuntu certified `<form>` hardware" links from the cards on the overview page. This should show the form-factor specific headings. 
- Use the secondary nav to select "Desktop" or "IoT" etc - these should show the specific form-factor headings - then select a filter and click update and you should be back to the generic search results page.
- Go back to the overview page and select from the drop down and type something to do a normal search. The header should be the generic search results header. 
- See the [wireframe](https://docs.google.com/document/d/1vIf1vC1mg72JbzmahrcKCaRZN-qMLCgin_i9iqjUxpM/edit#heading=h.b6q302go5m5l) for a description on the differences between the generic search results page and the form-factor pages.

#### Known issues:
- nav not highlighting correct page - @carkod will work on fixing [this](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/178) next week. 
- Numbers on overview page are incorrect: [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/9554) filed here


## Issue / Card

Fixes[ #176](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/176)

