### PR TITLE
Persist redux state to local storage

### DIFF
--- a/static/js/src/advantage/subscribe/product-selector.js
+++ b/static/js/src/advantage/subscribe/product-selector.js
@@ -1,4 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { debounce } from "../../utils/debounce";
+import { saveState } from "../../utils/persitState";
 import initFormInputs from "./listeners/form-event-listeners";
 import initUIControls from "./listeners/ui-event-listeners";
 
@@ -24,4 +26,7 @@ initUIControls(store);
 render(store.getState());
 store.subscribe(() => {
   render(store.getState());
+  debounce(function () {
+    saveState(store.getState(), "ua-subscribe-state");
+  }, 1000)();
 });

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { loadState } from "../../../utils/persitState";
 
 const initialFormState = {
   type: "physical",
@@ -96,7 +97,7 @@ function getProduct(state) {
 
 const formSlice = createSlice({
   name: "form",
-  initialState: initialFormState,
+  initialState: loadState("ua-subscribe-state", "form", initialFormState),
   reducers: {
     changeType(state, action) {
       state.type = action.payload;

--- a/static/js/src/advantage/subscribe/reducers/ui-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/ui-reducer.js
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { loadState } from "../../../utils/persitState";
 
 const initialUIState = {
   otherVersionsModal: {
@@ -8,7 +9,7 @@ const initialUIState = {
 
 const UISlice = createSlice({
   name: "ui",
-  initialState: initialUIState,
+  initialState: loadState("ua-subscribe-state", "ui", initialUIState),
   reducers: {
     toggleOtherVersionsModal(state) {
       state.otherVersionsModal.show = !state.otherVersionsModal.show;

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -831,6 +831,9 @@ function handleSuccessfulPayment(transaction) {
     const products = analyticsFriendlyProducts();
 
     purchaseEvent(purchaseInfo, products);
+
+    // Remove the product selection from the local storage
+    localStorage.removeItem("ua-subscribe-state");
   }
 
   disableProcessingState();

--- a/static/js/src/utils/persitState.js
+++ b/static/js/src/utils/persitState.js
@@ -1,0 +1,21 @@
+export function saveState(state, stateName) {
+  console.log("write");
+  try {
+    const serializedState = JSON.stringify(state);
+    localStorage.setItem(stateName, serializedState);
+  } catch (err) {
+    // ignore write errors
+  }
+}
+
+export function loadState(stateName, slice, defaultState) {
+  try {
+    const serializedState = localStorage.getItem(stateName);
+    if (serializedState === null) {
+      return defaultState;
+    }
+    return JSON.parse(serializedState)[slice];
+  } catch (err) {
+    return defaultState;
+  }
+}

--- a/static/js/src/utils/persitState.js
+++ b/static/js/src/utils/persitState.js
@@ -1,5 +1,4 @@
 export function saveState(state, stateName) {
-  console.log("write");
   try {
     const serializedState = JSON.stringify(state);
     localStorage.setItem(stateName, serializedState);


### PR DESCRIPTION
## Done

- Persist redux state to local storage so the form remembers the user's selection.

## QA

- go here https://ubuntu-com-9609.demos.haus/advantage/subscribe?test_backend=true
- make some changes to the form
- refresh/navigate to another page and go back
- check that the changes are still here
- make the purchase
- go back to /subscribe
- check that the form "forgot" about your last purchase and is reset to the default state


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9605

## Question

@wgx @elioqoshi The way it's done now, the form will remember "forever" the selection. Do we want to clear it at some point? (on a successful purchase or another action?)
