### PR TITLE
Removing lpid field from cloud contact form

### DIFF
--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -79,7 +79,6 @@
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formVid" class="mktoField" value="{{formid}}" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpId" class="mktoField" value="{{lpId}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="subId" class="mktoField" value="30" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="munchkinId" class="mktoField" value="066-EOV-335" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />


### PR DESCRIPTION
## Done

- Removing lpid field from cloud contact form to avoid overriding the form acquisition program name

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Fill a form such as `/support/contact-us?product=education-discount`
- Contact GE team to verify the outcome
