### PR TITLE
Update AI link

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -53,7 +53,7 @@
             <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="https://microk8s.io" title="Visit the MicroK8s website - external site" >Get K8s for your workstation and edge / IoT</a></li>
-            <li class="p-list__item"><a href="/ai/features">AI and ML on Kubernetes</a></li>
+            <li class="p-list__item"><a href="/ai/what-is-kubeflow">AI and ML on Kubernetes</a></li>
             <li class="p-list__item"><a href="http://charmed-kubeflow.io">Easy Kubeflow operations</a></li>
             <li class="p-list__item"><a href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE with Ubuntu on Google Cloud</a></li>
             <li class="p-list__item"><a href="/openstack/tco-calculator">TCO calculator</a></li>


### PR DESCRIPTION

## Done

Updated enterprise AI link to /ai/what-is-kubeflow

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check it against the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit#heading=h.x5bjdjaazslx)


## Issue / Card

Fixes #9520


