### PR TITLE
Update releases.yaml and mascot for 21.04

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -31,16 +31,16 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "21.04": "3ef833828009fb69d5c584f3701d6946f89fa304757b7947e792f9491caa270e *ubuntu-20.10-desktop-amd64.iso"
+    "21.04": "XXXXX *ubuntu-21.04-desktop-amd64.iso"
     "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
   live-server:
-    "21.04": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45 *ubuntu-20.10-live-server-amd64.iso"
+    "21.04": "XXXXX *ubuntu-21.04-live-server-amd64.iso"
     "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "21.04": "2fa19fb53fe0144549ff722d9cd755d9c12fb508bb890926bfe7940c0b3555e8 *ubuntu-20.10-preinstalled-desktop-arm64+raspi.img.xz"
+    "21.04": "XXXXX *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "21.04": "73a98e83fbb6398f86902c7a83c826536f1afbd0be2d80cb0d7faa94ede33137 *ubuntu-20.10-preinstalled-server-arm64+raspi.img.xz"
+    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
     "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "21.04": "941752f93313ba765069b48f38af18bbf961bebefcc9c4296a953cf1260f0fe1 *ubuntu-20.10-preinstalled-server-armhf+raspi.img.xz"
+    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
     "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,10 +1,10 @@
 latest:
-  slug: GroovyGorilla
-  name: "Groovy Gorilla"
-  short_version: "20.10"
-  full_version: "20.10"
-  release_date: "October 2020"
-  eol: "July 2021"
+  slug: HirsuteHippo
+  name: "Hirsute Hippo"
+  short_version: "21.04"
+  full_version: "21.04"
+  release_date: "April 2021"
+  eol: "January 2022"
   past_eol_date: false
 lts:
   slug: FocalFossa
@@ -29,16 +29,16 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "20.10": "3ef833828009fb69d5c584f3701d6946f89fa304757b7947e792f9491caa270e *ubuntu-20.10-desktop-amd64.iso"
+    "21.04": "3ef833828009fb69d5c584f3701d6946f89fa304757b7947e792f9491caa270e *ubuntu-20.10-desktop-amd64.iso"
     "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
   live-server:
-    "20.10": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45 *ubuntu-20.10-live-server-amd64.iso"
+    "21.04": "defdc1ad3af7b661fe2b4ee861fb6fdb5f52039389ef56da6efc05e6adfe3d45 *ubuntu-20.10-live-server-amd64.iso"
     "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "20.10": "2fa19fb53fe0144549ff722d9cd755d9c12fb508bb890926bfe7940c0b3555e8 *ubuntu-20.10-preinstalled-desktop-arm64+raspi.img.xz"
+    "21.04": "2fa19fb53fe0144549ff722d9cd755d9c12fb508bb890926bfe7940c0b3555e8 *ubuntu-20.10-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "20.10": "73a98e83fbb6398f86902c7a83c826536f1afbd0be2d80cb0d7faa94ede33137 *ubuntu-20.10-preinstalled-server-arm64+raspi.img.xz"
+    "21.04": "73a98e83fbb6398f86902c7a83c826536f1afbd0be2d80cb0d7faa94ede33137 *ubuntu-20.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "20.10": "941752f93313ba765069b48f38af18bbf961bebefcc9c4296a953cf1260f0fe1 *ubuntu-20.10-preinstalled-server-armhf+raspi.img.xz"
+    "21.04": "941752f93313ba765069b48f38af18bbf961bebefcc9c4296a953cf1260f0fe1 *ubuntu-20.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"

--- a/releases.yaml
+++ b/releases.yaml
@@ -6,6 +6,7 @@ latest:
   release_date: "April 2021"
   eol: "January 2022"
   past_eol_date: false
+  release_notes_url: "https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221"
 lts:
   slug: FocalFossa
   name: "Focal Fossa"
@@ -14,6 +15,7 @@ lts:
   full_version_desktop: "20.04.2.0"
   release_date: "April 2020"
   eol: "April 2025"
+  release_notes_url: "https://wiki.ubuntu.com/FocalFossa/ReleaseNotes"
 openstack_lts:
   slug: Ussuri
 previous_lts:

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -17,7 +17,7 @@
     <div class="row u-equal-height p-divider u-no-padding--left u-no-padding--right">
       <div class="col-8 p-divider__block">
         <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years, until {{ releases.lts.eol }}, of free security and maintenance updates, guaranteed.</p>
-        <p><a href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
+        <p><a href="{{ releases.lts.release_notes_url }}" class="p-link--external">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
         <p>Recommended system requirements:</p>
         <ul class="p-list is-split">
           <li class="p-list__item is-ticked">2 GHz dual core processor or better</li>
@@ -50,7 +50,7 @@
       <div class="col-8 p-divider__block">
         <p class="u-no-padding--top">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months, until {{ releases.latest.eol }}, of security and maintenance updates.</p>
         <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>.</p>
-        <p><a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
+        <p><a href="{{ releases.latest.release_notes_url }}" class="p-link--external">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
       </div>
       <div class="col-4">
         <p>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -47,14 +47,6 @@
     </div>
   </div>
   <div class="row">
-    <div class="p-heading-icon">
-      <div class="p-heading-icon__header">
-        <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" alt="Find out what's new in Ubuntu 20.10 in our webinar" class="p-heading-icon__img" style="width:64px;">
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/engage/ubuntu-20.10?utm_source=Download&amp;utm_medium=Download&amp;utm_campaign=7013z000001WldOAAS">Find out what's new in Ubuntu 20.10 in our webinar</a></h4>
-      </div>
-    </div>
-  </div>
-  <div class="row">
     <div class="col-12">
       <hr style="margin: 0 0 3rem 0;">
     </div>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -35,12 +35,11 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/817b07bd-GG-FF-download-mascots.svg",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/cae223aa-HH-FF-download-mascots.svg",
         alt="",
-        height="600",
-        width="1382",
+        width="504",
+        height="143",
         hi_def=True,
         loading="auto"
         ) | safe
@@ -64,12 +63,12 @@
     <div class="col-1 u-hide--small u-vertically-center u-align--center">
       {{
         image(
-            url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
-            alt="Ubuntu",
-            width="40",
-            height="40",
-            hi_def=True,
-            loading="auto",
+        url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
+        alt="Ubuntu",
+        width="40",
+        height="40",
+        hi_def=True,
+        loading="auto",
         ) | safe
       }}
     </div>
@@ -82,12 +81,12 @@
     <div class="col-1 u-hide--small u-vertically-center u-align--center">
       {{
         image(
-            url="https://assets.ubuntu.com/v1/08563efa-picto-windows.svg",
-            alt="Windows",
-            width="40",
-            height="40",
-            hi_def=True,
-            loading="auto",
+        url="https://assets.ubuntu.com/v1/08563efa-picto-windows.svg",
+        alt="Windows",
+        width="40",
+        height="40",
+        hi_def=True,
+        loading="auto",
         ) | safe
       }}
     </div>

--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -26,12 +26,12 @@
       <div class="u-hide--small u-align--center">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
-            alt="",
-            height="1500",
-            width="1922",
-            hi_def=True,
-            loading="lazy"
+          url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
+          alt="",
+          height="1500",
+          width="1922",
+          hi_def=True,
+          loading="lazy"
           ) | safe
         }}
       </div>
@@ -109,14 +109,14 @@
       </p>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg",
-          alt="",
-          height="237",
-          width="153",
-          hi_def=True,
-          loading="lazy"
+
+      {{ image (
+        url="https://assets.ubuntu.com/v1/2e66eda7-Hirsuit_Hippo_Colour.svg",
+        alt="",
+        width="300",
+        height="128",
+        hi_def=True,
+        loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -39,7 +39,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <ul class="p-inline-list">
+      <ul class="p-inline-list u-no-margin--bottom">
         <li class="p-inline-list__item">
           <form action="/download/server" method="post" class="p-inline-list__item" style="display: inline">
             <input type="hidden" name="version" value="{{ releases.lts.full_version }}">
@@ -52,6 +52,11 @@
         <li class="p-inline-list__item"><a href="#downloads">Alternative downloads&nbsp;&rsaquo;</a></li>
         <li class="p-inline-list__item"><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></li>
       </ul>
+      <p class="u-sv3">
+        <a href="{{ releases.lts.release_notes_url }}" class="p-link--external">
+          Download Ubuntu Server {{ releases.lts.short_version }} LTS release notes
+        </a>
+      </p>
     </div>
 
   </div>
@@ -95,15 +100,14 @@
         <input type="hidden" name="next-step" value="download">
         <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install - latest', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.latest.full_version }}</button>
       </form>
-
       <p>
-        <a href="https://www.brighttalk.com/webcast/6793/448578?utm_source=brighttalk-portal&utm_medium=web&utm_content=ubuntu%2020.10&utm_campaign=webcasts-search-results-feed" class="p-link--external">
-          Watch the webinar - "What's new in Ubuntu 20.10?"
+        <a href="/engage/ubuntu-21.04-release-webinar?utm_source=brighttalk-portal&utm_medium=web&utm_content=ubuntu%2021.04&utm_campaign=webcasts-server-download">
+          Watch the webinar - "What's new in Ubuntu Server 21.04?"&nbsp;&rsaquo;
         </a>
       </p>
 
       <p>
-        <a href="https://wiki.ubuntu.com/{{ releases.latest.slug }}/ReleaseNotes" class="p-link--external">
+        <a href="{{ releases.latest.release_notes_url }}" class="p-link--external">
           Download Ubuntu Server {{ releases.latest.short_version }} release notes
         </a>
       </p>

--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -107,8 +107,8 @@
       </p>
 
       <p>
-        <a href="{{ releases.latest.release_notes_url }}" class="p-link--external">
-          Download Ubuntu Server {{ releases.latest.short_version }} release notes
+        <a href="{{ releases.latest.release_notes_url }}">
+          Download Ubuntu Server {{ releases.latest.short_version }} release notes&nbsp;&rsaquo;
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- Update releases.yaml and mascot for 21.04
- Added release-notes-urls to releases.yaml

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) 
    - http://0.0.0.0:8001/download - see the new mascot and 20.10 webinar removed
    - http://0.0.0.0:8001/download/desktop - see 21.04 as the latest release
    - http://0.0.0.0:8001/download/alternative-downloads - see 21.04 as a bit torrent option
    - http://0.0.0.0:8001/download/server (manual step 2) - see 21.04 as latest and 21.04 webinar


## Issue / Card

Fixes #9564

## Screenshots

![image](https://user-images.githubusercontent.com/441217/115448792-06ac5380-a212-11eb-9dea-d771558b1210.png)
