### PR TITLE
Fix payment warning notification

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -88,7 +88,8 @@ def advantage_view(**kwargs):
 
             # If there are any pending purchase for a sub (active or locked)
             # we show the payment method warning.
-            payment_method_warning = subscription.get("pendingPurchases")
+            if subscription.get("pendingPurchases"):
+                payment_method_warning = subscription.get("pendingPurchases")
 
             previous_purchase_ids[period] = subscription.get("lastPurchaseID")
 


### PR DESCRIPTION
## Done

- Fix payment warning notification. The problem is that the `payment_method_warning` would take the value of the last subscription. Now the if conditions if you want to update it or not.