### PR TITLE
Read the... /download/server

### DIFF
--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -54,7 +54,7 @@
       </ul>
       <p class="u-sv3">
         <a href="{{ releases.lts.release_notes_url }}" class="p-link--external">
-          Download Ubuntu Server {{ releases.lts.short_version }} LTS release notes
+          Read the Ubuntu Server {{ releases.lts.short_version }} LTS release notes
         </a>
       </p>
     </div>
@@ -108,7 +108,7 @@
 
       <p>
         <a href="{{ releases.latest.release_notes_url }}">
-          Download Ubuntu Server {{ releases.latest.short_version }} release notes&nbsp;&rsaquo;
+          Read the Ubuntu Server {{ releases.latest.short_version }} release notes&nbsp;&rsaquo;
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- Replace 'Download the release notes' with 'Read the release notes'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server step 2
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the release note text is better

