### PR TITLE
Accept binary packages for notices

### DIFF
--- a/webapp/security/schemas.py
+++ b/webapp/security/schemas.py
@@ -78,6 +78,7 @@ class NoticePackage(Schema):
     version = String(required=True)
     description = String()
     is_source = Boolean(required=True)
+    is_binary = Boolean()
     source_link = String(allow_none=True)
     version_link = String(allow_none=True)
     pocket = Pocket(required=False)

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -47,6 +47,9 @@ def notice(notice_id):
             release_version = releases[codename]
             release_packages[release_version] = {}
             for package in pkgs:
+                if package.get("is_binary", False):
+                    continue
+
                 name = package["name"]
                 if not package["is_source"]:
                     release_packages[release_version][name] = package


### PR DESCRIPTION
## Done

- Accept binary packages for notices. These should not be displayed on the website, but they should be accessible through the API.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/46
