### PR TITLE
Add an "s" on /openstack/compare

### DIFF
--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -169,7 +169,7 @@
         <tr>
           <th>OpenStack deployment mechanism</th>
           <td class="p-accordion is-compact ">
-            <button class="p-accordion__tab " id="tab-deployment-mechanism" role="tab" aria-controls="content-deployment-mechanism" aria-expanded="false">OpenStack Charm</button>
+            <button class="p-accordion__tab " id="tab-deployment-mechanism" role="tab" aria-controls="content-deployment-mechanism" aria-expanded="false">OpenStack Charms</button>
             <div class="p-accordion__panel" aria-hidden="true" id="content-deployment-mechanism">
               <p><a class="p-link--external" href="https://charmhub.io/?q=openstack">OpenStack Charms</a> encapsulate the entire logic required to install and operate OpenStack post-deployment inside of composable software packages.</p>
             </div>


### PR DESCRIPTION
## Done

- I made a typo, fixed it
![image](https://user-images.githubusercontent.com/441217/121385252-db580200-c940-11eb-99ca-e0ab39be6afb.png)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/compare
- See that is says 'OpenStack Charms'
