### PR TITLE
Copy update on /compare

### DIFF
--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}OpenStack distributions comparison{% endblock %}
-{% block meta_description %}This page provides a detailed comparison of various OpenStack platforms including both business and technical aspects of each.{% endblock%}
+{% block meta_description %}A detailed comparison of various OpenStack platforms including both business and technical aspects of each.{% endblock%}
 {% block meta_copydoc %}https://docs.google.com/document/d/1ibpATi-e0rKP3GaLgvzwO_XyFU9ZTsUaCHMwrg96MZM/edit{% endblock %}
 
 {% block content %}
@@ -371,6 +371,27 @@
   </div>
 </section>
 
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a3694a61-Public+Cloud.svg",
+        alt="",
+        width="221",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-8">
+      <h2>More cost-efficient than public clouds</h2>
+      <p>Public clouds are expensive when running workloads in the long-term and at scale. Although they are a more economical solution at the beginning of the cloud transformation process, their costs keep growing over time. Canonical's Charmed OpenStack is a cost-efficient extension to public cloud infrastructure, ensuring lower TCO per VM and enabling businesses to run their workloads where it makes the most sense from an economical point of view.</p>
+      <p><a href="/tco-calculator">Learn more &nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip--light">
   <div class="row u-equal-height">
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
@@ -399,6 +420,9 @@
     </div>
   </div>
 </section>
+
+{% with first_item="_private_cloud_contact_us", second_item="_cloud_newsletter", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/shared/contextual_footers/_openstack_further_reading.html
+++ b/templates/shared/contextual_footers/_openstack_further_reading.html
@@ -1,3 +1,3 @@
-{% with limit="5", tagId="1327" %}
+{% with limit="5", tagId="1327, 1350" %}
   {% include "shared/contextual_footers/_further_reading.html" %}
 {% endwith %}

--- a/templates/shared/contextual_footers/_private_cloud_contact_us.html
+++ b/templates/shared/contextual_footers/_private_cloud_contact_us.html
@@ -1,0 +1,6 @@
+<div class="col-4 p-divider__block">
+  <h3 class="p-heading--four">Looking for an enterprise private cloud?</h3>
+  <p>Charmed OpenStack includes enterprise dashboards, an integrated observability stack, HA everywhere and data protection capabilities.</p>
+  <p>All of that with a commercial support from Canonical, including aggressive SLAs, phone and ticket support and compliance programmes.</p>
+  <p><a href="#get-in-touch" class="p-button--neutral js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Private cloud contact us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us</a></p>
+</div>


### PR DESCRIPTION
## Done

- Update `/openstack/compare`
- The copy doc asks for "Recent blogs tagged with 'openstack' and 'private cloud' keywords" but I'm not sure how to use 2 different tagIds? 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/compare
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check against [copy doc](https://docs.google.com/document/d/1ibpATi-e0rKP3GaLgvzwO_XyFU9ZTsUaCHMwrg96MZM/edit#)

## Issue / Card

Fixes #9846 

