### PR TITLE
Adding Docker security product card

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,6 +1,10 @@
 <div id="product-card">
+   {# Docker tag cards #}
+  {% if article.tags and 1567 in article.tags %}
+    {% include "blog/product-cards/_docker-security.html" %}
+
    {# Telco tag cards #}
-  {% if article.tags and 1377 in article.tags %}
+  {% elif article.tags and 1377 in article.tags %}
     {% include "blog/product-cards/_telco.html" %}
 
    {# IoT tag cards #}

--- a/templates/blog/product-cards/_docker-security.html
+++ b/templates/blog/product-cards/_docker-security.html
@@ -1,0 +1,12 @@
+<div class="p-card js-product-card u-hide">
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ed348358-logo-cof.svg" alt="ubuntu logo">
+  <hr class="u-sv1">
+  <h3>
+    <a href="/security/docker-images">What’s the risk of unsolved vulnerabilities in Docker images?</a>
+  </h3>
+  <p>Recent surveys found that many popular containers had known vulnerabilities. 
+  Container images provenance is critical for a secure software supply chain in production. 
+  Benefit from Canonical’s security expertise with the LTS Docker images portfolio, a curated set of application images, 
+  free of vulnerabilities, with a 24/7 commitment.</p>
+  <p><a href="/security/docker-images">Integrate with hardened LTS images&nbsp;&rsaquo;</a></p>
+</div>


### PR DESCRIPTION
## Done

- Adding the Docker security product card on blog posts with the "Docker" tag
 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure the card is present on blog posts tagged with "Docker", such as `/blog/what-is-virtualisation-the-basics`

## Issue / Card

Fixes #

## Screenshots

![Screenshot from 2021-06-03 21-21-55](https://user-images.githubusercontent.com/18480003/120707068-c4815d80-c4b1-11eb-97b0-1d40d4b88ed3.png)

