### PR TITLE
Add support to convert query strings in navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1614,6 +1614,8 @@ certification:
   title: Hardware
   path: /certification
   persist: True
+  # Use query value as page
+  query_page: form
 
   children:
     - title: Overview

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1614,12 +1614,11 @@ certification:
   title: Hardware
   path: /certification
   persist: True
-  # Use query value as page
-  query_page: form
+  match_query: True
 
   children:
     - title: Overview
-      path: /certification
+      path: /certification?
     - title: Desktops
       path: /certification?form=Desktop
     - title: Servers

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -103,8 +103,6 @@
             </span>
           </li>
           {% elif child.path != '/blog/archives' and child.path != '/blog/upcoming' %}
-          {{"hello"}}
-          {{child }}
           <li class="breadcrumbs__item">
             <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">{{ child.title }}</a>
           </li>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -1,4 +1,4 @@
-{% set breadcrumbs = get_navigation(request.path).breadcrumbs %}
+{% set breadcrumbs = get_navigation(request).breadcrumbs %}
 
 <header id="navigation" class="p-navigation">
   {% block header_banner %}
@@ -103,6 +103,8 @@
             </span>
           </li>
           {% elif child.path != '/blog/archives' and child.path != '/blog/upcoming' %}
+          {{"hello"}}
+          {{child }}
           <li class="breadcrumbs__item">
             <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">{{ child.title }}</a>
           </li>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -1,4 +1,4 @@
-{% set nav_sections = get_navigation(request.path).nav_sections %}
+{% set nav_sections = get_navigation(request).nav_sections %}
 
 {% block footer %}
 

--- a/templates/templates/header_noscript.html
+++ b/templates/templates/header_noscript.html
@@ -1,4 +1,4 @@
-{% set nav_sections = get_navigation(request.path).nav_sections %}
+{% set nav_sections = get_navigation(request).nav_sections %}
 
 {% block header %}
   {% with section=nav_sections.openstack %}{% include 'templates/_header_item_noscript.html' %}{% endwith %}

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -74,9 +74,18 @@ def get_navigation(request):
                 # always show "Topics" as active on child topic pages
                 child["active"] = True
                 break
+
             elif (
-                child["path"] == path and path.startswith(nav_section["path"])
-            ) or (child.get("persist") and path.startswith(child["path"])):
+                (
+                    child["path"] == path
+                    and path.startswith(nav_section["path"])
+                )
+                or (child.get("persist") and path.startswith(child["path"]))
+                or (
+                    nav_section.get("match_query")
+                    and child["path"] == request.full_path
+                )
+            ):
                 # If child path matches current path or has persist set to true
                 child["active"] = True
                 nav_section["active"] = True
@@ -95,7 +104,7 @@ def get_navigation(request):
                     breadcrumbs["children"] = _remove_hidden(
                         nav_section.get("children", [])
                     )
-                break
+
             else:
                 for grandchild in child.get("children", []):
                     if grandchild["path"] == path:
@@ -103,8 +112,6 @@ def get_navigation(request):
                         nav_section["active"] = True
                         breadcrumbs["section"] = nav_section
                         breadcrumbs["children"] = [child]
-
-                        # if ("query_page" in nav_section) and request.args.get(nav_section["query_page"]) == :
 
                         if grandchild.get("hidden"):
                             # Hidden nodes appear alone

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -50,7 +50,7 @@ def _remove_hidden(pages):
     return filtered_pages
 
 
-def get_navigation(path):
+def get_navigation(request):
     """
     Set "nav_sections" and "breadcrumbs" dictionaries
     as global template variables
@@ -58,6 +58,7 @@ def get_navigation(path):
 
     breadcrumbs = {}
 
+    path = request.path
     is_topic_page = path.startswith("/blog/topics/")
 
     sections = copy.deepcopy(nav_sections)
@@ -102,6 +103,8 @@ def get_navigation(path):
                         nav_section["active"] = True
                         breadcrumbs["section"] = nav_section
                         breadcrumbs["children"] = [child]
+
+                        # if ("query_page" in nav_section) and request.args.get(nav_section["query_page"]) == :
 
                         if grandchild.get("hidden"):
                             # Hidden nodes appear alone


### PR DESCRIPTION
## Done

Currently `navigation.yaml` supports only paths, i.e. `/parent/child/grandchild`.
This will support query strings i.e. `/parent?page=child` so that we can match the entire URL rather than just the path
To make this work, the `navigation.yaml` needs to contain a parameter `match_query: True`

## QA

- Go to https://ubuntu-com-9654.demos.haus/certification?form=Desktop and click on the navigation links and make sure they are highlighted when you change them.
- Other links to check to make sure this feature doesn't break existent navigation
  - https://ubuntu-com-9654.demos.haus/server/docs
  - https://ubuntu-com-9654.demos.haus/kubernetes/compare (click on the different navigation links)
  - https://ubuntu-com-9654.demos.haus/security/cve 
  - https://ubuntu-com-9654.demos.haus/tutorials

## Issue / Card

Fixes https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/178

