### PR TITLE
Toggle loading state on the correct button for cancellation

### DIFF
--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -35,6 +35,7 @@ function cancelSubscription(id, VPSize) {
     productListingId,
     previousPurchaseId,
   } = cancelSubscriptionButton.dataset;
+  const confirmCancelButton = document.querySelector(`#confirmCancelButton`);
 
   dataLayer.push({
     event: "GAEvent",
@@ -47,7 +48,7 @@ function cancelSubscription(id, VPSize) {
   handleAPICall(
     cancelContract,
     [accountId, previousPurchaseId, productListingId],
-    cancelSubscriptionButton
+    confirmCancelButton
   );
 }
 
@@ -98,6 +99,7 @@ function createModal(id, VPSize) {
   };
 
   const confirmCancelButton = document.createElement("button");
+  confirmCancelButton.id = "confirmCancelButton";
   confirmCancelButton.classList.add("p-button--negative");
   confirmCancelButton.disabled = true;
   confirmCancelButton.textContent = "Yes, cancel subscription";


### PR DESCRIPTION
## Done

- Show a spinner on the confirm cancel button when it's clicked

## QA

with a monthly subscription :

- go to https://ubuntu-com-9597.demos.haus/advantage?test_backend=true
- cancel your monthly subscription
- check that the spinner is displaying in the correct button


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9467

## Screenshots

![Peek 2021-04-22 11-44](https://user-images.githubusercontent.com/11927929/115693906-a5df6100-a360-11eb-809c-39a081242575.gif)

