### PR TITLE
Handle login failure when cookies are blocked or missing

### DIFF
--- a/templates/templates/_error_login.html
+++ b/templates/templates/_error_login.html
@@ -1,0 +1,32 @@
+{% extends "templates/one-column_no_nav.html" %}
+{% block title %}Login error{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg",
+          alt="",
+          height="365",
+          width="360",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h1 class="p-heading--two">Something's gone wrong.</h1>
+        <p>Your browser session appears to be missing the expected authentication macaroon.</p>
+        <p>
+          If the error persists, please note that it may be a <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues">known issue</a>.
+          If not, please <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new">file a new issue</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -78,7 +78,16 @@ def login_handler():
 
 @open_id.after_login
 def after_login(resp):
-    root = Macaroon.deserialize(flask.session.pop("macaroon_root"))
+    try:
+        root = Macaroon.deserialize(flask.session.pop("macaroon_root"))
+    except KeyError:
+        return (
+            flask.render_template(
+                "templates/_error_login.html",
+            ),
+            400,
+        )
+
     bound = root.prepare_for_request(
         Macaroon.deserialize(resp.extensions["macaroon"].discharge)
     )


### PR DESCRIPTION
## Done

- Show error page when user tries to login but has blocked cookies

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Disable cookies on your browser for `localahost:8001`
- Try to login and see the error page


## Issue / Card

Fixes #9283 
