### PR TITLE
Fix broken state after failed purchase

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -55,16 +55,16 @@
           <h2>Your {% if total_enterprise_contracts > 1 %}{{total_enterprise_contracts}} {% endif %}paid subscription{% if total_enterprise_contracts == 1 %}{% else %}s{% endif %}</h2>
         </div>
       </div>
+      {% if payment_method_warning %}
+        <div class="row">
+          <div class="p-notification--caution">
+            <p class="p-notification__response" role="status">
+              <span class="p-notification__status">Payment method:</span>You need to <a href="/advantage/payment-methods{% if is_test_backend %}?test_backend=true{% endif %}">update your payment methods</a> to ensure there is no interruption to your Ubuntu Advantage subscriptions
+            </p>
+          </div>
+        </div>
+      {% endif %}
       {% if monthly_information['has_monthly'] %}
-        {% if payment_method_warning %}
-          <div class="row">
-            <div class="p-notification--caution">
-              <p class="p-notification__response" role="status">
-                <span class="p-notification__status">Payment method:</span>You need to <a href="/advantage/payment-methods{% if is_test_backend %}?test_backend=true{% endif %}">update your payment methods</a> to ensure there is no interruption to your Ubuntu Advantage subscriptions
-              </p>
-            </div>
-          </div> 
-        {% endif %}
         <div class="row">
           <div class="col-8 col-medium-3">
             <p class="u-no-margin--bottom">Your next recurring payment of <strong><span class="js-format-price">{{monthly_information["next_payment"]["ammount"]}}</span></strong> will be taken on <strong>{{monthly_information["next_payment"]["date"]}}</strong>.</p>

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -74,7 +74,6 @@ def advantage_view(**kwargs):
         all_subscriptions = advantage.get_account_subscriptions(
             account_id=account["id"],
             marketplace="canonical-ua",
-            filters={"status": "active"},
         )
 
         monthly_subscriptions = []
@@ -83,12 +82,14 @@ def advantage_view(**kwargs):
             period = subscription["subscription"]["period"]
             status = subscription["subscription"]["status"]
 
-            # If there are any pending purchase, for monthly (active or locked)
-            # we show the payment method warning.
-            if period == "monthly" and status in ["active", "locked"]:
-                payment_method_warning = subscription.get("pendingPurchases")
+            if status not in ["active", "locked"]:
+                continue
 
-            previous_purchase_ids[period] = subscription["lastPurchaseID"]
+            # If there are any pending purchase for a sub (active or locked)
+            # we show the payment method warning.
+            payment_method_warning = subscription.get("pendingPurchases")
+
+            previous_purchase_ids[period] = subscription.get("lastPurchaseID")
 
             if subscription["subscription"]["period"] == "yearly":
                 yearly_subscriptions.append(subscription)
@@ -97,7 +98,10 @@ def advantage_view(**kwargs):
             monthly_subscriptions.append(subscription)
 
         for subscription in monthly_subscriptions:
-            purchased_products = subscription["purchasedProductListings"]
+            purchased_products = subscription.get("purchasedProductListings")
+            if purchased_products is None:
+                continue
+
             for purchased_product_listing in purchased_products:
                 product_listing = purchased_product_listing["productListing"]
                 product_id = product_listing["productID"]
@@ -111,7 +115,10 @@ def advantage_view(**kwargs):
             _prepare_monthly_info(monthly_info, subscription, advantage)
 
         for subscription in yearly_subscriptions:
-            purchased_products = subscription["purchasedProductListings"]
+            purchased_products = subscription.get("purchasedProductListings")
+            if purchased_products is None:
+                continue
+
             for purchased_product_listing in purchased_products:
                 product_listing = purchased_product_listing["productListing"]
                 product_id = product_listing["productID"]


### PR DESCRIPTION
## Done

- select every single subscription of the account, but filter out the deactivated ones. (locked subscriptions were excluded by mistake)
- both yearly and monthly subscriptions can have a locked status, but before we were only dealing with monthly ones
- if a user encounters payment issues, through resizing or purchasing, the transaction will finish they get redirected to /advantage and the notification saying that a payment issue has happen will show up.

## QA

1.
- Make a new purchase yearly and/or monthly product with this card number: 4000000000000341
- You will reach /advantage and you will see the notification
2.
- Change your default credit card to 4000000000000341
- Then resize a product
- You will reach /advantage and you will see the notification

## Issue / Card

Fixes #9463
