### PR TITLE
Update k8s text on /kubernetes

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -42,7 +42,7 @@
                 Canonical supports Kubeadm, MicroK8s and Charmed Kubernetes on VMware, OpenStack, bare metal, AWS, Azure, Google, Oracle Cloud, IBM Cloud and Rackspace.
             </p>
             <a href="/kubernetes" class="p-button--small p-button--positive u-align-text--left">
-              Get Kubernetes
+              Get Kuberdnetes
             </a>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">


### PR DESCRIPTION
## Done

- Update k8s text on /kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit)


## Issue / Card

Fixes #9705
