### PR TITLE
updates average hourly ubuntu pro cost range

### DIFF
--- a/templates/gcp/pro.html
+++ b/templates/gcp/pro.html
@@ -79,7 +79,7 @@
           <div class="p-matrix__content">
             <h3 class="p-matrix__title">Priced for the cloud</h3>
             <div class="p-matrix__desc">
-              <p>Ubuntu Pro pricing tracks the underlying compute cost. Ubuntu Pro price varies between 3-6% of the hourly compute cost, depending on the instance type.</p>
+              <p>Ubuntu Pro pricing tracks the underlying compute cost. Ubuntu Pro price varies between 3-4.5% of an average hourly compute cost, depending on the instance type.</p>
             </div>
           </div>
         </li>


### PR DESCRIPTION
## Done

- updated the 'Priced for cloud' section, changing the hourly price ranges.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4084
