### PR TITLE
Update /server for 21.04

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -85,7 +85,11 @@
         <li class="p-list__item is-ticked">Improved settings for battery percentage and microphone mute status</li>
         <li class="p-list__item is-ticked">New photographic and Raspberry Pi themed wallpapers</li>
       </ul>
-      <p><a class="p-link--external" href="https://discourse.ubuntu.com/t/groovy-gorilla-release-notes/15533">Read the full release notes</a></p>
+      <p>
+        <a href="{{ releases.latest.release_notes_url }}">
+          Read the full release notes&nbsp;&rsaquo;
+        </a>
+      </p>
     </div>
   </section>
 
@@ -108,7 +112,11 @@
         <li class="p-list__item is-ticked">LibreOffice 6.4</li>
         <li class="p-list__item is-ticked">nVIDIA hardware is now supported out of the box</li>
       </ul>
-      <p><a class="p-link--external" href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">Read the full release notes</a></p>
+      <p>
+        <a class="p-link--external" href="{{ releases.lts.release_notes_url }}">
+          Read the full release notes
+        </a>
+      </p>
     </div>
   </section>
 

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -19,8 +19,8 @@
         </a>
       </p>
       <p>
-        <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server">
-          Watch the webinar - "Ubuntu 20.04 LTS: What's new in server?"
+        <a class="p-link--inverted" href="/engage/ubuntu-21.04-release-webinar">
+          Watch the webinar - "What's new in Ubuntu Server 21.04?"&nbsp;&rsaquo;
         </a>
       </p>
     </div>
@@ -46,16 +46,16 @@
     </h2>
     <ul class="p-list is-split">
       <li class="p-list__item is-ticked">Supported by Canonical until {{ releases.latest.eol }}</li>
+      <li class="p-list__item is-ticked">Ability to convert Debian Installer (DI) preseed scripts into Ubuntu Server Live Installer artifacts</li>
+      <li class="p-list__item is-ticked">APT phased updates for regressions monitoring and immediate elimination</li>
+      <li class="p-list__item is-ticked">Stability updates to the high availability (HA) stack, including pacemaker and corosync</li>
+      <li class="p-list__item is-ticked">The latest stable Linux 5.11 kernel for the latest hardware and security updates</li>
       <li class="p-list__item is-ticked">Runs on all major architectures - x86-64, ARM v7, ARM64, POWER8, POWER9, IBM s390x (LinuxONE) and RISC-V</li>
-      <li class="p-list__item is-ticked">Nftables-based backend for ufw for improved performance and easier administration</li>
-      <li class="p-list__item is-ticked">Support for OVS schema modelling in Netplan for an advanced networking stack configuration</li>
-      <li class="p-list__item is-ticked">Native configuration for WireGuard VPN in Netplan</li>
-      <li class="p-list__item is-ticked">The latest long-term Linux 5.8 kernel for the latest hardware and security updates</li>
-      <li class="p-list__item is-ticked">Updates to QEMU (5.0), libvirt (6.6), PHP (7.4.9), Apache2 (2.4.46), GCC (1.189), Python (3.8.6), Bind9 (9.16.6)</li>
+      <li class="p-list__item is-ticked">Updates to QEMU (5.2), libvirt (7.0), PHP (7.4.9), Apache2 (2.4.46), nginx (1.18), GCC (1.189), Python (3.9.2), Bind9 (9.16.8)</li>
     </ul>
     <p>
       <a class="p-link--external"
-      href="https://discourse.ubuntu.com/t/groovy-gorilla-release-notes/15533">
+      href="https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221">
       Read more in the release notes
       </a>
     </p>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -55,8 +55,8 @@
     </ul>
     <p>
       <a
-      href="https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221">
-      Read more in the release notes&nbsp;&rsaquo;
+      href="{{ releases.latest.release_notes_url }}">
+        Read more in the release notes&nbsp;&rsaquo;
       </a>
     </p>
   </div>
@@ -83,8 +83,8 @@
     </ul>
     <p>
       <a class="p-link--external"
-      href="https://wiki.ubuntu.com/{{ releases.lts.slug }}/ReleaseNotes">
-      Read more in the release notes
+      href="{{ releases.lts.release_notes_url }}">
+        Read more in the release notes&nbsp;&rsaquo;
       </a>
     </p>
   </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -54,9 +54,9 @@
       <li class="p-list__item is-ticked">Updates to QEMU (5.2), libvirt (7.0), PHP (7.4.9), Apache2 (2.4.46), nginx (1.18), GCC (1.189), Python (3.9.2), Bind9 (9.16.8)</li>
     </ul>
     <p>
-      <a class="p-link--external"
+      <a
       href="https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221">
-      Read more in the release notes
+      Read more in the release notes&nbsp;&rsaquo;
       </a>
     </p>
   </div>


### PR DESCRIPTION
## Done

- Updated the /server page with:
    - new 21.04 webinar
    - new what's new
    - updated release note links on /server and /desktop/developers with variables

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/server and https://0.0.0.0:8001/desktop/developers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the webinar and what's new and release note link are all updated

## Issue / Card

Fixes #9563

## Screenshots

![image](https://user-images.githubusercontent.com/441217/115453570-b20bd700-a217-11eb-8362-e2aed8c58f33.png)
