### PR TITLE
Azure private offer link text

### DIFF
--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -47,9 +47,7 @@
         <li class="p-list__item is-ticked">Volume based pricing</li>
       </ul>
       <p>
-        <a href="/azure/pro">
-          Visit the Azure Marketplace to download Ubuntu Pro&nbsp;&rsaquo;
-        </a>
+        <a href="/azure/pro">Learn more&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-5">


### PR DESCRIPTION
## Done

- Update link text to match the latest change in the [copydoc](https://docs.google.com/document/d/1ZgV1ZiyHJe3UNQkj0I-OCpZ4MIAWLHheig2Q2rclcuk/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure/private-offer
- Check the link text is now `Learn more >`
