### PR TITLE
Add FIPS to the UA service description

### DIFF
--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -107,6 +107,12 @@
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
+        <tr id="fips">
+          <td><a href="/security/certifications#fips">FIPS 140-2 Level 1</a> certified crypto modules</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        </tr>
         <tr>
           <td><a href="/security/certifications#common-criteria">Common Criteria EAL2</a></td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>


### PR DESCRIPTION
## Done
Add FIPS to the UA service description

## QA
- Go to https://ubuntu-com-9718.demos.haus/legal/ubuntu-advantage-service-description
- Check FIPs is a row on the table
- Also check its in the table at https://ubuntu-com-9718.demos.haus/pricing/infra

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9716
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9717

