### PR TITLE
Fix vendor param issue

### DIFF
--- a/webapp/certification/api.py
+++ b/webapp/certification/api.py
@@ -78,6 +78,8 @@ class CertificationAPI:
                 "offset": offset,
                 "level": level,
                 "major_release__in": major_release__in,
+                # If vendor is a list, requests will tranform into
+                # &vendor=item&vendor=item
                 "vendor": vendor,
                 "make__iexact": make__iexact,
                 "query": query,

--- a/webapp/certification/views.py
+++ b/webapp/certification/views.py
@@ -286,7 +286,7 @@ def certification_home():
             else None
         )
         vendors = (
-            ",".join(request.args.getlist("vendor"))
+            request.args.getlist("vendor")
             if request.args.getlist("vendor")
             else None
         )


### PR DESCRIPTION
## Done

Fix vendor params for certified models endpoint

## QA

- Go to https://ubuntu-com-9600.demos.haus/certification?text=&form=SoC&vendor=Applied+Micro+Circuits+Corp.&vendor=Qualcomm+Inc&filters=True Some results show up

## Issue / Card

Fixes https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/179