### PR TITLE
K8s1.21+ck1 release updates

### DIFF
--- a/templates/kubernetes/docs/1.21/release-notes.md
+++ b/templates/kubernetes/docs/1.21/release-notes.md
@@ -57,7 +57,7 @@ to easily determine what registry changes are needed prior to an upgrade.
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.21](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
 
-## Notes / Known Issues
+## Notes and Known Issues
 
 - [LP 1920216](https://bugs.launchpad.net/operator-metallb/+bug/1920216) MetalLB
 speaker pod logs error with "selfLink was empty, can't make reference".

--- a/templates/kubernetes/docs/1.21/release-notes.md
+++ b/templates/kubernetes/docs/1.21/release-notes.md
@@ -13,6 +13,16 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.21+ck1 Bugfix release
+
+### May 04, 2021 - [charmed-kubernetes-655](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-655/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
+
+
 # 1.21
 
 ### April 15, 2021 - [charmed-kubernetes-632](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-632/archive/bundle.yaml)
@@ -45,9 +55,9 @@ to easily determine what registry changes are needed prior to an upgrade.
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
+[https://launchpad.net/charmed-kubernetes/+milestone/1.21](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
 
-## Notes and Known Issues
+## Notes / Known Issues
 
 - [LP 1920216](https://bugs.launchpad.net/operator-metallb/+bug/1920216) MetalLB
 speaker pod logs error with "selfLink was empty, can't make reference".

--- a/templates/kubernetes/docs/1.21/release-notes.md
+++ b/templates/kubernetes/docs/1.21/release-notes.md
@@ -20,7 +20,7 @@ toc: False
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
 
 
 # 1.21
@@ -55,7 +55,7 @@ to easily determine what registry changes are needed prior to an upgrade.
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[https://launchpad.net/charmed-kubernetes/+milestone/1.21](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
 
 ## Notes and Known Issues
 

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.21.x    | [charmed-kubernetes-632](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-632/archive/bundle.yaml) |
+| 1.21.x    | [charmed-kubernetes-655](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-655/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
 | 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -14,6 +14,16 @@ toc: False
 ---
 
 
+# 1.21+ck1 Bugfix release
+
+### May 04, 2021 - [charmed-kubernetes-655](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-655/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
+
+
 # 1.21
 
 ### April 15, 2021 - [charmed-kubernetes-632](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-632/archive/bundle.yaml)
@@ -46,9 +56,9 @@ to easily determine what registry changes are needed prior to an upgrade.
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
+[https://launchpad.net/charmed-kubernetes/+milestone/1.21](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
 
-## Notes and Known Issues
+## Notes / Known Issues
 
 - [LP 1920216](https://bugs.launchpad.net/operator-metallb/+bug/1920216) MetalLB
 speaker pod logs error with "selfLink was empty, can't make reference".

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -21,7 +21,7 @@ toc: False
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
 
 
 # 1.21
@@ -56,7 +56,7 @@ to easily determine what registry changes are needed prior to an upgrade.
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[https://launchpad.net/charmed-kubernetes/+milestone/1.21](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
 
 ## Notes and Known Issues
 
@@ -95,7 +95,7 @@ Please see [this page][rel] for release notes of earlier versions.
 ## Fixes
 
 A list of bug fixes and other minor feature updates in this release can be found at
-[https://launchpad.net/charmed-kubernetes/+milestone/1.20+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.20+ck1).
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.20+ck1)
 
 ## Notes / Known Issues
 

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -58,7 +58,7 @@ to easily determine what registry changes are needed prior to an upgrade.
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.21](https://launchpad.net/charmed-kubernetes/+milestone/1.21).
 
-## Notes / Known Issues
+## Notes and Known Issues
 
 - [LP 1920216](https://bugs.launchpad.net/operator-metallb/+bug/1920216) MetalLB
 speaker pod logs error with "selfLink was empty, can't make reference".

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -57,7 +57,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.21.x    | [charmed-kubernetes-632](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-632/archive/bundle.yaml) |
+| 1.21.x    | [charmed-kubernetes-655](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-655/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
 | 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |


### PR DESCRIPTION
## Done

- Added 1.21ck1 release notes
- Updated bundle revision number in various places

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
