### PR TITLE
Pop-up survey

### DIFF
--- a/templates/kubernetes/kubernetes-operations-survey.html
+++ b/templates/kubernetes/kubernetes-operations-survey.html
@@ -12,6 +12,9 @@
         <h1>Kubernetes & cloud native operations survey</h1>
         <p>The Cloud Native space is rapidly expanding and everyone wants to know what everyone else is doing. Where are we succeeding? Where are we hitting walls? Where can I get that amazing T-Shirt? The answers to all are right here - click start - contribute and get the chance to win that snazzy T.</p>
         <p>In submitting the below survey, I confirm I have read and agreed to Canonical’s <a href="/legal/data-privacy">Privacy Policy</a>, <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Kubernetes %26 CloudNative Survey - _Privacy Notice %E2%80%93 Survey_.pdf">Privacy Notice</a>, and this <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Operator Day Raffle 2021 - Terms and Conditions .pdf">Competition’s Terms and Conditions</a>.</p>
+        <p>
+          <a class="p-button--positive typeform-share button" href="https://form.typeform.com/to/lZ0RY5km?typeform-medium=embed-snippet" data-mode="popup" data-size="100" target="_blank">Take the survey </a> 
+       </p>
     </div>
     <div class="col-6 u-align--center">
     {{
@@ -25,16 +28,8 @@
     </div>
   </div>
 </section>
-
-<section class="p-strip u-no-padding--top">
-    <div class="row">
-        <div class="col-12">
-            <div class="typeform-widget" data-url="https://form.typeform.com/to/lZ0RY5km?typeform-medium=embed-snippet" style="width: 100%; height: 500px;"></div>
-        </div>
-    </div>
-</section>
 {% endblock content %}
 
 {% block footer_extra %}
-<script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm", b="https://embed.typeform.com/"; if(!gi.call(d,id)) { js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
+<script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })()</script>
 {% endblock %}


### PR DESCRIPTION
## Done

- making the typeform not an iframe, but a popup

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes/kubernetes-operations-survey
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that is works as a popup better than before


## Issue / Card

Fixes #9650

