### PR TITLE
Updated small text in "Free for personal use" section

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -452,7 +452,7 @@
         <h2>Free for personal use</h2>
         <p>Anyone can use UA Infrastructure Essential for free on up to 3 machines (limitations apply).  All you need is an Ubuntu One account. And if you're a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it's free on up to 50 machines.</p>
         <p class="u-no-margin--bottom">
-          <span class="u-sv1"><small>Initially, free subscription is available for Ubuntu 14.04 LTS only. By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
+          <span class="u-sv1"><small>Ubuntu 14.04 LTS machines can receive Extended Security Maintenance (ESM) updates and other Ubuntu Advantage benefits. By registering you agree to our <a href="/legal/ubuntu-advantage/personal">Terms of Service</a>.</small><br /></span>
           <a href="/login" class="p-button--positive" onclick="dataLayer.push({
             'event' : 'GAEvent',
             'eventCategory' : 'Advantage',


### PR DESCRIPTION


## Done

Changed "Initially, free subscription is available for Ubuntu 14.04 LTS only." to "Ubuntu 14.04 LTS machines can receive Extended Security Maintenance (ESM) updates and other Ubuntu Advantage benefits" as per the copy doc; https://docs.google.com/document/d/1So3n5HEpBX39xxEkkChnve09gKSr9TgYUcbfdOTCevk/edit?ts=6082875c

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the change against the [copy doc](https://docs.google.com/document/d/1So3n5HEpBX39xxEkkChnve09gKSr9TgYUcbfdOTCevk/edit?ts=6082875c).

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
