### PR TITLE
update removes title from ubuntu on azure video at /16-04/azure

### DIFF
--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -152,9 +152,6 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2>
-        Ubuntu on Azure video
-      </h2>
       <p class="u-embedded-media">
         <iframe title="Ubuntu on Azure" class="u-embedded-media__element" src="https://www.youtube.com/embed/SIwIqiJ6FcE" allowfullscreen="" frameborder="0"></iframe>
       </p>


### PR DESCRIPTION
## Done

- Update removes title from 'ubuntu on azure' video at /16-04/azure

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/16-04/azure
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to copy doc (https://docs.google.com/document/d/1V99KwimN8Hla8L_CikNc6I0amqj99cSrBsVlAjIkBqE/edit?ts=6082b410) and mark as resolved


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9621 

