### PR TITLE
Update payment-methods page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1143,9 +1143,6 @@ support:
     - title: Your subscriptions
       path: /advantage
       persist: True
-    - title: Payment methods
-      path: /advantage/payment-methods
-      persist: True
     - title: Community support
       path: /support/community-support
     - title: Contact us

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -19,6 +19,7 @@ from webapp.advantage.api import (
     UnauthorizedError,
     UAContractsUserHasNoAccount,
     UAContractsAPIError,
+    UAContractsAPIErrorView,
 )
 
 from webapp.advantage.schemas import (
@@ -357,11 +358,11 @@ def advantage_payment_methods_view(**kwargs):
     try:
         account = advantage.get_purchase_account()
     except UAContractsUserHasNoAccount as error:
-        raise UAContractsAPIError(error)
+        raise UAContractsAPIErrorView(error)
 
     account_info = advantage.get_customer_info(account["id"])
     customer_info = account_info["customerInfo"]
-    default_payment_method = customer_info["defaultPaymentMethod"]
+    default_payment_method = customer_info.get("defaultPaymentMethod")
 
     return flask.render_template(
         "advantage/payment-methods/index.html",


### PR DESCRIPTION
Remove the /payment-methods link from the sub-nav.

If a user has no ubuntu one account and they try to go to
/payment-methods, we send them back to /advantage

If a user has an ubuntu one account but no stripe account we throw a
500.

Users should have no business on the /payment-methods page without both
a ubuntu one account or a stripe account.

## QA

- Go to https://ubuntu-com-9653.demos.haus/advantage the payment-methods link from the sub-nav is gone
- Log out and try to go to https://ubuntu-com-9653.demos.haus/advantage/payment-methods it will send you to /advantage because you are not logged in
- Log in and try to go to https://ubuntu-com-9653.demos.haus/advantage/payment-methods it will throw a 500. A bit rude but you should not try to update a card of an account that does not exist. At least for now.
- If you happen to have an account with no default payment method. This is an anomaly, but the page should allow you now to insert a credit card.


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/4073
#9649
