### PR TITLE
CUBE: Microcerts page copy

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -113,8 +113,8 @@
   <div class="row">
     <div class="col-5" style="margin-top: 3rem;">
       <h2>Refresh your knowledge</h2>
-      <p><strong>Be prepared for every exam</strong></p>
-      <p class="u-sv2">Brush up on your Ubuntu skills with preparatory materials that cover every microcert.</p>
+      <p><strong>Be prepared for every microcert</strong></p>
+      <p class="u-sv2">Check your baseline understanding of Ubuntu fundamentals and preview the exam experience in a practice environment.</p>
       {% if has_prepare_material %}
       <a href="{{ prepare_material_url }}" class="p-button--positive">Prepare</a>
       {% else %}

--- a/webapp/cube/content/cube-qa.yaml
+++ b/webapp/cube/content/cube-qa.yaml
@@ -70,8 +70,8 @@ courses:
       - Find and review information about activities and processes
       - Manage user privileges
       - Create backups
-      - View and record system utilization.
-      - Configure remote logging.
+      - View and record system utilization
+      - Configure remote logging
   -
     id: course-v1:CUBE+systemd+2020
     name: Managing System Services
@@ -130,8 +130,8 @@ courses:
       class: O818aQFRSqKHmLXoai6Qtw
       url: https://assets.ubuntu.com/v1/64422ff3-Virtualisation.svg
     topics:
-      - Create and use LXC containers.
-      - Create and use KVM VMs.
+      - Create and use LXC containers
+      - Create and use KVM VMs
   -
     id: course-v1:CUBE+microk8s+2020
     name: MicroK8s

--- a/webapp/cube/content/cube.yaml
+++ b/webapp/cube/content/cube.yaml
@@ -70,8 +70,8 @@ courses:
       - Find and review information about activities and processes
       - Manage user privileges
       - Create backups
-      - View and record system utilization.
-      - Configure remote logging.
+      - View and record system utilization
+      - Configure remote logging
   -
     id: course-v1:CUBE+systemd+2020
     name: Managing System Services
@@ -130,8 +130,8 @@ courses:
       class: ebAvD4D1S_qQ1pkUYnyRgQ
       url: https://assets.ubuntu.com/v1/64422ff3-Virtualisation.svg
     topics:
-      - Create and use LXC containers.
-      - Create and use KVM VMs.
+      - Create and use LXC containers
+      - Create and use KVM VMs
   -
     id: course-v1:CUBE+microk8s+2020
     name: MicroK8s


### PR DESCRIPTION
## Done
Update `/cube/microcerts` copy

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- go to `/cube/microcerts`
- check against [copy](https://docs.google.com/document/d/1IHmr2SIxcEKVNN2sA-z_32PV0fCXi38pmeVP7k7O1mM/edit?ts=60a669a4#) and resolve the comments


## Issue / Card

Fixes #9800 