### PR TITLE
Fixes over-sized navbar

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -102,6 +102,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
 
     &__logo {
       background: $color-brand;
+      height: 3rem;
     }
 
     & &__nav {


### PR DESCRIPTION
## Done

- Fixes over-sized navbar

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check to see if the navbar is the right size.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9814

## Screenshots

![image](https://user-images.githubusercontent.com/58276363/120285397-7c99e500-c2bd-11eb-8b64-3563c764e9d1.png)

