### PR TITLE
Update OpenStack X to Xena on /about/release-cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1127,7 +1127,7 @@ export var openStackReleases = [
   {
     startDate: new Date("2021-10-01T00:00:00"),
     endDate: new Date("2023-04-01T00:00:00"),
-    taskName: "OpenStack X",
+    taskName: "OpenStack Xena",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
@@ -1513,7 +1513,7 @@ export var openStackReleaseNames = [
   "OpenStack Y LTS",
   "Ubuntu 22.04 LTS",
   "OpenStack Y",
-  "OpenStack X",
+  "OpenStack Xena",
   "OpenStack Wallaby",
   "OpenStack Victoria",
   "OpenStack Ussuri LTS",

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -442,7 +442,7 @@
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>OpenStack X</td>
+              <td>OpenStack Xena</td>
               <td>&nbsp;</td>
               <td>Oct 2021</td>
               <td>Apr 2023</td>


### PR DESCRIPTION
## Done

- Update OpenStack X to Xena on /about/release-cycle

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-openstack-release-cycle
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that X is now Xena


## Issue / Card

Fixes [#4080](https://github.com/canonical-web-and-design/web-squad/issues/4080)
