### PR TITLE
Add a + to the support prices to show it's additional cost

### DIFF
--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -101,7 +101,7 @@ function setSupportCost(state, support) {
   const element = form.querySelector(`#${support}-support-costs`);
   const value = state.product.supportPriceRange[support];
   element.innerHTML = value
-    ? `${formatter.format(value / 100)} per machine per year`
+    ? `+${formatter.format(value / 100)} per machine per year`
     : "";
 }
 


### PR DESCRIPTION
## Done

- Add a + to the support prices to show it's additional cost

## QA

- go to https://ubuntu-com-9584.demos.haus/advantage/subscribe?test_backend=true
- check that there is a + in front of the support price

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4030

