### PR TITLE
PoC: React in ubuntu.com/advantage

### DIFF
--- a/build.js
+++ b/build.js
@@ -19,6 +19,7 @@ let entries = {
   "ua-product-selector": "./static/js/src/ua-product-selector.js",
   "ua-entitlements-callout":
     "./static/js/src/advantage/entitlements-callout.js",
+  "ua": "./static/js/src/advantage/ua.jsx",
 };
 
 for (const [key, value] of Object.entries(entries)) {
@@ -29,6 +30,7 @@ for (const [key, value] of Object.entries(entries)) {
     sourcemap: true,
     outfile: "static/js/dist/" + key + ".js",
     target: ["chrome58", "firefox57", "safari11", "edge16"],
+    define: {'process.env.NODE_ENV': '"production"'},
   };
 
   esbuild.build(options).then((result) => {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "devDependencies": {
-    "esbuild": "0.9.2",
     "@babel/core": "7.12.13",
     "@babel/plugin-transform-runtime": "7.12.15",
     "@babel/preset-env": "7.12.13",
@@ -40,6 +39,7 @@
     "babel-loader": "8.2.2",
     "concurrently": "6.0.0",
     "cypress": "5.6.0",
+    "esbuild": "0.9.2",
     "eslint": "7.19.0",
     "eslint-config-prettier": "7.2.0",
     "eslint-plugin-cypress": "2.11.2",
@@ -62,9 +62,11 @@
     "@canonical/cookie-policy": "3.2.0",
     "@canonical/global-nav": "2.4.5",
     "@canonical/latest-news": "1.2.0",
-    "url-polyfill": "1.1.12",
     "date-fns": "2.17.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "smartquotes": "2.3.2",
+    "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.0",
     "vanilla-framework": "2.27.0"
   },

--- a/static/js/src/advantage/ua.jsx
+++ b/static/js/src/advantage/ua.jsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+// This is copied from ua-contracts-web, it's the React hook we use to call any
+// ua-contracts endpoint. Full docs available at:
+// https://github.com/CanonicalLtd/ua-contracts/blob/develop/web/src/Hooks.js#L46
+function useContracts(method, url, body, opts) {
+    const [state, dispatch] = React.useReducer(setRequestState, {
+        error: null,
+        data: null,
+        status: 0,
+        loading: null,
+        fetchTs: null,
+    });
+
+    let fetchFn = React.useCallback(() => {
+        dispatch({type: "MAKE_REQUEST_AGAIN"});
+    }, []);
+
+    opts = opts || {};
+    let deps = opts.deps || [];
+    let onDemand = opts.onDemand || false;
+    let adapter = opts.adapter || (rsp => rsp);
+    if (body !== undefined) {
+        body = JSON.stringify(body);
+    }
+
+    React.useEffect(() => {
+        let canceled = false;
+        // If we should only fetch on demand, and no request was made to fetch,
+        // then do nothing.
+        if (onDemand && state.fetchTs === null) {
+            return;
+        }
+
+        let makeRequest = async () => {
+            try {
+                let rsp = await fetch("/ua-contracts" + url, {
+                    headers: {
+                        "Content-Type": "application/json",
+                        // We use the Accept header because we only expect
+                        // JSON, and also because our reverse proxy understands
+                        // a request with a header like this to mean we want it
+                        // to forward the request to ua-contracts.
+                        "Accept": "application/json",
+                    },
+                    method,
+                    body,
+                })
+                if (canceled) return;
+
+                let data = await rsp.text();
+                if (!data) {
+                    data = "{}"
+                }
+                data = JSON.parse(data);
+                if (canceled) return;
+                dispatch({
+                    type: "SET_REQUEST_AS_DONE",
+                    payload: adapter({
+                        data: data,
+                        error: rsp.status !== 200 ? (data || true) : null,
+                        status: rsp.status,
+                        loading: false,
+                    })
+                });
+            } catch (err) {
+                if (canceled) return;
+                console.error("Error in request to ua-contracts:", err);
+                dispatch({
+                    type: "SET_REQUEST_AS_DONE",
+                    payload: adapter({
+                        data: err.toString(),
+                        error: err.toString(),
+                        status: 0,
+                        loading: false,
+                    })
+                });
+            }
+        }
+        makeRequest();
+        dispatch({type: "SET_REQUEST_IN_PROGRESS"});
+
+        return () => {
+            canceled = true;
+        }
+        // eslint-disable-next-line
+    }, [method, url, body, onDemand, state.fetchTs, ...deps]);
+
+    let indicator = null;
+    let error = state.error;
+    // Kind of silly, but resilient, as we basically want to skip {}, null and
+    // undefined, and that is tougher than it looks in JS...
+    if (error && error !== "{}" && error !== "null") {
+        indicator = <div>{JSON.stringify(error)}</div>;
+    } else if (state.loading || (!onDemand && !state.data)) {
+        indicator = <div>Loading...</div>;
+    }
+
+    return {
+        fetch: fetchFn,
+        data: state.data,
+        error: state.error,
+        status: state.status,
+        loading: state.loading,
+        indicator: indicator,
+        lastFetch: state.fetchTs,
+    }
+}
+
+// Used by useContracts above.
+function setRequestState(state, action) {
+    if (action.type === "SET_REQUEST_IN_PROGRESS") {
+        return {
+            data: state.data,
+            error: null,
+            status: 0,
+            loading: true,
+            fetchTs: state.fetchTs,
+        }
+    }
+    if (action.type === "SET_REQUEST_AS_DONE") {
+        return {
+            data: action.payload.data,
+            error: action.payload.error ? action.payload.data : null,
+            status: action.payload.status,
+            loading: action.payload.loading,
+            fetchTs: state.fetchTs,
+        }
+    }
+    if (action.type === "MAKE_REQUEST_AGAIN") {
+        return {
+            data: state.data,
+            error: state.error,
+            status: state.status,
+            loading: state.loading,
+            fetchTs: Date.now(),
+        }
+    }
+}
+
+// This is a component to illustrate how to use useContracts to implement a
+// simple component (in this case, just shows the list of accounts the user is
+// a part of).
+function Accounts() {
+  let rsp = useContracts("GET", "/v1/accounts");
+  if (rsp.indicator) return rsp.indicator;
+
+  let accounts = rsp.data.accounts.map(account => {
+    return <li key={account.id}>
+      {account.name}
+    </li>;
+  });
+
+  return <div style={{backgroundColor: "#ccc"}}>
+    <h3>Accounts</h3>
+    <ul>
+      {accounts}
+    </ul>
+  </div>;
+}
+
+ReactDOM.render(<Accounts/>, document.getElementById('root'));

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -44,6 +44,9 @@
         </p>
       </div>
     </div>
+
+    <div class="row" id="root"></div>
+    <script src="{{ versioned_static('js/dist/ua.js') }}" type="module" defer></script>
   </section>
 
   {% if enterprise_contracts %}
@@ -546,7 +549,6 @@
     }
   }
 </script>
-
 
 {% with first_item="_ua_got_questions", second_item="_ua_legal", third_item="_ua_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -70,6 +70,7 @@ from webapp.views import (
     engage_thank_you,
     sitemap_index,
     sixteen_zero_four,
+    ua_contracts,
 )
 from webapp.login import login_handler, logout, user_info
 from webapp.security.database import db_session
@@ -173,6 +174,8 @@ def utility_processor():
 # Simple routes
 app.add_url_rule("/sitemap.xml", view_func=sitemap_index)
 app.add_url_rule("/account.json", view_func=account_query)
+app.add_url_rule("/ua-contracts/<path:path>", view_func=ua_contracts, methods=["GET", "POST", "PUT", "DELETE", "HEAD"])
+
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -10,6 +10,7 @@ import re
 
 # Packages
 import dateutil.parser
+import requests
 import feedparser
 import flask
 import gnupg
@@ -778,6 +779,28 @@ def post_advantage_subscriptions(preview):
 
     return flask.jsonify(purchase), 200
 
+# This view proxies requests from /ua-contracts/* to ua-contracts in staging,
+# keeping the method, path, query string and body (if any). It should work with
+# any endpoint, without needing to code anything extra. It is not the most
+# efficient way of proxying requests, but it's certainly the easiest to
+# demonstrate :)
+def ua_contracts(path):
+    body = flask.request.get_json(silent=True)
+    srv = flask.current_app.config["CONTRACTS_TEST_API_URL"]
+    url = f"{srv}/{path}"
+    if flask.request.query_string:
+        url = f"{url}?{flask.request.query_string.encode('utf-8')}"
+    headers = {}
+    if flask.session.get("authentication_token"):
+        headers["Authorization"] = f"Macaroon {flask.session['authentication_token']}"
+
+    res = requests.request(flask.request.method, url, headers=headers, json=body)
+    try:
+        data = res.json()
+    except:
+        data = res.text
+
+    return flask.jsonify(data), res.status_code
 
 @store_maintenance
 def advantage_shop_view():


### PR DESCRIPTION
**This PR is _not_ meant to be merged, but rather to be a place for discussing architectural changes to `/advantage`**

I wrote this small PoC to show how React components could be gradually introduced in `/advantage`.

It does not disrupt the current build system, but instead leverages it. It also introduces a new way to directly contact ua-contracts without needing to wrap endpoints in the Flask application. These two approaches should allow you to greatly simplify existing views/components without having to make a hard stop-the-world migration. It should also allow you to easily leverage components I wrote for [ua-contracts-web](https://github.com/CanonicalLtd/ua-contracts/tree/develop/web).

To see it running, go to: https://ubuntu-com-9628.demos.haus/advantage?test_backend=true and login with your SSO account. It should display the list of accounts associated with your user. Conveniently enough, this is the first thing one must to do implement account management :-)