### PR TITLE
Support query strings in navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1616,17 +1616,19 @@ ubuntu1604:
 certification:
   title: Hardware
   path: /certified
+  persist: True
+  match_query: True
 
   children:
     - title: Overview
-      path: /certified
+      path: /certified?
     - title: Laptops
-      path: /certified/laptops
+      path: /certified?category=Laptop
     - title: Desktops
-      path: /certified/desktops
+      path: /certified?category=Desktop
     - title: Servers
-      path: /certified/servers
+      path: /certified?category=Server
     - title: Devices
-      path: /certified/devices
+      path: /certified?category=Device
     - title: SoCs
-      path: /certified/socs
+      path: /certified?category=SoC

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -1,4 +1,4 @@
-{% set breadcrumbs = get_navigation(request.path).breadcrumbs %}
+{% set breadcrumbs = get_navigation(request).breadcrumbs %}
 
 <header id="navigation" class="p-navigation">
   {% block header_banner %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -1,4 +1,4 @@
-{% set nav_sections = get_navigation(request.path).nav_sections %}
+{% set nav_sections = get_navigation(request).nav_sections %}
 
 {% block footer %}
 

--- a/templates/templates/header_noscript.html
+++ b/templates/templates/header_noscript.html
@@ -1,4 +1,4 @@
-{% set nav_sections = get_navigation(request.path).nav_sections %}
+{% set nav_sections = get_navigation(request).nav_sections %}
 
 {% block header %}
   {% with section=nav_sections.openstack %}{% include 'templates/_header_item_noscript.html' %}{% endwith %}

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -50,13 +50,14 @@ def _remove_hidden(pages):
     return filtered_pages
 
 
-def get_navigation(path):
+def get_navigation(request):
     """
     Set "nav_sections" and "breadcrumbs" dictionaries
     as global template variables
     """
 
     breadcrumbs = {}
+    path = request.path
 
     is_topic_page = path.startswith("/blog/topics/")
 
@@ -73,9 +74,18 @@ def get_navigation(path):
                 # always show "Topics" as active on child topic pages
                 child["active"] = True
                 break
+
             elif (
-                child["path"] == path and path.startswith(nav_section["path"])
-            ) or (child.get("persist") and path.startswith(child["path"])):
+                (
+                    child["path"] == path
+                    and path.startswith(nav_section["path"])
+                )
+                or (child.get("persist") and path.startswith(child["path"]))
+                or (
+                    nav_section.get("match_query")
+                    and child["path"] == request.full_path
+                )
+            ):
                 # If child path matches current path or has persist set to true
                 child["active"] = True
                 nav_section["active"] = True


### PR DESCRIPTION
## Done

Currently `navigation.yaml` supports only paths, i.e. `/parent/child/grandchild`.
This will support query strings i.e. `/parent?page=child` so that we can match the entire URL rather than just the path
To make this work, the `navigation.yaml` needs to contain a parameter `match_query: True`

## QA

- Go to https://ubuntu-com-9774.demos.haus/certified?form=Desktop and click on the navigation links and make sure they are highlighted when you change them.
- Other links to check to make sure this feature doesn't break existent navigation
  - https://ubuntu-com-9774.demos.haus/server/docs
  - https://ubuntu-com-9774.demos.haus/kubernetes/compare (click on the different navigation links)
  - https://ubuntu-com-9774.demos.haus/security/cve 
  - https://ubuntu-com-9774.demos.haus/tutorials

## Issue / Card

Fixes https://github.com/canonical-web-and-design/certification.ubuntu.com/issues/178