### PR TITLE
Fix typo on /download/iot

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -147,7 +147,7 @@
     </section>
 
     <section class="p-strip--light is-deep">
-      {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual machinei" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
+      {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual machine" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
     </section>
 
 


### PR DESCRIPTION
## Done

- Fix typo on /download/iot - replace s/machinei/machine/

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the typo has been fixed

