### PR TITLE
Move is-dark class from strip to row

### DIFF
--- a/templates/0_docs/content_strips.html
+++ b/templates/0_docs/content_strips.html
@@ -55,10 +55,10 @@
   </div>
 </section>
 
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru">
   <div class="u-fixed-width">
     <h3>Webinars and case studies</h3>
-    <div class="row p-divider u-no-padding--left u-no-padding--right">
+    <div class="row p-divider u-no-padding--left u-no-padding--right is-dark">
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon--muted">
           <div class="p-heading-icon__header">

--- a/templates/aws/fips.html
+++ b/templates/aws/fips.html
@@ -318,13 +318,13 @@
   </div>
 </section>
 
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru">
   <div class="row">
     <div class="col-12">
       <h2>Get Ubuntu Pro FIPS on AWS now:</h2>
     </div>
   </div>
-  <div class="row p-divider">
+  <div class="row p-divider is-dark">
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://aws.amazon.com/marketplace/pp/B08GCSCZJK" class="p-link--inverted">18.04 LTS</a></h3>
     </div>

--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -353,13 +353,13 @@
   </div>
 </section>
 
-<section class="p-strip--suru is-dark">
+<section class="p-strip--suru">
   <div class="row">
     <div class="col-12">
       <h2>Get Ubuntu Pro FIPS on Azure now:</h2>
     </div>
   </div>
-  <div class="row p-divider">
+  <div class="row p-divider is-dark">
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--four"><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips?tab=Overview" class="p-link--inverted">18.04 LTS</a></h3>
     </div>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -45,8 +45,8 @@
     </div>
   </div>
 
-  <section class="p-strip--suru-accent is-dark">
-    <div class="row p-divider">
+  <section class="p-strip--suru-accent">
+    <div class="row p-divider is-dark">
       <div class="col-6 p-divider__block">
         <div class="p-heading-icon--small">
           <div class="p-heading-icon__header">


### PR DESCRIPTION
## Done

- Found all places where the `is-dark` class on the strip has a `row p-divider` child - as the text contrast is broken 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #9854 

## Screenshots

[Before]

![Screenshot 2021-06-03 at 11 17 46](https://user-images.githubusercontent.com/58959073/120629111-62970880-c45d-11eb-835b-0a6e5ca1efea.png)

[After]

![Screenshot 2021-06-03 at 11 18 33](https://user-images.githubusercontent.com/58959073/120629183-7478ab80-c45d-11eb-83a2-0f07d5832f56.png)


