### PR TITLE
Update links to point to /certification

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -899,7 +899,7 @@ kubernetes:
               hidden: True
             - title: 1.20 vSphere integrator
               path: /kubernetes/docs/1.20/charm-vsphere-integrator
-              hidden: True 
+              hidden: True
             - title: 1.21 AWS IAM
               path: /kubernetes/docs/1.21/charm-aws-iam
               hidden: True
@@ -1626,3 +1626,5 @@ certification:
       path: /certification?form=Ubuntu%20Core
     - title: SoCs
       path: /certification?form=SoC
+    - title: Get certified
+      path: https://partners.ubuntu.com/contact-us

--- a/templates/appliance/community.html
+++ b/templates/appliance/community.html
@@ -162,7 +162,7 @@
         Hardware compatibility
       </h2>
       <p>
-        Ubuntu Core is guaranteed to work on any <a class="p-link--external" href="https://certification.ubuntu.com/">Ubuntu certified hardware</a>. We recommend the Raspberry Pi or Intel NUCs for your development and testing. We recommend that you work with Canonical to certify any other hardware that is particularly relevant for your appliance. Certification means that every update, bug fix or security patch is tested on these boards in Canonical's testing lab to minimise regressions.
+        Ubuntu Core is guaranteed to work on any <a href="/certification">Ubuntu certified hardware</a>. We recommend the Raspberry Pi or Intel NUCs for your development and testing. We recommend that you work with Canonical to certify any other hardware that is particularly relevant for your appliance. Certification means that every update, bug fix or security patch is tested on these boards in Canonical's testing lab to minimise regressions.
       </p>
     </div>
     <div class="col-4 u-hide--small u-align--center u-vertically-center">

--- a/templates/appliance/hardware.html
+++ b/templates/appliance/hardware.html
@@ -75,7 +75,7 @@
       <h2>Not the hardware you're looking for?</h2>
       <p>We test every Ubuntu Appliance to work perfectly across all certified boards and boxes.</p>
       <p>If you want your hardware to be certified for Ubuntu Appliances let us know.</p>
-      <p><a href="https://certification.ubuntu.com/iot" class="p-link--external">See all Canonical certified hardware</a></p>
+      <p><a href="/certification?form=Ubuntu%20Core">See all Canonical certified hardware&nbsp;&rsaquo;</a></p>
       <p><a href="/appliance/contact-us" class="js-invoke-modal p-button u-no-margin--bottom">Get in touch</a></p>
     </div>
     <div class="col-4 u-hide--small">

--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -336,7 +336,7 @@
         We test all the certified combinations of appliance image and device, every time we change the system, for a decade or more. You can relax and let Ubuntu Core keep you up to date year after year with the latest features and fixes, and never miss a beat.
       </p>
       <p>
-        <a class="p-link--external" href="https://certification.ubuntu.com/iot">See Canonical-certified hardware</a>
+        <a href="/certification?form=Ubuntu%20Core">See Canonical-certified hardware&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>

--- a/templates/certification/search-results.html
+++ b/templates/certification/search-results.html
@@ -14,7 +14,7 @@
       <h1 class="u-sv3">Ubuntu certified hardware from {{ vendors }}</h1>
     </div>
     {% elif filters != True%}
-      {% if form == "Desktop" %}
+      {% if form == "Desktop" or form == "Desktop,Laptop" %}
       <div class="row">
         <div class="col-8">
           <h1>Ubuntu Certified desktop hardware</h1>

--- a/templates/core/features/full-disk-encryption.html
+++ b/templates/core/features/full-disk-encryption.html
@@ -62,7 +62,7 @@
     </div>
     <div class="p-card col-6 u-vertically-center">
       <h3 class="p-card__title">Free for pre-certified boards</h3>
-      <p class="p-card__content">Full disk encryption is available out of the box on <a class="p-link--external" href="https://certification.ubuntu.com/iot">certified devices</a>, with TPM support, at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards.</p>
+      <p class="p-card__content">Full disk encryption is available out of the box on <a href="/certification?form=Ubuntu%20Core">certified devices</a>, with TPM support, at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards.</p>
     </div>
   </div>
 </section>

--- a/templates/core/features/recovery.html
+++ b/templates/core/features/recovery.html
@@ -61,7 +61,7 @@
     </div>
     <div class="p-card col-6 u-vertically-center">
       <h3 class="p-card__title">Free for pre-certified boards</h3>
-      <p class="p-card__content">Recovery mode is available out of the box on <a class="p-link--external" href="https://certification.ubuntu.com/iot">certified devices</a>, like the Raspberry Pi, at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards. </p>
+      <p class="p-card__content">Recovery mode is available out of the box on <a href="/certification?form=Ubuntu%20Core">certified devices</a>, like the Raspberry Pi, at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards. </p>
     </div>
   </div>
 </section>

--- a/templates/core/features/secure-boot.html
+++ b/templates/core/features/secure-boot.html
@@ -70,7 +70,7 @@
     </div>
     <div class="p-card col-6 u-vertically-center">
       <h3 class="p-card__title">Free for pre-certified boards</h3>
-      <p class="p-card__content">Secure boot is available out of the box on <a class="p-link--external" href="https://certification.ubuntu.com/iot">certified devices</a>, like the Raspberry Pi, at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards.</p>
+      <p class="p-card__content">Secure boot is available out of the box on <a href="/certification?form=Ubuntu%20Core">certified devices</a>, like the Raspberry Pi, at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards.</p>
     </div>
   </div>
 </section>

--- a/templates/core/smartstart/guide/certification-and-validation.md
+++ b/templates/core/smartstart/guide/certification-and-validation.md
@@ -10,9 +10,9 @@ context:
 
 Device certification keeps devices secure with security fixes and bug fixes over the life of the certified release (and the next LTS). Several instances of the target device model will undergo regular testing in our certification lab. Continuous testing ensures that updates do not cause regressions.
 
-In the case regressions are found, Canonical is committed to fix the issues promptly. Ubuntu Certified devices are listed on our [certification website](http://certification.ubuntu.com/iot). Canonical assigns a dedicated engineer as the point of contact for each Ubuntu Certified device.
+In the case regressions are found, Canonical is committed to fix the issues promptly. Ubuntu Certified devices are listed on our [certification website](/certification?form=Ubuntu%20Core). Canonical assigns a dedicated engineer as the point of contact for each Ubuntu Certified device.
 
-In order to be granted Ubuntu certification, devices must first undergo rigorous testing by Canonical QA to ensure that Ubuntu running on the system meets Canonical's standards. Once testing is complete Canonical issues a [certificate](http://certification.ubuntu.com), and the system will be placed into the certification lab to undergo continuous testing.
+In order to be granted Ubuntu certification, devices must first undergo rigorous testing by Canonical QA to ensure that Ubuntu running on the system meets Canonical's standards. Once testing is complete Canonical issues a [certificate](/certification), and the system will be placed into the certification lab to undergo continuous testing.
 
 ## Device validation
 
@@ -22,7 +22,7 @@ The scope of testing under device validation is low-level software testing, rath
 
 ## Helpful resources
 
-- [Ubuntu Certified IoT devices](http://certification.ubuntu.com/iot)
+- [Ubuntu Certified IoT devices](/certification?form=Ubuntu%20Core)
 
 <footer class="p-article-pagination">
   <a class="p-article-pagination__link--previous" href="/core/smartstart/guide/device-enablement">

--- a/templates/core/smartstart/guide/hardware-setup.md
+++ b/templates/core/smartstart/guide/hardware-setup.md
@@ -8,7 +8,7 @@ context:
   copydoc: "https://docs.google.com/document/d/1kpZihTOUrC1VlyeN376l3mpiAqd_g3apsgzPj0sX5H8/edit"
 ---
 
-Board certification for Ubuntu is a prerequisite for commercialisation with SMART START. Canonical has [certified a selection x86 and ARM-based](https://certification.ubuntu.com/iot) off-the-shelf boards for Ubuntu. Customers can choose one, and benefit from the shortest time to market (two weeks delivery). Alternatively, customers can purchase [Canonical's device enablement](/smartstart/guide/device-enablement) service as an add-on to get any board on their choice certified for Ubuntu.
+Board certification for Ubuntu is a prerequisite for commercialisation with SMART START. Canonical has [certified a selection x86 and ARM-based](/certification?form=Ubuntu%20Core) off-the-shelf boards for Ubuntu. Customers can choose one, and benefit from the shortest time to market (two weeks delivery). Alternatively, customers can purchase [Canonical's device enablement](/smartstart/guide/device-enablement) service as an add-on to get any board on their choice certified for Ubuntu.
 
 ## Certified boards
 
@@ -16,7 +16,7 @@ Boards certified for Ubuntu span x86, ARM, 32bit and 64bit architectures. These 
 
 | amd64|i386|arm64|armhf|
 | --- | --- | --- | --- |
-|[Intel NUC7CJYH](https://certification.ubuntu.com/hardware/201805-26256)<br> [Intel NUC7PJYH](https://certification.ubuntu.com/hardware/201805-26252)<br> [Intel NUC7i3DNHE](https://certification.ubuntu.com/hardware/201802-26085)<br> [Intel NUC7i5DNHE](https://certification.ubuntu.com/hardware/201802-26086)<br> [Intel NUC7i5DNHE](https://certification.ubuntu.com/hardware/201802-26087)<br> [Intel TANK-870-Q170](https://certification.ubuntu.com/hardware/201808-26450) | Intel Edison  | Qualcomm Dragonboard 410c<br> Raspberry Pi model 3<br> Raspberry Pi model 4| Raspberry Pi model 2<br>Raspberry Pi model 3<br>Raspberry Pi model 4<br>Raspberry Pi CM3|
+|[Intel NUC7CJYH](/certification/201805-26256)<br> [Intel NUC7PJYH](/certification/201805-26252)<br> [Intel NUC7i3DNHE](/certification/201802-26085)<br> [Intel NUC7i5DNHE](/certification/201802-26086)<br> [Intel NUC7i5DNHE](/certification/201802-26087)<br> [Intel TANK-870-Q170](/certification/201808-26450) | Intel Edison  | Qualcomm Dragonboard 410c<br> Raspberry Pi model 3<br> Raspberry Pi model 4| Raspberry Pi model 2<br>Raspberry Pi model 3<br>Raspberry Pi model 4<br>Raspberry Pi CM3|
 
 ## Device enablement
 
@@ -26,9 +26,9 @@ Canonical also can port drivers and board support packages to Ubuntu. Once certi
 
 ### Helpful resources
 
-- [Ubuntu certified IoT hardware](https://certification.ubuntu.com/iot)
+- [Ubuntu certified IoT hardware](/certification?form=Ubuntu%20Core)
 - [Advanced options](/smart-start/guide/advanced-options)
-- [Device enablement](https://certification.ubuntu.com/iot)
+- [Device enablement](/certification?form=Ubuntu%20Core)
 - [Technical support](/smart-start/guide/technical-support)
 
 <footer class="p-article-pagination">

--- a/templates/core/smartstart/guide/index.md
+++ b/templates/core/smartstart/guide/index.md
@@ -34,7 +34,7 @@ SMART START brings agility to enterprise IoT projects. Through this bundle enter
 
 ### Helpful resources
 
-- [Ubuntu pre-certified IoT hardware](https://certification.ubuntu.com/iot)
+- [Ubuntu pre-certified IoT hardware](/certification?form=Ubuntu%20Core)
 - [SMART START pricing](/pricing/devices)
 - [Ubuntu Core](/core)
 

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -225,7 +225,7 @@
       <div class="col-7">
         <h2>By developers, for developers</h2>
         <p>Ubuntu is the result of contributions by thousands of developers, motivated by the desire to create their own perfect developer environment. That's why it's used by some of the world's most exciting technology companies and it's why Valve decided to port its hugely popular Steam virtual games store to Ubuntu. Ubuntu runs on architectures from x86 to ARM and on cloud platforms from OpenStack to Azure and EC2. This versatility makes it the ideal choice for companies with a diverse hardware infrastructure.</p>
-        <p><a href="/certification?form=Desktop">See all Ubuntu certified PCs&nbsp;&rsaquo;</a></p>
+        <p><a href="/certification?form=Desktop&form=Laptop">See all Ubuntu certified PCs&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-vertically-center">
         {{

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -225,7 +225,7 @@
       <div class="col-7">
         <h2>By developers, for developers</h2>
         <p>Ubuntu is the result of contributions by thousands of developers, motivated by the desire to create their own perfect developer environment. That's why it's used by some of the world's most exciting technology companies and it's why Valve decided to port its hugely popular Steam virtual games store to Ubuntu. Ubuntu runs on architectures from x86 to ARM and on cloud platforms from OpenStack to Azure and EC2. This versatility makes it the ideal choice for companies with a diverse hardware infrastructure.</p>
-        <p><a class="p-link--external" href="https://certification.ubuntu.com/desktop">See all Ubuntu certified PCs</a></p>
+        <p><a href="/certification?form=Desktop">See all Ubuntu certified PCs&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-vertically-center">
         {{

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -252,7 +252,7 @@
     <div class="col-6">
       <h2>Pre-installed on certified hardware</h2>
       <p>Ubuntu runs on the world's best hardware from partners such as Dell, HP and Lenovo. And with nearly 90% of PCs shipped by the major PC companies already certified to work with Ubuntu, it is easy to find hardware that will work for your business.</p>
-      <p><a class="p-link--external" href="https://certification.ubuntu.com">Learn more about Ubuntu certified hardware</a></p>
+      <p><a href="/certification">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -114,7 +114,7 @@
     <div class="col-6">
       <h2>Ubuntu Desktop certified hardware</h2>
       <p>To offer top performance on Ubuntu, manufacturers are pre-loading devices with an Ubuntu Certified image. This ensures driver integration and superior device performance.  Canonical is committed to working closely with with the world's leading manufacturers to optimise and certify Ubuntu on their laptops and PCs.</p>
-      <p><a class="p-link--external" href="https://certification.ubuntu.com/certification/">Learn more about Ubuntu Certified hardware</a></p>
+      <p><a href="/certification">Learn more about Ubuntu Certified hardware&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-vertically-center">
       {{

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -17,9 +17,6 @@
           <a href="https://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://certification.ubuntu.com">certification.ubuntu.com</a>
-        </li>
-        <li class="p-list__item">
           <a href="https://cloud-images.ubuntu.com">cloud-images.ubuntu.com</a>
         </li>
         <li class="p-list__item">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -458,7 +458,7 @@
         <li class="p-list__item is-ticked">Block and object storage</li>
         <li class="p-list__item is-ticked">High availability</li>
       </ul>
-      <p>Design and delivery on certified hardware.</p>
+      <p>Design and delivery on <a href="/certification?form=Server">certified hardware</a>.</p>
       <p><a href="/openstack/consulting">Get OpenStack&nbsp;›</a></p>
     </div>
     <div class="col-6 p-card">

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -222,7 +222,7 @@
         }}
       </li>
     </ul>
-    <p class="u-align--center u-vertically-spaced"><a href="https://certification.ubuntu.com">
+    <p class="u-align--center u-vertically-spaced"><a href="/certification">
       View all certified hardware partners&nbsp;&rsaquo;
     </a></p>
 

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -47,7 +47,7 @@
       </div>
 
       <div class="js-formfield">
-        <h3 class="p-heading--five">Have you tested your applications on <a href="https://certification.ubuntu.com/iot">certified hardware</a>? (e.g Raspberry Pi, Intel NUC, etc.)</h3>
+        <h3 class="p-heading--five">Have you tested your applications on <a href="/certification?form=Ubuntu%20Core">certified hardware</a>? (e.g Raspberry Pi, Intel NUC, etc.)</h3>
         <div class="u-sv3">
           <input type="radio" id="tested-certified-hardware-yes" name="tested-certified-hardware" value="Yes, it works">
           <label for="tested-certified-hardware-yes" class="u-no-margin--bottom">Yes, it works</label>

--- a/templates/shared/pricing/_smart-start-prices.html
+++ b/templates/shared/pricing/_smart-start-prices.html
@@ -24,7 +24,7 @@
     <div class="col-7">
       <p>Time to market is crucial. Canonical will validate your hardware, package your apps, set up your app store and prepare your device image.</p>
 
-      <p>The package includes one year of app store services and device security updates for up to 1,000 devices. Choose from our extensive list of <a class="p-link--external" href="https://certification.ubuntu.com/iot">certified boards and boxes</a>.</p>
+      <p>The package includes one year of app store services and device security updates for up to 1,000 devices. Choose from our extensive list of <a href="/certification?form=Ubuntu%20Core">certified boards and boxes</a>.</p>
     </div>
   </div>
 

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -82,7 +82,7 @@
             <li class="p-list__item"><a href="/appliance">Appliance images</a></li>
             <li class="p-list__item"><a href="/embedded">Embedded Linux with Ubuntu</a></li>
             <li class="p-list__item"><a href="https://snapcraft.io" title="Visit Snapcraft - external site">Snaps - secure packages for IoT</a></li>
-            <li class="p-list__item"><a href="/download/iot">Supported boards and SoCs</a></li>
+            <li class="p-list__item"><a href="/certification">Supported boards and SoCs</a></li>
             <li class="p-list__item"><a href="/internet-of-things/digital-signage">Digital signage and smart displays</a></li>
             <li class="p-list__item"><a href="/robotics">Robots and drones with app stores</a></li>
             <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways with Ubuntu</a></li>
@@ -114,7 +114,7 @@
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>
             <li class="p-list__item"><a href="/security">Security</a></li>
-            <li class="p-list__item"><a href="https://certification.ubuntu.com">Hardware certification</a></li>
+            <li class="p-list__item"><a href="/certification">Hardware certification</a></li>
             <li class="p-list__item"><a href="/aws">Get Ubuntu Pro on AWS</a></li>
             <li class="p-list__item"><a href="/azure">Get Ubuntu Pro on Azure</a></li>
           </ul>
@@ -147,7 +147,7 @@
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS - fast server provisioning</a></li>
           <li class="p-list__item"><a href="https://jaas.ai" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
           <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
-          <li class="p-list__item"><a href="https://certification.ubuntu.com/server" title="Visit certification - external site">Certified hardware</a></li>
+          <li class="p-list__item"><a href="/certification?form=Server">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>
           <li class="p-list__item"><a href="https://anbox-cloud.io/" title="Visit Anbox Cloud">Anbox Cloud - Android in the cloud</a></li>
         </ul>


### PR DESCRIPTION
## Done

- Update links to point to /certification
- Add `Get certified` to secondary nav

## QA

- Visit https://ubuntu-com-9619.demos.haus
- Check all links that previously pointed to `certification.ubuntu.com` now point to `/certification`
- Check the "Get certified" link from the secondary nav


## Issue / Card

Fixes [#168](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/168)

