### PR TITLE
CUBE: Use links that authenticate the user before redirecting to EDX

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -280,7 +280,7 @@
           <td>
             <div class="p-table--cube__contents u-align--right">
               {% if has_prepare_material %}
-              <a class="p-button--neutral u-no-margin--right" href="{{ module.prepare_url }}">Prepare</a>
+              <a class="p-button--neutral u-no-margin--right" href="{{ prepare_material_url }}">Prepare</a>
               {% endif %}
               <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.take_url }}">Take</a>
             </div>

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 # Packages
 from flask import template_rendered
 from vcr_unittest import VCRTestCase
@@ -72,12 +74,9 @@ class TestCube(VCRTestCase):
             self.assertEqual(module["status"], expected_module[module["id"]])
             self.assertTrue(
                 module["take_url"].endswith(
-                    f"{module['id']}/courseware/2020/start/?child=first"
-                )
-            )
-            self.assertTrue(
-                module["prepare_url"].endswith(
-                    "/course-v1:CUBE+study_labs_2020+alpha/course/"
+                    quote_plus(
+                        f"{module['id']}/courseware/2020/start/?child=first"
+                    )
                 )
             )
 


### PR DESCRIPTION
## Done
CUBE: Use links that authenticate the user before redirecting to EDX

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Asked Kellen to QA see his comment bellow

## Issue / Card

Fixes #9787
