### PR TITLE
Add endpoint to submit marketo forms

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -64,6 +64,16 @@ env:
       key: client-secret
       name: cube-edx
 
+  - name: MARKETO_API_CLIENT
+    secretKeyRef:
+      key: api_client
+      name: marketo
+
+  - name: MARKETO_API_SECRET
+    secretKeyRef:
+      key: api_secret
+      name: marketo
+
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 

--- a/static/js/src/bg-form-submit.js
+++ b/static/js/src/bg-form-submit.js
@@ -165,7 +165,7 @@ const backgroundSubmit = function (marketoForm, submitCallback) {
   }
 
   // get the return url if it exists to redirect users after
-  let return_url = marketoForm.querySelector("input[name=return_url]");
+  let return_url = marketoForm.querySelector("input[name=returnURL]");
   if (return_url != null) {
     return_url = return_url.value;
   }

--- a/static/js/src/bg-form-submit.js
+++ b/static/js/src/bg-form-submit.js
@@ -99,8 +99,7 @@ const backgroundSubmitHandlerClosure = function () {
     const marketoForm = document.getElementById(submitEvent.target.id);
 
     // Change the form's action location
-    marketoForm.action =
-      "https://app-sjg.marketo.com/index.php/leadCapture/save2";
+    marketoForm.action = "/marketo/submit";
 
     // Submit the form in the background
     backgroundSubmit(marketoForm);

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -44,12 +44,12 @@ import { assignMarketoBackgroundSubmit } from "./bg-form-submit";
           formContainer.classList.remove("u-hide");
           formContainer.innerHTML = text
             .replace(/%% formid %%/g, formData.formId)
-            .replace(/%% lpId %%/g, formData.lpId)
-            .replace(/%% returnURL %%/g, formData.returnUrl)
-            .replace(/%% lpurl %%/g, formData.lpUrl);
+            .replace(/%% returnURL %%/g, formData.returnUrl);
+
           setProductContext(contactButton);
           setUTMs();
           setGclid();
+          setFBclid();
           loadCaptchaScript();
           initialiseForm();
         })
@@ -132,15 +132,36 @@ import { assignMarketoBackgroundSubmit } from "./bg-form-submit";
       if (utm_medium) {
         utm_medium.value = params.get("utm_medium");
       }
+
+      var utm_content = document.getElementById("utm_content");
+      if (utm_content) {
+        utm_content.value = params.get("utm_content");
+      }
+
+      var utm_term = document.getElementById("utm_term");
+      if (utm_term) {
+        utm_term.value = params.get("utm_term");
+      }
     }
 
     function setGclid() {
       if (localStorage.getItem("gclid")) {
-        var gclidField = document.getElementById("gclid");
+        var gclidField = document.getElementById("GCLID__c");
         var gclid = JSON.parse(localStorage.getItem("gclid"));
         var isGclidValid = new Date().getTime() < gclid.expiryDate;
         if (gclid && isGclidValid && gclidField) {
           gclidField.value = gclid.value;
+        }
+      }
+    }
+
+    function setFBclid() {
+      if (localStorage.getItem("fbclid")) {
+        var fbclidField = document.getElementById("FBCLID__c");
+        var fbclid = JSON.parse(localStorage.getItem("fbclid"));
+        var fbclidIsValid = new Date().getTime() < fbclid.expiryDate;
+        if (fbclid && fbclidIsValid && fbclidField) {
+          fbclidField.value = fbclid.value;
         }
       }
     }

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -1103,20 +1103,15 @@ function showPayMode() {
 function submitMarketoForm() {
   let request = new XMLHttpRequest();
   let formData = new FormData();
-  formData.append("munchkinId", "066-EOV-335");
   formData.append("formid", 3756);
-  formData.append("formVid", 3756);
-  formData.append("Email", customerInfo.email);
+  formData.append("email", customerInfo.email);
   formData.append("Consent_to_Processing__c", "yes");
   formData.append("GCLID__c", getSessionData("gclid"));
   formData.append("utm_campaign", getSessionData("utm_campaign"));
   formData.append("utm_source", getSessionData("utm_source"));
   formData.append("utm_medium", getSessionData("utm_medium"));
 
-  request.open(
-    "POST",
-    "https://app-sjg.marketo.com/index.php/leadCapture/save2"
-  );
+  request.open("POST", "/marketo/submit");
   request.send(formData);
 
   request.onreadystatechange = () => {

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -4,32 +4,32 @@
   </header>
 
   <div class="blog-p-card__content">
-    <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+    <form action="/marketo/submit" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
       <h3 class="p-card--title p-heading--four">Select topics you're <br />interested in</h3>
 
       <ul class="p-list">
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="true" />
           <label for="insightscloudserver">Cloud and Server</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="true" />
           <label for="insightsdesktop">Desktop</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="true" />
           <label for="insightsiot">Internet of Things</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="Robotics" type="checkbox">
+          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
           <label for="insightsrobotics">Robotics</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="true" type="checkbox">
           <label for="insightstutorials">Tutorials</label>
         </li>
       </ul>
@@ -37,13 +37,13 @@
       <div class="mktFormReq mktField">
         <label>
           <span class="u-no-margin--top">Work email: <span>*</span></span>
-          <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+          <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
         </label>
       </div>
 
       <div class="mktField mktLblRight">
         <span class="mktInput mktLblRight">
-          <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+          <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
           <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
             <small>I agree to receive information about Canonical's products and services.</small>
           </label>
@@ -62,23 +62,15 @@
           <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
         </span>
 
-        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-
-        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-
-        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-
-        <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
         <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-        <input value="1212" class="mktoField mktoFieldDescriptor" name="formVid" type="hidden">
-        <input type="hidden" name="ret" value="{{request.build_absolute_uri}}?newsletter=true" />
-        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-        <input name="kw" value="" type="hidden">
-        <input name="cr" value="" type="hidden">
-        <input name="searchstr" value="" type="hidden">
-        <input name="_mkt_disp" value="return" type="hidden">
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
-        <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
+        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
         <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
       </div>
     </form>

--- a/templates/core/build/index.html
+++ b/templates/core/build/index.html
@@ -239,8 +239,8 @@
         <input type="hidden" name="system" value="" />
         <input type="hidden" name="snaps" value="" />
         <input type="hidden" name="arch" value="" />
-        <input type="hidden" name="FullName" value="{{ user_info.fullname }}" />
-        <input type="hidden" name="Email" value="{{ user_info.email }}" />
+        <input type="hidden" name="fullName" value="{{ user_info.fullname }}" />
+        <input type="hidden" name="email" value="{{ user_info.email }}" />
         <p><button class="p-button--positive js-build-button">Build image</button></p>
       </form>
     </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -166,39 +166,39 @@
         <h4 class="p-muted-heading">Newsletter signup</h4>
         <hr class="u-sv1" />
         <h3 class="p-card--title">Select topics you're interested in</h3>
-        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+        <form action="/marketo/submit" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
           <div class="p-card--content">
             <ul class="p-list">
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="Cloud and server" />
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="true" />
                 <label for="insightscloudserver">Cloud and Server</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="Desktop" />
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="true" />
                 <label for="insightsdesktop">Desktop</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="Internet of Things" />
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="true" />
                 <label for="insightsiot">Internet of Things</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="Robotics" type="checkbox">
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
                 <label for="insightsrobotics">Robotics</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="Tutorials" type="checkbox">
+                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="true" type="checkbox">
                 <label for="insightstutorials">Tutorials</label>
               </li>
             </ul>
             <div class="mktFormReq mktField">
               <label>
                 <span class="u-no-margin--top">Work email: <span>*</span></span>
-                <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+                <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
               </label>
             </div>
             <div class="mktField mktLblRight">
               <span class="mktInput mktLblRight">
-                <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="Receive updates" type="checkbox" />
+                <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
                 <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
                   <small>I agree to receive information about Canonical's products and services.</small>
                 </label>
@@ -215,20 +215,16 @@
               <span class="mktoButtonWrap p-card--content">
                 <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
               </span>
-              <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-              <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden">
-              <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden">
-              <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
               <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
-              <input value="1212" class="mktoField mktoFieldDescriptor" name="formVid" type="hidden">
-              <input type="hidden" name="ret" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
-              <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
-              <input name="kw" value="" type="hidden">
-              <input name="cr" value="" type="hidden">
-              <input name="searchstr" value="" type="hidden">
-              <input name="_mkt_disp" value="return" type="hidden">
-              <input name="_mkt_trk" value="id:066-EOV-335&amp;token:_mch-ubuntu.com-1473266321199-95160" type="hidden">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
               <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
             </div>
           </div>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -127,4 +127,6 @@
 
 {% with first_item="_download_server_installation", second_item="_download_server_guide", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
+<script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer />
+
 {% endblock content %}

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -24,28 +24,28 @@
     <div class="col-5 col-start-large-8">
 
       <!-- MARKETO FORM -->
-      <form class="p-form u-no-margin--top" action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
+      <form class="p-form u-no-margin--top" action="/marketo/submit" method="post" id="mktoForm_1400">
         <fieldset style="border: 1px solid #c0c0c0;">
           <ul class="p-list u-no-margin--bottom">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" aria-label="FirstName" class="mktoLabel">First name: <span>*</span></label>
-              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <label for="firstName" aria-label="FirstName" class="mktoLabel">First name: <span>*</span></label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" aria-label="LastName" class="mktoLabel">Last name: <span>*</span></label>
-              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <label for="lastName" aria-label="LastName" class="mktoLabel">Last name: <span>*</span></label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Company" aria-label="Company" class="mktoLabel">Company name: <span>*</span></label>
-              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <label for="company" aria-label="Company" class="mktoLabel">Company name: <span>*</span></label>
+              <input required id="company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" aria-label="Email" class="mktoLabel">Email address: <span>*</span></label>
-              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              <label for="email" aria-label="Email" class="mktoLabel">Email address: <span>*</span></label>
+              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" aria-label="Phone" class="mktoLabel">Mobile/cell phone number: <span>*</span></label>
-              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+              <label for="phone" aria-label="phone" class="mktoLabel">Mobile/cell phone number: <span>*</span></label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
             </li>
             <li class="mktField p-list__item">
               <label for="NumUbuntuServers__c" aria-label="NumUbuntuServers__c" class="mktoLabel">Number of drawers you are purchasing support for:</label>
@@ -105,21 +105,18 @@
             <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank" rel="noopener noreferrer">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
             <li class="mktField p-list__item">
               <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
+              <input type="hidden" aria-hidden="true" name="formid" class="mktoField " value="1400">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </li>
           </ul>
         </fieldset>
-        <input type="hidden" aria-hidden="true" name="formid" class="mktoField " value="1400">
-        <input type="hidden" aria-hidden="true" name="lpId" class="mktoField " value="2469">
-        <input type="hidden" aria-hidden="true" name="subId" class="mktoField " value="30">
-        <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField " value="066-EOV-335">
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
-        <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}">
-        <input type="hidden" aria-hidden="true" name="cr" class="mktoField " value="">
-        <input type="hidden" aria-hidden="true" name="kw" class="mktoField " value="">
-        <input type="hidden" aria-hidden="true" name="q" class="mktoField " value="">
-        <input type="hidden" aria-hidden="true" name="return_url" value="https://ubuntu.com/download/server/thank-you-s390x" />
-        <input type="hidden" aria-hidden="true" name="returnURL" value="https://ubuntu.com/download/server/thank-you-s390x" />
-        <input type="hidden" aria-hidden="true" name="retURL" value="https://ubuntu.com/download/server/thank-you-s390x" />
+        <input type="hidden" aria-hidden="true" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
       </form>
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -30,28 +30,28 @@
 
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1917" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_1917" class="marketo-form">
         <fieldset style="border: 0;">
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
               <label for="firstName" class="mktoLabel">First name:</label>
-              <input required  id="firstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" >
+              <input required  id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" >
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="lastName" class="mktoLabel">Last name:</label>
-              <input required  id="lastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired">
+              <input required  id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="company" class="mktoLabel">Company Name:</label>
-              <input required  id="company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired">
+              <input required  id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel ">Work email address:</label>
-              <input required  id="email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+              <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required  id="phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired mktoInvalid">
+              <input required  id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired mktoInvalid">
             </li>
             {% include "shared/forms/_country.html" %}
             {% include "shared/forms/_state.html" %}
@@ -71,18 +71,21 @@
             <li class="mktField p-list__item">
               <button type="submit" class="mktoButton p-button--positive">Download the white paper</button>
               <input type="hidden" name="formid" class="mktoField" value="1917">
-              <input type="hidden" name="formVid" class="mktoField" value="1917">
-              <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
               <input type="hidden" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" name="download_asset_url" value="https://assets.ubuntu.com/v1/fe2cb442-IoTSecurityWhitepaper-FinalReport.zip" aria-label="">
               <input type="hidden" name="thankyoumessage" value="Thank you<br />Enjoy the ebook!" aria-lable="">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>
           </ul>
       </fieldset>
       <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/IoTSecurityWhitepaper-Fullreport.html" />
-      <input type="hidden" name="retURL" value="https://pages.ubuntu.com/IoTSecurityWhitepaper-Fullreport.html" />
       </form>
     </div>
   </div>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -34,21 +34,21 @@
 
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1862" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_1862" class="marketo-form">
         <fieldset style="border: 0;">
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
               <label for="1-FirstName" class="mktoLabel">First name:</label>
-              <input required id="1-FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <input required id="1-FirstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="1-LastName" class="mktoLabel">Last name:</label>
-              <input required id="1-LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <input required id="1-LastName" name="lastName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
               <label for="1-Company" class="mktoLabel">Company name:</label>
-              <input required id="1-Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <input required id="1-Company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
@@ -58,14 +58,14 @@
 
             <li class="mktFormReq mktField p-list__item">
               <label for="1-Email" class="mktoLabel">Email:</label>
-              <input required id="1-Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              <input required id="1-Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
             </li>
 
             {% include "shared/forms/_country.html" %}
 
             <li class="mktFormReq mktField p-list__item">
               <label for="1-Phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="1-Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+              <input required id="1-Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
             </li>
 
             <li class="mktField p-list__item">
@@ -80,19 +80,21 @@
             <li class="mktField p-list__item">
               <button type="submit" class="p-button--positive mktoButton" aria-label="Submit">Download the eBook</button>
               <input type="hidden" name="formid" class="mktoField " value="1862" aria-label="">
-              <input type="hidden" name="formVid" class="mktoField " value="1862" aria-label="">
-              <input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335" aria-label="">
-              <input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/LP-MAAS_eBook.html" aria-label="">
               <input type="hidden" name="download_asset_url" value="https://assets.ubuntu.com/v1/05f610df-eBook_MAAS.pdf.zip" aria-label="">
               <input type="hidden" name="thankyoumessage" value="Thank you<br />Enjoy the ebook!" aria-lable="">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>
           </ul>
         </fieldset>
 
         <input type="hidden" name="returnURL" value="{{ return_url }}" aria-label="" />
-        <input type="hidden" name="retURL" value="{{ return_url }}" aria-label="" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" aria-label="" />
       </form>
       <!-- /MARKETO FORM -->

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -52,8 +52,8 @@
             </li>
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="Title" class="mktoLabel">Job title:</label>
-              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="title" class="mktoLabel">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
 
             <li class="mktFormReq mktField p-list__item">

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -4,36 +4,40 @@
       <h2 class="p-modal__title" id="modal-title">Get Ubuntu Server pro tips</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
     </header>
-    <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3485" class="marketo-form">
+    <form action="/marketo/submit" method="post" id="mktoForm_3485" class="marketo-form">
       <div class="row u-no-padding">
         <div class="col-6">
           <label for="firstName" class="mktoLabel">First name:</label>
-          <input required  id="firstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" >
+          <input required  id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" >
           <label for="lastName" class="mktoLabel">Last name:</label>
-          <input required  id="lastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired">
+          <input required  id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired">
           <label for="company" class="mktoLabel">Company name:</label>
-          <input required  id="company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired">
+          <input required  id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
         </div>
         <div class="col-6">
           <label for="title" class="mktoLabel">Job title:</label>
           <input required  id="title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired">
           <label for="email" class="mktoLabel ">Work email:</label>
-          <input required  id="email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
-          <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-          <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+          <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+          <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+          <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
         </div>
       </div>
-      <input class="mktoField" value="yes" id="CanonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-      <label class="mktoLabel mktoHasWidth" for="CanonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
+      <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+      <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
       <p><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></p>
       <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       <button type="submit" class="mktoButton p-button--positive">Download the pro tips</button>
       <input type="hidden" name="formid" class="mktoField" value="3485">
-      <input type="hidden" name="formVid" class="mktoField" value="3485">
-      <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
       <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
-      <input type="hidden" name="return_url" value="https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf" />
     </form>
   </div>
 </div>

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -16,7 +16,7 @@
         </div>
         <div class="col-6">
           <label for="title" class="mktoLabel">Job title:</label>
-          <input required  id="title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired">
+          <input required  id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired">
           <label for="email" class="mktoLabel ">Work email:</label>
           <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
           <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -19,8 +19,8 @@
         <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Title" class="mktoLabel ">Tätigkeitsbezeichnung:</label>
-        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+        <label for="title" class="mktoLabel ">Tätigkeitsbezeichnung:</label>
+        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField">
         <label for="phone" class="mktoLabel ">Handynummer:</label>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,30 +1,30 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list u-no-margin--bottom">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel ">Vorname:</label>
-        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name">
+        <label for="firstName" class="mktoLabel ">Vorname:</label>
+        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="LastName" class="mktoLabel ">Nachname:</label>
-        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
+        <label for="lastName" class="mktoLabel ">Nachname:</label>
+        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Email" class="mktoLabel ">Email beruflich:</label>
-        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
+        <label for="email" class="mktoLabel ">Email beruflich:</label>
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Company" class="mktoLabel ">Name des Unternehmens:</label>
-        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
+        <label for="company" class="mktoLabel ">Name des Unternehmens:</label>
+        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField">
         <label for="Title" class="mktoLabel ">Tätigkeitsbezeichnung:</label>
         <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Phone" class="mktoLabel ">Handynummer:</label>
-        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
+        <label for="phone" class="mktoLabel ">Handynummer:</label>
+        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
       </li>
       <li class="mktField">
         <input name="utm_campaign" class="mktoField mktoFormCol" value="{{utm_campaign}}" type="hidden" aria-label="utm_campaign">
@@ -51,14 +51,15 @@
       </li>
       <li class="mktField">
         <button type="submit" class="mktoButton">eBook herunterladen</button>
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" class="mktoField" value="{{ id }}" type="hidden" aria-label="formid">
-        <input name="formVid" class="mktoField" value="{{ id }}" type="hidden" aria-label="formVid">
         <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="returnURL">
-        <input type="hidden" name="retURL" value="{{ returnURL }}" aria-label="retURL">
-        <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="return_url">
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,25 +1,25 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel">First Name:</label>
-        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="firstName" class="mktoLabel">First Name:</label>
+        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="First Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="LastName" class="mktoLabel ">Last Name:</label>
-        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="lastName" class="mktoLabel ">Last Name:</label>
+        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Last Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Email" class="mktoLabel ">Work email:</label>
-        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <label for="email" class="mktoLabel ">Work email:</label>
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Company" class="mktoLabel ">Company Name:</label>
-        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="company" class="mktoLabel ">Company Name:</label>
+        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField">
@@ -27,8 +27,8 @@
         <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+        <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
           aria-label="Phone Number">
       </li>
       <li class="mktField">
@@ -59,13 +59,15 @@
       </li>
       <li class="mktField">
         <button type="submit" class="mktoButton u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
-        <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -23,8 +23,8 @@
           aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Title" class="mktoLabel ">Job Title:</label>
-        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+        <label for="title" class="mktoLabel ">Job Title:</label>
+        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField">
         <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,25 +1,25 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel">Nombre:</label>
-        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="firstName" class="mktoLabel">Nombre:</label>
+        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Nombre">
       </li>
       <li class="mktFormReq mktField">
-        <label for="LastName" class="mktoLabel ">Apellido:</label>
-        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="lastName" class="mktoLabel ">Apellido:</label>
+        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Apellido">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Email" class="mktoLabel ">E-mail de trabajo:</label>
-        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <label for="email" class="mktoLabel ">E-mail de trabajo:</label>
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
           aria-label="E-mail de trabajo">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Company" class="mktoLabel ">Nombre de la compañía:</label>
-        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="company" class="mktoLabel ">Nombre de la compañía:</label>
+        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Nombre de la compañía">
       </li>
       <li class="mktFormReq mktField">
@@ -27,8 +27,8 @@
         <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Título del puesto de trabajo">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Phone" class="mktoLabel ">Número del teléfono móvil/celular:</label>
-        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+        <label for="phone" class="mktoLabel ">Número del teléfono móvil/celular:</label>
+        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
           aria-label="Número de teléfono">
       </li>
       <li class="mktField">
@@ -58,13 +58,15 @@
       </li>
       <li class="mktField">
         <button type="submit" class="mktoButton u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descargar el documento técnico{% endif %}</button>
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
-        <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -23,8 +23,8 @@
           aria-label="Nombre de la compañía">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Title" class="mktoLabel ">Título del puesto de trabajo:</label>
-        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Título del puesto de trabajo">
+        <label for="title" class="mktoLabel ">Título del puesto de trabajo:</label>
+        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Título del puesto de trabajo">
       </li>
       <li class="mktFormReq mktField">
         <label for="phone" class="mktoLabel ">Número del teléfono móvil/celular:</label>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -23,8 +23,8 @@
         <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Title" class="mktoLabel">Votre fonction ou poste:</label>
-        <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+        <label for="title" class="mktoLabel">Votre fonction ou poste:</label>
+        <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
         <label for="Comments_from_lead__c" class="mktoLabel">Décrivez vos besoins de support :</label>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -1,26 +1,26 @@
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{ id }}" class="marketo-form" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" class="marketo-form" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset>
     <h3>Prenons contact</h3>
     <ul class="p-list u-no-margin--bottom">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel">Prénom :</label>
-        <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+        <label for="firstName" class="mktoLabel">Prénom :</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="LastName" class="mktoLabel">Nom :</label>
-        <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+        <label for="lastName" class="mktoLabel">Nom :</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Email" class="mktoLabel">Adresse électronique professionnelle :</label>
-        <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+        <label for="email" class="mktoLabel">Adresse électronique professionnelle :</label>
+        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Phone" class="mktoLabel">N° de téléphone portable:</label>
-        <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+        <label for="phone" class="mktoLabel">N° de téléphone portable:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Company" class="mktoLabel">Société :</label>
-        <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+        <label for="company" class="mktoLabel">Société :</label>
+        <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
         <label for="Title" class="mktoLabel">Votre fonction ou poste:</label>
@@ -46,14 +46,15 @@
       </li>
     </ul>
     <!-- hidden fields -->
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ id }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{ id }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{ returnURL }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{ returnURL }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
   </fieldset>
 </form>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -23,8 +23,8 @@
           aria-label="Nome società">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Title" class="mktoLabel ">Titolo lavorativo:</label>
-        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Titolo lavorativo">
+        <label for="title" class="mktoLabel ">Titolo lavorativo:</label>
+        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Titolo lavorativo">
       </li>
       <li class="mktFormReq mktField">
         <label for="phone" class="mktoLabel ">Numero di telefono:</label>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,25 +1,25 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel">Nome:</label>
-        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="firstName" class="mktoLabel">Nome:</label>
+        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Nome">
       </li>
       <li class="mktFormReq mktField">
-        <label for="LastName" class="mktoLabel ">Cognome:</label>
-        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="lastName" class="mktoLabel ">Cognome:</label>
+        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Cognome">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Email" class="mktoLabel ">E-mail lavorativa:</label>
-        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <label for="email" class="mktoLabel ">E-mail lavorativa:</label>
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
           aria-label="E-mail lavorativa">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Company" class="mktoLabel ">Nome società:</label>
-        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="company" class="mktoLabel ">Nome società:</label>
+        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Nome società">
       </li>
       <li class="mktFormReq mktField">
@@ -27,8 +27,8 @@
         <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Titolo lavorativo">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Phone" class="mktoLabel ">Numero di telefono:</label>
-        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+        <label for="phone" class="mktoLabel ">Numero di telefono:</label>
+        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
           aria-label="Numero di telefono">
       </li>
       <li class="mktField">
@@ -58,13 +58,15 @@
       </li>
       <li class="mktField">
         <button type="submit" class="mktoButton u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Scarica il whitepaper{% endif %}</button>
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
-        <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -23,8 +23,8 @@
           aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Title" class="mktoLabel ">Titulo do trabalho:</label>
-        <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+        <label for="title" class="mktoLabel ">Titulo do trabalho:</label>
+        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField">
         <label for="phone" class="mktoLabel ">Telemóvel:</label>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,25 +1,25 @@
 <!-- MARKETO FORM -->
-<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel">Primeiro Nome:</label>
-        <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="firstName" class="mktoLabel">Primeiro Nome:</label>
+        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="First Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="LastName" class="mktoLabel ">Último Nome:</label>
-        <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="lastName" class="mktoLabel ">Último Nome:</label>
+        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Last Name">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Email" class="mktoLabel ">Email do trabalho:</label>
-        <input required id="Email" name="Email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <label for="email" class="mktoLabel ">Email do trabalho:</label>
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Company" class="mktoLabel ">Nome da Empresa:</label>
-        <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
+        <label for="company" class="mktoLabel ">Nome da Empresa:</label>
+        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField">
@@ -27,8 +27,8 @@
         <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField">
-        <label for="Phone" class="mktoLabel ">Telemóvel:</label>
-        <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+        <label for="phone" class="mktoLabel ">Telemóvel:</label>
+        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
           aria-label="Phone Number">
       </li>
       <li class="mktField">
@@ -58,13 +58,15 @@
       </li>
       <li class="mktField">
         <button type="submit" class="mktoButton u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descarregue o documento{% endif %}</button>
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
         <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
-        <input name="formVid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" name="retURL" aria-label="retURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/gov/form.html
+++ b/templates/gov/form.html
@@ -168,23 +168,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Work phone:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Work phone:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -203,23 +203,17 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/internet-of-things/edgex.html
+++ b/templates/internet-of-things/edgex.html
@@ -113,14 +113,14 @@
           }
         </style>
         <p class="p-heading--four" id="subscribe">Subscribe to our monthly newsletter</p>
-        <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post" id="mktoForm_3415" class="p-form--stacked">
+        <form action="/marketo/submit" method="post" id="mktoForm_3415" class="p-form--stacked">
           <div class="p-form__group">
-            <label for="Email">Email:*</label>
-            <input class="u-no-margin--bottom" id="Email" placeholder="Email" name="Email" maxlength="255" type="email" required="">
+            <label for="email">Email:*</label>
+            <input class="u-no-margin--bottom" id="email" placeholder="Email" name="email" maxlength="255" type="email" required="">
           </div>
           <div class="p-form__group">
-            <label for="Company">Company:</label>
-            <input class="u-no-margin--bottom" id="Company" placeholder="Company (optional)" name="Company" maxlength="255" type="text">
+            <label for="company">Company:</label>
+            <input class="u-no-margin--bottom" id="company" placeholder="Company (optional)" name="company" maxlength="255" type="text">
           </div>
 
           <p>
@@ -137,15 +137,14 @@
 
           <input type="hidden" name="formid" value="3690">
           <input type="hidden" name="edgeXblogsubscription" value="yes">
-          <input type="hidden" name="lpId" value="">
-          <input type="hidden" name="munchkinId" value="066-EOV-335">
-          <input type="hidden" name="lpurl" value="">
-          <input type="hidden" name="ret" value="https://ubuntu.com/internet-of-things/edgex#subscribed">
-          <input type="hidden" name="return_url" value="https://ubuntu.com/internet-of-things/edgex#subscribed">
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
-          <input type="hidden" name="cr" value="">
-          <input type="hidden" name="kw" value="">
-          <input type="hidden" name="q" value="">
+          <input type="hidden" name="returnURL" value="/internet-of-things/edgex#subscribed">
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
         </form>
       </div>
 

--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -27,32 +27,32 @@
     </div>
     <div class="col-4 col-start-large-8">
       <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_2542" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_2542" class="marketo-form">
         <ul class="p-list">
           <li class="mktFormReq mktField p-list__item">
             <label for="3-FirstName" class="mktoLabel">First name:</label>
-            <input required id="3-FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <input required id="3-FirstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
           </li>
           <li class="mktFormReq mktField p-list__item">
             <label for="3-LastName" class="mktoLabel">Last name:</label>
-            <input required id="3-LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <input required id="3-LastName" name="lastName" maxlength="255" type="text" class="mktoField   mktoRequired">
           </li>
 
           <li class="mktFormReq mktField p-list__item">
             <label for="3-Company" class="mktoLabel">Company name:</label>
-            <input required id="3-Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <input required id="3-Company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
           </li>
 
           <li class="mktFormReq mktField p-list__item">
             <label for="3-Email" class="mktoLabel">Email:</label>
-            <input required id="3-Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+            <input required id="3-Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
           </li>
 
           {% include "shared/forms/_country.html" %}
 
           <li class="mktFormReq mktField p-list__item">
             <label for="3-Phone" class="mktoLabel">Mobile/cell phone number:</label>
-            <input required id="3-Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+            <input required id="3-Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
           </li>
 
           <li class="mktField p-list__item">
@@ -65,18 +65,20 @@
           <li class="mktField p-list__item">
             <button type="submit" class="p-button--positive mktoButton" aria-label="Submit">Get the whitepaper</button>
             <input type="hidden" name="formid" class="mktoField " value="2542" aria-label="">
-            <input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335" aria-label="">
-            <input type="hidden" name="lpurl" class="mktoField " value="https://pages.ubuntu.com/ty-container-whitepaper.html?cr={creative}&amp;kw={keyword}" aria-label="">
             <input type="hidden" name="thankyoumessage" value="Thank you<br />Enjoy the ebook!" aria-lable="">
           </li>
           <li><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></li>
         </ul>
 
         <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
-        <input type="hidden" name="retURL" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
-        <input type="hidden" name="return_url" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" aria-label="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </form>
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -30,38 +30,38 @@
     </div>
     <div class="col-6">
       <!-- MARKETO FORM -->
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3285" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_3285" class="marketo-form">
         <fieldset>
           <ul class="p-list">
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel ">First name:</label>
-              <input required="" id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <label for="firstName" class="mktoLabel ">First name:</label>
+              <input required="" id="firstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel ">Last name:</label>
-              <input required="" id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired">
+              <label for="lastName" class="mktoLabel ">Last name:</label>
+              <input required="" id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="Company" class="mktoLabel ">Company:</label>
-              <input required="" id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired">
+              <label for="company" class="mktoLabel ">Company:</label>
+              <input required="" id="company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel ">Email:</label>
-              <input required="" id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              <label for="email" class="mktoLabel ">Email:</label>
+              <input required="" id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="Title" class="mktoLabel ">Title:</label>
-              <input required="" id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoTelField  mktoRequired">
+              <label for="title" class="mktoLabel ">Title:</label>
+              <input required="" id="title" name="title" maxlength="255" type="text" class="mktoField mktoTelField  mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-              <input required="" id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+              <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+              <input required="" id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
             </li>
 
             <li  class="p-list__item mktFormReq mktField">
@@ -97,18 +97,15 @@
           </ul>
         </fieldset>
 
-        <input type="hidden" name="lpId" value="6404" />
-        <input type="hidden" name="subId" value="30" />
-        <input type="hidden" name="lpurl" value="//pages.ubuntu.com/Contact_Us_Ubuntu_RFI_Contact-us-form.html?cr={creative}&kw={keyword}" />
         <input type="hidden" name="formid" value="3285" />
-        <input type="hidden" name="ret" value="https://ubuntu.com/openstack/thank-you?product=rfp" />
-        <input type="hidden" name="munchkinId" value="066-EOV-335"/>
-        <input type="hidden" name="kw" value=""/>
-        <input type="hidden" name="cr" value=""/>
-        <input type="hidden" name="searchstr" value=""/>
-        <input type="hidden" name="_mkt_disp" value="return"/>
-        <input type="hidden" name="_mkt_trk" value=""/>
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" name="returnURL" value="/openstack/thank-you?product=rfp" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </form>
 
     <!-- /MARKETO FORM -->

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -39,8 +39,8 @@
               <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Title" class="mktoLabel">Job title:</label>
-              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="title" class="mktoLabel">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
 
           </ul>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -7,25 +7,25 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{formid}}">
+      <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
           <h3>About you</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">First name:</label>
-              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="firstName" class="mktoLabel">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">Last name:</label>
-              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="lastName" class="mktoLabel">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">Email address:</label>
-              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <label for="email" class="mktoLabel">Email address:</label>
+              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+              <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
             </li>
             {% include "shared/forms/_country.html" %} {% include "shared/forms/_state.html" %}
           </ul>
@@ -35,8 +35,8 @@
           <h3>About your company</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="Company" class="mktoLabel">Company:</label>
-              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="company" class="mktoLabel">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Title" class="mktoLabel">Job title:</label>
@@ -65,21 +65,16 @@
               <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{lpId}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/things-contact-us.html?cr={creative}&amp;kw={keyword}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -43,8 +43,8 @@
               <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Title" class="mktoLabel">Ihre Position/Verantwortungsbereich:</label>
-              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="title" class="mktoLabel">Ihre Position/Verantwortungsbereich:</label>
+              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
           </ul>
         </fieldset>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -9,25 +9,25 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{formid}}">
+      <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
           <h3>Über Sie</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">Vorname:</label>
-              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="firstName" class="mktoLabel">Vorname:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">Nachname:</label>
-              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="lastName" class="mktoLabel">Nachname:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">Email-Adresse:</label>
-              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <label for="email" class="mktoLabel">Email-Adresse:</label>
+              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel">Handynummer:</label>
-              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+              <label for="phone" class="mktoLabel">Handynummer:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
             </li>
             <!-- country -->
             {% with country='Land' %}{% include "shared/forms/_country.html" %}{% endwith %}
@@ -39,8 +39,8 @@
           <h3>Über Ihr Unternehmen</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="Company" class="mktoLabel">Name des Unternehmens:</label>
-              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="company" class="mktoLabel">Name des Unternehmens:</label>
+              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Title" class="mktoLabel">Ihre Position/Verantwortungsbereich:</label>
@@ -73,19 +73,15 @@
           </ul>
           <!-- hidden fields -->
           <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="{{formid}}" aria-label="formid" />
-          <input type="hidden" aria-hidden="true" name="formVid" class="mktoField" value="{{formid}}" aria-label="formid" />
-          <input type="hidden" aria-hidden="true" name="lpId" class="mktoField" value="{{lpId}}" aria-label="lpId" />
-          <input type="hidden" aria-hidden="true" name="subId" class="mktoField" value="30" aria-label="subId" />
-          <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField" value="066-EOV-335" aria-label="munchkinId" />
-          <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" aria-label="lpurl" />
-          <input type="hidden" aria-hidden="true" name="cr" class="mktoField" value="" aria-label="cr" />
-          <input type="hidden" aria-hidden="true" name="kw" class="mktoField" value="" aria-label="kw" />
-          <input type="hidden" aria-hidden="true" name="q" class="mktoField" value="" aria-label="q" />
           <input type="hidden" aria-hidden="true" name="returnURL" value="{{returnURL}}" aria-label="returnURL" />
-          <input type="hidden" aria-hidden="true" name="retURL" value="{{returnURL}}" aria-label="retURL" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" aria-label="Consent_to_Processing__c" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -7,25 +7,25 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{formid}}">
+      <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
           <h3>About you</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">First name:</label>
-              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="firstName" class="mktoLabel">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">Last name:</label>
-              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="lastName" class="mktoLabel">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">Email address:</label>
-              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <label for="email" class="mktoLabel">Email address:</label>
+              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+              <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
             </li>
             <!-- country -->
             {% include "shared/forms/_country.html" %}
@@ -37,8 +37,8 @@
           <h3>About your company</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="Company" class="mktoLabel">Company name:</label>
-              <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="company" class="mktoLabel">Company name:</label>
+              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Title" class="mktoLabel">Job title:</label>
@@ -76,20 +76,16 @@
             </li>
           </ul>
           <!-- hidden fields -->
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -41,8 +41,8 @@
               <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Title" class="mktoLabel">Job title:</label>
-              <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="title" class="mktoLabel">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
           </ul>
         </fieldset>

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -7,21 +7,21 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_{{formid}}">
+      <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
           <h3>About you</h3>
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">First name:</label>
-              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="firstName" class="mktoLabel">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">Last name:</label>
-              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <label for="lastName" class="mktoLabel">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">Email address:</label>
-              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <label for="email" class="mktoLabel">Email address:</label>
+              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
             </li>
           </ul>
         </fieldset>
@@ -46,21 +46,16 @@
             </li>
           </ul>
           <!-- hidden fields -->
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{lpId}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="{{returnURL}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="return_url" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -1,10 +1,10 @@
 <div class="col-4 p-divider__block">
-  <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
+  <form class="mktoForm mktoNoJS" action="/marketo/submit" method="post">
     <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
     <ul class="p-list mktoFormRow u-clearfix">
       <li class="mktoFormCol p-list__item">
-        <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-        <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
+        <label class="u-off-screen mktoLabel" for="email">Your email</label>
+        <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="email" id="email" required />
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">
@@ -16,21 +16,17 @@
         <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
       </li>
       <li class="p-list__item">
-        <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
         <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input value="1959" class="mktoField mktoFieldDescriptor" name="lpId" type="hidden" />
-        <input value="30" class="mktoField mktoFieldDescriptor" name="subId" type="hidden" />
-        <input type="hidden" name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" />
         <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
-        <input type="hidden" name="ret" value="https://ubuntu.com/openstack/newsletter-thank-you" />
-        <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
-        <input type="hidden" name="kw" value="" />
-        <input type="hidden" name="cr" value="" />
-        <input type="hidden" name="searchstr" value="" />
-        <input type="hidden" name="_mkt_disp" value="return" />
-        <input type="hidden" name="_mkt_trk" value="" />
+        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" name="returnURL" value="/openstack/newsletter-thank-you" />
       </li>
     </ul>
   </form>

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -1,12 +1,12 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">IoT newsletter</h3>
   <!-- MARKETO FORM -->
-  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1670" class="marketo-form">
+  <form action="/marketo/submit" method="post" id="mktoForm_1670" class="marketo-form">
     <p>Receive regular updates from our IoT newsletter.</p>
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="Email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+        <label for="email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
+        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">
@@ -22,16 +22,16 @@
       <li class="mktField p-list__item">
         <button type="submit" class="mktoButton p-button--neutral">Submit</button>
         <input type="hidden" name="formid" class="mktoField" value="1670">
-        <input type="hidden" name="formVid" class="mktoField" value="1670">
-        <input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335">
-        <input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/Opt-In_IoTNewsletters.html?cr={creative}&amp;kw={keyword}">
-        <input type="hidden" name="source" class="mktoField  mktoFormCol" value="ubuntu.com">
-        <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True">
-        <input type="hidden" name="returnURL" value="https://ubuntu.com/internet-of-things/thank-you?product=newsletter" />
-        <input type="hidden" name="retURL" value="https://ubuntu.com/internet-of-things/thank-you?product=newsletter" />
-        <input type="hidden" name="return_url" value="https://ubuntu.com/internet-of-things/thank-you?product=newsletter" />
+        <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="true">
+        <input type="hidden" name="returnURL" value="/internet-of-things/thank-you?product=newsletter" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </form>

--- a/templates/shared/contextual_footers/_kubeflow_news_signup.html
+++ b/templates/shared/contextual_footers/_kubeflow_news_signup.html
@@ -1,12 +1,12 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Kubeflow news</h3>
   <!-- MARKETO FORM -->
-  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_3415" class="marketo-form">
+  <form action="/marketo/submit" method="post" id="mktoForm_3415" class="marketo-form">
     <p>Subscribe to our newsletter and get a weekly update of <a class="p-link--external" href="https://kubeflow-news.com/">Kubeflow news</a> from across the web.</p>
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="Email" class="mktoLabel contextual-footer__text--label">Work email:</label>
-        <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+        <label for="email" class="mktoLabel contextual-footer__text--label">Work email:</label>
+        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="p-list__item u-no-margin--top">
         <p>
@@ -23,10 +23,13 @@
     <div>
       <input type="hidden" name="Consent_to_Processing__c" value="Yes">
       <input type="hidden" name="formid" value="3415">
-      <input type="hidden" name="formVid" value="3415">
-      <input type="hidden" name="lpId" value="">
-      <input type="hidden" name="munchkinId" value="066-EOV-335">
-      <input type="hidden" name="lpurl" value="">
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
     </div>
   </form>

--- a/templates/shared/contextual_footers/_robotics_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_robotics_newsletter_signup.html
@@ -1,7 +1,7 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Robotics newsletter</h3>
   <!-- MARKETO FORM -->
-  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1212" class="marketo-form">
+  <form action="/marketo/submit" method="post" id="mktoForm_1212" class="marketo-form">
     <p>Receive regular updates from our Robotics newsletter.</p>
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
@@ -25,18 +25,16 @@
       <li class="mktField p-list__item">
         <button type="submit" class="mktoButton p-button--neutral">Submit</button>
         <input type="hidden" name="formid" value="1212">
-        <input type="hidden" name="formVid" value="1212">
-        <input type="hidden" name="lpId" value="1959">
-        <input type="hidden" name="subId" value="30">
-        <input type="hidden" name="munchkinId" value="066-EOV-335">
-        <input type="hidden" name="lpurl" value="//pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&kw={keyword}">
-        <input type="hidden" name="source" value="ubuntu.com">
-        <input type="hidden" name="insightsrobotics" value="Robotics">
-        <input type="hidden" name="returnURL" value="https://ubuntu.com/robotics/thank-you?product=newsletter" />
-        <input type="hidden" name="retURL" value="https://ubuntu.com/robotics/thank-you?product=newsletter" />
-        <input type="hidden" name="return_url" value="https://ubuntu.com/robotics/thank-you?product=newsletter" />
+        <input type="hidden" name="insightsrobotics" value="true">
+        <input type="hidden" name="returnURL" value="/robotics/thank-you?product=newsletter" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
       </li>
     </ul>
   </form>

--- a/templates/shared/forms/_country.html
+++ b/templates/shared/forms/_country.html
@@ -1,11 +1,11 @@
 {% if raw != "true" %}
 <li class="mktFormReq mktField p-list_">
-  <label for="Country" class="mktoLabel">{{ country or 'Country' }}:</label>
+  <label for="country" class="mktoLabel">{{ country or 'Country' }}:</label>
   {% endif %}
   <select
     required
-    id="Country"
-    name="Country"
+    id="country"
+    name="country"
     class="mktoField mktoRequired mktoValid"
   >
     <option value="">Select...</option

--- a/templates/shared/forms/_state.html
+++ b/templates/shared/forms/_state.html
@@ -1,10 +1,10 @@
 <li class="mktoPlaceholder mktoPlaceholderState mktoPlaceholderState--CA p-list__item">
-    <label for="State" class="mktoPlaceholderState__label mktoLabel mktoHasWidth">
+    <label for="state" class="mktoPlaceholderState__label mktoLabel mktoHasWidth">
         <span class="mktoPlaceholderState__label--CA">Province:</span>
         <span class="mktoPlaceholderState__label--US">State:</span>
     </label>
 
-    <select id="State" name="State" class="mktoField mktoRequired mktFReq mktoPlaceholderState__group">
+    <select id="state" name="state" class="mktoField mktoRequired mktFReq mktoPlaceholderState__group">
         <optgroup class="mktoPlaceholderState__group--CA" label="Select Province" value="SelectProvince">
             <option value="AB">Alberta</option><option value="BC">British Columbia</option><option value="MB">Manitoba</option><option value="NB">New Brunswick</option><option value="NF">Newfoundland</option><option value="NT">Northwest Territories</option><option value="NS">Nova Scotia</option><option value="NU">Nunavut</option><option value="ON">Ontario</option><option value="PE">Prince Edward Island</option><option value="QC">Quebec</option><option value="SK">Saskatchewan</option><option value="YT">Yukon Territory</option>
         </optgroup>

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -120,19 +120,19 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -152,24 +152,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -1,0 +1,177 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title  u-sv1" id="modal-title">Register your interest for the Ubuntu Pro on-prem beta</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <p>In 2020, Canonical launched Ubuntu Pro for comprehensive security and compliance for Azure and AWS production environments, and <strong>now is extending Ubuntu Pro to be available on-prem through a beta programme</strong>. This programme will give Ubuntu users a free, one-month subscription to Ubuntu Pro &mdash; please register your interest below to learn more.</p>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Which Ubuntu LTS are you using?</h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="which-ubuntu-Xenial">
+            <label for="which-ubuntu-Xenial">16.04 (Xenial)</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="which-ubuntu-Bionic">
+            <label for="which-ubuntu-Bionic">18.04 (Bionic)</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="which-ubuntu-Focal">
+            <label for="which-ubuntu-Focal">20.04 (Focal)</label>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Do you use any of the below packages?</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="packages-redis">
+            <label for="packages-redis">redis</label>
+            <input type="checkbox" id="packages-zookeeper">
+            <label for="packages-zookeeper">zookeeper</label>
+            <input type="checkbox" id="packages-python-rsa">
+            <label for="packages-python-rsa">python-rsa</label>
+            <input type="checkbox" id="packages-pigz">
+            <label for="packages-pigz">pigz</label>
+            <input type="checkbox" id="packages-opencv">
+            <label for="packages-opencv">opencv</label>
+            <input type="checkbox" id="packages-openjpeg2">
+            <label for="packages-openjpeg2">openjpeg2</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="packages-xerces-c">
+            <label for="packages-xerces-c">xerces-c</label>
+            <input type="checkbox" id="packages-monit">
+            <label for="packages-monit">monit</label>
+            <input type="checkbox" id="packages-ntp">
+            <label for="packages-ntp">ntp</label>
+            <input type="checkbox" id="packages-wireshark">
+            <label for="packages-wireshark">wireshark</label>
+            <input type="checkbox" id="packages-runc">
+            <label for="packages-runc">runc</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="packages-jq">
+            <label for="packages-jq">jq</label>
+            <input type="checkbox" id="packages-nodejs">
+            <label for="packages-nodejs">nodejs</label>
+            <input type="checkbox" id="packages-tomcat">
+            <label for="packages-tomcat">tomcat 6 or 7</label>
+            <input type="checkbox" id="packages-libonig">
+            <label for="packages-libonig">libonig</label>
+            <input type="checkbox" id="packages-zeromq3">
+            <label for="packages-zeromq3">zeromq3</label>
+            <div class="col-4 u-sv3">
+              <div class="js-other-container">
+                <input type="checkbox" class="js-other-container__checkbox" id="packages-other">
+                <label for="packages-other">Other</label>
+                <input type="text" id="packages-other-specified" class="js-other-container__input" placeholder="Please specify" style="opacity: 0; margin-top: .25rem;" aria-label="Other Board">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <h3 class="p-heading--five">Where do you get your open source software from?</h3>
+        <div class="row u-no-padding u-equal-height">
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="open-source-from-Ubuntu-repositories">
+            <label for="open-source-from-Ubuntu-repositories">Ubuntu repositories</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="open-source-from-Upstream-packages">
+            <label for="open-source-from-Upstream-packages">Upstream packages</label>
+          </div>
+          <div class="col-4 u-sv3">
+            <input type="checkbox" id="open-source-from-Github">
+            <label for="open-source-from-Github">Github</label>
+          </div>
+        </div>
+      </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--2 u-hide">
+      <h3 class="p-heading--five">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <ul class="p-list">
+              <li class="mktFormReq mktField p-list__item">
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              </li>
+              <li class="mktFormReq mktField p-list__item">
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              </li>
+              <li class="mktField p-list__item">
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
+              </li>
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="mktFormReq mktField p-list__item">
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+            </div>
+
+            <div class="pagination">
+              <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
+              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="js-pagination js-pagination--3 u-hide">
+      <div class="row u-no-padding u-equal-height">
+        <div class="col-7">
+          <h3 class="p-heading--two">Thank you</h3>
+          <p>Thank you for registering your interest in the Ubuntu Pro on-prem beta programme. If selected as a participant, you will receive an email from Canonical with more details on getting started.</p>
+        </div>
+        <div class="col-5 u-vertically-center u-align--center u-hide--small">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+            alt="smile",
+            width="200",
+            height="200",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+      </div>
+      <a class="js-close p-button--neutral" href="">Close</a>
+    </div>
+  </div>
+</div>

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -110,23 +110,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -146,24 +146,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/azure-1604.html
+++ b/templates/shared/forms/interactive/azure-1604.html
@@ -115,19 +115,19 @@
         <h3 class="p-heading--five">How should we get in touch?</h3>
         <div class="row u-no-padding">
           <div class="col-6">
-            <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
               <ul class="p-list">
                 <li class="mktFormReq mktField p-list__item">
-                  <label for="FirstName" class="mktoLabel">First name:</label>
-                  <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                  <label for="firstName" class="mktoLabel">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
                 </li>
                 <li class="mktFormReq mktField p-list__item">
-                  <label for="LastName" class="mktoLabel">Last name:</label>
-                  <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                  <label for="lastName" class="mktoLabel">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
                 </li>
                 <li class="mktFormReq mktField p-list__item">
-                  <label for="Email" class="mktoLabel">Work email:</label>
-                  <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                  <label for="email" class="mktoLabel">Work email:</label>
+                  <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
                 </li>
                 <li class="mktField p-list__item">
                   <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -147,23 +147,16 @@
                     <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                   </li>
                 </ul>
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-                <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="%% formid %%" />
-                <input type="hidden" aria-hidden="true" name="formVid" class="mktoField" value="%% formid %%" />
-                <input type="hidden" aria-hidden="true" name="lpId" class="mktoField" value="%% lpId %%" />
-                <input type="hidden" aria-hidden="true" name="subId" class="mktoField" value="30" />
-                <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField" value="066-EOV-335" />
-                <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-                <input type="hidden" aria-hidden="true" name="cr" class="mktoField" value="" />
-                <input type="hidden" aria-hidden="true" name="kw" class="mktoField" value="" />
-                <input type="hidden" aria-hidden="true" name="q" class="mktoField" value="" />
-                <input type="hidden" aria-hidden="true" name="returnURL" value="%% returnURL %%" />
-                <input type="hidden" aria-hidden="true" name="retURL" value="%% returnURL %%" />
-                <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" />
-                <input type="hidden" aria-hidden="true" name="productContext" id="product-context" value="{{ product }}" />
-                <input type="hidden" aria-hidden="true" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" name="utm_source" class="mktoField" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               </div>
 
               <div class="pagination">

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -110,23 +110,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -146,24 +146,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -294,23 +294,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -330,24 +330,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -8,19 +8,19 @@
       <h3 class="p-heading--five">Provide your contact information to join the beta candidate pool.</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -42,24 +42,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -143,27 +143,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Company" class="mktoLabel">Company:</label>
-                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="company" class="mktoLabel">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Email address:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -183,24 +183,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -87,23 +87,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -123,22 +123,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-              <input type="hidden" aria-hidden="true" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="retURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" name="productContext" id="product-context" value="{{ product }}" />
-              <input type="hidden" aria-hidden="true" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/financial.html
+++ b/templates/shared/forms/interactive/financial.html
@@ -101,19 +101,19 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -133,23 +133,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-              <input type="hidden" aria-hidden="true" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="retURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" name="productContext" id="product-context" value="{{ product }}" />
-              <input type="hidden" aria-hidden="true" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/gcp.html
+++ b/templates/shared/forms/interactive/gcp.html
@@ -110,23 +110,23 @@
             <h3 class="p-heading--five">How should we get in touch?</h3>
             <div class="row u-no-padding">
             <div class="col-6">
-                <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+                <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
                 <ul class="p-list">
                     <li class="mktFormReq mktField p-list__item">
-                    <label for="FirstName" class="mktoLabel">First name:</label>
-                    <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                    <label for="firstName" class="mktoLabel">First name:</label>
+                    <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
-                    <label for="LastName" class="mktoLabel">Last name:</label>
-                    <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                    <label for="lastName" class="mktoLabel">Last name:</label>
+                    <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
-                    <label for="Email" class="mktoLabel">Work email:</label>
-                    <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                    <label for="email" class="mktoLabel">Work email:</label>
+                    <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
-                    <label for="Phone" class="mktoLabel ">Phone number:</label>
-                    <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                    <label for="phone" class="mktoLabel ">Phone number:</label>
+                    <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
                     </li>
                     <li class="mktField p-list__item">
                     <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -147,24 +147,16 @@
                         <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                     </li>
                     </ul>
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
                 </div>
 
                 <div class="pagination">

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -179,23 +179,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -215,24 +215,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -55,27 +55,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Company" class="mktoLabel">Company:</label>
-                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="company" class="mktoLabel">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -95,24 +95,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -129,23 +129,23 @@
       <h3 class="p-heading--five">How should we stay in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -165,24 +165,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -210,23 +210,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -246,24 +246,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -173,23 +173,23 @@
     <h3 class="p-heading--five">How should we get in touch?</h3>
     <div class="row u-no-padding">
       <div class="col-6">
-        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+        <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
           <ul class="p-list">
             <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">First name:</label>
-              <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <label for="firstName" class="mktoLabel">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">Last name:</label>
-              <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <label for="lastName" class="mktoLabel">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">Work email:</label>
-              <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <label for="email" class="mktoLabel">Work email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
             </li>
             <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-              <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
             </li>
             <li class="mktField p-list__item">
               <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -209,24 +209,16 @@
                 <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
               </li>
             </ul>
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
           </div>
 
           <div class="pagination">

--- a/templates/shared/forms/interactive/managed-cassandra.html
+++ b/templates/shared/forms/interactive/managed-cassandra.html
@@ -213,19 +213,19 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -244,24 +244,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -171,19 +171,19 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -202,24 +202,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>

--- a/templates/shared/forms/interactive/managed-kubernetes.html
+++ b/templates/shared/forms/interactive/managed-kubernetes.html
@@ -129,23 +129,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -165,24 +165,17 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -9,15 +9,15 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -32,24 +32,16 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -296,23 +296,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -332,24 +332,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -195,23 +195,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -231,24 +231,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -151,23 +151,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -186,24 +186,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -163,23 +163,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -199,24 +199,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -78,31 +78,31 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Company" class="mktoLabel">Company:</label>
-                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired">
+                <label for="company" class="mktoLabel">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Title" class="mktoLabel">Job title:</label>
                 <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email address:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Email address:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel">Phone number:</label>
-                <input id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField">
+                <label for="phone" class="mktoLabel">Phone number:</label>
+                <input id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField">
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -122,23 +122,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-              <input type="hidden" aria-hidden="true" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="retURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" name="productContext" id="product-context" value="{{ product }}" />
-              <input type="hidden" aria-hidden="true" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -93,8 +93,8 @@
                 <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Title" class="mktoLabel">Job title:</label>
-                <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="title" class="mktoLabel">Job title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email address:</label>

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -175,27 +175,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Company" class="mktoLabel">Company:</label>
-                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="company" class="mktoLabel">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -215,24 +215,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -138,23 +138,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -174,24 +174,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -502,18 +502,18 @@
       <div class="row u-no-padding">
         <div class="col-6">
           <form
-            action="https://pages.ubuntu.com/index.php/leadCapture/save"
+            action="/marketo/submit"
             method="post"
             id="mktoForm_%% formid %%"
             class="modal-form marketo-form"
           >
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
+                <label for="firstName" class="mktoLabel">First name:</label>
                 <input
                   required
-                  id="FirstName"
-                  name="FirstName"
+                  id="firstName"
+                  name="firstName"
                   maxlength="255"
                   type="text"
                   class="mktoField mktoRequired"
@@ -521,11 +521,11 @@
                 />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
+                <label for="lastName" class="mktoLabel">Last name:</label>
                 <input
                   required
-                  id="LastName"
-                  name="LastName"
+                  id="lastName"
+                  name="lastName"
                   maxlength="255"
                   type="text"
                   class="mktoField mktoRequired"
@@ -533,11 +533,11 @@
                 />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
+                <label for="email" class="mktoLabel">Work email:</label>
                 <input
                   required
-                  id="Email"
-                  name="Email"
+                  id="email"
+                  name="email"
                   maxlength="255"
                   type="email"
                   class="mktoField mktoEmailField mktoRequired"
@@ -545,8 +545,8 @@
                 />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input
@@ -583,129 +583,19 @@
               <h3>Your comments</h3>
               <ul class="p-list">
                 <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel"
-                    >What would you like to talk to us about?</label
-                  >
-                  <textarea
-                    id="Comments_from_lead__c"
-                    name="Comments_from_lead__c"
-                    rows="5"
-                    class="mktoField"
-                    maxlength="2000"
-                  ></textarea>
+                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="formValidation"
-                value=""
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="formid"
-                class="mktoField"
-                value="%% formid %%"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="formVid"
-                class="mktoField"
-                value="%% formid %%"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="lpId"
-                class="mktoField"
-                value="%% lpId %%"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="subId"
-                class="mktoField"
-                value="30"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="munchkinId"
-                class="mktoField"
-                value="066-EOV-335"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="lpurl"
-                class="mktoField"
-                value="%% lpurl %%?cr={creative}&amp;kw={keyword}"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="cr"
-                class="mktoField"
-                value=""
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="kw"
-                class="mktoField"
-                value=""
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="q"
-                class="mktoField"
-                value=""
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="returnURL"
-                value="%% returnURL %%"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="retURL"
-                value="%% returnURL %%"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="Consent_to_Processing__c"
-                value="yes"
-              />
-              <input
-                type="hidden"
-                aria-hidden="true"
-                aria-label="hidden field"
-                name="productContext"
-                id="product-context"
-                value="{{ product }}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -149,23 +149,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -185,24 +185,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/telco.html
+++ b/templates/shared/forms/interactive/telco.html
@@ -243,27 +243,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="MEmail" class="mktoLabel">Work email:</label>
-                <input required id="MEmail" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required="" id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required="" id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
               </li>
               <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="McanonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="McanonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -279,24 +279,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&kw={keyword}" />
-              <input type="hidden" aria-hidden="true" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="retURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" name="productContext" id="product-context" value="{{ product }}" />
-              <input type="hidden" aria-hidden="true" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -79,27 +79,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="firstName" class="mktoLabel">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="lastName" class="mktoLabel">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Company" class="mktoLabel">Company:</label>
-                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <label for="company" class="mktoLabel">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Work email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <label for="email" class="mktoLabel">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
@@ -119,24 +119,15 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="%% lpId %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="%% lpurl %%?cr={creative}&amp;kw={keyword}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="cr" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="kw" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="q" class="mktoField" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="retURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">

--- a/tests/cypress/forms_spec.js
+++ b/tests/cypress/forms_spec.js
@@ -31,7 +31,7 @@ context("Marketo form", () => {
     cy.get('input[name="firstName"]').type("Test");
     cy.get('input[name="lastName"]').type("Test");
     cy.get('input[name="company"]').type("Test");
-    cy.get('input[name="Title"]').type("Test");
+    cy.get('input[name="title"]').type("Test");
     cy.get('input[name="email"]').type("test@test.com");
 
     getIframeBody().find(".rc-anchor-content").click();
@@ -49,7 +49,7 @@ context("Marketo form", () => {
     cy.get('input[name="phone"]').type("000000000");
     cy.get('select[name="Country"]').select("Colombia");
     cy.get('input[name="company"]').type("Test");
-    cy.get('input[name="Title"]').type("Test");
+    cy.get('input[name="title"]').type("Test");
     cy.get('textarea[name="Comments_from_lead__c"]').type(
       "Test test test test"
     );
@@ -67,7 +67,7 @@ context("Marketo form", () => {
     cy.get('input[name="firstName"]').type("Test");
     cy.get('input[name="lastName"]').type("Test");
     cy.get('input[name="company"]').type("Test");
-    cy.get('input[name="Title"]').type("Test");
+    cy.get('input[name="title"]').type("Test");
     cy.get('input[name="email"]').type("test@test.com");
     cy.get('input[name="phone"]').type("000000000");
 

--- a/tests/cypress/forms_spec.js
+++ b/tests/cypress/forms_spec.js
@@ -15,10 +15,7 @@ const getIframeBody = () => {
 context("Marketo form", () => {
   beforeEach(() => {
     cy.server();
-    cy.route(
-      "POST",
-      "https://app-sjg.marketo.com/index.php/leadCapture/save2"
-    ).as("captureLead");
+    cy.route("POST", "/marketo/submit").as("captureLead");
   });
 
   // afterEach(() => {
@@ -31,11 +28,11 @@ context("Marketo form", () => {
   it("/download/server/thank-you", () => {
     cy.visit("/download/server/thank-you");
 
-    cy.get('input[name="FirstName"]').type("Test");
-    cy.get('input[name="LastName"]').type("Test");
-    cy.get('input[name="Company"]').type("Test");
+    cy.get('input[name="firstName"]').type("Test");
+    cy.get('input[name="lastName"]').type("Test");
+    cy.get('input[name="company"]').type("Test");
     cy.get('input[name="Title"]').type("Test");
-    cy.get('input[name="Email"]').type("test@test.com");
+    cy.get('input[name="email"]').type("test@test.com");
 
     getIframeBody().find(".rc-anchor-content").click();
 
@@ -46,12 +43,12 @@ context("Marketo form", () => {
   it("/core/contact-us", () => {
     cy.visit("/core/contact-us");
 
-    cy.get('input[name="FirstName"]').type("Test");
-    cy.get('input[name="LastName"]').type("Test");
-    cy.get('input[name="Email"]').type("test@test.com");
-    cy.get('input[name="Phone"]').type("000000000");
+    cy.get('input[name="firstName"]').type("Test");
+    cy.get('input[name="lastName"]').type("Test");
+    cy.get('input[name="email"]').type("test@test.com");
+    cy.get('input[name="phone"]').type("000000000");
     cy.get('select[name="Country"]').select("Colombia");
-    cy.get('input[name="Company"]').type("Test");
+    cy.get('input[name="company"]').type("Test");
     cy.get('input[name="Title"]').type("Test");
     cy.get('textarea[name="Comments_from_lead__c"]').type(
       "Test test test test"
@@ -67,12 +64,12 @@ context("Marketo form", () => {
   it("/engage/anbox-cloud-gaming-whitepaper", () => {
     cy.visit("/engage/anbox-cloud-gaming-whitepaper");
 
-    cy.get('input[name="FirstName"]').type("Test");
-    cy.get('input[name="LastName"]').type("Test");
-    cy.get('input[name="Company"]').type("Test");
+    cy.get('input[name="firstName"]').type("Test");
+    cy.get('input[name="lastName"]').type("Test");
+    cy.get('input[name="company"]').type("Test");
     cy.get('input[name="Title"]').type("Test");
-    cy.get('input[name="Email"]').type("test@test.com");
-    cy.get('input[name="Phone"]').type("000000000");
+    cy.get('input[name="email"]').type("test@test.com");
+    cy.get('input[name="phone"]').type("000000000");
 
     getIframeBody().find(".rc-anchor-content").click();
 
@@ -94,9 +91,9 @@ context("Marketo dynamic form", () => {
       ".p-modal__dialog .js-pagination--2 .pagination__link--next"
     ).click();
 
-    cy.get('input[name="FirstName"]').type("Test");
-    cy.get('input[name="LastName"]').type("Test");
-    cy.get('input[name="Email"]').type("test@test.com");
+    cy.get('input[name="firstName"]').type("Test");
+    cy.get('input[name="lastName"]').type("Test");
+    cy.get('input[name="email"]').type("test@test.com");
     cy.get('label[for="canonicalUpdatesOptIn"]').click();
 
     getIframeBody().find(".rc-anchor-content").click();
@@ -105,9 +102,7 @@ context("Marketo dynamic form", () => {
     cy.get("#mktoForm_1251")
       .submit()
       .should((page) => {
-        expect(page[0].action).to.equal(
-          "https://pages.ubuntu.com/index.php/leadCapture/save"
-        );
+        expect(page[0].action).to.equal("/marketo/submit");
       });
   });
 });

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -70,6 +70,7 @@ from webapp.views import (
     account_query,
     sixteen_zero_four,
     openstack_install,
+    marketo_submit,
 )
 
 from webapp.advantage.views import (
@@ -267,6 +268,7 @@ def context():
         "releases": releases(),
         "user_info": user_info(flask.session),
         "utm_campaign": flask.request.args.get("utm_campaign", ""),
+        "utm_content": flask.request.args.get("utm_content", ""),
         "utm_medium": flask.request.args.get("utm_medium", ""),
         "utm_source": flask.request.args.get("utm_source", ""),
         "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
@@ -285,6 +287,7 @@ def utility_processor():
 # Simple routes
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 app.add_url_rule("/account.json", view_func=account_query)
+app.add_url_rule("/marketo/submit", view_func=marketo_submit, methods=["POST"])
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -1,0 +1,45 @@
+from requests import Session
+from urllib.parse import urlencode
+
+
+class MarketoAPI:
+    def __init__(
+        self,
+        base_url: str,
+        client_id: str,
+        client_secret: str,
+        session: Session,
+    ):
+        self.base_url = base_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.session = session
+        self.token = None
+
+    def _authenticate(self):
+        auth_url = (
+            f"{self.base_url}/identity/oauth/token"
+            "?grant_type=client_credentials&"
+            f"client_id={self.client_id}&client_secret={self.client_secret}"
+        )
+        request = self.session.get(auth_url)
+        self.token = request.json()["access_token"]
+
+    def request(self, method, url, url_args={}, json=None):
+        if not self.token:
+            self._authenticate()
+
+        params = urlencode(url_args)
+        url = f"{self.base_url}{url}?access_token={self.token}&{params}"
+        response = self.session.request(method=method, url=url, json=json)
+
+        if response.status_code in [601, 602]:
+            self._authenticate()
+            response = self.session.request(method=method, url=url, json=json)
+
+        return response
+
+    def submit_form(self, data):
+        return self.request(
+            "POST", "/rest/v1/leads/submitForm.json", json=data
+        )

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -33,7 +33,8 @@ class MarketoAPI:
         url = f"{self.base_url}{url}?access_token={self.token}&{params}"
         response = self.session.request(method=method, url=url, json=json)
 
-        if response.status_code in [601, 602]:
+        errors = response.json().get("errors")
+        if errors and errors[0]["code"] in ["601", "602"]:
             self._authenticate()
             response = self.session.request(method=method, url=url, json=json)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -787,10 +787,6 @@ def sitemap_index():
     return response
 
 
-def marketo_describe():
-    return flask.jsonify(marketo_api.describe().json())
-
-
 def marketo_submit():
     form_fields = {}
     for key, value in flask.request.form.items():

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -18,6 +18,7 @@ from ubuntu_release_info.data import Data
 from canonicalwebteam.store_api.stores.snapstore import SnapStore
 from canonicalwebteam.launchpad import Launchpad
 from geolite2 import geolite2
+from requests import Session
 from requests.exceptions import HTTPError
 from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
@@ -30,11 +31,21 @@ from canonicalwebteam.discourse import (
 
 # Local
 from webapp.login import user_info
+from webapp.marketo import MarketoAPI
 
 
 ip_reader = geolite2.reader()
 session = talisker.requests.get_session()
 store_api = SnapStore(session=talisker.requests.get_session())
+
+marketo_session = Session()
+talisker.requests.configure(marketo_session)
+marketo_api = MarketoAPI(
+    "https://066-EOV-335.mktorest.com",
+    os.getenv("MARKETO_API_CLIENT"),
+    os.getenv("MARKETO_API_SECRET"),
+    marketo_session,
+)
 
 
 def _build_mirror_list():
@@ -247,9 +258,9 @@ def post_build():
     """
 
     opt_in = flask.request.values.get("canonicalUpdatesOptIn")
-    full_name = flask.request.values.get("FullName")
+    full_name = flask.request.values.get("fullName")
     names = full_name.split(" ")
-    email = flask.request.values.get("Email")
+    email = flask.request.values.get("email")
     board = flask.request.values.get("board")
     system = flask.request.values.get("system")
     snaps = flask.request.values.get("snaps", "").split(",")
@@ -269,19 +280,22 @@ def post_build():
     context = {}
 
     # Submit user to marketo
-    session.post(
-        "https://pages.ubuntu.com/index.php/leadCapture/save",
-        data={
-            "canonicalUpdatesOptIn": opt_in,
-            "FirstName": " ".join(names[:-1]),
-            "LastName": names[-1] if len(names) > 1 else "",
-            "Email": email,
-            "formid": "3546",
-            "lpId": "2154",
-            "subId": "30",
-            "munchkinId": "066-EOV-335",
-            "imageBuilderStatus": "NULL",
-        },
+    marketo_api.submit_form(
+        {
+            "formId": "3546",
+            "input": [
+                {
+                    "leadFormFields": {
+                        "canonicalUpdatesOptIn": opt_in,
+                        "firstName": " ".join(names[:-1]),
+                        "lastName": names[-1] if len(names) > 1 else "",
+                        "email": email,
+                        "formid": "3546",
+                        "imageBuilderStatus": "NULL",
+                    }
+                }
+            ],
+        }
     )
 
     # Ensure webhook is created
@@ -404,25 +418,28 @@ def notify_build():
             f"{build_url}?ws.op=getFileUrls"
         ).json()[0]
 
-    session.post(
-        "https://pages.ubuntu.com/index.php/leadCapture/save",
-        data={
-            "FirstName": " ".join(names[:-1]),
-            "LastName": names[-1] if len(names) > 1 else "",
-            "Email": email,
-            "formid": "3546",
-            "lpId": "2154",
-            "subId": "30",
-            "munchkinId": "066-EOV-335",
-            "imageBuilderVersion": version,
-            "imageBuilderArchitecture": arch,
-            "imageBuilderBoard": board,
-            "imageBuilderSnaps": snaps,
-            "imageBuilderID": build_id,
-            "imageBuilderBuildlink": build_link,
-            "imageBuilderStatus": status,
-            "imageBuilderDownloadlink": download_url,
-        },
+    marketo_api.submit_form(
+        {
+            "formId": "3546",
+            "input": [
+                {
+                    "leadFormFields": {
+                        "firstName": " ".join(names[:-1]),
+                        "lastName": names[-1] if len(names) > 1 else "",
+                        "email": email,
+                        "formid": "3546",
+                        "imageBuilderVersion": version,
+                        "imageBuilderArchitecture": arch,
+                        "imageBuilderBoard": board,
+                        "imageBuilderSnaps": snaps,
+                        "imageBuilderID": build_id,
+                        "imageBuilderBuildlink": build_link,
+                        "imageBuilderStatus": status,
+                        "imageBuilderDownloadlink": download_url,
+                    }
+                }
+            ],
+        }
     )
 
     return "Submitted\n", 202
@@ -768,3 +785,48 @@ def sitemap_index():
 
     response.headers["Content-Type"] = "application/xml"
     return response
+
+
+def marketo_describe():
+    return flask.jsonify(marketo_api.describe().json())
+
+
+def marketo_submit():
+    form_fields = {}
+    for key, value in flask.request.form.items():
+        if value:
+            form_fields[key] = value
+
+    form_fields.pop("thankyoumessage", None)
+    form_fields.pop("g-recaptcha-response", None)
+    return_url = form_fields.pop("returnURL", None)
+
+    payload = {
+        "formId": form_fields.pop("formid"),
+        "input": [{"leadFormFields": form_fields}],
+    }
+
+    try:
+        response = marketo_api.submit_form(payload)
+        data = response.json()
+        if data["result"][0]["status"] == "skipped":
+            flask.current_app.extensions["sentry"].captureMessage(
+                f"Markerto form {payload['formId']} failed to submit",
+                extra={"payload": payload, "response": data},
+            )
+    except Exception:
+        flask.current_app.extensions["sentry"].captureException(
+            extra={"payload": payload}
+        )
+
+        return (
+            flask.jsonify(
+                {"error": "There was an issue submitting the form."}
+            ),
+            400,
+        )
+
+    if return_url:
+        return flask.redirect(return_url)
+
+    return flask.jsonify({"message": "Form submitted."})


### PR DESCRIPTION
## Done
- Add endpoint to submit marketo forms.
- Update all forms to match the rest API field names.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card
Fixes https://github.com/canonical-web-and-design/web-squad/issues/3657

