### PR TITLE
Update list of active Canonical websites on /legal/websites

### DIFF
--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -9,138 +9,150 @@
   <div class="row">
     <div class="col-8">
       <h1>Canonical websites</h1>
-      <ul class="p-list">
+      <ul class="p-list is-split">
         <li class="p-list__item">
-          <a href="https://canonical.com">canonical.com</a>
+          <a class="p-link--external" href="https://anbox-cloud.io">anbox-cloud.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
+          <a class="p-link--external" href="https://canonical.com">canonical.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://certification.ubuntu.com">certification.ubuntu.com</a>
+          <a class="p-link--external" href="https://cdimages.ubuntu.com">cdimages.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://cloud-images.ubuntu.com">cloud-images.ubuntu.com</a>
+          <a class="p-link--external" href="https://certification.ubuntu.com">certification.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://cloud-init.io">cloud-init.io</a>
+          <a class="p-link--external" href="https://charmed-osm.com">charmed-osm.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://cn.ubuntu.com">cn.ubuntu.com</a>
+          <a class="p-link--external" href="https://charmhub.io">charmhub.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
+          <a class="p-link--external" href="https://cloud-images.ubuntu.com">cloud-images.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://design.ubuntu.com">design.ubuntu.com</a>
+          <a class="p-link--external" href="https://cloud-init.io">cloud-init.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://discourse.juju.is">discourse.juju.is</a>
+          <a class="p-link--external" href="https://cn.ubuntu.com">cn.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://discourse.maas.io">discourse.maas.io</a>
+          <a class="p-link--external" href="https://design.ubuntu.com">design.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
+          <a class="p-link--external" href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://docs.snapcraft.io">docs.snapcraft.io</a>
+          <a class="p-link--external" href="https://discourse.juju.is">discourse.juju.is</a>
         </li>
         <li class="p-list__item">
-          <a href="https://docs.ubuntu.com">docs.ubuntu.com</a>
+          <a class="p-link--external" href="https://discourse.maas.io">discourse.maas.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://dqlite.io">dqlite.io</a>
+          <a class="p-link--external" href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://errors.ubuntu.com">errors.ubuntu.com</a>
+          <a class="p-link--external" href="https://docs.snapcraft.io">docs.snapcraft.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://fridge.ubuntu.com">fridge.ubuntu.com</a>
+          <a class="p-link--external" href="https://docs.ubuntu.com">docs.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://help.ubuntu.com">help.ubuntu.com</a>
+          <a class="p-link--external" href="https://dqlite.io">dqlite.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://jaas.ai">jaas.ai</a>
+          <a class="p-link--external" href="https://errors.ubuntu.com">errors.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://jp.ubuntu.com">jp.ubuntu.com</a>
+          <a class="p-link--external" href="https://fridge.ubuntu.com">fridge.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://juju.is">juju.is</a>
+          <a class="p-link--external" href="https://help.ubuntu.com">help.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://landscape.canonical.com">landscape.canonical.com</a>
+          <a class="p-link--external" href="https://jaas.ai">jaas.ai</a>
         </li>
         <li class="p-list__item">
-          <a href="https://launchpad.net">launchpad.net</a>
+          <a class="p-link--external" href="https://jp.ubuntu.com">jp.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://linuxcontainers.org">linuxcontainers.org</a>
+          <a class="p-link--external" href="https://juju.is">juju.is</a>
         </li>
         <li class="p-list__item">
-          <a href="https://lists.ubuntu.com">lists.ubuntu.com</a>
+          <a class="p-link--external" href="https://kubeflow-news.com">kubeflow-news.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://loco.ubuntu.com">loco.ubuntu.com</a>
+          <a class="p-link--external" href="https://landscape.canonical.com">landscape.canonical.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://login.ubuntu.com">login.ubuntu.com</a>
+          <a class="p-link--external" href="https://launchpad.net">launchpad.net</a>
         </li>
         <li class="p-list__item">
-          <a href="https://maas.io">maas.io</a>
+          <a class="p-link--external" href="https://linuxcontainers.org">linuxcontainers.org</a>
         </li>
         <li class="p-list__item">
-          <a href="https://merges.ubuntu.com">merges.ubuntu.com</a>
+          <a class="p-link--external" href="https://lists.ubuntu.com">lists.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://microk8s.io">microk8s.io</a>
+          <a class="p-link--external" href="https://loco.ubuntu.com">loco.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://microstack.run">microstack.run</a>
+          <a class="p-link--external" href="https://login.ubuntu.com">login.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://mir-server.io">mir-server.io</a>
+          <a class="p-link--external" href="https://maas.io">maas.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://multipass.io">multipass.io</a>
+          <a class="p-link--external" href="https://merges.ubuntu.com">merges.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://netplan.io">netplan.io</a>
+          <a class="p-link--external" href="https://microk8s.io">microk8s.io</a>
         </li>
         <li class="p-list__item">
-          <a href="http://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
+          <a class="p-link--external" href="https://microstack.run">microstack.run</a>
         </li>
         <li class="p-list__item">
-          <a href="https://packaging.ubuntu.com">packaging.ubuntu.com</a>
+          <a class="p-link--external" href="https://mir-server.io">mir-server.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://planet.ubuntu.com">planet.ubuntu.com</a>
+          <a class="p-link--external" href="https://multipass.run">multipass.run</a>
         </li>
         <li class="p-list__item">
-          <a href="https://popcon.ubuntu.com">popcon.ubuntu.com</a>
+          <a class="p-link--external" href="https://netplan.io">netplan.io</a>
         </li>
         <li class="p-list__item">
-          <a href="https://releases.ubuntu.com">releases.ubuntu.com</a>
+          <a class="p-link--external" href="http://old-releases.ubuntu.com">old-releases.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://snapcraft.io">snapcraft.io</a>
+          <a class="p-link--external" href="https://packages.ubuntu.com">packages.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a class="p-link--external" href="https://packaging.ubuntu.com">packaging.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a class="p-link--external" href="https://planet.ubuntu.com">planet.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a class="p-link--external" href="https://popcon.ubuntu.com">popcon.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a class="p-link--external" href="https://releases.ubuntu.com">releases.ubuntu.com</a>
+        </li>
+        <li class="p-list__item">
+          <a class="p-link--external" href="https://snapcraft.io">snapcraft.io</a>
         </li>
         <li class="p-list__item">
           <a href="https://ubuntu.com">ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://ubuntuforums.org">ubuntuforums.org</a>
+          <a class="p-link--external" href="https://ubuntuforums.org">ubuntuforums.org</a>
         </li>
         <li class="p-list__item">
-          <a href="https://ubuntuonair.com">ubuntuonair.com</a>
+          <a class="p-link--external" href="https://ubuntuonair.com">ubuntuonair.com</a>
         </li>
         <li class="p-list__item">
-          <a href="https://usn.ubuntu.com">usn.ubuntu.com</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://vanillaframework.io">vanillaframework.io</a>
+          <a class="p-link--external" href="https://vanillaframework.io">vanillaframework.io</a>
         </li>
       </ul>
     </div>

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -53,9 +53,6 @@
           <a class="p-link--external" href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--external" href="https://docs.snapcraft.io">docs.snapcraft.io</a>
-        </li>
-        <li class="p-list__item">
           <a class="p-link--external" href="https://docs.ubuntu.com">docs.ubuntu.com</a>
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

- Update list of active Canonical websites
- Made the list `is-split`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/websites
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1UPhx8ARReA6-vDYNHbsGmJN-rY1LHGacq6g4PV6eCoA/edit#)


## Issue / Card

Fixes #9878
