### PR TITLE
Pass customer name when setting customer info as guest

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -240,6 +240,7 @@ export async function postCustomerInfoToStripeAccount(
 
 export async function postCustomerInfoForPurchasePreview(
   accountID,
+  name,
   address,
   taxID
 ) {
@@ -255,6 +256,7 @@ export async function postCustomerInfoForPurchasePreview(
     },
     body: JSON.stringify({
       account_id: accountID,
+      name: name,
       address: address,
       tax_id: taxID,
     }),

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -382,6 +382,7 @@ function applyLoggedInPurchaseTotals() {
 
     postCustomerInfoForPurchasePreview(
       currentTransaction.accountId,
+      customerInfo.name,
       address,
       taxObject
     )

--- a/webapp/advantage/api.py
+++ b/webapp/advantage/api.py
@@ -144,12 +144,12 @@ class UAContractsAPI:
 
         return response.json()
 
-    def put_anonymous_customer_info(self, account_id, address, tax_id):
+    def put_anonymous_customer_info(self, account_id, name, address, tax_id):
         try:
             response = self._request(
                 method="put",
                 path=f"v1/accounts/{account_id}/customer-info/stripe",
-                json={"address": address, "taxID": tax_id},
+                json={"address": address, "name": name, "taxID": tax_id},
             )
         except HTTPError as error:
             if error.response.status_code == 401:

--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -46,6 +46,7 @@ cancel_advantage_subscriptions = {
 
 post_anonymised_customer_info = {
     "account_id": String(required=True),
+    "name": String(required=True),
     "address": Nested(AddressSchema, required=True),
     "tax_id": Nested(TaxIdSchema, allow_none=True),
 }

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -521,6 +521,7 @@ def post_anonymised_customer_info(**kwargs):
     token = kwargs.get("token")
     token_type = kwargs.get("token_type")
     account_id = kwargs.get("account_id")
+    name = kwargs.get("name")
     address = kwargs.get("address")
     tax_id = kwargs.get("tax_id")
 
@@ -528,7 +529,9 @@ def post_anonymised_customer_info(**kwargs):
         session, token, token_type=token_type, api_url=api_url
     )
 
-    return advantage.put_anonymous_customer_info(account_id, address, tax_id)
+    return advantage.put_anonymous_customer_info(
+        account_id, name, address, tax_id
+    )
 
 
 @advantage_checks(check_list=["need_user"])


### PR DESCRIPTION
This is needed for a new requirement we will be introducing in ua-contracts: that calls to set customer info must always contain the customer name and country. While that doesn't roll out to production in ua-contracts, it should still be safe to call this method with this added field.