### PR TITLE
Re-add captcha to /desktop/download/thank-you

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -279,6 +279,7 @@
 
 {% block footer_extra %}
 <script src="{{ versioned_static('js/src/contributions.js') }}"></script>
+<script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>
 
 {% if version %}
   <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>


### PR DESCRIPTION
## Done

- Re-add captcha to /desktop/download/thank-you

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- On /desktop/download/thank-you, ensure - in the console - that the nl subscription form goes through when submitting.
