### PR TITLE
Fix contact us modals on /kubernetes and /kubernetes/install

### DIFF
--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-managed' %}
@@ -18,7 +18,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-kubeadm' %}
@@ -26,7 +26,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'multicloud' %}
@@ -34,7 +34,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=multicloud" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=multicloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-install' %}
@@ -42,7 +42,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-features' %}
@@ -50,7 +50,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-consulting' %}
@@ -58,7 +58,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-add-on' %}
@@ -66,7 +66,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-support' %}
@@ -74,7 +74,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
@@ -82,7 +82,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://www.ubuntu.com/kubernetes/thank-you" %}
+  returnURL="https://ubuntu.com/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -19,8 +19,8 @@
         Our cloud-native automation framework ensures developer productivity and business innovation.
       </p>
       <p>
-        <a class="p-button--positive" href="/kubernetes/contact-us">Schedule a demo</a>
-        <a class="js-invoke-modal" href="/kubernetes/install">Try it now&nbsp;&rsaquo;</a>
+        <a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us">Schedule a demo</a>
+        <a href="/kubernetes/install">Try it now&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
@@ -593,7 +593,7 @@
     <div class="col-6">
       <h1 class="p-heading--3">Kubernetes clusters with Kubeadm</h1>
       <p>Canonical provides commercial support for Kubernetes clusters deployed using kubeadm.</p>
-      <p><a class="p-button--positive" href="">Get support for kubeadm</a></p>
+      <p><a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us">Get support for kubeadm</a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
@@ -714,7 +714,7 @@
         url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
         alt="",
         width="240",
-        height="171",        
+        height="171",
         hi_def=True,
         loading="lazy",
         attrs={"class": "p-inline-images__logos"},
@@ -727,7 +727,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -12,13 +12,12 @@
     <div class="col-7">
       <h1>Install Kubernetes</h1>
       <p>
-        Canonical Kubernetes is pure upstream and works on any cloud, from bare metal to public and edge. Deploy single
-        node and multi-node clusters with Charmed Kubernetes and MicroK8s to support container orchestration, from
-        testing to production. Both distributions bring the latest innovations from the Kubernetes community within a
-        week of upstream release, allowing for time to learn, experiment and upskill.
+        Canonical Kubernetes is pure upstream and works on any cloud, from bare metal to public and edge. Deploy single node and multi-node clusters with Charmed Kubernetes and MicroK8s to support container orchestration, from testing to production. Both distributions bring the latest innovations from the Kubernetes community within a week of upstream release, allowing for time to learn, experiment and upskill.
       </p>
       <p>
-        <a class="p-button--positive" href="/kubernetes/install#get-in-touch">Get support for Kubernetes</a>
+        <a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-install">
+          Get support for Kubernetes
+        </a>
       </p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
@@ -94,7 +93,7 @@
               loading="lazy"
               ) | safe
             }}
-          </td>        
+          </td>
         </tr>
         <tr>
           <td aria-label="Product"><a href="/kubernetes">Charmed Kubernetes</a></td>
@@ -121,7 +120,7 @@
               loading="lazy"
               ) | safe
             }}
-          </td>          
+          </td>
           <td class="u-align--center" aria-label="Managed Kubernetes">
             {{ image (
               url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg",
@@ -131,7 +130,7 @@
               loading="lazy"
               ) | safe
             }}
-          </td>        
+          </td>
         </tr>
         <tr>
           <td aria-label="Product">
@@ -189,7 +188,7 @@
     </table>
     <p><strong>(i).</strong> Use Ubuntu’s platform to run worker nodes on all public clouds (AKS, EKS, and GKE)</p>
     <p>
-      <a href="/kubernetes/contact-us?product=kubernetes-install">Looking for help running Kubernetes? Get in touch&nbsp;&rsaquo;</a>
+      <a class="js-invoke-modal" href="/kubernetes/contact-us?product=kubernetes-install">Looking for help running Kubernetes? Get in touch&nbsp;&rsaquo;</a>
     </p>
   </div>
 </section>
@@ -312,7 +311,7 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}      
+      }}
     </a>
 
     <a id="tab-aws" href="#tab-aws__content" class="col-3 p-card p-tab u-align--center u-vertically-center js-tab-multi" role="tab" aria-selected="false">
@@ -366,7 +365,7 @@
     </div>
   </div>
 
-  
+
 
   <div class="row">
     <h1 class="p-heading--4">Multi-node, highly available Kubernetes with MicroK8s</h1>


### PR DESCRIPTION
## Done

- Fix contact us modals on /kubernetes and /kubernetes/install

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes and http://0.0.0.0:8001/kubernetes/install
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all the contact us cta's open a modal
