### PR TITLE
Remove space after Sign in link on /advantage

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -29,10 +29,7 @@
                 'eventAction' : 'Authentication',
                 'eventLabel' : 'Sign in',
                 'eventValue' : undefined
-              });">
-            Sign in
-          </a>
-          to edit existing or add new subscriptions.
+              });">Sign in</a> to edit existing or add new subscriptions.
         </h5>
         <p>
           <a href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}" class="p-button--neutral">Sign up to Ubuntu Advantage</a>


### PR DESCRIPTION
## Done

- Remove space after Sign in link on /advantage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Hover over the 'Sign in' link and see that there is no underline on the space after the 'n'


## Issue / Card

Fixes #9661