### PR TITLE
Hide monthly options if no products are available

### DIFF
--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -22,7 +22,7 @@ const initialFormState = {
       advanced: 127500,
     },
   },
-  hasMultiplePeriods: false,
+  hasMonthly: false,
 };
 
 const prefixMap = {
@@ -31,14 +31,14 @@ const prefixMap = {
   "infra+apps": "uaia",
 };
 
-function hasMultiplePeriods(productID) {
-  let numberOfPeriods = 0;
+function hasMonthly(productID) {
+  let containsMonthly = false;
   productsArray.forEach((product) => {
-    if (product[1].productID === productID) {
-      numberOfPeriods++;
+    if (product[1].productID === productID && product[1].period == "monthly") {
+      containsMonthly = true;
     }
   });
-  return numberOfPeriods > 1;
+  return containsMonthly;
 }
 
 function matchingProduct(testItem, selectedProductID, selectedBillingPeriod) {
@@ -130,7 +130,7 @@ const formSlice = createSlice({
         state.support = "essential";
       }
       state.product = getProduct(state);
-      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
     changeVersion(state, action) {
       state.version = action.payload;
@@ -152,7 +152,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
-      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
     changeSupport(state, action) {
       state.support = action.payload;
@@ -160,7 +160,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
-      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
     changeQuantity(state, action) {
       if (action.payload >= 1) {
@@ -170,7 +170,7 @@ const formSlice = createSlice({
     changeBilling(state, action) {
       state.billing = action.payload;
       state.product = getProduct(state);
-      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
   },
 });

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -6,13 +6,6 @@ const isSmallVP =
   875;
 
 const productsArray = Object.entries(window.productList);
-function hasMonthly() {
-  var hasMonthly = false;
-  productsArray.map((product) => {
-    hasMonthly = hasMonthly || product[1].period === "monthly";
-  });
-  return hasMonthly;
-}
 
 const initialFormState = {
   type: "physical",
@@ -38,6 +31,16 @@ const prefixMap = {
   "infra+apps": "uaia",
 };
 
+function hasMonthly(productID) {
+  let numberOfPeriods = 0;
+  productsArray.forEach((product) => {
+    if (product[1].productID === productID) {
+      numberOfPeriods++;
+    }
+  });
+  return numberOfPeriods > 1;
+}
+
 function matchingProduct(testItem, selectedProductID, selectedBillingPeriod) {
   if (
     testItem.productID === selectedProductID &&
@@ -54,7 +57,10 @@ function getProductByID(productID, billing) {
     const listingProduct = product[1];
     listingProduct.id = product[0];
     if (matchingProduct(listingProduct, productID, billing)) {
-      selectedProduct = { ...listingProduct, ok: true };
+      selectedProduct = {
+        ...listingProduct,
+        ok: true,
+      };
       return;
     }
   });
@@ -109,10 +115,7 @@ function getProduct(state) {
 
 const formSlice = createSlice({
   name: "form",
-  initialState: {
-    ...loadState("ua-subscribe-state", "form", initialFormState),
-    hasMonthly: hasMonthly(),
-  },
+  initialState: loadState("ua-subscribe-state", "form", initialFormState),
   reducers: {
     changeType(state, action) {
       state.type = action.payload;
@@ -127,6 +130,7 @@ const formSlice = createSlice({
         state.support = "essential";
       }
       state.product = getProduct(state);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
     changeVersion(state, action) {
       state.version = action.payload;
@@ -148,6 +152,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
     changeSupport(state, action) {
       state.support = action.payload;
@@ -155,6 +160,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
     changeQuantity(state, action) {
       if (action.payload >= 1) {
@@ -164,6 +170,7 @@ const formSlice = createSlice({
     changeBilling(state, action) {
       state.billing = action.payload;
       state.product = getProduct(state);
+      state.hasMonthly = hasMonthly(state.product.productID);
     },
   },
 });

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -5,6 +5,15 @@ const isSmallVP =
   Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0) <
   875;
 
+const productsArray = Object.entries(window.productList);
+function hasMonthly() {
+  var hasMonthly = false;
+  productsArray.map((product) => {
+    hasMonthly = hasMonthly || product[1].period === "monthly";
+  });
+  return hasMonthly;
+}
+
 const initialFormState = {
   type: "physical",
   version: "18.04",
@@ -20,6 +29,7 @@ const initialFormState = {
       advanced: 127500,
     },
   },
+  hasMonthly: false,
 };
 
 const prefixMap = {
@@ -27,8 +37,6 @@ const prefixMap = {
   apps: "uaa",
   "infra+apps": "uaia",
 };
-
-const productsArray = Object.entries(window.productList);
 
 function matchingProduct(testItem, selectedProductID, selectedBillingPeriod) {
   if (
@@ -101,7 +109,10 @@ function getProduct(state) {
 
 const formSlice = createSlice({
   name: "form",
-  initialState: loadState("ua-subscribe-state", "form", initialFormState),
+  initialState: {
+    ...loadState("ua-subscribe-state", "form", initialFormState),
+    hasMonthly: hasMonthly(),
+  },
   reducers: {
     changeType(state, action) {
       state.type = action.payload;

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -22,7 +22,7 @@ const initialFormState = {
       advanced: 127500,
     },
   },
-  hasMonthly: false,
+  periods: [],
 };
 
 const prefixMap = {
@@ -31,14 +31,14 @@ const prefixMap = {
   "infra+apps": "uaia",
 };
 
-function hasMonthly(productID) {
-  let containsMonthly = false;
+function getProductPeriods(productID) {
+  const productPeriods = [];
   productsArray.forEach((product) => {
-    if (product[1].productID === productID && product[1].period == "monthly") {
-      containsMonthly = true;
+    if (product[1].productID === productID) {
+      productPeriods.push(product[1].period);
     }
   });
-  return containsMonthly;
+  return productPeriods;
 }
 
 function matchingProduct(testItem, selectedProductID, selectedBillingPeriod) {
@@ -130,7 +130,7 @@ const formSlice = createSlice({
         state.support = "essential";
       }
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.periods = getProductPeriods(state.product.productID);
     },
     changeVersion(state, action) {
       state.version = action.payload;
@@ -152,7 +152,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.periods = getProductPeriods(state.product.productID);
     },
     changeSupport(state, action) {
       state.support = action.payload;
@@ -160,7 +160,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.periods = getProductPeriods(state.product.productID);
     },
     changeQuantity(state, action) {
       if (action.payload >= 1) {
@@ -170,7 +170,7 @@ const formSlice = createSlice({
     changeBilling(state, action) {
       state.billing = action.payload;
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.periods = getProductPeriods(state.product.productID);
     },
   },
 });

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -22,7 +22,7 @@ const initialFormState = {
       advanced: 127500,
     },
   },
-  hasMonthly: false,
+  hasMultiplePeriods: false,
 };
 
 const prefixMap = {
@@ -31,7 +31,7 @@ const prefixMap = {
   "infra+apps": "uaia",
 };
 
-function hasMonthly(productID) {
+function hasMultiplePeriods(productID) {
   let numberOfPeriods = 0;
   productsArray.forEach((product) => {
     if (product[1].productID === productID) {
@@ -130,7 +130,7 @@ const formSlice = createSlice({
         state.support = "essential";
       }
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
     },
     changeVersion(state, action) {
       state.version = action.payload;
@@ -152,7 +152,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
     },
     changeSupport(state, action) {
       state.support = action.payload;
@@ -160,7 +160,7 @@ const formSlice = createSlice({
         state.billing = "yearly";
       }
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
     },
     changeQuantity(state, action) {
       if (action.payload >= 1) {
@@ -170,7 +170,7 @@ const formSlice = createSlice({
     changeBilling(state, action) {
       state.billing = action.payload;
       state.product = getProduct(state);
-      state.hasMonthly = hasMonthly(state.product.productID);
+      state.hasMultiplePeriods = hasMultiplePeriods(state.product.productID);
     },
   },
 });

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -145,7 +145,7 @@ const imgUrl = {
 
 function renderSummary(state) {
   const billing = state.billing;
-  const hasMonthly = state.hasMonthly;
+  const hasMultiplePeriods = state.hasMultiplePeriods;
   const type = state.type;
   const quantity = state.quantity;
   const summarySection = form.querySelector("#summary-section");
@@ -185,7 +185,7 @@ function renderSummary(state) {
     buyButton.dataset.previousPurchaseId = previous_purchase_id;
   }
 
-  if (hasMonthly) {
+  if (hasMultiplePeriods) {
     billingSection.classList.remove("u-hide");
   } else {
     billingSection.classList.add("u-hide");

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -5,6 +5,10 @@ const formatter = new Intl.NumberFormat("en-US", {
   currency: "USD",
 });
 
+String.prototype.capitalize = function () {
+  return this.charAt(0).toUpperCase() + this.slice(1);
+};
+
 const form = document.querySelector(".js-shop-form");
 
 function renderRadios(state, sections) {
@@ -145,12 +149,13 @@ const imgUrl = {
 
 function renderSummary(state) {
   const billing = state.billing;
-  const hasMonthly = state.hasMonthly;
+  const periods = state.periods;
   const type = state.type;
   const quantity = state.quantity;
   const summarySection = form.querySelector("#summary-section");
   const saveMessage = summarySection.querySelector("#summary-save-with-annual");
   const billingSection = summarySection.querySelector(".js-summary-billing");
+  const billingSelect = summarySection.querySelector("select#billing-period");
   const buyButton = summarySection.querySelector(".js-ua-shop-cta");
 
   if (!state.product.ok || quantity <= 0) {
@@ -185,8 +190,13 @@ function renderSummary(state) {
     buyButton.dataset.previousPurchaseId = previous_purchase_id;
   }
 
-  if (hasMonthly) {
+  if (periods.length > 1) {
     billingSection.classList.remove("u-hide");
+    let options = "";
+    periods.forEach((period) => {
+      options += `<option value="${period}">${period.capitalize()} billing</option>`;
+    });
+    billingSelect.innerHTML = options;
   } else {
     billingSection.classList.add("u-hide");
   }
@@ -197,7 +207,6 @@ function renderSummary(state) {
     saveMessage.classList.remove("u-hide");
   }
 
-  const billingSelect = form.querySelector("#billing-period");
   billingSelect.value = billing;
 }
 

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -185,11 +185,7 @@ function renderSummary(state) {
     buyButton.dataset.previousPurchaseId = previous_purchase_id;
   }
 
-  // Monthlty is only available for infra and essential
-  if (
-    hasMonthly &&
-    (state.feature === "infra" || state.support === "essential")
-  ) {
+  if (hasMonthly) {
     billingSection.classList.remove("u-hide");
   } else {
     billingSection.classList.add("u-hide");

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -5,10 +5,6 @@ const formatter = new Intl.NumberFormat("en-US", {
   currency: "USD",
 });
 
-String.prototype.capitalize = function () {
-  return this.charAt(0).toUpperCase() + this.slice(1);
-};
-
 const form = document.querySelector(".js-shop-form");
 
 function renderRadios(state, sections) {
@@ -194,7 +190,11 @@ function renderSummary(state) {
     billingSection.classList.remove("u-hide");
     let options = "";
     periods.forEach((period) => {
-      options += `<option value="${period}">${period.capitalize()} billing</option>`;
+      if (period === "monthly") {
+        options += `<option value="monthly">Monthly billing</option>`;
+      } else if (period === "yearly") {
+        options += `<option value="yearly">Annual billing</option>`;
+      }
     });
     billingSelect.innerHTML = options;
   } else {

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -145,6 +145,7 @@ const imgUrl = {
 
 function renderSummary(state) {
   const billing = state.billing;
+  const hasMonthly = state.hasMonthly;
   const type = state.type;
   const quantity = state.quantity;
   const summarySection = form.querySelector("#summary-section");
@@ -185,10 +186,13 @@ function renderSummary(state) {
   }
 
   // Monthlty is only available for infra and essential
-  if (state.feature !== "infra" || state.support !== "essential") {
-    billingSection.classList.add("u-hide");
-  } else {
+  if (
+    hasMonthly &&
+    (state.feature === "infra" || state.support === "essential")
+  ) {
     billingSection.classList.remove("u-hide");
+  } else {
+    billingSection.classList.add("u-hide");
   }
 
   if (billing === "yearly") {

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -145,7 +145,7 @@ const imgUrl = {
 
 function renderSummary(state) {
   const billing = state.billing;
-  const hasMultiplePeriods = state.hasMultiplePeriods;
+  const hasMonthly = state.hasMonthly;
   const type = state.type;
   const quantity = state.quantity;
   const summarySection = form.querySelector("#summary-section");
@@ -185,7 +185,7 @@ function renderSummary(state) {
     buyButton.dataset.previousPurchaseId = previous_purchase_id;
   }
 
-  if (hasMultiplePeriods) {
+  if (hasMonthly) {
     billingSection.classList.remove("u-hide");
   } else {
     billingSection.classList.add("u-hide");

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -99,8 +99,6 @@
             class="u-no-margin--bottom"
             style="width: auto"
           >
-            <option value="monthly">Monthly billing</option>
-            <option value="yearly">Annual billing</option>
           </select>
           <p
             id="summary-save-with-annual"


### PR DESCRIPTION
## Done

- Added a check to add the period dropdown if no monthly products are present

## QA

- check here, https://ubuntu-com-9651.demos.haus/advantage/subscribe?test_backend=true select server, essential and see that you can choose monthly or yearly at the bottom
- Check here, https://ubuntu-com-9651.demos.haus/advantage/subscribe select server essential and see that there is no dropdown for the billing period


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9647

