### PR TITLE
Fix error handling for payment methods page

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -350,7 +350,9 @@ def advantage_payment_methods_view(**kwargs):
     api_url = kwargs.get("api_url")
     token = kwargs.get("token")
 
-    advantage = UAContractsAPI(session, token, api_url=api_url)
+    advantage = UAContractsAPI(
+        session, token, api_url=api_url, is_for_view=True
+    )
 
     try:
         account = advantage.get_purchase_account()


### PR DESCRIPTION
## Done

- Fix error handling for payment methods page

## QA

How it worked before:
- Go to https://ubuntu-com-9240.demos.haus/advantage?test_backend=true and login
- Go to https://ubuntu-com-9240.demos.haus/advantage/payment-methods?test_backend=true
- Go to https://ubuntu-com-9240.demos.haus/advantage/payment-methods
- it will return you an ugly json saying authentication required

How it works after:
- Go to https://ubuntu-com-9620.demos.haus/advantage?test_backend=true and login
- Go to https://ubuntu-com-9620.demos.haus/advantage/payment-methods?test_backend=true
- Go to https://ubuntu-com-9620.demos.haus/advantage/payment-methods
- It will redirect you nicely to /advantage

