### PR TITLE
Update resizing and cancellation

### DIFF
--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -1,14 +1,15 @@
 import {
-  resizeContract,
   cancelContract,
   getPurchase,
+  resizeContract,
 } from "./contracts-api.js";
 
 const stripe = window.Stripe(window.stripePublishableKey);
 
 const getMessage = (code, default_message) => {
   const map = {
-    resizing_machines_success: "Your changes were saved successfully, the page will reload",
+    resizing_machines_success:
+      "Your changes were saved successfully, the page will reload",
     cancelling_subscription_success:
       "Subscription cancelled! Reloading page...",
     resizing_machines_fail:
@@ -283,7 +284,7 @@ const createModal = (id, VPSize) => {
     confirmCancelButton.disabled = e.target.value.toLowerCase() !== "cancel";
   };
 
-  const content = `
+  container.innerHTML = `
     <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" style="overflow: auto;">
       <header class="p-modal__header">
         <h2 class="p-modal__title ">
@@ -309,7 +310,6 @@ const createModal = (id, VPSize) => {
       </div>
     </div>
   `;
-  container.innerHTML = content;
   document.body.appendChild(container);
 
   const fieldWrapper = document.querySelector("#cancel-modal-field-wrapper");

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -8,7 +8,7 @@ const stripe = window.Stripe(window.stripePublishableKey);
 
 const getMessage = (code, default_message) => {
   const map = {
-    resizing_machines_success: "Resizing successful! Reloading page...",
+    resizing_machines_success: "Your changes were saved successfully, the page will reload",
     cancelling_subscription_success:
       "Subscription cancelled! Reloading page...",
     resizing_machines_fail:

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -16,7 +16,7 @@ const getMessage = (code, default_message) => {
     subscription_missing:
       "<strong>Cancelling subscription failed:</strong> It could be that you have a pending payment that is blocking this action. Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     cancelling_subscription_failed:
-      "<strong>Cancelling subscription failed:</strong> Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
+      "<strong>Could not cancel subscription:</strong> Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     pending_purchase:
       "<strong>Error:</strong> You already have a pending purchase. Please go to <a href='/advantage/payment-methods'>payment methods</a> to fix it. Reloading page...",
     unknown_error:

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -9,17 +9,17 @@ const stripe = window.Stripe(window.stripePublishableKey);
 const getMessage = (code, default_message) => {
   const map = {
     resizing_machines_success:
-      "Your changes were saved successfully, the page will reload",
+      "Your changes were saved successfully, the page will reload.",
     cancelling_subscription_success:
-      "Subscription cancelled! Reloading page...",
+      "Your subscription was cancelled, the page will reload.",
     resizing_machines_fail:
-      "<strong>Payment method:</strong> There was an error with the payment please <a href='/advantage/payment-methods'>update your payment methods</a> to fix it.",
+      "<strong>Payment method:</strong> There was problem with your payment. Please <a href='/advantage/payment-methods'>update your payment methods</a> to retry.",
     subscription_missing:
-      "<strong>Cancelling subscription failed:</strong> It could be that you have a pending payment that is blocking this action. Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
+      "<strong>Could not cancel subscription:</strong> It could be that you have a pending payment that is blocking this action. Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     cancelling_subscription_failed:
       "<strong>Could not cancel subscription:</strong> Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     pending_purchase:
-      "<strong>Error:</strong> You already have a pending purchase. Please go to <a href='/advantage/payment-methods'>payment methods</a> to fix it. Reloading page...",
+      "<strong>Error:</strong> You already have a pending purchase. Please go to <a href='/advantage/payment-methods'>payment methods</a> to retry.",
     unknown_error:
       "<strong>Unknown error:</strong> Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
   };

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -262,7 +262,7 @@
                       <td class="plan" style="text-transform: capitalize;"><span class="u-truncate" style="padding-top: 0.35rem;">{{ contract['supportLevel'] }}</span></td>
                       <td class="u-align--right machines {% if new_subscription_id == contract['contractInfo']['id'] %} p-table--open{% endif %}">
                         <button class="u-toggle" aria-controls="#expanded-row-token-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="{% if new_subscription_id == contract['contractInfo']['id'] %} p-table--open{% endif %}" data-shown-text="Hide" data-hidden-text="Show">
-                          {{ contract['machineCount'] }}&nbsp;<i class="p-icon--contextual-menu {% if default_open_cell %}u-rotate{% endif %}">Open</i>
+                          {{ contract['rowMachineCount'] }}&nbsp;<i class="p-icon--contextual-menu {% if default_open_cell %}u-rotate{% endif %}">Open</i>
                         </button>
                       </td>
                       <td class="spacer"></td>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -48,7 +48,7 @@
 
   <hr class="p-separator" />
 
-  {% if payment_method_warning %}
+  {% if pending_purchase_id %}
   <div class="row">
     <div class="p-notification--caution">
       <p class="p-notification__response" role="status">
@@ -57,6 +57,7 @@
     </div>
   </div>
   {% endif %}
+
   {% if enterprise_contracts %}
     <section class="p-strip is-shallow" style="overflow: visible;">
       <div class="row u-vertically-center">
@@ -508,6 +509,10 @@
 
     price.innerText = formatter.format(ammount)
   });
+</script>
+
+<script>
+  window.pendingPurchaseId = "{{ pending_purchase_id }}";
 </script>
 
 <script src="{{ versioned_static('js/src/advantage/auto-renewal.js') }}" type="module" defer></script>

--- a/templates/advantage/payment-methods/index.html
+++ b/templates/advantage/payment-methods/index.html
@@ -47,7 +47,7 @@
         <div id="payment-warnings" class="p-notification--caution u-hide">
           <p class="p-notification__response">
             <span class="p-notification__message">
-              You have one or more failed payments. Use your saved card to <a class="p-notification__action" id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
+              You have one or more pending payments. Use your saved card to <a class="p-notification__action" id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
           </p>
         </div>
 

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -18,7 +18,7 @@
 
     <div class="change-subscription {% if mobile %}u-align--center{% endif %}">
       <p>Auto-renewal {% if monthly_information['is_auto_renewal_enabled'] %}enabled{% else %}disabled{% endif %}</p>
-      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}--monthly" data-viewport="{% if mobile %}small{% else %}large{% endif %}" {% if payment_method_warning %}disabled{% endif %}>Change subscription</button>
+      <button class="p-button--neutral js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}--monthly" data-viewport="{% if mobile %}small{% else %}large{% endif %}" {% if pending_purchase_id %}disabled{% endif %}>Change subscription</button>
     </div>
   </div>
 </div>
@@ -26,8 +26,21 @@
 <div class="col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}--monthly" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
   <div class="row">
     {% if mobile %}
-      <hr />
+      <hr class="p-separator" />
     {% endif %}
+
+    <div class="p-notification--positive success-{{contract["contractInfo"]["id"]}}--monthly u-hide">
+      <p class="p-notification__response">
+        <span class="p-notification__message"></span>
+      </p>
+    </div>
+
+    <div class="p-notification--caution caution-{{contract["contractInfo"]["id"]}}--monthly u-hide">
+      <p class="p-notification__response">
+        <span class="p-notification__message"></span>
+      </p>
+    </div>
+
     <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (monthly)</h5>
     {% if not mobile %}
       <hr />

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -16,7 +16,7 @@
     {% endif %}
     {% if not contract["is_detached"] and contract['machineCount']%}
       <div class="change-subscription">
-        <button class="p-button--neutral u-no-margin--left js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}--yearly" data-viewport="{% if mobile %}small{% else %}large{% endif %}" {% if payment_method_warning %}disabled{% endif %}>Change subscription</button>
+        <button class="p-button--neutral u-no-margin--left js-change-subscription-button" data-id="{{contract["contractInfo"]["id"]}}--yearly" data-viewport="{% if mobile %}small{% else %}large{% endif %}" {% if pending_purchase_id %}disabled{% endif %}>Change subscription</button>
       </div>
     {% endif %}
   </div>
@@ -25,8 +25,21 @@
 <div class="col-start-large-2 col-10 u-hide" id="edit-mode--{{contract["contractInfo"]["id"]}}--yearly" data-viewport="{% if mobile %}small{% else %}large{% endif %}">
   <div class="row">
     {% if mobile %}
-      <hr />
+      <hr class="p-separator" />
     {% endif %}
+
+    <div class="p-notification--positive success-{{contract["contractInfo"]["id"]}}--yearly u-hide">
+      <p class="p-notification__response">
+        <span class="p-notification__message"></span>
+      </p>
+    </div>
+
+    <div class="p-notification--caution caution-{{contract["contractInfo"]["id"]}}--yearly u-hide">
+      <p class="p-notification__response">
+        <span class="p-notification__message"></span>
+      </p>
+    </div>
+
     <h5 class="u-no-padding--top" {% if not mobile %}style="margin-bottom: .5rem"{% endif %}>{{contract['contractInfo']['name']}} (annual)</h5>
     {% if not mobile %}
       <hr />

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -202,6 +202,7 @@ def advantage_view(**kwargs):
             contract["productID"] = product_name
             contract["is_detached"] = False
             contract["machineCount"] = 0
+            contract["rowMachineCount"] = 0
 
             allowances = contract_info.get("allowances")
             if (
@@ -209,11 +210,12 @@ def advantage_view(**kwargs):
                 and len(allowances) > 0
                 and allowances[0]["metric"] == "units"
             ):
-                contract["machineCount"] = allowances[0]["value"]
+                contract["rowMachineCount"] = allowances[0]["value"]
 
             if product_name in yearly_purchased_products:
                 purchased_product = yearly_purchased_products[product_name]
                 contract["price_per_unit"] = purchased_product["price"]
+                contract["machineCount"] = purchased_product["quantity"]
                 contract["product_listing_id"] = purchased_product[
                     "product_listing_id"
                 ]
@@ -233,6 +235,7 @@ def advantage_view(**kwargs):
                 contract = contract.copy()
                 purchased_product = monthly_purchased_products[product_name]
                 contract["price_per_unit"] = purchased_product["price"]
+                contract["machineCount"] = purchased_product["quantity"]
                 contract["is_cancelable"] = True
                 contract["product_listing_id"] = purchased_product[
                     "product_listing_id"

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -47,7 +47,7 @@ def advantage_view(**kwargs):
     personal_account = None
     new_subscription_id = None
     new_subscription_start_date = None
-    payment_method_warning = None
+    pending_purchase_id = None
 
     enterprise_contracts = {}
     previous_purchase_ids = {"monthly": "", "yearly": ""}
@@ -86,10 +86,8 @@ def advantage_view(**kwargs):
             if status not in ["active", "locked"]:
                 continue
 
-            # If there are any pending purchase for a sub (active or locked)
-            # we show the payment method warning.
             if subscription.get("pendingPurchases"):
-                payment_method_warning = subscription.get("pendingPurchases")
+                pending_purchase_id = subscription.get("pendingPurchases")[0]
 
             previous_purchase_ids[period] = subscription.get("lastPurchaseID")
 
@@ -272,7 +270,7 @@ def advantage_view(**kwargs):
         accounts=accounts,
         monthly_information=monthly_info,
         total_enterprise_contracts=total_enterprise_contracts,
-        payment_method_warning=payment_method_warning,
+        pending_purchase_id=pending_purchase_id,
         enterprise_contracts=enterprise_contracts,
         previous_purchase_ids=previous_purchase_ids,
         personal_account=personal_account,
@@ -499,7 +497,7 @@ def cancel_advantage_subscriptions(**kwargs):
     )
 
     if not monthly_subscriptions:
-        return flask.jsonify({"error": "no monthly subscriptions found"}), 400
+        return flask.jsonify({"errors": "no monthly subscriptions found"}), 400
 
     monthly_subscription = monthly_subscriptions[0]
 


### PR DESCRIPTION
## Done

TLDR; List of changes:
- display messages on success or failure for both resizing and cancellation
- show up the 3DS modal if the resizing fails because of 3ds_authorizaion missing.
_______

#### [Current behaviour] Resizing works successfully 
- we refresh the page
- the new number of machines will be displayed
#### [New behaviour] Resizing works successfully
- we echo message saying that the resizing was successful
![image](https://user-images.githubusercontent.com/6387619/119503714-2b40a180-bd63-11eb-9828-0028cfaa09e3.png)
- we refresh the page
- the new number of machines will be displayed
_______

#### [Current behaviour] Resizing fails because of `payment_method_failed` 
- we refresh the page
- the number of machines does not change
- we show the payment methods notification
#### [New behaviour] Resizing fails because of `payment_method_failed`
- we do not refresh the page
- we show a message giving some feedback of what happened
![image](https://user-images.githubusercontent.com/6387619/119506522-e702d080-bd65-11eb-9d0f-59a7001d0601.png)
- if the user tries to make any other resizing of this subscription of another subscription of the same type we will show the following message and reload the page (the reload is needed because they likely have a pending payment, and after the reload we disable the change subscription button):
![image](https://user-images.githubusercontent.com/6387619/119522328-c6417780-bd73-11eb-9b9e-19730537e779.png)
- we show the payment methods notification after reload
_______

#### [Current behaviour] Resizing fails because of `3ds_authorisation` 
- we refresh the page
- the number of machines does not change
- we show the payment methods notification
#### [New behaviour] Resizing fails because of `3ds_authorisation` 
- we trigger the 3ds modal
##### [New behaviour] `3ds_authorisation` successful
- we echo message saying that the resizing was successful
![image](https://user-images.githubusercontent.com/6387619/119503714-2b40a180-bd63-11eb-9828-0028cfaa09e3.png)
- we refresh the page
- the new number of machines will be displayed
##### [New behaviour] `3ds_authorisation` failed
- we echo the following message
![image](https://user-images.githubusercontent.com/6387619/119506522-e702d080-bd65-11eb-9d0f-59a7001d0601.png)
- if the user tries to make any other resizing of this subscription of another subscription of the same type we will show the following message and reload the page (the reload is needed because they likely have a pending payment, and after the reload we disable the change subscription button):
![image](https://user-images.githubusercontent.com/6387619/119522328-c6417780-bd73-11eb-9b9e-19730537e779.png)
- we show the payment methods notification after reload
_______

#### [Current behaviour] Cancelling successful 
- we refresh the page
#### [New behaviour] Cancelling successful 
- we echo message saying that the cancellation was successful
![image](https://user-images.githubusercontent.com/6387619/119524584-b034b680-bd75-11eb-91a9-a48bf7d1335a.png)
- we refresh the page
#### [Current behaviour] Cancelling failed 
- page reloads, but the subscription does not get cancelled
#### [New behaviour] Cancelling failed 
- modal closes and an error message shows up: 
 - if there is a pending payment the following message shows up and we reload the page (the reload is needed because they likely have a pending payment, and after the reload we disable the change subscription button):
![image](https://user-images.githubusercontent.com/6387619/119534398-c4c97c80-bd7e-11eb-99e3-7628fde3f9de.png)
 - if there is any other error we show a more generic error message:
![image](https://user-images.githubusercontent.com/6387619/119534984-6fda3600-bd7f-11eb-8b74-556430de5b14.png)


## QA

Few things to check:
1) Successful resizing up and down with normal card
- Set card number to 4242424242424242 on https://ubuntu-com-9808.demos.haus/advantage/payment-methods?test_backend=true
- Go to https://ubuntu-com-9808.demos.haus/advantage?test_backend=true
- Resize up and/or down
- You should see the Success message

2) Successful resizing up triggering 3ds modal with the card
- Set card number to 4000002760003184 on https://ubuntu-com-9808.demos.haus/advantage//payment-methods?test_backend=true
- Go to https://ubuntu-com-9808.demos.haus/advantage?test_backend=true
- Resize up
- You should trigger the 3ds modal
- Finish the 3ds check successfully
- You should see the Success message

3) Failed resizing up triggering 3ds modal with the card (4000002760003184) should show error message
- Set card number to 4000002760003184 on https://ubuntu-com-9808.demos.haus/advantage/payment-methods?test_backend=true
- Go to https://ubuntu-com-9808.demos.haus/advantage?test_backend=true
- Resize up
- You should trigger the 3ds modal
- Finish the 3ds check successfully
- You should see an error message
- try to resize again should reload page

4) Failed cancelling subscription by having a pending payment
- Have a monthly purchase
- Manually remove the `disabled` attribute from the Change Subscription button
- Click Cancel Subscription
- It should throw an error message

5) Successfully cancelling subscription
- Resolve the pending payment by going to https://ubuntu-com-9808.demos.haus/advantage/payment-methods?test_backend=true
- I will not explain how to resolve it, with the hope that the process is intuitive enough
- Once the payment is resolved go to https://ubuntu-com-9808.demos.haus/advantage?test_backend=true
- Change monthly subscription
- Cancel it
- See success message

6) Go wild try to resize both monthly and yearly subscriptions. Have multiple pending payments try to resolve them on /payment-methods


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/3
