### PR TITLE
Fix stylelint command, and `lint-scss`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test-python": "python3 -m unittest discover tests",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "format-python": "black --line-length 79 webapp tests",
-    "lint-scss": "stylelint static/sass/**/*.scss",
+    "lint-scss": "stylelint 'static/sass/**/*.scss'",
     "lint-js": "eslint static/js/src/**/*.js",
     "test-js": "NODE_ICU_DATA=node_modules/full-icu jest",
     "test-links": "./entrypoint 0.0.0.0:${PORT} && sleep 2 && linkchecker --threads 2 --ignore-url /usn --ignore-url /resources --ignore-url /search --ignore-url /server/docs --no-warnings http://127.0.0.1:8000",


### PR DESCRIPTION
Fixes #9838

Since there's no hope of actually fixing these errors in this PR, I'm making the `lint-scss` check non-mandatory for now. And I've filed https://github.com/canonical-web-and-design/ubuntu.com/issues/9843 to be addressed soon.

QA
--

See the glorious `lint-scss` check fail.