### PR TITLE
Fix certified device count for IoT and SoC

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -152,7 +152,7 @@
       <ul class="p-inline-list">
         {% for iot_vendor in iot_vendors %}
         <li class="p-inline-list__item">
-          <a href="/certified?category=Device&vendor={{ iot_vendor.make }}">{{ iot_vendor.make }}&nbsp;({{ iot_vendor.total }})</a>
+          <a href="/certified?category=Device&vendor={{ iot_vendor.make }}">{{ iot_vendor.make }}&nbsp;({{ iot_vendor.smart_core }})</a>
         </li>
         {% endfor %}
       </ul>
@@ -178,7 +178,7 @@
       <ul class="p-inline-list">
         {% for soc_vendor in soc_vendors %}
         <li class="p-inline-list__item">
-          <a href="/certified?category=Server&vendor={{ soc_vendor.make }}">{{ soc_vendor.make }} ({{ soc_vendor.total }})</a>
+          <a href="/certified?category=SoC&vendor={{ soc_vendor.make }}">{{ soc_vendor.make }} ({{ soc_vendor.soc }})</a>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Done

- The API returns the number of IoT devices for a make in the `smart_core` field and `soc` for SoC devices. The `total` field counts all of the machines for that make, not just the IoT or SoC ones. This fixes the template to get the data from the correct field.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Verify that the total for IoT Dell is 4 and not 326 and that the total for SoC Huwai is 6 and not 72.


## Issue / Card

Fixes #9825
