### PR TITLE
updates datasheet link on livepatch page

### DIFF
--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -257,7 +257,7 @@
           <li class="p-list__item is-ticked">Answers to frequently asked questions</li>
         </ul>
         <p>
-          <a class="p-button" href="https://assets.ubuntu.com/v1/737708e8-Livepatch-Datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/livepatch', 'eventValue' : undefined });"><span class="p-link--external">Download the datasheet</span></a>
+          <a class="p-button" href="https://assets.ubuntu.com/v1/737708e8-Livepatch-Datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/security/livepatch', 'eventValue' : undefined });"><span class="p-link--external">Download the datasheet</span></a>
         </p>
       </div>
     </div>

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -257,7 +257,7 @@
           <li class="p-list__item is-ticked">Answers to frequently asked questions</li>
         </ul>
         <p>
-          <a class="p-button" href="https://assets.ubuntu.com/v1/ef19ede0-Datasheet_Livepatch_AW_Web_30.07.18.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/livepatch', 'eventValue' : undefined });"><span class="p-link--external">Download the datasheet</span></a>
+          <a class="p-button" href="https://assets.ubuntu.com/v1/737708e8-Livepatch-Datasheet.pdf" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'resource', 'eventAction' : 'Livepatch datasheet', 'eventLabel' : 'from ubuntu.com/livepatch', 'eventValue' : undefined });"><span class="p-link--external">Download the datasheet</span></a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated datasheet link on livepatch page

## QA

- Open the demo and go to /security/livepatch
- Check the asset link goes to the new link suggested in the issue

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9681
