### PR TITLE
Fix w3c non-compliant issues

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -25,7 +25,7 @@
       </div>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-      <img id="takeover-image" src="" width="200" alt="" />
+      <img id="takeover-image" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" width="200" alt="" />
     </div>
   </div>
 </section>
@@ -1519,10 +1519,6 @@
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-<style media="screen">
-  .p-inline-images__item { margin: 1.5rem; }
-</style>
 
 {% endblock content %}
 {% endblock outer_content %}


### PR DESCRIPTION
## Done

Fixes according to [w3c validation ](https://validator.w3.org/nu/?doc=https%3A%2F%2Fubuntu.com%2F)

## QA

Check demo on w3 Validator:
https://validator.w3.org/nu/?doc=https%3A%2F%2Fubuntu-com-9666.demos.haus%2F

as opposed to current ubuntu.com
https://validator.w3.org/nu/?doc=https%3A%2F%2Fubuntu.com%2F

- Check nothing looks wrong on the takeovers
- Check that logos or elements with `p-inline-images__item` look all right.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9665

