### PR TITLE
[CUBE] Fix progression hero and broken mobile view

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "smartquotes": "2.3.2",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.0",
-    "vanilla-framework": "2.29.0"
+    "vanilla-framework": "2.30.0"
   },
   "resolutions": {
     "lodash": "4.17.21",

--- a/static/sass/_pattern_cube-progression.scss
+++ b/static/sass/_pattern_cube-progression.scss
@@ -171,8 +171,7 @@
   }
 
   .is-faded {
-    // Without !important the background only applies to certain microcerts
-    background-color: rgba(255, 255, 255, 0.1) !important;
+    background-image: rgba(255, 255, 255, 0.1);
     clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
     opacity: 0.5;
 

--- a/static/sass/_pattern_cube-progression.scss
+++ b/static/sass/_pattern_cube-progression.scss
@@ -28,34 +28,14 @@
       width: map-get($rhombusSize, "width") * 1px;
     }
 
-    %is-faded {
-      background-color: rgba(255, 255, 255, 0.1);
-      clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-      opacity: 0.5;
-
-      &--right {
-        @extend %is-faded;
-
-        clip-path: polygon(0% 34%, 100% 0%, 100% 66.6%, 0% 100%);
-      }
-
-      &--left {
-        @extend %is-faded;
-
-        clip-path: polygon(0% 0%, 100% 34%, 100% 100%, 0% 66.6%);
-      }
-    }
-
     &.is-architecture {
       @extend %diamond-badge;
-      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/8b175afd-Architecture.svg);
     }
 
     &.is-bash {
       @extend %rhombus-badge;
-      @extend %is-faded--right;
 
       background: url(https://assets.ubuntu.com/v1/4b2c2de2-bash.svg);
       transform: translate(
@@ -66,7 +46,6 @@
 
     &.is-devices {
       @extend %rhombus-badge;
-      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/9ba960cc-devices+and+files.svg);
       transform: translate(0, map-get($diamondSize, "height") * 0.5px);
@@ -74,7 +53,6 @@
 
     &.is-packages {
       @extend %diamond-badge;
-      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/eb3be63d-Packages.svg);
       transform: translate(map-get($diamondSize, "width") * 1px, 0);
@@ -82,7 +60,6 @@
 
     &.is-services {
       @extend %rhombus-badge;
-      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/74e5c92e-Services.svg);
       transform: translate(
@@ -93,7 +70,6 @@
 
     &.is-admin {
       @extend %rhombus-badge;
-      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/0a374de7-Admin.svg);
       transform: translate(
@@ -104,7 +80,6 @@
 
     &.is-commands {
       @extend %diamond-badge;
-      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/5e068487-Commands.svg);
       transform: translate(map-get($diamondSize, "width") * 2px, 0);
@@ -112,7 +87,6 @@
 
     &.is-security {
       @extend %rhombus-badge;
-      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/d9074c81-Security.svg);
       transform: translate(
@@ -123,7 +97,6 @@
 
     &.is-networking {
       @extend %rhombus-badge;
-      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/3f3f2687-Networking.svg);
       transform: translate(
@@ -134,7 +107,6 @@
 
     &.is-kernel {
       @extend %diamond-badge;
-      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/7b4466fe-Kernel.svg);
       transform: translate(
@@ -145,7 +117,6 @@
 
     &.is-microk8s {
       @extend %rhombus-badge;
-      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/c26080a5-Microk8s.svg);
       transform: translate(
@@ -157,7 +128,6 @@
 
     &.is-virtualisation {
       @extend %rhombus-badge;
-      @extend %is-faded--left;
 
       background-image: url(https://assets.ubuntu.com/v1/4f1c55a5-Virtualisation.svg);
       transform: translate(
@@ -169,7 +139,6 @@
 
     &.is-storage {
       @extend %diamond-badge;
-      @extend %is-faded;
 
       background-image: url(https://assets.ubuntu.com/v1/090ef9e2-Storage.svg);
       transform: translate(
@@ -180,7 +149,6 @@
 
     &.is-juju {
       @extend %rhombus-badge;
-      @extend %is-faded--right;
 
       background-image: url(https://assets.ubuntu.com/v1/ce96b82f-Juju.svg);
       transform: translate(
@@ -192,7 +160,6 @@
 
     &.is-maas {
       @extend %rhombus-badge;
-      @extend %is-faded--left;
 
       background: url(https://assets.ubuntu.com/v1/711b3e71-MAAS.svg);
       transform: translate(
@@ -200,6 +167,25 @@
         (map-get($rhombusSize, "height") * 1px) +
           (map-get($diamondSize, "height") * 0.5px)
       );
+    }
+  }
+
+  .is-faded {
+    // Without !important the background only applies to certain microcerts
+    background-color: rgba(255, 255, 255, 0.1) !important;
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+    opacity: 0.5;
+
+    &--right {
+      @extend .is-faded;
+
+      clip-path: polygon(0% 34%, 100% 0%, 100% 66.6%, 0% 100%);
+    }
+
+    &--left {
+      @extend .is-faded;
+
+      clip-path: polygon(0% 0%, 100% 34%, 100% 100%, 0% 66.6%);
     }
   }
 }

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -25,9 +25,12 @@
 
     &:nth-child(5) {
       width: 13%;
-      i,
-      small {
-        display: none !important;
+
+      @media only screen and (max-width: $breakpoint-medium) {
+        i,
+        small {
+          display: none !important;
+        }
       }
     }
 

--- a/static/sass/_pattern_cube-table.scss
+++ b/static/sass/_pattern_cube-table.scss
@@ -25,12 +25,9 @@
 
     &:nth-child(5) {
       width: 13%;
-
-      @media only screen and (max-width: $breakpoint-medium) {
-        i,
-        small {
-          display: none !important;
-        }
+      i,
+      small {
+        display: none !important;
       }
     }
 

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -210,17 +210,18 @@
             </div>
           </td>
           <td class="p-table--cube__badge-column" aria-label="Badge">
-              <img
-                class="p-table--cube__badge"
-                src="{{ module.badge.url }}"
-                alt="Badge for {{ module.name }}"
-                {% if module.status == 'passed' %}
-                style="margin-left: -0.2rem;"
-                {% endif %}
-              />
+            <img
+              class="p-table--cube__badge"
+              src="{{ module.badge.url }}"
+              alt="Badge for {{ module.name }}"
+              {% if module.status == 'passed' %}
+              style="margin-left: -0.2rem;"
+              {% endif %}
+            />
           </td>
           <td aria-label="Module">
-            <div class="p-table--cube__contents">
+            <!-- inline style here and line 230 can be removed when this is fixed https://github.com/canonical-web-and-design/vanilla-framework/issues/3754 -->
+            <div class="p-table--cube__contents" style="white-space: normal">
               <h5>{{ module.name }}</h5>
             </div>
             <p class="u-text--muted u-hide--small">
@@ -229,7 +230,7 @@
           </td>
           <td aria-label="Topics">
             <div class="p-table--cube__contents">
-              <ul class="p-list u-no-margin">
+              <ul class="p-list u-no-margin" style="white-space: normal">
                 {% for topic in module.topics %}
                 <li class="p-list__item">{{ topic }}</li>
                 {% endfor %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7146,10 +7146,10 @@ vanilla-framework@2.19.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
   integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
-vanilla-framework@2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.29.0.tgz#19bcdc9ccfafcb8fed91747e24aab7bbabd0cb90"
-  integrity sha512-lDTInGGNGH29e9Clvi6CBvzGK5BfX3MejtwkDEKOR0ERadwH2AmIytmSsR7YVC9AdkJA9gRDxSGAlzBdxzN20w==
+vanilla-framework@2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.30.0.tgz#191317a65886c9f076a975b640c4cc86afeedbea"
+  integrity sha512-swyKGt8s6KtVIBnrg3LBWNKybaEy3Rl/+lBg7sYWdC9pQVxX0HKNw0mED4QNLvDaAEKjLLEfD63wXywwH7hXuQ==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Extract `.is-faded` to it's own class so it can be conditionally added to progression hero depending on module status
- Add media query to width of tables to fix mobile view
- Fix text overflow on cards by adding `white-space: normal` to the list of topics
- Filed an [issue](https://github.com/canonical-web-and-design/vanilla-framework/issues/3754) on Vanilla

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/microcerts
- Force all statuses of modules to passed by adding `course["status"] = "passed"` to line 127 of `webapp/cube/views.py`
- See the progression hero change to show passed microcerts
- Check the microcerts table on mobile view


## Issue / Card

Fixes #9789 

## Screenshots

none passed:

![image](https://user-images.githubusercontent.com/58959073/119157234-e0661780-ba4c-11eb-967d-c11426ba193c.png)

force passed all:

![image](https://user-images.githubusercontent.com/58959073/119157398-0ee3f280-ba4d-11eb-83b7-71614a517008.png)

mobile view: 

![image](https://user-images.githubusercontent.com/58959073/119317528-19320680-bc70-11eb-98b1-956c03a65050.png)


