### PR TITLE
Update /download/raspberry-pi layout

### DIFF
--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -5,10 +5,10 @@
   </div>
   {% endif %}
   <div class="col-2">
-    <a href="/appliance/openhab" class="p-link--soft">
+    <a href="/appliance/openhab">
       <p class="u-no-padding--top" style="margin-bottom: .5rem;">OpenHAB</p>
       <hr>
-      <div>
+      <div class="u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png",
@@ -24,10 +24,10 @@
     </a>
   </div>
   <div class="col-2">
-    <a href="/appliance/plex" class="p-link--soft">
+    <a href="/appliance/plex">
       <p class="u-no-padding--top" style="margin-bottom: .5rem;">Plex<span class="u-hide--medium"> Media Server</span></p>
       <hr>
-      <div>
+      <div class="u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3cd85693-Plex.png",
@@ -43,10 +43,10 @@
     </a>
   </div>
   <div class="col-2">
-    <a href="/appliance/nextcloud" class="p-link--soft">
+    <a href="/appliance/nextcloud">
       <p class="u-no-padding--top" style="margin-bottom: .5rem;">Nextcloud</p>
       <hr>
-      <div>
+      <div class="u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/99a0b969-Nextcloud_Logo.svg",
@@ -62,10 +62,10 @@
     </a>
   </div>
   <div class="col-2">
-    <a href="/appliance/adguard" class="p-link--soft">
+    <a href="/appliance/adguard">
       <p class="u-no-padding--top" style="margin-bottom: .5rem;">AdGuard</p>
       <hr>
-      <div>
+      <div class="u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/b430a72e-adguard_logo.svg",
@@ -82,10 +82,10 @@
   </div>
   {% if request.path == "/appliance/vm" %}
   <div class="col-2">
-    <a href="/appliance/mosquitto" class="p-link--soft">
+    <a href="/appliance/mosquitto">
       <p class="u-no-padding--top" style="margin-bottom: .5rem;">Mosquitto</p>
       <hr>
-      <div>
+      <div class="u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
@@ -102,10 +102,10 @@
   </div>
   {% else %}
   <div class="col-2">
-    <a href="/appliance/lxd" class="p-link--soft">
+    <a href="/appliance/lxd">
       <p class="u-no-padding--top" style="margin-bottom: .5rem;">LXD</p>
       <hr>
-      <div>
+      <div class="u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg",

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -6,17 +6,18 @@
   {% endif %}
   <div class="col-2">
     <a href="/appliance/openhab" class="p-link--soft">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">OpenHAB</p>
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">OpenHAB</p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
             url="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png",
             alt="",
-            height="48",
-            width="219",
+            height="32",
+            width="148",
             hi_def=True,
             loading="lazy",
+            attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           ) | safe
         }}
       </div>
@@ -24,17 +25,18 @@
   </div>
   <div class="col-2">
     <a href="/appliance/plex" class="p-link--soft">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">Plex<span class="u-hide--medium"> Media Server</span></p>
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">Plex<span class="u-hide--medium"> Media Server</span></p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
             url="https://assets.ubuntu.com/v1/3cd85693-Plex.png",
             alt="",
-            height="48",
-            width="149",
+            height="27",
+            width="84",
             hi_def=True,
             loading="lazy",
+            attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           ) | safe
         }}
       </div>
@@ -42,17 +44,18 @@
   </div>
   <div class="col-2">
     <a href="/appliance/nextcloud" class="p-link--soft">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">Nextcloud</p>
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">Nextcloud</p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
-            url="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png",
+            url="https://assets.ubuntu.com/v1/99a0b969-Nextcloud_Logo.svg",
             alt="",
             height="48",
-            width="67",
+            width="73",
             hi_def=True,
             loading="lazy",
+            attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           ) | safe
         }}
       </div>
@@ -60,17 +63,18 @@
   </div>
   <div class="col-2">
     <a href="/appliance/adguard" class="p-link--soft">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">AdGuard</p>
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">AdGuard</p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
             url="https://assets.ubuntu.com/v1/b430a72e-adguard_logo.svg",
             alt="",
-            height="48",
-            width="219",
+            height="32",
+            width="145",
             hi_def=True,
             loading="lazy",
+            attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           ) | safe
         }}
       </div>
@@ -79,9 +83,9 @@
   {% if request.path == "/appliance/vm" %}
   <div class="col-2">
     <a href="/appliance/mosquitto" class="p-link--soft">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">Mosquitto</p>
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">Mosquitto</p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
             url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
@@ -90,6 +94,7 @@
             width="48",
             hi_def=True,
             loading="lazy",
+            attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           ) | safe
         }}
       </div>
@@ -98,17 +103,18 @@
   {% else %}
   <div class="col-2">
     <a href="/appliance/lxd" class="p-link--soft">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">LXD</p>
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">LXD</p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
             url="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg",
             alt="",
-            height="48",
-            width="146",
+            height="32",
+            width="97",
             hi_def=True,
             loading="lazy",
+            attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           ) | safe
         }}
       </div>

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -6,18 +6,17 @@
   {% endif %}
   <div class="col-2">
     <a href="/appliance/openhab" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">OpenHAB</h3>
-      <hr />
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">OpenHAB</p>
+      <hr>
       <div class="u-align--center">
         {{
           image(
             url="https://assets.ubuntu.com/v1/fa5dd451-OpenHAB.png",
             alt="",
-            height="32",
-            width="146",
+            height="48",
+            width="219",
             hi_def=True,
             loading="lazy",
-            attrs={"style": "margin-top: 2rem;"}
           ) | safe
         }}
       </div>
@@ -25,18 +24,17 @@
   </div>
   <div class="col-2">
     <a href="/appliance/plex" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Plex<span class="u-hide--medium"> Media Server</span></h3>
-      <hr />
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">Plex<span class="u-hide--medium"> Media Server</span></p>
+      <hr>
       <div class="u-align--center">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3cd85693-Plex.png",
             alt="",
-            height="32",
-            width="99",
+            height="48",
+            width="149",
             hi_def=True,
             loading="lazy",
-            attrs={"style": "margin-top: 2rem;"}
           ) | safe
         }}
       </div>
@@ -44,18 +42,17 @@
   </div>
   <div class="col-2">
     <a href="/appliance/nextcloud" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Nextcloud</h3>
-      <hr />
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">Nextcloud</p>
+      <hr>
       <div class="u-align--center">
         {{
           image(
             url="https://assets.ubuntu.com/v1/d3a211c9-Nextcloud.png",
             alt="",
-            height="62",
-            width="87",
+            height="48",
+            width="67",
             hi_def=True,
             loading="lazy",
-            attrs={"style": "margin-top: 1.25rem;"}
           ) | safe
         }}
       </div>
@@ -63,18 +60,17 @@
   </div>
   <div class="col-2">
     <a href="/appliance/adguard" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">AdGuard</h3>
-      <hr />
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">AdGuard</p>
+      <hr>
       <div class="u-align--center">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/1ec45573-AdGuard.png",
+            url="https://assets.ubuntu.com/v1/b430a72e-adguard_logo.svg",
             alt="",
-            height="62",
-            width="62",
+            height="48",
+            width="219",
             hi_def=True,
             loading="lazy",
-            attrs={"style": "margin-top: 1.25rem;"}
           ) | safe
         }}
       </div>
@@ -83,18 +79,17 @@
   {% if request.path == "/appliance/vm" %}
   <div class="col-2">
     <a href="/appliance/mosquitto" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">Mosquitto</h3>
-      <hr />
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">Mosquitto</p>
+      <hr>
       <div class="u-align--center">
         {{
           image(
             url="https://assets.ubuntu.com/v1/c2c39a7a-mosquitto-logo.png",
             alt="",
-            height="72",
-            width="72",
+            height="48",
+            width="48",
             hi_def=True,
             loading="lazy",
-            attrs={"style": "margin-top: 1rem;"}
           ) | safe
         }}
       </div>
@@ -103,18 +98,17 @@
   {% else %}
   <div class="col-2">
     <a href="/appliance/lxd" class="p-link--soft">
-      <h3 class="p-heading--five u-no-padding--top">LXD</h3>
-      <hr />
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">LXD</p>
+      <hr>
       <div class="u-align--center">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/3a24a2f9-lxd.png",
+            url="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg",
             alt="",
-            height="72",
-            width="72",
+            height="48",
+            width="146",
             hi_def=True,
             loading="lazy",
-            attrs={"style": "margin-top: 1rem;"}
           ) | safe
         }}
       </div>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -12,9 +12,15 @@
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Install Ubuntu <br class="u-hide--small">on a Raspberry Pi</h1>
-      <p>Running Ubuntu on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your Pi and away you go.</p>
-      <p>First time installing Ubuntu on Raspberry Pi?</p>
+      <h1>
+        Install Ubuntu <br class="u-hide--small">on a Raspberry Pi
+      </h1>
+      <p>
+        Running Ubuntu on your Raspberry Pi is easy. Just pick the OS image you want, flash it onto a microSD card, load it onto your Pi and away you go.
+      </p>
+      <p>
+        First time installing Ubuntu on Raspberry Pi?
+      </p>
       <p>
         Follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">desktop</a> or <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">server</a> tutorials.
       </p>
@@ -33,10 +39,83 @@
     </div>
   </div>
 </section>
-<section class="p-strip u-hide--small">
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-start-large-2 col-2">
-      <div>
+
+{# server lts #}
+<section class="p-strip--light {% if releases.latest.short_version < releases.lts.short_version %}is-bordered{% endif %}">
+  <div class="row">
+    <div class="col-6">
+      <h2>
+        Download Ubuntu Server
+      </h2>
+      <p class="p-muted-heading">
+        Recommended server
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>
+        Ubuntu Server {{ releases.lts.full_version }} LTS
+      </h3>
+      <p>
+        The version of Ubuntu with five years of long term support, until {{ releases.lts.eol }}.
+      </p>
+      <p>
+        <a class="p-button--positive" href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+        <a class="p-button" href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit
+        </a>
+      </p>
+    </div>
+
+    {# server latest #}
+    {% if releases.latest.short_version > releases.lts.short_version %}
+    <div class="col-6">
+      <h3>
+        Ubuntu Server {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.
+      </p>
+      <p>
+        <a class="p-button--positive" href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+        <a class="p-button" href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit
+        </a>
+      </p>
+    </div>
+    {% endif %}
+  </div>
+
+  <div class="row u-hide--medium u-hide--large">
+    <div class="col-6">
+      <p>Works on:</p>
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
+        <li class="p-list__item is-ticked">Raspberry Pi 3</li>
+        <li class="p-list__item is-ticked">Raspberry Pi 4</li>
+        <li class="p-list__item is-ticked">Raspberry Pi 400</li>
+        <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="u-fixed-width u-hide--small">
+    <h3>
+      Works on:
+    </h3>
+  </div>
+  <div class="row u-hide--small">
+    <div class="col-2">
+      <h3 class="p-heading--five u-no-padding--top">
+        Raspberry Pi 2
+      </h3>
+      <hr>
+      <div class="u-align--center">
         {{
           image(
           url="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png",
@@ -48,9 +127,18 @@
           ) | safe
         }}
       </div>
+      <p>
+        <em>
+          * 32-bit only
+        </em>
+      </p>
     </div>
     <div class="col-2">
-      <div>
+      <h3 class="p-heading--five u-no-padding--top">
+        Raspberry Pi 3
+      </h3>
+      <hr>
+      <div class="u-align--center">
         {{
           image(
           url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
@@ -64,7 +152,11 @@
       </div>
     </div>
     <div class="col-2">
-      <div>
+      <h3 class="p-heading--five u-no-padding--top">
+        Raspberry Pi 4
+      </h3>
+      <hr>
+      <div class="u-align--center">
         {{
           image(
           url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
@@ -78,142 +170,118 @@
       </div>
     </div>
     <div class="col-2">
-      <div>
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/9df28d88-RPI_400_rotated.png",
-          alt="",
-          height="92",
-          width="127",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
-      </div>
-    </div>
-    <div class="col-2">
-      <div>
-        {{ image (
-          url="https://assets.ubuntu.com/v1/22136bb8-pi-cm4-removebg-preview.png",
-          alt="",
-          width="344",
-          height="222",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-  <div class="row u-vertically-center u-sv3">
-    <div class="col-start-large-2 col-2">
-      <p class="u-no-margin--bottom"><strong>Raspberry Pi 2</strong></p>
-    </div>
-    <div class="col-2">
-      <p class="u-no-margin--bottom"><strong>Raspberry Pi 3</strong></p>
-    </div>
-    <div class="col-2">
-      <p class="u-no-margin--bottom"><strong>Raspberry Pi 4</strong></p>
-    </div>
-    <div class="col-2">
-      <p class="u-no-margin--bottom"><strong>Raspberry Pi 400</strong></p>
-    </div>
-    <div class="col-2">
-      <p class="u-no-margin--bottom"><strong>Raspberry Pi CM4</strong></p>
-    </div>
-  </div>
-</section>
-
-{# server lts row #}
-<section class="p-strip--light u-no-padding--bottom {% if releases.latest.short_version < releases.lts.short_version %}is-bordered{% endif %}">
-  <div class="row">
-    <h2>Ubuntu Server {{ releases.lts.full_version }} LTS</h2>
-    <p class="p-muted-heading">Recommended server</p>
-  </div>
-  <div class="row u-equal-height p-divider">
-    <div class="col-8 p-divider__block">
-      <p>The version of Ubuntu with long term support, until {{ releases.lts.eol }}.</p>
-      <p>Works on:</p>
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
-        <li class="p-list__item is-ticked">Raspberry Pi 3</li>
-        <li class="p-list__item is-ticked">Raspberry Pi 4</li>
-        <li class="p-list__item is-ticked">Raspberry Pi 400</li>
-        <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
-      </ul>
-    </div>
-    <div class="col-4">
-      <p>
-        <a class="p-button--positive is-wide" href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download 64-bit</a>
-      </p>
-      <p>
-        <a class="p-button is-wide" href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download 32-bit</a>
-      </p>
-    </div>
-  </div>
-
-  {# server latest row #}
-
-  {% if releases.latest.short_version > releases.lts.short_version %}
-  <div class="p-strip is-shallow">
-    <div class="u-fixed-width">
+      <h3 class="p-heading--five u-no-padding--top">
+        Raspberry Pi 400
+      </h3>
       <hr>
+      <div class="u-align--center">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
+          alt="",
+          width="1478",
+          height="760",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+    <div class="col-2">
+      <h3 class="p-heading--five u-no-padding--top">
+        Raspberry Pi CM4
+      </h3>
+      <hr>
+      <div class="u-align--center">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
+          alt="",
+          width="932",
+          height="660",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
     </div>
   </div>
-
-  <div class="u-fixed-width">
-    <h2>Ubuntu Server {{ releases.latest.full_version }}</h2>
-  </div>
-  <div class="row u-equal-height p-divider">
-    <div class="col-8 p-divider__block">
-      <p>The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.</p>
-      <p>Works on:</p>
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
-        <li class="p-list__item is-ticked">Raspberry Pi 3</li>
-        <li class="p-list__item is-ticked">Raspberry Pi 4</li>
-        <li class="p-list__item is-ticked">Raspberry Pi 400</li>
-        <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
-      </ul>
-    </div>
-    <div class="col-4">
-      <p>
-        <a class="p-button--positive is-wide" href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download 64-bit</a>
-      </p>
-      <p>
-        <a class="p-button is-wide" href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download 32-bit</a>
-      </p>
-    </div>
-  </div>
-  {% endif %}
 </section>
 
 
 {# desktop latest #}
 <section class="p-strip">
   <div class="u-fixed-width">
-    <h2>Ubuntu Desktop {{ releases.latest.full_version }}</h2>
+    <h2>
+      Download Ubuntu Desktop
+    </h2>
   </div>
-  <div class="row u-equal-height p-divider">
-    <div class="col-8 p-divider__block">
-      <p>The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.</p>
-      <p>Works on:</p>
-      <ul class="p-list is-split">
-        <li class="p-list__item is-ticked">Raspberry Pi 4</li>
-        <li class="p-list__item is-ticked">Raspberry Pi 400</li>
-      </ul>
-    </div>
-    <div class="col-4">
+  <div class="row">
+    <div class="col-6">
+      <h3>
+        Ubuntu Desktop {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.
+      </p>
       <p>
         <a
-        class="p-button--positive is-wide"
+        class="p-button--positive"
         href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
         Download 64-bit
       </a>
     </p>
+    <div class="u-hide--medium u-hide--large">
+      <p>Works on:</p>
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Raspberry Pi 400</li>
+        <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
+      </ul>
+    </div>
   </div>
 </div>
+
+<div class="u-fixed-width u-hide--small">
+  <h3>
+    Works on:
+  </h3>
+</div>
+<div class="row u-hide--small">
+  <div class="col-2">
+    <h3 class="p-heading--five u-no-padding--top">
+      Raspberry Pi 400
+    </h3>
+    <hr>
+    <div class="u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
+        alt="",
+        width="1478",
+        height="760",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="col-2">
+    <h3 class="p-heading--five u-no-padding--top">
+      Raspberry Pi CM4
+    </h3>
+    <hr>
+    <div class="u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
+        alt="",
+        width="932",
+        height="660",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</div>
+</section>
 </section>
 
 

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -44,7 +44,7 @@
 <section class="p-strip--light {% if releases.latest.short_version < releases.lts.short_version %}is-bordered{% endif %}">
   <div class="row">
     <div class="col-6">
-      <h2>
+      <h2 class="u-sv2">
         Download Ubuntu Server
       </h2>
       <p class="p-muted-heading">
@@ -105,46 +105,46 @@
   </div>
 
   <div class="u-fixed-width u-hide--small">
-    <h3>
+    <h4>
       Works on:
-    </h3>
+    </h4>
   </div>
   <div class="row u-hide--small">
     <div class="col-2">
-      <h3 class="p-heading--five u-no-padding--top">
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
         Raspberry Pi 2
-      </h3>
+      </p>
       <hr>
       <div class="u-align--center">
         {{
           image(
           url="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png",
           alt="",
-          height="156",
-          width="236",
+          height="48",
+          width="72",
           hi_def=True,
           loading="auto"
           ) | safe
         }}
       </div>
-      <p>
+      <h6 class="u-text-light">
         <em>
           * 32-bit only
         </em>
-      </p>
+      </h6>
     </div>
     <div class="col-2">
-      <h3 class="p-heading--five u-no-padding--top">
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
         Raspberry Pi 3
-      </h3>
+      </p>
       <hr>
       <div class="u-align--center">
         {{
           image(
           url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
           alt="",
-          height="151",
-          width="236",
+          height="48",
+          width="75",
           hi_def=True,
           loading="auto"
           ) | safe
@@ -152,17 +152,17 @@
       </div>
     </div>
     <div class="col-2">
-      <h3 class="p-heading--five u-no-padding--top">
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
         Raspberry Pi 4
-      </h3>
+      </p>
       <hr>
       <div class="u-align--center">
         {{
           image(
           url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
           alt="",
-          height="151",
-          width="236",
+          height="48",
+          width="75",
           hi_def=True,
           loading="auto"
           ) | safe
@@ -170,16 +170,16 @@
       </div>
     </div>
     <div class="col-2">
-      <h3 class="p-heading--five u-no-padding--top">
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
         Raspberry Pi 400
-      </h3>
+      </p>
       <hr>
       <div class="u-align--center">
         {{ image (
           url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
           alt="",
-          width="1478",
-          height="760",
+          height="48",
+          width="93",
           hi_def=True,
           loading="lazy"
           ) | safe
@@ -187,16 +187,16 @@
       </div>
     </div>
     <div class="col-2">
-      <h3 class="p-heading--five u-no-padding--top">
+      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
         Raspberry Pi CM4
-      </h3>
+      </p>
       <hr>
       <div class="u-align--center">
         {{ image (
           url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
           alt="",
-          width="932",
-          height="660",
+          height="48",
+          width="68",
           hi_def=True,
           loading="lazy"
           ) | safe
@@ -241,22 +241,22 @@
 </div>
 
 <div class="u-fixed-width u-hide--small">
-  <h3>
+  <h4>
     Works on:
-  </h3>
+  </h4>
 </div>
 <div class="row u-hide--small">
   <div class="col-2">
-    <h3 class="p-heading--five u-no-padding--top">
+    <p class="u-no-padding--top" style="margin-bottom: 1rem;">
       Raspberry Pi 400
-    </h3>
+    </p>
     <hr>
     <div class="u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
         alt="",
-        width="1478",
-        height="760",
+        height="48",
+        width="93",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -264,16 +264,16 @@
     </div>
   </div>
   <div class="col-2">
-    <h3 class="p-heading--five u-no-padding--top">
+    <p class="u-no-padding--top" style="margin-bottom: 1rem;">
       Raspberry Pi CM4
-    </h3>
+    </p>
     <hr>
     <div class="u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
         alt="",
-        width="932",
-        height="660",
+        height="48",
+        width="68",
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -282,8 +282,6 @@
   </div>
 </div>
 </section>
-</section>
-
 
 <section class="p-strip--light">
   <div class="row">

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -111,11 +111,11 @@
   </div>
   <div class="row u-hide--small">
     <div class="col-2">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
         Raspberry Pi 2
       </p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
           url="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png",
@@ -123,6 +123,7 @@
           height="48",
           width="72",
           hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           loading="auto"
           ) | safe
         }}
@@ -134,11 +135,11 @@
       </h6>
     </div>
     <div class="col-2">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
         Raspberry Pi 3
       </p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
           url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
@@ -146,17 +147,18 @@
           height="48",
           width="75",
           hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           loading="auto"
           ) | safe
         }}
       </div>
     </div>
     <div class="col-2">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
         Raspberry Pi 4
       </p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{
           image(
           url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
@@ -164,40 +166,43 @@
           height="48",
           width="75",
           hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           loading="auto"
           ) | safe
         }}
       </div>
     </div>
     <div class="col-2">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
         Raspberry Pi 400
       </p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{ image (
           url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
           alt="",
           height="48",
           width="93",
           hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           loading="lazy"
           ) | safe
         }}
       </div>
     </div>
     <div class="col-2">
-      <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
         Raspberry Pi CM4
       </p>
       <hr>
-      <div class="u-align--center">
+      <div>
         {{ image (
           url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
           alt="",
           height="48",
           width="68",
           hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
           loading="lazy"
           ) | safe
         }}
@@ -247,34 +252,36 @@
 </div>
 <div class="row u-hide--small">
   <div class="col-2">
-    <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+    <p class="u-no-padding--top" style="margin-bottom: .5rem;">
       Raspberry Pi 400
     </p>
     <hr>
-    <div class="u-align--center">
+    <div>
       {{ image (
         url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
         alt="",
         height="48",
         width="93",
         hi_def=True,
+        attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
         loading="lazy"
         ) | safe
       }}
     </div>
   </div>
   <div class="col-2">
-    <p class="u-no-padding--top" style="margin-bottom: 1rem;">
+    <p class="u-no-padding--top" style="margin-bottom: .5rem;">
       Raspberry Pi CM4
     </p>
     <hr>
-    <div class="u-align--center">
+    <div>
       {{ image (
         url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
         alt="",
         height="48",
         width="68",
         hi_def=True,
+        attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
         loading="lazy"
         ) | safe
       }}


### PR DESCRIPTION
## Done

- Updated /download/raspberry-pi layout
- Added a list when small for the 'Works on'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it matches the [design](https://app.zeplin.io/project/6033b7828f2f35114a10d3b0/screen/6033b7a465dbf119a81a9187)

## Issue / Card

Fixes [#3844](https://github.com/canonical-web-and-design/web-squad/issues/3844)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/115673800-e9c46d00-a344-11eb-8977-1e3579cc22d7.png)

