### PR TITLE
Update releases.yaml and mascot for 21.04

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -76,16 +76,18 @@
     </div>
     <div class="u-fixed-width">
       <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Support for the Raspberry Pi 4 with 4GB and 8GB RAM</li>
-        <li class="p-list__item is-ticked">Linux 5.8 kernel</li>
-        <li class="p-list__item is-ticked">GNOME Desktop 3.38 with all the latest features</li>
-        <li class="p-list__item is-ticked">Uniquely generated QR codes for sharing private WiFi hotspots</li>
-        <li class="p-list__item is-ticked">LibreOffice 7.0</li>
-        <li class="p-list__item is-ticked">Thunderbird email client integrated calendar and user friendly PGP encryption</li>
-        <li class="p-list__item is-ticked">Improved settings for battery percentage and microphone mute status</li>
-        <li class="p-list__item is-ticked">New photographic and Raspberry Pi themed wallpapers</li>
+        <li class="p-list__item is-ticked">Redesigned Yaru dark theme is the  default</li>
+        <li class="p-list__item is-ticked">New MIME type icons in the Yaru theme</li>
+        <li class="p-list__item is-ticked">Wayland is the default display server</li>
+        <li class="p-list__item is-ticked">Installer is now using Flutter</li>
+        <li class="p-list__item is-ticked">Active directory integration is included in the installer</li>
+        <li class="p-list__item is-ticked">New power mode option for laptops</li>
+        <li class="p-list__item is-ticked">Recovery key option for encrypted installs</li>
+        <li class="p-list__item is-ticked">Private home directory</li>
+        <li class="p-list__item is-ticked">Linux 5.11 kernel</li>
+        <li class="p-list__item is-ticked">LibreOffice 7.1.2, Python 3.9, Firefox 87, GNOME Desktop 3.38.5</li>
       </ul>
-      <p><a class="p-link--external" href="https://discourse.ubuntu.com/t/groovy-gorilla-release-notes/15533">Read the full release notes</a></p>
+      <p><a class="p-link--external" href="{{ releases.latest.release_notes_url }}">Read the full release notes</a></p>
     </div>
   </section>
 


### PR DESCRIPTION
## Done

- [Wrote](https://docs.google.com/document/d/1VJ3xT2ViC-CvL0UmsAUzpYFmvpuqUP4AbpnlPm8tqOA/edit#) and updated the what's new on /desktop/developers

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/developers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is 21.04 copy and a link to the discourse release notes


## Issue / Card

Fixes #9562

## Screenshots

![image](https://user-images.githubusercontent.com/441217/115559421-9c47f180-a2ab-11eb-9415-95f4550d5a7a.png)
