### PR TITLE
Update adds managed app link to navigation

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -112,6 +112,7 @@
             <li class="p-list__item"><a href="/esm">Extended Security Maintenance</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/">Landscape remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
+            <li class="p-list__item"><a href="/managed">Managed Apps</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>
             <li class="p-list__item"><a href="/security">Security</a></li>
             <li class="p-list__item"><a href="https://certification.ubuntu.com">Hardware certification</a></li>


### PR DESCRIPTION
## Done

- Update adds managed app link to navigation
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against [Copy-doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9776
