### PR TITLE
CUBE: Show register modal if user as no eDX account

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -333,6 +333,20 @@
 
 {% endif %}
 
+{% if not edx_user %}
+<div class="p-modal" id="modal">
+  <section class="p-modal__dialog" role="dialog">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">edX Account</h2>
+    </header>
+    <p>In order to use CUBE you will need to create an account with edX. By clicking the button below you are accepting the <a href="/legal/terms-and-policies/cube-terms" target="_blank" rel="noopener noreferrer">terms of service</a> and an account will be created for you.</p>
+    <footer class="p-modal__footer">
+      <a class="p-button p-button--positive u-no-margin--bottom" href="{{edx_register_url}}">Accept and register</a>
+    </footer>
+  </section>
+</div>
+{% endif %}
+
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
 </div>

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -130,7 +130,13 @@ def cube_microcerts():
     return flask.render_template(
         "cube/microcerts.html",
         **{
-            "user": sso_user,
+            "edx_user": edx_user,
+            "edx_register_url": (
+                f"{edx_api.base_url}/"
+                "auth/login/tpa-saml/"
+                "?auth_entry=register&next=%2F&idp=ubuntuone"
+            ),
+            "sso_user": sso_user,
             "certified_badge": certified_badge,
             "modules": courses,
             "passed_courses": passed_courses,


### PR DESCRIPTION
## Done
When a user lands in `cube/microcerts` and have no eDX account, they are then presented a modal where they can accept the terms and register for an account. When the button is clicked they are redirected to cube.ubuntu.com and then redirected back to ubuntu.com/microcerts(in QA they are redirected to qa.cube.ubuntu.com and not redirected back).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- If you have no account you should see a popup where you can accept the terms and create an account.


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/3934

## Screenshots
![image](https://user-images.githubusercontent.com/8145209/115309067-be216700-a139-11eb-9814-bd2d8b1a27c6.png)
