### PR TITLE
Build vendor specific view of search results

### DIFF
--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -9,13 +9,17 @@
     th,
     td {
       &:nth-child(1) {
-        width: 85%;
+        width: 70%;
         @media only screen and (max-width: $breakpoint-small) {
           width: 60%;
         }
       }
 
       &:nth-child(2) {
+        width: 15%;
+      }
+
+      &:nth-child(3) {
         width: 15%;
       }
     }

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -166,6 +166,10 @@
             </aside>
             <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
             <input hidden id="filters" value="True" name="filters">
+            {% if vendor_page %}
+            <input hidden value="{{ vendors }}" name="vendor">
+            <input hidden value="True" name="vendor_page">
+            {% endif %}
           </div>
         </nav>
       </div>

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -9,7 +9,11 @@
 
 <form class="form">
   <section class="p-strip--suru-topped">
-    {% if filters != True%}
+    {% if vendor_page %}
+    <div class="u-fixed-width">
+      <h1 class="u-sv3">Ubuntu certified hardware from {{ vendors }}</h1>
+    </div>
+    {% elif filters != True%}
       {% if form == "Desktop" %}
       <div class="row">
         <div class="col-8">
@@ -140,6 +144,7 @@
                     {% endfor %}
                   </section>
                 </li>
+                {% if vendor_page != True %}
                 <li class="p-accordion__group">
                   <div role="heading" aria-level="2" class="p-accordion__heading">
                     <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
@@ -156,6 +161,7 @@
                     {% endfor %}
                   </section>
                 </li>
+                {% endif %}
               </ul>
             </aside>
             <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
@@ -181,13 +187,15 @@
                 {% endif %}
                 {{ total_results }} result{% if total_results != 1 %}s{% endif %}
               </th>
-              <th>type</th>
+              <th>Vendor</th>
+              <th>Type</th>
             </tr>
           </thead>
           <tbody>
             {% for result in results %}
             <tr>
             <td><a href="/certification/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
+            <td><a href="/certification?vendor={{ result.make }}&vendor_page=True">{{ result.make }}</a></td>
             <td>{{ result.category }}</td>
             </tr>
             {% endfor %}

--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -51,8 +51,8 @@
         At the heart of the data centre and a key component to building a hybrid strategy, Dell PowerEdge servers come certified with Ubuntu as the operating system.  Offering the performance and versatility to get the most from your infrastructure, Dell's flexible designs offer a range of options for price, functionality and scalability to meet your workload needs. Those servers can be provisioned with <a href="https://maas.io" class="p-link--external">MAAS</a> for a cloud-like experience and enhanced automation.
       </p>
       <p>
-        <a class="p-button" href="https://certification.ubuntu.com/server/models/?vendors=Dell%20EMC">
-          <span class="p-link--external">
+        <a class="p-button" href="/certification?form=Server&vendor=Dell&vendor_page=True">
+          <span>
             View Dell's certified server options
           </span>
         </a>
@@ -155,7 +155,14 @@
         Edge computing is transforming all sectors from robotics to 5G infrastructure. Ubuntu is the standard for <a href="/internet-of-things">Linux for edge deployments</a>, bringing efficiencies with regular updates, robust security, and enhanced controls. Combine this with Dell Edge Gateways, that are engineered for the extreme environment and can withstand even the harshest of conditions, making them a premium gateway option.
       </p>
       <p>
-        <a class="p-button" href="https://www.dell.com/en-us/work/shop/gateways-embedded-computing/sf/edge-gateway">
+        <a class="p-button" href="/certification?vendor=Dell&text=edge+gateway&vendor_page=True">
+          <span>
+            Ubuntu certified Dell Edge Gateways
+          </span>
+        </a>
+      </p>
+      <p>
+        <a href="https://www.dell.com/en-us/work/shop/gateways-embedded-computing/sf/edge-gateway">
           <span class="p-link--external">
             Learn more about Edge Gateways
           </span>
@@ -164,7 +171,7 @@
       <p>
         <a href="https://www.brighttalk.com/webcast/6793/362197">
           <span class="p-link--external">
-            Watch our "A guide to edge computing" webinars
+            Webinar: A guide to edge computing
           </span>
         </a>
       </p>
@@ -197,8 +204,8 @@
         Dell Linux desktops, laptops and workstations are built with the developer in mind. Powered by Ubuntu they include the tools and libraries needed for a productive cloud, AI and IOT development experience. Over 160 Dell laptop, desktop and workstation models ship with Ubuntu preinstalled for an optimised, secure and constantly updated platform. Ranging from value-priced to premium systems, all options are certified and ship with Ubuntu.
       </p>
       <p>
-        <a class="p-link--external" href="https://certification.ubuntu.com/desktop/models?vendors=Dell">
-          See all Ubuntu certified Dell desktops
+        <a href="/certification?form=Desktop&vendor=Dell&vendor_page=True">
+          See all Ubuntu certified Dell desktops&nbsp;&rsaquo;
         </a>
       </p>
     </div>

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -250,7 +250,7 @@ def certification_home():
             offset=offset,
             limit=limit,
             filters=filters,
-            vendor_page=vendor_page
+            vendor_page=vendor_page,
         )
 
     else:

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -176,6 +176,7 @@ def certification_home():
         limit = request.args.get("limit", default=20, type=int)
         offset = request.args.get("offset", default=0, type=int)
         filters = request.args.get("filters", default=False, type=bool)
+        vendor_page = request.args.get("vendor_page", default=False, type=bool)
 
         selected_forms = request.args.getlist("form")
         if "SoC" in selected_forms:
@@ -249,6 +250,7 @@ def certification_home():
             offset=offset,
             limit=limit,
             filters=filters,
+            vendor_page=vendor_page
         )
 
     else:


### PR DESCRIPTION
## Done

- Add vendor specific view to search results page
- Update links on `/dell` to point to `/certification`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certification
- Search for something to view the search results page
- Click through to the vendor view by clicking the link to the vendor in the table (e.g. Dell or Acer)
- The vendor filters on the left should now not be visible
- The h1 should include the vendor name

## Issue / Card

Fixes [#182](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/182)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/115408958-3a26b800-a1e9-11eb-9320-19221039932c.png)

