### PR TITLE
Update /openstack with new whitepaper and logo

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -19,8 +19,8 @@
         </a>
       </p>
       <p>
-        <a href="/engage/redhat-openstack-comparison-whitepaper">
-          Read the whitepaper &mdash; "Comparing Red Hat OpenStack Platform and Canonical's Charmed OpenStack"&nbsp;&rsaquo;
+        <a href="/engage/multi-cloud-business-guide">
+          Read the whitepaper &mdash; "A business guide to multi-cloud"&nbsp;&rsaquo;
         </a>
       </p>
     </div>
@@ -140,12 +140,11 @@
       </li>
       <li class="p-inline-images__item">
         {{ image (
-          url="https://assets.ubuntu.com/v1/cf1920c8-1200px-University_of_Cape_Town_logo.svg.png",
-          alt="University of capetown",
-          width="130",
-          height="131",
+          url="https://assets.ubuntu.com/v1/2d2e1ab2-king-abdullah-university-of-science-kaust-logo.png",
+          alt="",
+          width="160",
+          height="81",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
           loading="auto"
           ) | safe
         }}


### PR DESCRIPTION
## Done

- Update /openstack with new whitepaper and logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is a new whitepaper in the banner and the KAUST logo replaces Cape Town


## Issue / Card

Fixes [#4081](https://github.com/canonical-web-and-design/web-squad/issues/4081)

## Screenshots
![image](https://user-images.githubusercontent.com/441217/116705487-7d8cdd80-a9c4-11eb-9ba3-e2b17981e6d4.png)
