### PR TITLE
Update /openstack/consulting page

### DIFF
--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -118,7 +118,7 @@
     </div>
 
     <div class="row u-equal-height">
-      <div class="col-4 p-card u-align--center">
+      <div class="col-6 p-card u-align--center">
         <a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">
           {{
             image(
@@ -135,7 +135,7 @@
         <h4 class="u-no-margin--bottom"><a href="/openstack/contact-us?product=foundation-cloud"  class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Talk to us', 'eventLabel' : 'Talk to us - get started', 'eventValue' : undefined });">Talk to us&nbsp;&rsaquo;</a></h4>
       </div>
 
-      <div class="col-4 p-card u-align--center">
+      <div class="col-6 p-card u-align--center">
         <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf">
           {{
             image(
@@ -159,7 +159,9 @@
       <h2>Consulting, design and delivery pricing</h2>
       <p>Our consulting delivery package comes in two flavours &mdash; Private Cloud Build and Private Cloud Build Plus, with the latter offering more consulting time to evaluate and integrate a wider range of custom architectural possibilities.</p>
     </div>
-    {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
+
+    {% include "shared/pricing/_openstack-packages.html" %}
+    
     <div class="u-fixed-width">
       <p><a href="/openstack/contact-us?product=foundation-cloud" class="js-invoke-modal">For more information about services please contact us&nbsp;&rsaquo;</a></p>
     </div>

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -151,23 +151,6 @@
         </a>
         <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf">Read the datasheet&nbsp;&rsaquo;</a></h4>
       </div>
-
-      <div class="col-4 p-card u-align--center">
-        <a href="https://assets.ubuntu.com/v1/193373c7-canonical-foundation-cloud-requirements-2018-07-18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/0b6436ab-hardware+requirements+double.svg",
-              alt="Hardware requirements",
-              height="32",
-              width="32",
-              hi_def=True,
-              attrs={"class": "p-card__icon u-no-margin--bottom"},
-              loading="lazy",
-            ) | safe
-          }}
-        </a>
-        <h4 class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/193373c7-canonical-foundation-cloud-requirements-2018-07-18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Hardware requirements', 'eventLabel' : 'Hardware requirements - get started', 'eventValue' : undefined });">Hardware&nbsp;requirements&nbsp;&rsaquo;</a></h4>
-      </div>
     </div>
   </section>
 

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -435,7 +435,9 @@
 </section>
 
 <section class="p-strip--light">
-  {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
+
+  {% include "shared/pricing/_openstack-packages.html" %}
+
   <div class="u-fixed-width">
     <p>
       <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -435,57 +435,8 @@
 </section>
 
 <section class="p-strip--light">
+  {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
   <div class="u-fixed-width">
-    <h2>Fixed-price delivery</h2>
-    <p class="p-heading--4">Consulting packages tailored to your needs</p>
-    <p>No hidden costs. No surprises. Everything is clear from the beginning. We design the cloud. We build the cloud.</p>
-    <p>Choose your package:</p>
-  </div>
-  <div class="row">
-    <div class="col-6 p-card">
-      <h2 class="p-heading--four">Private Cloud Build</h2>
-      <p><span class="p-heading--two">$75,000</span> fixed price</p>
-      <hr class="u-sv1">
-      <p>Design and deployment of a baseline OpenStack cloud based on the reference architecture.</p>
-      <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
-        <li class="p-list__item is-ticked">Reference architecture</li>
-        <li class="p-list__item is-ticked">Simplified networking</li>
-        <li class="p-list__item is-ticked">Hyper-converged or Converged</li>
-        <li class="p-list__item is-ticked">Containerised control plane</li>
-        <li class="p-list__item is-ticked">Observability stack</li>
-        <li class="p-list__item is-ticked">Block and object storage</li>
-        <li class="p-list__item is-ticked">High availability</li>
-      </ul>
-      <p>Design and delivery on certified hardware.</p>
-      <p><a href="/openstack/consulting">Get OpenStack&nbsp;›</a></p>
-    </div>
-    <div class="col-6 p-card">
-      <h2 class="p-heading--four">Private Cloud Build Plus</h2>
-      <p><span class="p-heading--two">$150,000</span> fixed price</p>
-      <hr class="u-sv1">
-      <p>Design and deployment of a carrier-grade, feature-rich OpenStack cloud based on a custom architecture.</p>
-      <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
-      <p>Everything in Private Cloud Build, plus:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Custom architecture</li>
-        <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
-        <li class="p-list__item is-ticked">Complex networking</li>
-        <li class="p-list__item is-ticked">LDAP or Active Directory integration</li>
-        <li class="p-list__item is-ticked">Regulatory compliance</li>
-        <li class="p-list__item is-ticked">Encryption in flight and at rest</li>
-        <li class="p-list__item is-ticked">EPA tuning options</li>
-        <li class="p-list__item is-ticked">Block, object and file storage</li>
-        <li class="p-list__item is-ticked">Layer&ndash;7 load balancer</li>
-        <li class="p-list__item is-ticked">Secrets management</li>
-      </ul>
-      <p>Workshops determine the optimal architecture for your workloads and integration requirements.</p>
-      <p><a href="/openstack/consulting">Migrate from VMware&nbsp;›</a></p>
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <p id="os-footnote">* Additional features, functionality and integrations are available via add-ons</p>
     <p>
       <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">
         Download the datasheet

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -19,18 +19,13 @@
     <h2 id="openstack">OpenStack</h2>
   </div>
 
-  {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
+  {% include "shared/pricing/_openstack-packages.html" %}
 
   <div class="u-fixed-width">
     <p>
       <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">
         Download the datasheet
       </a>
-    </p>
-    <p>
-      <a href="/openstack/consulting">Learn more about our consulting packages&nbsp;&rsaquo;</a>
-    </p>
-    <p>
       <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">
         Get in touch
       </a>

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -6,46 +6,57 @@
 
 {% block content %}
 
-  <section class="p-strip--suru-topped">
-    <div class="row">
-      <div class="col-8">
-        <h1>Open Infrastructure consulting &amp; training</h1>
-      </div>
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col-8">
+      <h1>Open Infrastructure consulting &amp; training</h1>
     </div>
-  </section>
-
-  <section class="p-strip--light">
-    <div class="u-fixed-width">
-      <h2 id="openstack">OpenStack</h2>
-    </div>
-
-    <div class="row u-equal-height">
-      {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
-    </div>
-    <div class="u-fixed-width">
-      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">Get in touch</a>
-    </div>
-  </section>
-
-  <section class="p-strip">
-    <div class="u-fixed-width">
-      <h2 id="kubernetes">Kubernetes</h2>
-    </div>
-    {% include 'shared/pricing/_kubernetes-consulting.html' %}
-  </section>
-
-  <section class="p-strip--light">
-    <div class="u-fixed-width">
-      <h2 id="kubeflow">Kubeflow Machine Learning Starter</h2>
-    </div>
-    {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
-  </section>
-
-  {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2 id="openstack">OpenStack</h2>
+  </div>
+
+  {% with columns=2 %}{% include "shared/pricing/_openstack-packages.html" %}{% endwith %}
+
+  <div class="u-fixed-width">
+    <p>
+      <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">
+        Download the datasheet
+      </a>
+    </p>
+    <p>
+      <a href="/openstack/consulting">Learn more about our consulting packages&nbsp;&rsaquo;</a>
+    </p>
+    <p>
+      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">
+        Get in touch
+      </a>
+    </p>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 id="kubernetes">Kubernetes</h2>
+  </div>
+  {% include 'shared/pricing/_kubernetes-consulting.html' %}
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2 id="kubeflow">Kubeflow Machine Learning Starter</h2>
+  </div>
+  {% include "shared/pricing/_kubernetes-consulting-add-ons.html" %}
+</section>
+
+{% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
 
 
 

--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -1,76 +1,52 @@
-<div class="row u-equal-height">
-  <div class="col-{{ 12 // columns }} p-card">
-    <h2 class="p-heading--four">Private Cloud Build</h2>
-    <p><span class="p-heading--two">$75,000</span> fixed price</p>
-    <hr class="u-sv1" />
-    <p>Design and deployment of OpenStack reference architecture.</p>
-    <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
-    <ul class="p-list">
-      <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
-      <li class="p-list__item is-ticked">Reference architecture</li>
-      <li class="p-list__item is-ticked">Open source storage</li>
-      <li class="p-list__item is-ticked">Simplified networking</li>
-      <li class="p-list__item is-ticked">Hyper-converged</li>
-      <li class="p-list__item is-ticked">Containerised control plane</li>
-      <li class="p-list__item is-ticked">Log aggregation</li>
-      <li class="p-list__item is-ticked">Monitoring cluster</li>
-      <li class="p-list__item is-ticked">Upgrades on demand</li>
-      <li class="p-list__item is-ticked">High availability</li>
-    </ul>
-    <p>Design and delivery on certified hardware.</p>
-    <p><a href="/openstack/consulting">Get OpenStack&nbsp;&rsaquo;</a></p>
+  <div class="u-fixed-width">
+    <h2>Fixed-price delivery</h2>
+    <p class="p-heading--4">Consulting packages tailored to your needs</p>
+    <p>No hidden costs. No surprises. Everything is clear from the beginning. We design the cloud. We build the cloud.</p>
+    <p>Choose your package:</p>
   </div>
-  <div class="col-{{ 12 // columns }} p-card">
-    <h2 class="p-heading--four">Private Cloud Build Plus</h2>
-    <p><span class="p-heading--two">$150,000</span> fixed price</p>
-    <hr class="u-sv1" />
-    <p>Design and Deployment of a secure, carrier grade, feature rich OpenStack custom architecture.</p>
-    <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
-    <ul class="p-list">
-      <li class="p-list__item is-ticked">Workload analysis</li>
-      <li class="p-list__item is-ticked">Customised architecture</li>
-      <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
-      <li class="p-list__item is-ticked">Complex networking</li>
-      <li class="p-list__item is-ticked">LDAP or Active Directory</li>
-      <li class="p-list__item is-ticked">Regulatory compliance</li>
-      <li class="p-list__item is-ticked">High availability</li>
-      <li class="p-list__item is-ticked">Encryption in flight and at rest</li>
-      <li class="p-list__item is-ticked">Layer-7 load balancer</li>
-      <li class="p-list__item is-ticked">Secrets Management</li>
-    </ul>
-    <p>On site workshops determine the optimal architecture for your workloads and integration requirements.</p>
-    <p><a href="/openstack/consulting">Migrate from VMware&nbsp;&rsaquo;</a></p>
+  <div class="row">
+    <div class="col-6 p-card">
+      <h2 class="p-heading--four">Private Cloud Build</h2>
+      <p><span class="p-heading--two">$75,000</span> fixed price</p>
+      <hr class="u-sv1">
+      <p>Design and deployment of a baseline OpenStack cloud based on the reference architecture.</p>
+      <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
+        <li class="p-list__item is-ticked">Reference architecture</li>
+        <li class="p-list__item is-ticked">Simplified networking</li>
+        <li class="p-list__item is-ticked">Hyper-converged or Converged</li>
+        <li class="p-list__item is-ticked">Containerised control plane</li>
+        <li class="p-list__item is-ticked">Observability stack</li>
+        <li class="p-list__item is-ticked">Block and object storage</li>
+        <li class="p-list__item is-ticked">High availability</li>
+      </ul>
+      <p>Design and delivery on certified hardware.</p>
+      <p><a href="/openstack/consulting">Get OpenStack&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 p-card">
+      <h2 class="p-heading--four">Private Cloud Build Plus</h2>
+      <p><span class="p-heading--two">$150,000</span> fixed price</p>
+      <hr class="u-sv1">
+      <p>Design and deployment of a carrier-grade, feature-rich OpenStack cloud based on a custom architecture.</p>
+      <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
+      <p>Everything in Private Cloud Build, plus:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Custom architecture</li>
+        <li class="p-list__item is-ticked">Containerised or isolated control plane</li>
+        <li class="p-list__item is-ticked">Complex networking</li>
+        <li class="p-list__item is-ticked">LDAP or Active Directory integration</li>
+        <li class="p-list__item is-ticked">Regulatory compliance</li>
+        <li class="p-list__item is-ticked">Encryption in flight and at rest</li>
+        <li class="p-list__item is-ticked">EPA tuning options</li>
+        <li class="p-list__item is-ticked">Block, object and file storage</li>
+        <li class="p-list__item is-ticked">Layer&ndash;7 load balancer</li>
+        <li class="p-list__item is-ticked">Secrets management</li>
+      </ul>
+      <p>Workshops determine the optimal architecture for your workloads and integration requirements.</p>
+      <p><a href="/openstack/consulting">Migrate from VMware&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
-  {% if columns == 3 %}
-  <div class="col-4 p-card">
-    <h2 class="p-heading--four">Fully managed cloud</h2>
-    <p><span class="p-heading--two">$15</span> per server per day</p>
-    <hr class="u-sv1" />
-    <p>Full remote operations of your Canonical OpenStack at half the price of VMware.</p>
-    <p>What's included: <sup><a href="#os-footnote">*</a></sup></p>
-    <ul class="p-list">
-      <li class="p-list__item is-ticked">24/7 monitoring</li>
-      <li class="p-list__item is-ticked">Proactive management</li>
-      <li class="p-list__item is-ticked">EU and US regulatory compliance options</li>
-      <li class="p-list__item is-ticked">Integrated data protection</li>
-      <li class="p-list__item is-ticked">Telco NFV options</li>
-      <li class="p-list__item is-ticked">Finance sector options</li>
-      <li class="p-list__item is-ticked">SDN options</li>
-    </ul>
-    <p>The best way to start with OpenStack. <a href="engage/cloud-economics ">Recognised by cloud economists</a> as the best value private cloud.</p>
-    <p><a href="/openstack/managed">Fully Managed OpenStack&nbsp;&rsaquo;</a></p>
+  <div class="u-fixed-width">
+    <p id="os-footnote">* Additional features, functionality and integrations are available via add-ons</p>
   </div>
-  {% endif %}
-  <div class="u-no-fixed-width">
-    <p id="os-footnote">
-      <small>
-      <sup>*</sup> Additional features, functionality and integrations are available via add-ons
-      </small>
-    </p>
-      <p class="p-button">
-        <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf">
-          Read the datasheet
-        </a>
-      </p>
-  </div>
-</div>


### PR DESCRIPTION
## Done

- Update /openstack/consulting page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at:
    - http://0.0.0.0:8001/openstack
    - http://0.0.0.0:8001/openstack/consulting
    - http://0.0.0.0:8001/pricing/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the 'Private Cloud Build' and 'Private Cloud Build Plus' tables are the same, but have different CTA

## Issue / Card

Fixes [#4078](https://github.com/canonical-web-and-design/web-squad/issues/4078)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/116859310-b4970500-abf7-11eb-94d6-8d3ee5894dd0.png)

