### PR TITLE
Change to number of machines

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -203,12 +203,19 @@ def advantage_view(**kwargs):
 
             contract["productID"] = product_name
             contract["is_detached"] = False
-            contract["machineCount"] = "-"
+            contract["machineCount"] = 0
+
+            allowances = contract_info.get("allowances")
+            if (
+                allowances
+                and len(allowances) > 0
+                and allowances[0]["metric"] == "units"
+            ):
+                contract["machineCount"] = allowances[0]["value"]
 
             if product_name in yearly_purchased_products:
                 purchased_product = yearly_purchased_products[product_name]
                 contract["price_per_unit"] = purchased_product["price"]
-                contract["machineCount"] = purchased_product["quantity"]
                 contract["product_listing_id"] = purchased_product[
                     "product_listing_id"
                 ]
@@ -228,7 +235,6 @@ def advantage_view(**kwargs):
                 contract = contract.copy()
                 purchased_product = monthly_purchased_products[product_name]
                 contract["price_per_unit"] = purchased_product["price"]
-                contract["machineCount"] = purchased_product["quantity"]
                 contract["is_cancelable"] = True
                 contract["product_listing_id"] = purchased_product[
                     "product_listing_id"


### PR DESCRIPTION
## Done

- Use contract allocations to display the number of machines on the table row.

## QA

- Have a detached contract
- Check the /advantage page. You should see a number instead of the "-" as the number of machines.

## Issue / Card

Fixes #9750
