### PR TITLE
Add docs navigation for OpenStack

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -164,6 +164,9 @@ openstack:
       path: /openstack/tco-calculator
     - title: Install
       path: /openstack/install
+    - title: Docs
+      path: /openstack/docs
+      persist: True
     - title: Thank you
       path: /openstack/newsletter-thank-you
       hidden: True


### PR DESCRIPTION
## Done
Add docs navigation for OpenStack

## QA
- Open the demo and go to /openstack
- Click the docs navigation item and check docs load
- Click around docs and see the navigation is persistent 
