### PR TITLE
Add Goverment back to enterprise mega menu and footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -82,6 +82,7 @@
             </h2>
             <ul class="second-level-nav">
               <li class="p-footer-list--margin"><a href="/industrial">Industrial</a></li>
+              <li class="p-footer-list--margin"><a href="/gov">Government</a></li>
               <li class="p-footer-list--margin"><a href="/telco">Telco</a></li>
               <li class="p-footer-list--margin"><a href="/financial-services">Finance</a></li>
             </ul>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -180,6 +180,7 @@
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/telco">Telco</a></li>
           <li class="p-inline-list__item"><a href="/financial-services">Finance</a></li>
+          <li class="p-inline-list__item"><a href="/gov">Government</a></li>
           <li class="p-inline-list__item"><a href="/internet-of-things/digital-signage">Signage</a></li>
           <li class="p-inline-list__item"><a href="/internet-of-things/robotics">Robotics</a></li>
           <li class="p-inline-list__item"><a href="/internet-of-things/gateways">Gateways</a></li>


### PR DESCRIPTION
## Done

- Add Goverment back to enterprise mega menu and footer

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/#enterprise
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that 'Government' is in the list of sectors


## Issue / Card

Fixes #9664
