### PR TITLE
WIP - Increase height of kubernetes survey

### DIFF
--- a/templates/kubernetes/kubernetes-operations-survey.html
+++ b/templates/kubernetes/kubernetes-operations-survey.html
@@ -29,7 +29,7 @@
 <section class="p-strip u-no-padding--top">
     <div class="row">
         <div class="col-12">
-            <div class="typeform-widget" data-url="https://form.typeform.com/to/lZ0RY5km?typeform-medium=embed-snippet" style="width: 100%; height: 500px;"></div>
+            <div class="typeform-widget" data-url="https://form.typeform.com/to/lZ0RY5km?typeform-medium=embed-snippet" style="height: 1000px; width: 100%;"></div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

- Request from @SirSamTumless - Increase height of survey to remove scrolling. This is the best I can get without losing the form too far down the screen. The scrolling still happens on the really long lists but on most of them it should be removed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/kubernetes-operations-survey
- Check the form has reduced scrolling


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
