### PR TITLE
Update CTA on aws and azure

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -1,4 +1,4 @@
-{% extends "ceph/base_ceph.html" %}
+{% extends "aws/base_aws.html" %}
 
 {% block title %}Ubuntu Pro for AWS{% endblock %}
 {% block meta_description %}Ubuntu Pro for AWS, the Ubuntu image optimized for production and professional use on public cloud. Including broad security coverage, live kernel patching, certified components with hardening profiles, and backed by a 10-years maintenance commitment by Canonical. Get it on the AWS marketplace.{% endblock %}
@@ -13,7 +13,7 @@
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for AWS is a premium image delivering the most comprehensive security and compliance features. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations — no contract necessary.</p>
         <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on AWS</span></a></p>
-        <p><a href="https://assets.ubuntu.com/v1/feafb61c-Ubuntu_Pro_AWS_04.11.19.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
+        <p><a href="/aws/contact-us" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -13,7 +13,7 @@
         <p class="p-heading--three">For production. For professionals.</p>
         <p>Ubuntu Pro for Azure is a premium image delivering the most comprehensive security and compliance features. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations — no contract necessary.</p>
         <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS on Azure</span></a></p>
-        <p><a href="https://assets.ubuntu.com/v1/26408fa0-UbuntuPro_Azure_Datasheet_21.pdf" class="p-link--external">Get the Ubuntu Pro datasheet</a></p>
+        <p><a href="/azure/get-in-touch" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{


### PR DESCRIPTION
## Done

- Update CTA on `/aws/pro` and `azure/pro` to point to contact us modal
- Fix extend from ceph to aws

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/aws/pro and http://0.0.0.0:8001/azure/pro
- Check against comments and resolve them in [aws copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit) and [azure copy doc](https://docs.google.com/document/d/1WaQ5n3GxwZzbX0T6rLiRNejFvxIPIHd5V5XgdAwKmSw/edit?ts=6082cee7#) 


## Issue / Card

Fixes #9614 

