### PR TITLE
Add rich structure data ubuntu.com/blog posts

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -9,6 +9,31 @@
 {% block body_class %}blog-article{% endblock %}
 {% block canonical_url %}{% if 2996 in article.tags %}https://snapcraft.io/blog/{{ article.slug }}{% elif 4059 in article.tags %}https://juju.is/blog/{{ article.slug }}{% else %}{{ super() }}{% endif %}{% endblock canonical_url %}
 
+{% block extra_metatags %}
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@id": "https://ubuntu.com/#article",
+    "@type": "Article",
+    "name": "{{ article.title.renderered|safe }}",
+    "headline": "{{ article.excerpt.raw }}",
+    "author": {
+       "@type": "Person",
+       "name": "{{ article.author.name }}"
+    },
+    "datePublished": "{{ article.date_gmt }}",
+    {% if article.image and article.image.source_url %}
+      "image": "{{ article.image.source_url }}",
+    {% endif %}
+    "url": "{{ request.url }}",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Ubuntu"
+    }
+  }
+  </script>
+{% endblock %}
+
 {% block content %}
 <article>
   <header class="p-strip--image is-shallow" style="background-image: url(https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png);">


### PR DESCRIPTION
## Done

- Add rich strucutre data for blog posts https://developers.google.com/search/docs/data-types/article

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Connect to the VPN
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/ubuntu-16-04-lts-transitions-to-extended-security-maintenance-esm
- Inspect HTML
- Make sure that there is a `application/ld+json` script in the header with the releavant information
- This should be green (test with the demo link): https://search.google.com/test/rich-results
