### PR TITLE
Fix 16-04 links

### DIFF
--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -70,7 +70,7 @@
     {% for notice in latest_notices %}
       <hr>
       <div class="col-6">
-        <strong><span><a>{{ notice.title }}</a></span></strong><br>
+        <strong><span><a href="/security/notices/{{ notice.id }}">{{ notice.title }}</a></span></strong><br>
         <span class="p-muted-heading">{{ notice.date }}</span><br><br>
       </div>
       <div class="col-6">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -107,6 +107,7 @@ def sixteen_zero_four():
 
         latest_notices = [
             {
+                "id": notice.get("id"),
                 "title": notice.get("title"),
                 "date": dateutil.parser.parse(
                     notice.get("published")


### PR DESCRIPTION
## Done

- Fix links without `href` on production.

## QA

- https://ubuntu-com-9595.demos.haus/16-04 
- scroll down to `Ubuntu 16.04 LTS security updates`
- Latest notice release titles should be working links. They will redirect to 404 on the demo, but if you change the host to ubuntu.com, they should work
