### PR TITLE
Remove default quantity for small screens

### DIFF
--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -1,11 +1,15 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+const isSmallVP =
+  Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) <
+  875;
+
 const initialFormState = {
   type: "physical",
   version: "18.04",
   feature: "infra",
   support: "unset",
-  quantity: 1,
+  quantity: isSmallVP ? 0 : 1,
   billing: "yearly",
   product: {
     ok: false,

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -150,7 +150,7 @@ function renderSummary(state) {
   const billingSection = summarySection.querySelector(".js-summary-billing");
   const buyButton = summarySection.querySelector(".js-ua-shop-cta");
 
-  if (!state.product.ok) {
+  if (!state.product.ok || quantity <= 0) {
     summarySection.classList.add("p-shop-cart--hidden");
     buyButton.classList.add("u-disable");
   } else {

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -132,7 +132,9 @@ function renderSupport(state) {
 function renderQuantity(state) {
   const quantity = state.quantity;
   const quantityInput = form.querySelector("#quantity-input");
-  quantityInput.value = quantity;
+  if (quantityInput !== document.activeElement) {
+    quantityInput.value = quantity;
+  }
 }
 
 const imgUrl = {


### PR DESCRIPTION
## Done

- Set the default quantity to 0 on small screens so the product summary doesn't show until the user has chosen a quantity

## QA

- go here https://ubuntu-com-9606.demos.haus/advantage/subscribe?test_backend=true
- resize your browser until you get the small VP view (875px)
- refresh and fill the form
- The summary and buy button should remain hidden until you increase the quantity
- Verify that it isn't the case on large VP sizes


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9573

