### PR TITLE
Meta title fix for K8s overview page

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,6 +1,6 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
-{% block title %}Canonical Kubernetes enterprise webpage{% endblock %}
+{% block title %}Enterprise Kubernetes for multi-cloud operations{% endblock %}
 
 {% block meta_description %}Canonical Kubernetes enterprise solutions build up from Ubuntu OS to hybrid multi-cloud container orchestration clouds, edge and IoT, managed Kubernetes and enterprise support packages.{% endblock meta_description %}
 


### PR DESCRIPTION
## Done

- Fix meta title of the K8s overview page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the meta title of the kubernetes overview page is "Enterprise Kubernetes for multi-cloud operations | Ubuntu"

## Screenshots

![Screenshot from 2021-05-04 11-29-55](https://user-images.githubusercontent.com/18480003/116986843-9223eb00-acce-11eb-9e15-022d56d66a40.png)

