### PR TITLE
Change cube register link

### DIFF
--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -134,7 +134,7 @@ def cube_microcerts():
             "edx_register_url": (
                 f"{edx_api.base_url}/"
                 "auth/login/tpa-saml/"
-                "?auth_entry=register&next=%2F&idp=ubuntuone"
+                "?auth_entry=logins&next=%2F&idp=ubuntuone"
             ),
             "sso_user": sso_user,
             "certified_badge": certified_badge,


### PR DESCRIPTION
## Done

- auth_entry=login instead of auth_entry=register

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- see the changed get parameter


## Issue / Card

Fixes #9674
