### PR TITLE
Build hardware details page

### DIFF
--- a/static/sass/_pattern_component-table.scss
+++ b/static/sass/_pattern_component-table.scss
@@ -1,4 +1,4 @@
-.p-table--devices {
+.p-table-component-devices {
   th,
   td {
     &:nth-child(1) {

--- a/static/sass/_pattern_hardware-details-table.scss
+++ b/static/sass/_pattern_hardware-details-table.scss
@@ -1,0 +1,18 @@
+.p-table-hardware-details {
+  th,
+  td {
+    &:nth-child(1) {
+      width: 20%;
+      @media screen and (max-width: $breakpoint-medium) {
+        width: 28%;
+      }
+    }
+
+    &:nth-child(2) {
+      width: 80%;
+      @media screen and (max-width: $breakpoint-medium) {
+        width: 72%;
+      }
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -55,6 +55,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_gaming";
 @import "pattern_grid";
 @import "pattern_footer";
+@import "pattern_hardware-details-table";
 @import "pattern_heading-icon";
 @import "pattern_icons";
 @import "pattern_inline-images";

--- a/templates/certification/hardware-details.html
+++ b/templates/certification/hardware-details.html
@@ -1,35 +1,93 @@
-<h1>This is the hardware details page</h1>
+{% extends "certification/base_certification.html" %}
 
-<h2>ID (Canonical ID)</h2>
-{{canonical_id}}
+{% block title %} {{ vendor }} {{ model }} certified with Ubuntu {{ release }} | Ubuntu{% endblock %}
 
-<h2>Name:</h2>
-{{ name }}
+{% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
-<h2>Category/Form</h2>
-{{ category }}
+{% block content %}
 
-<h2>form_factor</h2>
-{{ form_factor }}
+<section class="p-strip--suru-topped">
+  <div class="row u-sv3">
+    <div class="col-7">
+      <p class="p-heading--4">
+        <a href="/certification/{{ release_details.canonical_id }}">{{ release_details.make }} {{ release_details.model }} certified on Ubuntu {{ release_details.certified_release }}</a>
+      </p>
+      <h1 class="p-heading--2">Hardware details</h1>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
+    {% if release_details.category == "Desktop" or release_details.category == "Laptop" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
+        alt="",
+        width="132",
+        height="77",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+      {% if release_details.category == "Server" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
+        alt="Server",
+        width="80",
+        height="96",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+      {% if release_details.category == "Ubuntu Core" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
+        alt="Gateway",
+        width="96",
+        height="100",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+      {% if release_details.category == "Server SoC" %}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
+        alt="Chip",
+        width="84",
+        height="100",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+      {% endif %}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <table class="p-table-hardware-details" aria-label="Hardware details for {{ release_details.make }} {{ release_details.model }}">
+        <tbody>
+          {% for category, devices in hardware_details.items() %}
+            {% if category != "Other" %}
+            <tr>
+              <th class="p-muted-text">
+                {{ category }}
+              </th>
+              <td>
+                <ul class="p-list u-no-margin--bottom">
+                {% for device in devices %}
+                <li class="p-list__item u-no-padding--top">
+                  {{ device.name }} {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
+                </li>
+                {% endfor %}
+                </ul>
+              </td>
+            </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
 
-<h2>vendor</h2>
-{{ vendor }}
-
-<h2>major release</h2>
-{{ major_release }}
-
-<h2>Release details</h2>
-<p>This contains data for all elements in the table </p>
-<ul>
-    <li>release.name</li>
-    <li>ubuntu image or not (release.level)</li>
-    <li>release.kernel</li>
-    <li>release.notes</li>
-    <li>whole hardware details page, but you need to filter the amount of data accordingly</li>
-</ul>
-<p>Links need to be built in the for of /certification/{model-id}/{release} to link to the corresponding hardware details page</p>
-{{ release_details }}
-
-<h2>Processor, network, video are contained within release.components</h2>
-<p>hardware_details contains info about cdrom, keyboard etc... what's called devices</p>
-{{ hardware_details }}
+{% endblock content %}

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -1,6 +1,6 @@
 {% extends "certification/base_certification.html" %}
 
-{% block title %}Model details | Ubuntu{% endblock %}
+{% block title %} {{ vendor }} {{ model }} certified with Ubuntu | Ubuntu{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
@@ -119,7 +119,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2 class="u-sv2">Components certified with this system</h2>
-    <table class="p-table--mobile-card p-table--devices" aria-label="Component Devices table">
+    <table class="p-table--mobile-card p-table-component-devices" aria-label="Component Devices table">
       <thead>
         <tr>
           <th>Component</th>
@@ -171,7 +171,7 @@
                 }}
               </td>
               {% elif details[0].status == 'inprogress' %}
-              <td aria-label="16.04 ESM"><i class="p-icon--help">In progress</i></td>
+              <td aria-label="16.04 ESM"><i class="p-icon--help">Untested</i></td>
               {% elif details[0].status == 'certified'%}
               <td aria-label="16.04 LTS"><i class="p-icon--success">Supported</i></td>
               {% endif %}

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -9,6 +9,7 @@
 
 <form class="form">
   <section class="p-strip--suru-topped">
+<<<<<<< HEAD
     {% if vendor_page %}
     <div class="u-fixed-width">
       <h1 class="u-sv3">Ubuntu certified hardware from {{ vendors }}</h1>
@@ -21,6 +22,16 @@
           <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
         </div>
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
+=======
+    {% if filters != True%}
+      {% if form == "Desktop" %}
+      <div class="row">
+        <div class="col-7">
+          <h1>Ubuntu Certified desktop hardware</h1>
+          <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
+        </div>
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+>>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
             alt="",
@@ -34,12 +45,20 @@
       </div>
       {% elif form == "Server" %}
       <div class="row">
+<<<<<<< HEAD
         <div class="col-8">
+=======
+        <div class="col-7">
+>>>>>>> Add filters=true check
           <h1>Ubuntu Certified server hardware</h1>
           <p>Ubuntu Server gives you the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
           <p class="u-sv3">Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-centre environments.</p>
         </div>
+<<<<<<< HEAD
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
+=======
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+>>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
             alt="Server",
@@ -53,12 +72,20 @@
       </div>
       {% elif form == "Ubuntu Core" %}
       <div class="row">
+<<<<<<< HEAD
         <div class="col-8">
+=======
+        <div class="col-7">
+>>>>>>> Add filters=true check
           <h1>Ubuntu Certified IoT hardware</h1>
           <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
           <p class="u-sv3">Canonical's certification program offers you peace of mind that all your Internet of Things devices will remain secure and regularly updated over the long term.</p>
         </div>
+<<<<<<< HEAD
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
+=======
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+>>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
             alt="Gateway",
@@ -70,14 +97,24 @@
           }}
         </div>
       </div>
+<<<<<<< HEAD
       {% elif form == "SoC" %}
       <div class="row">
         <div class="col-8">
+=======
+      {% elif form == "Server SoC" %}
+      <div class="row">
+        <div class="col-7">
+>>>>>>> Add filters=true check
           <h1>Ubuntu Certified SoC hardware</h1>
           <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
           <p class="u-sv3">Canonical's certification program offers manufacturers a selection of SoCs officially supported and maintained in Ubuntu.</p>
         </div>
+<<<<<<< HEAD
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
+=======
+        <div class="col-5 u-align--center u-vertically-center u-hide--small">
+>>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
             alt="Chip",
@@ -113,6 +150,7 @@
           </div>
           <div>
             <aside class="p-accordion">
+<<<<<<< HEAD
               <ul class="p-accordion__list">
                 <li class="p-accordion__group">
                   <div role="heading" aria-level="2" class="p-accordion__heading">
@@ -122,11 +160,23 @@
                     {% for form_filter, total in form_filters.items() %}
                     <label class="p-checkbox">
                       <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form or form == "Models" %}checked{% endif %}>
+=======
+            <ul class="p-accordion__list">
+              <li class="p-accordion__group">
+                <div role="heading" aria-level="2" class="p-accordion__heading">
+                  <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Show</button>
+                </div>
+                <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
+                    {% for form_filter, total in form_filters.items() %}
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form %}checked{% endif %}>
+>>>>>>> Add filters=true check
                       <div class="p-checkbox__label" id="{{ form_filter }}">
                         <span>{{ form_filter }}</span>
                       </div>
                     </label>
                     {% endfor %}
+<<<<<<< HEAD
                   </section>
                 </li>
                 <li class="p-accordion__group">
@@ -175,6 +225,49 @@
       </div>
       {% if total_results > 0 %}
       <div class="col-9">
+=======
+                </section>
+              </li>
+              <li class="p-accordion__group">
+                <div role="heading" aria-level="2" class="p-accordion__heading">
+                  <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Certified for Ubuntu</button>
+                </div>
+                <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab2">
+                  {% for release_filter, total in release_filters.items() %}
+                  <label class="p-checkbox">
+                    <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
+                    <div class="p-checkbox__label" id="{{ release_filter }}">
+                      <span>{{ release_filter }}</span>
+                    </div>
+                  </label>
+                  {% endfor %}
+                </section>
+              </li>
+              <li class="p-accordion__group">
+                <div role="heading" aria-level="2" class="p-accordion__heading">
+                  <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
+                </div>
+                <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
+                  {% for vendor_filter, total in vendor_filters.items() %}
+                  <label class="p-checkbox">
+                    <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendors" value="{{ vendor_filter }}" {% if query and vendor_filter|lower in query|lower %}checked{% endif %}>
+                    <div class="p-checkbox__label" id="{{ vendor_filter }}">
+                      <span>{{ vendor_filter }}</span>
+                    </div>
+                  </label>
+                  {% endfor %}
+                </section>
+              </li>
+            </ul>
+          </aside>
+            <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
+            <input hidden id="filters" value="True" name="filters">
+          </div>
+        </nav>
+      </div>
+      <div class="col-9">
+        {% if total_results > 0 %}
+>>>>>>> Add filters=true check
         <table class="p-certification-results">
           <thead>
             <tr>
@@ -191,20 +284,28 @@
                 {% endif %}
                 {{ total_results }} result{% if total_results != 1 %}s{% endif %}
               </th>
+<<<<<<< HEAD
               <th>Vendor</th>
               <th>Type</th>
+=======
+              <th>type</th>
+>>>>>>> Add filters=true check
             </tr>
           </thead>
           <tbody>
             {% for result in results %}
             <tr>
             <td><a href="/certification/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
+<<<<<<< HEAD
             <td><a href="/certification?vendor={{ result.make }}&vendor_page=True">{{ result.make }}</a></td>
+=======
+>>>>>>> Add filters=true check
             <td>{{ result.category }}</td>
             </tr>
             {% endfor %}
           </tbody>
         </table>
+<<<<<<< HEAD
         {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
         {% include "security/cve/_pagination.html" %}
         {% endwith %}
@@ -224,6 +325,16 @@
         </ul>
       </div>
       {% endif %}
+=======
+          {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
+          {% include "security/cve/_pagination.html" %}
+          {% endwith %}
+    
+        {% else %}
+        <p>There are no results to show</p>
+        {% endif %}
+      </div>
+>>>>>>> Add filters=true check
     </div>
   </section>
 </form>

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -9,7 +9,6 @@
 
 <form class="form">
   <section class="p-strip--suru-topped">
-<<<<<<< HEAD
     {% if vendor_page %}
     <div class="u-fixed-width">
       <h1 class="u-sv3">Ubuntu certified hardware from {{ vendors }}</h1>
@@ -22,16 +21,6 @@
           <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
         </div>
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
-=======
-    {% if filters != True%}
-      {% if form == "Desktop" %}
-      <div class="row">
-        <div class="col-7">
-          <h1>Ubuntu Certified desktop hardware</h1>
-          <p class="u-sv3">Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
-        </div>
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
->>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
             alt="",
@@ -45,20 +34,12 @@
       </div>
       {% elif form == "Server" %}
       <div class="row">
-<<<<<<< HEAD
         <div class="col-8">
-=======
-        <div class="col-7">
->>>>>>> Add filters=true check
           <h1>Ubuntu Certified server hardware</h1>
           <p>Ubuntu Server gives you the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
           <p class="u-sv3">Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-centre environments.</p>
         </div>
-<<<<<<< HEAD
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
-=======
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
->>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
             alt="Server",
@@ -72,20 +53,12 @@
       </div>
       {% elif form == "Ubuntu Core" %}
       <div class="row">
-<<<<<<< HEAD
         <div class="col-8">
-=======
-        <div class="col-7">
->>>>>>> Add filters=true check
           <h1>Ubuntu Certified IoT hardware</h1>
           <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
           <p class="u-sv3">Canonical's certification program offers you peace of mind that all your Internet of Things devices will remain secure and regularly updated over the long term.</p>
         </div>
-<<<<<<< HEAD
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
-=======
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
->>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
             alt="Gateway",
@@ -97,24 +70,14 @@
           }}
         </div>
       </div>
-<<<<<<< HEAD
       {% elif form == "SoC" %}
       <div class="row">
         <div class="col-8">
-=======
-      {% elif form == "Server SoC" %}
-      <div class="row">
-        <div class="col-7">
->>>>>>> Add filters=true check
           <h1>Ubuntu Certified SoC hardware</h1>
           <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
           <p class="u-sv3">Canonical's certification program offers manufacturers a selection of SoCs officially supported and maintained in Ubuntu.</p>
         </div>
-<<<<<<< HEAD
         <div class="col-4 u-align--center u-vertically-center u-hide--small">
-=======
-        <div class="col-5 u-align--center u-vertically-center u-hide--small">
->>>>>>> Add filters=true check
           {{ image (
             url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
             alt="Chip",
@@ -150,7 +113,6 @@
           </div>
           <div>
             <aside class="p-accordion">
-<<<<<<< HEAD
               <ul class="p-accordion__list">
                 <li class="p-accordion__group">
                   <div role="heading" aria-level="2" class="p-accordion__heading">
@@ -160,23 +122,11 @@
                     {% for form_filter, total in form_filters.items() %}
                     <label class="p-checkbox">
                       <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form or form == "Models" %}checked{% endif %}>
-=======
-            <ul class="p-accordion__list">
-              <li class="p-accordion__group">
-                <div role="heading" aria-level="2" class="p-accordion__heading">
-                  <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Show</button>
-                </div>
-                <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
-                    {% for form_filter, total in form_filters.items() %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ form_filter }}" class="p-checkbox__input" id="form-filter" name="form" value="{{ form_filter }}" {% if form and form_filter in form %}checked{% endif %}>
->>>>>>> Add filters=true check
                       <div class="p-checkbox__label" id="{{ form_filter }}">
                         <span>{{ form_filter }}</span>
                       </div>
                     </label>
                     {% endfor %}
-<<<<<<< HEAD
                   </section>
                 </li>
                 <li class="p-accordion__group">
@@ -225,49 +175,6 @@
       </div>
       {% if total_results > 0 %}
       <div class="col-9">
-=======
-                </section>
-              </li>
-              <li class="p-accordion__group">
-                <div role="heading" aria-level="2" class="p-accordion__heading">
-                  <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Certified for Ubuntu</button>
-                </div>
-                <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab2">
-                  {% for release_filter, total in release_filters.items() %}
-                  <label class="p-checkbox">
-                    <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                    <div class="p-checkbox__label" id="{{ release_filter }}">
-                      <span>{{ release_filter }}</span>
-                    </div>
-                  </label>
-                  {% endfor %}
-                </section>
-              </li>
-              <li class="p-accordion__group">
-                <div role="heading" aria-level="2" class="p-accordion__heading">
-                  <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
-                </div>
-                <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
-                  {% for vendor_filter, total in vendor_filters.items() %}
-                  <label class="p-checkbox">
-                    <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendors" value="{{ vendor_filter }}" {% if query and vendor_filter|lower in query|lower %}checked{% endif %}>
-                    <div class="p-checkbox__label" id="{{ vendor_filter }}">
-                      <span>{{ vendor_filter }}</span>
-                    </div>
-                  </label>
-                  {% endfor %}
-                </section>
-              </li>
-            </ul>
-          </aside>
-            <button href="#" class="p-button--positive p-update-results" type=submit>Update</button>
-            <input hidden id="filters" value="True" name="filters">
-          </div>
-        </nav>
-      </div>
-      <div class="col-9">
-        {% if total_results > 0 %}
->>>>>>> Add filters=true check
         <table class="p-certification-results">
           <thead>
             <tr>
@@ -284,28 +191,20 @@
                 {% endif %}
                 {{ total_results }} result{% if total_results != 1 %}s{% endif %}
               </th>
-<<<<<<< HEAD
               <th>Vendor</th>
               <th>Type</th>
-=======
-              <th>type</th>
->>>>>>> Add filters=true check
             </tr>
           </thead>
           <tbody>
             {% for result in results %}
             <tr>
             <td><a href="/certification/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-<<<<<<< HEAD
             <td><a href="/certification?vendor={{ result.make }}&vendor_page=True">{{ result.make }}</a></td>
-=======
->>>>>>> Add filters=true check
             <td>{{ result.category }}</td>
             </tr>
             {% endfor %}
           </tbody>
         </table>
-<<<<<<< HEAD
         {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
         {% include "security/cve/_pagination.html" %}
         {% endwith %}
@@ -325,16 +224,6 @@
         </ul>
       </div>
       {% endif %}
-=======
-          {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-          {% include "security/cve/_pagination.html" %}
-          {% endwith %}
-    
-        {% else %}
-        <p>There are no results to show</p>
-        {% endif %}
-      </div>
->>>>>>> Add filters=true check
     </div>
   </section>
 </form>


### PR DESCRIPTION
## Done

- Build hardware details page for each model-release
- Change in progress to untested as per wireframe

## QA

- Go to https://ubuntu-com-9598.demos.haus/certification
- Search for something to land on search results page. 
- Select any model to land on model details page
- Click the hardware details link in the releases section
- See a list of hardware. The list is no longer links as we no longer have the "component catalog" which exists on the current site. 
- Compare the page against the [design](https://app.zeplin.io/project/5f3f890c6afe2512594898b2/screen/606c439a5cdfed97af0303f0) 


## Issue / Card

Fixes [#158](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/158)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/115698191-41220780-a35c-11eb-8d15-d421d42d3e18.png)
