### PR TITLE
Feature flag esm apps

### DIFF
--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -117,7 +117,7 @@ const formSlice = createSlice({
     },
     changeFeature(state, action) {
       const urlParams = new URLSearchParams(window.location.search);
-      const isAppsEnabled = urlParams.get("ESMApps") === "true";
+      const isAppsEnabled = urlParams.get("esm_apps") === "true";
       state.feature = isAppsEnabled ? action.payload : "infra"; //if ESM Apps is disabled we default to infra
 
       if (

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -116,7 +116,10 @@ const formSlice = createSlice({
       state.version = action.payload;
     },
     changeFeature(state, action) {
-      state.feature = action.payload;
+      const urlParams = new URLSearchParams(window.location.search);
+      const isAppsEnabled = urlParams.get("ESMApps") === "true";
+      state.feature = isAppsEnabled ? action.payload : "infra"; //if ESM Apps is disabled we default to infra
+
       if (
         action.payload === "apps" &&
         state.type === "desktop" &&

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -74,7 +74,7 @@ function renderFeature(state) {
   const radios = featureSection.querySelectorAll(".js-radio");
 
   const urlParams = new URLSearchParams(window.location.search);
-  const isAppsEnabled = urlParams.get("ESMApps") === "true";
+  const isAppsEnabled = urlParams.get("esm_apps") === "true";
 
   if (isAppsEnabled) {
     featureSection.classList.remove("u-hide");

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -77,9 +77,9 @@ function renderFeature(state) {
   const isAppsEnabled = urlParams.get("ESMApps") === "true";
 
   if (isAppsEnabled) {
-    featureSection.classList.add("u-hide");
-  } else {
     featureSection.classList.remove("u-hide");
+  } else {
+    featureSection.classList.add("u-hide");
   }
 
   // Disable infra + apps if desktop is selected

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -68,10 +68,19 @@ function renderPublicClouds(state, sections) {
 }
 
 function renderFeature(state) {
-  const supportSection = form.querySelector(
+  const featureSection = form.querySelector(
     ".js-form-section[data-step=feature]"
   );
-  const radios = supportSection.querySelectorAll(".js-radio");
+  const radios = featureSection.querySelectorAll(".js-radio");
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const isAppsEnabled = urlParams.get("ESMApps") === "true";
+
+  if (isAppsEnabled) {
+    featureSection.classList.add("u-hide");
+  } else {
+    featureSection.classList.remove("u-hide");
+  }
 
   // Disable infra + apps if desktop is selected
   if (state.type === "desktop") {

--- a/templates/advantage/subscribe/form/_tech_support.html
+++ b/templates/advantage/subscribe/form/_tech_support.html
@@ -77,7 +77,7 @@
         <p id="advanced-support-costs">$1,500 per machine per year</p>
       </div>
     </div>
-    <div class="col-12">
+    <div class="col-12 subscribe-section">
       <p>
         <a
           href="/legal/ubuntu-advantage-service-description"


### PR DESCRIPTION
## Done

- Added a feature flag around ESM apps to hide the option and allow us to release UA monthly

drive by: 
- Aligned the tech support link with the rest of the form

## QA

- go to https://ubuntu-com-9558.demos.haus/advantage/subscribe?test_backend=true
- check that everything is working correctly and the "Feature coverage" section is missing.
- go to https://ubuntu-com-9558.demos.haus/advantage/subscribe?test_backend=true&esm_apps=true
- check that the feature coverage is showing and working as expected.

