### PR TITLE
Fix link to MAAS on hyperscale page

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -90,7 +90,7 @@
       <h3 class="p-heading--four">Bare metal provisioning with MAAS</h3>
       <p>With their unique architecture, hyperscale servers need to be provisioned through scalable automation. Canonical's Metal as a Service (MAAS) addresses the problem of deploying hundreds of OS instances to a cluster of nodes:</p>
       <p>MAAS provides a flexible mechanism to automatically detect, provision and configure individual nodes with Ubuntu server without any complex or manual configuration </p>
-      <p><a href="/cloud/orchestration/maas">Learn more about MAAS&nbsp;&rsaquo;</a></p>
+      <p><a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updated link to MAAS

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Hover over link to MAAS (or inspect in DevTools)
- Verify it points straight to https://maas.io/ and not /cloud/orchestration/...

## Issue / Card

## Screenshots

