### PR TITLE
Remove loading state from modal if the payment preview fails

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -410,6 +410,7 @@ function applyLoggedInPurchaseTotals() {
           })
           .catch((error) => {
             modal.classList.remove("is-processing");
+            setOrderTotals(null, false, currentTransaction, modal);
             console.error(error);
           });
       })

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -406,11 +406,29 @@ function applyLoggedInPurchaseTotals() {
             currentTransaction.total = purchasePreview.total;
             currentTransaction.tax = purchasePreview.taxAmount;
             modal.classList.remove("is-processing");
-            setOrderTotals(country, vatApplicable, purchasePreview, modal);
+            if (purchasePreview.errors) {
+              setOrderTotals(
+                null,
+                false,
+                {
+                  total: currentTransaction.subtotal,
+                },
+                modal
+              );
+            } else {
+              setOrderTotals(country, vatApplicable, purchasePreview, modal);
+            }
           })
           .catch((error) => {
             modal.classList.remove("is-processing");
-            setOrderTotals(null, false, currentTransaction, modal);
+            setOrderTotals(
+              null,
+              false,
+              {
+                total: currentTransaction.subtotal,
+              },
+              modal
+            );
             console.error(error);
           });
       })

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -401,14 +401,20 @@ function applyLoggedInPurchaseTotals() {
           currentTransaction.accountId,
           currentTransaction.products,
           currentTransaction.previousPurchaseId
-        ).then((purchasePreview) => {
-          currentTransaction.total = purchasePreview.total;
-          currentTransaction.tax = purchasePreview.taxAmount;
-          modal.classList.remove("is-processing");
-          setOrderTotals(country, vatApplicable, purchasePreview, modal);
-        });
+        )
+          .then((purchasePreview) => {
+            currentTransaction.total = purchasePreview.total;
+            currentTransaction.tax = purchasePreview.taxAmount;
+            modal.classList.remove("is-processing");
+            setOrderTotals(country, vatApplicable, purchasePreview, modal);
+          })
+          .catch((error) => {
+            modal.classList.remove("is-processing");
+            console.error(error);
+          });
       })
       .catch((error) => {
+        modal.classList.remove("is-processing");
         console.error(error);
       });
   }


### PR DESCRIPTION
## Done

- Correctly catch errors for the payment modal call and remove loading state even if it fails.

## QA

This is a bit tricky to QA

Here is one way: https://app.zenhub.com/workspaces/web--ubuntu-clan-5931746dba512f05402b61f6/issues/canonical-web-and-design/ubuntu.com/9724

Another way would be to fetch this branch and modify the call to purchase preview so it always returns an error and see that the modal still loads.


## Important
This addresses https://github.com/canonical-web-and-design/web-squad/issues/4087 and should remove the bug for users but I don't believe this fixes the root cause of the payment preview failing.
