### PR TITLE
Add missing "Add a new subscription" link to shop on small screens

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -213,6 +213,18 @@
           {% endfor %}
           {% endfor %}
         </div>
+          <a 
+            href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}" 
+            class="p-button--positive"   
+            onclick="dataLayer.push({
+              'event' : 'GAEvent',
+              'eventCategory' : 'Advantage',
+              'eventAction' : 'go-to-shop',
+              'eventLabel' : 'Add new subscription',
+              'eventValue' : 5
+            });">
+              Add new subscription
+          </a>
       </div>
       <div class="row u-hide--small">
         <div class="col-12">
@@ -347,7 +359,7 @@
               'eventValue' : 5
             });">
               Add new subscription
-            </a>
+          </a>
         </div>
         <hr class="p-separator" />
       </div>


### PR DESCRIPTION
## Done

- Add missing link to /advantage/subscribe on /advantage on small screens

## QA

- go to https://ubuntu-com-9596.demos.haus/advantage?test_backend=true
- resize the window to get the small VP layout
- check that the "Add a new subscription" button is here and working


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9574

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/115688659-a295a680-a35b-11eb-9f02-43f825687a50.png)

