### PR TITLE
Build component page

### DIFF
--- a/static/sass/_pattern_component-details-table.scss
+++ b/static/sass/_pattern_component-details-table.scss
@@ -1,0 +1,24 @@
+.p-table--component-details {
+  th,
+  td {
+    &:nth-child(1) {
+      width: 16%;
+      @media only screen and (max-width: $breakpoint-medium) {
+        width: 25%;
+      }
+      @media only screen and (max-width: $breakpoint-small) {
+        width: 33%;
+      }
+    }
+
+    &:nth-child(2) {
+      width: 84%;
+      @media only screen and (max-width: $breakpoint-medium) {
+        width: 75%;
+      }
+      @media only screen and (max-width: $breakpoint-small) {
+        width: 67%;
+      }
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -42,6 +42,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_card";
 @import "pattern_certification-results";
 @import "pattern_chart";
+@import "pattern_component-details-table";
 @import "pattern_component-table";
 @import "pattern_contact-modal";
 @import "pattern_contextual-footer";

--- a/templates/certification/component-details.html
+++ b/templates/certification/component-details.html
@@ -1,56 +1,99 @@
-<h1>This is the components detail page</h1>
+{% extends "certification/base_certification.html" %}
 
+{% block title %}Ubuntu certified component: {{ component.vendor_name }} {{ component.model }}{% endblock %}
 
-<h1>Components certified in Ubuntu releases</h1>
-{% for name, details in component.lts_releases.items() %}
-    <p>{{ details.0.status.title() }}</p>
-    <p>{{ details.0.release }}</p>
-    <p>{{ details.0.third_party_driver }}</p>
-{% endfor %}
+{% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
-<h1>Component details</h1>
-<table>
-    <tbody>
-        <tr>
-        <th scope="row">Vendor</th>
-        <td>{{ component.vendor_name }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Component model name</th>
-        <td>{{ component.model }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Identifier</th>
-        <td>{{ component.identifier }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Subsystem Identifier</th>
-        <td>{{ component.subsystem_identifier}}</td>
-        </tr>
-        <tr>
-        <th scope="row">Hardware Vendor Make</th>
-        <td>{{ component.hardware_vendor_make }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Vendor Make</th>
-        <td>{{ component.vendor_make }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Part Number</th>
-        <td>{{ component.part_number }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Device Category</th>
-        <td>{{ component.category }}</td>
-        </tr>
-        <tr>
-        <th scope="row">Note</th>
-        <td>{{ component.note }}</td>
-        </tr>
-    </tbody>
-</table>
+{% block content %}
+<section class="p-strip--suru-topped">
+  <div class="row u-sv3">
+    <div class="col-12">
+      <h1>{{ component.vendor_name }} {{ component.model }}</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h2 class="u-sv2">Components certified in Ubuntu releases</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <table class="u-sv1" aria-label="Components certified in ubuntu releases">
+        <thead>
+          <tr>
+            <th>Release</th>
+            <th>Status</th>
+            <th>Third-party driver</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for name, details in component.lts_releases.items() %}
+          <tr>
+            <td>{{ details.0.release }}</td>
+            <td>{{ details.0.status.title() }}</td>
+            <td>{% if details.0.third_party_driver != True %}No{% else %}Yes{% endif %}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="row u-sv1">
+    <div class="col-12">
+      <h2 class="u-sv2">Component details</h2>
+      <table class="p-table--component-details" aria-label="Component details table">
+        <tbody>
+          <tr>
+            <th class="p-muted-text">Vendor</th>
+            <td>{{ component.vendor_name }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Model name</th>
+            <td>{{ component.model }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Identifier</th>
+            <td>{{ component.identifier }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Subsystem Identifier</th>
+            <td>{{ component.subsystem_identifier}}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Hardware Vendor make</th>
+            <td>{{ component.hardware_vendor_make }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Vendor make</th>
+            <td>{{ component.vendor_make }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Part number</th>
+            <td>{{ component.part_number }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Device category</th>
+            <td>{{ component.category }}</td>
+          </tr>
+          <tr>
+            <th class="p-muted-text">Note</th>
+            <td>{{ component.note }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <h2>Present in {{ machines|length }} certified system{% if machines|length > 1 %}s{% endif %}</h2>
+    <ul class="p-list">
+      {% for machine in machines %}
+      <li class="p-list__item">
+        <a href="/certification/{{ machine.canonical_id }}">{{ machine.canonical_id }} {{ machine.make }} {{ machine.model }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
 
-<h2>Present in {{total_results}} certified systems</h2>
-{% for machine in machines %}
-<p>{{ machine }}</p>
-{% endfor %}
+{% endblock content %}

--- a/templates/certification/model-details.html
+++ b/templates/certification/model-details.html
@@ -133,7 +133,7 @@
       <tbody>
         {% for component in components%}
         <tr>
-          <th aria-label="Component"><a href="/certification/component/{{ canonical_id }}">{{ component.vendor_name }} {{ component.model}}</a></th>
+          <th aria-label="Component"><a href="/certification/component/{{ component.id }}">{{ component.vendor_name }} {{ component.model }}</a></th>
           {% for lts_release, details in component.lts_releases.items() %}
             {% if lts_release == '14.04 ESM' %}
               {% if details[0].third_party_driver == True %}


### PR DESCRIPTION
## Done

- Build component page
- Update URL from model details page to point to component page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certification/component/682 or http://0.0.0.0:8001/certification/component/710
- Check the page against the [design](https://app.zeplin.io/project/5f3f890c6afe2512594898b2/screen/6076cde233a60f47a193f604)


## Issue / Card

Fixes [#162](https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/162)

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/116100069-7f912c80-a6a4-11eb-8ebb-323b11f4dd1c.png)
