### PR TITLE
Updated checksums for 21.04 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -31,16 +31,16 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "21.04": "XXXXX *ubuntu-21.04-desktop-amd64.iso"
+    "21.04": "fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.04-desktop-amd64.iso"
     "20.04.2.0": "93bdab204067321ff131f560879db46bee3b994bf24836bb78538640f689e58f *ubuntu-20.04.2.0-desktop-amd64.iso"
   live-server:
-    "21.04": "XXXXX *ubuntu-21.04-live-server-amd64.iso"
+    "21.04": "e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.04-live-server-amd64.iso"
     "20.04.2": "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423 *ubuntu-20.04.2-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "21.04": "XXXXX *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
+    "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
+    "21.04": "3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
     "20.04.2": "31884b07837099a5e819527af66848a9f4f92c1333e3ef0693d6d77af66d6832 *ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "21.04": "XXXXX *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
+    "21.04": "c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
     "20.04.2": "7b348d080648b8e36e1f29671afd973a0878503091b935b69828f2c7722dfb58 *ubuntu-20.04.2-preinstalled-server-armhf+raspi.img.xz"


### PR DESCRIPTION
## Done

- Updated checksums for 21.04 release

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Test the raspberry-pi, desktop and server downloads to see if the checksums appear on the thank-you page
- 
## Issue / Card

Fixes #9565

