### PR TITLE
Fix up a load of urls that have www, http, or /certification

### DIFF
--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -160,6 +160,6 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure-1604" data-form-id="3870" data-lp-id="" data-return-url="https://www.ubuntu.com/azure/thank-you" data-lp-url="https://www.ubuntu.com/azure/contact-us">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure-1604" data-form-id="3870" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://www.ubuntu.com/azure/contact-us">
 </div>
 {% endblock content %}

--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -160,6 +160,6 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure-1604" data-form-id="3870" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://www.ubuntu.com/azure/contact-us">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure-1604" data-form-id="3870" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://ubuntu.com/azure/contact-us">
 </div>
 {% endblock content %}

--- a/templates/16-04/base_16-04.html
+++ b/templates/16-04/base_16-04.html
@@ -6,6 +6,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://ubuntu.com/gcp/thank-you" data-lp-url="https://www.ubuntu.com/gcp/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://ubuntu.com/gcp/thank-you" data-lp-url="https://ubuntu.com/gcp/contact-us">
   </div>
 {% endblock %}

--- a/templates/16-04/base_16-04.html
+++ b/templates/16-04/base_16-04.html
@@ -6,6 +6,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://www.ubuntu.com/gcp/thank-you" data-lp-url="https://www.ubuntu.com/gcp/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://ubuntu.com/gcp/thank-you" data-lp-url="https://www.ubuntu.com/gcp/contact-us">
   </div>
 {% endblock %}

--- a/templates/about/base_about.html
+++ b/templates/about/base_about.html
@@ -8,7 +8,7 @@
   {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below -->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/advantage/base_advantage.html
+++ b/templates/advantage/base_advantage.html
@@ -7,7 +7,7 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/advantage-beta" data-form-id="3856" data-lp-id="3856" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/advantage-beta" data-form-id="3856" data-lp-id="3856" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 {% endblock %}

--- a/templates/ai/services.html
+++ b/templates/ai/services.html
@@ -119,7 +119,7 @@
       <p>Align your sysadmins, devops, data engineers and data scientists with the latest MLOps solutions.</p>
       <p>Any infra and level of expertise. Tailored to your use cases. Up to 15 attendees. 4-day on-premise training for $29.500.</p>
       <p>
-        <a class="p-link--external p-button--neutral" href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf?_ga=2.202291033.951646160.1607941648-154096706.1586788067">See Curriculum</a>
+        <a class="p-link--external p-button--neutral" href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf" >See Curriculum</a>
         <a class="p-button--neutral js-invoke-modal" href="/training/contact-us?product=kubeflow-training-onsite">Talk to us</a>
       </p>
     </div>

--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -4,6 +4,6 @@
 
 {% block outer_content %}
     {% block content %}{% endblock %}
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_appliance" data-form-id="3231" data-lp-id="6279" data-return-url="https://www.ubuntu.com/appliance/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_appliance" data-form-id="3231" data-lp-id="6279" data-return-url="https://ubuntu.com/appliance/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
     <script src="{{ versioned_static('js/dist/appliance.js') }}" defer></script>
 {% endblock %}

--- a/templates/aws/base_aws.html
+++ b/templates/aws/base_aws.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/aws" data-form-id="3790" data-lp-id="" data-return-url="https://ubuntu.com/aws/thank-you" data-lp-url="https://www.ubuntu.com/aws/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/aws" data-form-id="3790" data-lp-id="" data-return-url="https://ubuntu.com/aws/thank-you" data-lp-url="https://ubuntu.com/aws/contact-us">
   </div>
 {% endblock %}

--- a/templates/aws/base_aws.html
+++ b/templates/aws/base_aws.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/aws" data-form-id="3790" data-lp-id="" data-return-url="https://www.ubuntu.com/aws/thank-you" data-lp-url="https://www.ubuntu.com/aws/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/aws" data-form-id="3790" data-lp-id="" data-return-url="https://ubuntu.com/aws/thank-you" data-lp-url="https://www.ubuntu.com/aws/contact-us">
   </div>
 {% endblock %}

--- a/templates/azure/base_azure.html
+++ b/templates/azure/base_azure.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure" data-form-id="3791" data-lp-id="" data-return-url="https://www.ubuntu.com/azure/thank-you" data-lp-url="https://www.ubuntu.com/azure/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure" data-form-id="3791" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://www.ubuntu.com/azure/contact-us">
   </div>
 {% endblock %}

--- a/templates/azure/base_azure.html
+++ b/templates/azure/base_azure.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure" data-form-id="3791" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://www.ubuntu.com/azure/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/azure" data-form-id="3791" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://ubuntu.com/azure/contact-us">
   </div>
 {% endblock %}

--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -428,7 +428,7 @@
       </a>
       <h4>Optimized scaling in the cloud</h4>
       <p>Building enterprise-grade infrastructure with open source quickly with stability, yet with no contract seems impossible, but Ubuntu Pro for Azure allows organisations to do just that. Ubuntu Pro is a premium image delivering the most comprehensive security and compliance features and is suitable for small to large-scale Linux enterprise operations — no contract necessary.  This piece explains the new ways Ubuntu and Microsoft Azure are driving reliability and security at speed and scale.</p>
-      <p><a class="p-button--positive p-link--external" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf?_ga=2.100590814.1744838369.1605604394-842710078.1584639728">Download the e-book</a></p>
+      <p><a class="p-button--positive p-link--external" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf" >Download the e-book</a></p>
     </div>
   </div>
 </section>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1521,7 +1521,7 @@
 </script>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/ceph/base_ceph.html
+++ b/templates/ceph/base_ceph.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/storage" data-form-id="1233" data-lp-id="2001" data-return-url="https://www.ubuntu.com/ceph/thank-you" data-lp-url="https://www.ubuntu.com/ceph/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/storage" data-form-id="1233" data-lp-id="2001" data-return-url="https://ubuntu.com/ceph/thank-you" data-lp-url="https://www.ubuntu.com/ceph/contact-us">
   </div>
 {% endblock %}

--- a/templates/ceph/base_ceph.html
+++ b/templates/ceph/base_ceph.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/storage" data-form-id="1233" data-lp-id="2001" data-return-url="https://ubuntu.com/ceph/thank-you" data-lp-url="https://www.ubuntu.com/ceph/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/storage" data-form-id="1233" data-lp-id="2001" data-return-url="https://ubuntu.com/ceph/thank-you" data-lp-url="https://ubuntu.com/ceph/contact-us">
   </div>
 {% endblock %}

--- a/templates/cloud/_base-cloud.html
+++ b/templates/cloud/_base-cloud.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
 

--- a/templates/community/_base_community.html
+++ b/templates/community/_base_community.html
@@ -8,7 +8,7 @@
   {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below -->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -88,7 +88,7 @@
   </div>
 </section>
 
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/containers/base_containers.html
+++ b/templates/containers/base_containers.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1964" data-lp-id="3828" data-return-url="https://www.ubuntu.com/containers/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1964" data-lp-id="3828" data-return-url="https://ubuntu.com/containers/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/build/index.html
+++ b/templates/core/build/index.html
@@ -252,7 +252,7 @@
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 {% endif %}

--- a/templates/core/features/full-disk-encryption.html
+++ b/templates/core/features/full-disk-encryption.html
@@ -134,7 +134,7 @@
 </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/features/index.html
+++ b/templates/core/features/index.html
@@ -228,7 +228,7 @@
 </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/features/ota-updates.html
+++ b/templates/core/features/ota-updates.html
@@ -211,7 +211,7 @@
 </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/features/recovery.html
+++ b/templates/core/features/recovery.html
@@ -134,7 +134,7 @@
 </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/features/secure-boot.html
+++ b/templates/core/features/secure-boot.html
@@ -143,7 +143,7 @@
 </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1252,7 +1252,7 @@
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -304,7 +304,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}
 

--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -424,7 +424,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
 </div>
 
 <script>

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -340,7 +340,7 @@
 {% endif %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://www.ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/cube-beta" data-form-id="3801" data-lp-id="7140" data-return-url="https://ubuntu.com/cube/thank-you" data-lp-url="https://pages.ubuntu.com/Contact_Us_Ubuntu_CUBEbetatest_Cube-contact-us-landing-page.html">
 </div>
 
 <script >

--- a/templates/dell/base_dell.html
+++ b/templates/dell/base_dell.html
@@ -3,7 +3,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/partner-dell" data-form-id="3454" data-lp-id="1409" data-return-url="https://www.ubuntu.com/dell/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/partner-dell" data-form-id="3454" data-lp-id="1409" data-return-url="https://ubuntu.com/dell/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
 

--- a/templates/desktop/base_desktop.html
+++ b/templates/desktop/base_desktop.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1253" data-lp-id="1409" data-return-url="https://www.ubuntu.com/desktop/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1253" data-lp-id="1409" data-return-url="https://ubuntu.com/desktop/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
 

--- a/templates/download/_base_download.html
+++ b/templates/download/_base_download.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
 

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -117,9 +117,9 @@
         <input type="hidden" aria-hidden="true" name="cr" class="mktoField " value="">
         <input type="hidden" aria-hidden="true" name="kw" class="mktoField " value="">
         <input type="hidden" aria-hidden="true" name="q" class="mktoField " value="">
-        <input type="hidden" aria-hidden="true" name="return_url" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-        <input type="hidden" aria-hidden="true" name="returnURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
-        <input type="hidden" aria-hidden="true" name="retURL" value="https://www.ubuntu.com/download/server/thank-you-s390x" />
+        <input type="hidden" aria-hidden="true" name="return_url" value="https://ubuntu.com/download/server/thank-you-s390x" />
+        <input type="hidden" aria-hidden="true" name="returnURL" value="https://ubuntu.com/download/server/thank-you-s390x" />
+        <input type="hidden" aria-hidden="true" name="retURL" value="https://ubuntu.com/download/server/thank-you-s390x" />
       </form>
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -855,7 +855,7 @@
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://www.ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/financial-services/_base_financial-services.html
+++ b/templates/financial-services/_base_financial-services.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/financial" data-form-id="3709" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/financial" data-form-id="3709" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 {% endblock %}

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -570,7 +570,7 @@
       <p>An <a href="/desktop">Ubuntu workstation</a> is the <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">professional developer’s preference</a>. Highly secure, reliable and with low cost of ownership, Ubuntu workstations are widely adopted by application engineering teams at financial institutions.</p>
       <p>Canonical provides 24x7 support and <a class="p-link--external" href="https://landscape.canonical.com/">management tools</a> for monitoring, managing, patching and compliance reporting on all your Ubuntu workstations.</p>
       <p>
-        <a class="p-link--external" href="https://buy.ubuntu.com/?_ga=2.170240736.1542483846.1604916464-1912709568.1604434903">Learn about Ubuntu Advantage</a>
+        <a class="p-link--external" href="https://buy.ubuntu.com/" >Learn about Ubuntu Advantage</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">

--- a/templates/gcp/base_gcp.html
+++ b/templates/gcp/base_gcp.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://www.ubuntu.com/gcp/thank-you" data-lp-url="https://www.ubuntu.com/gcp/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://ubuntu.com/gcp/thank-you" data-lp-url="https://www.ubuntu.com/gcp/contact-us">
   </div>
 {% endblock %}

--- a/templates/gcp/base_gcp.html
+++ b/templates/gcp/base_gcp.html
@@ -4,6 +4,6 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://ubuntu.com/gcp/thank-you" data-lp-url="https://www.ubuntu.com/gcp/contact-us">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/gcp" data-form-id="3860" data-lp-id="" data-return-url="https://ubuntu.com/gcp/thank-you" data-lp-url="https://ubuntu.com/gcp/contact-us">
   </div>
 {% endblock %}

--- a/templates/gov/index.html
+++ b/templates/gov/index.html
@@ -121,7 +121,7 @@
     <div class="col-7">
       <h2>Find out why the UK Government puts Ubuntu in first place for security </h2>
       <p>CESG, the security arm of the UK government rated Ubuntu as the most secure operating system of the 11 they tested.</p>
-      <a href="https://insights.ubuntu.com/2014/01/10/ubuntu-scores-highest-in-uk-gov-security-assessment/?_ga=2.112079751.2078786262.1509620345-1171504626.1506072082" class="p-button--neutral">Read the case study</a>
+      <a href="https://insights.ubuntu.com/2014/01/10/ubuntu-scores-highest-in-uk-gov-security-assessment/"  class="p-button--neutral">Read the case study</a>
     </div>
   </div>
 </section>
@@ -588,7 +588,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/gov/form" data-form-id="3609" data-return-url="https://www.ubuntu.com/gov/thank-you">
+<div class="u-hide" id="contact-form-container" data-form-location="/gov/form" data-form-id="3609" data-return-url="https://ubuntu.com/gov/thank-you">
 </div>
 
 {% endblock content %}

--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -253,7 +253,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -462,7 +462,7 @@
 
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-compare" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-compare" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -265,7 +265,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-features" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -540,7 +540,7 @@ include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes"
   data-form-id="3230" data-lp-id="6274"
-  data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-install"
+  data-return-url="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-install"
   data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -549,7 +549,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-kubernetes" data-form-id="3897" data-lp-id="" data-return-url="https://www.ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-kubernetes" data-form-id="3897" data-lp-id="" data-return-url="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/kubernetes/partners.html
+++ b/templates/kubernetes/partners.html
@@ -77,7 +77,7 @@
 {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -670,7 +670,7 @@
   {% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://www.ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -34,7 +34,7 @@ When Ubuntu Advantage subscriptions are attached to all physical hosts in an Env
   4. Specific kernel versions are not guaranteed to receive livepatches indefinitely.  
   5. Only the default LTS kernel is available for livepatching. This includes  its backport as the last HWE kernel to the previous LTS release.
 4. Extended Security Maintenance
-  1. Extended Security Maintenance provides available High and Critical CVE fixes for a number of server packages. A complete list of packages included in Extended Security Maintenance for a given release can be found at: [https://wiki.ubuntu.com/SecurityTeam/ESM/](https://wiki.ubuntu.com/SecurityTeam/ESM/)
+  1. Extended Security Maintenance provides available High and Critical CVE fixes for a number of server packages. A complete list of packages included in Extended Security Maintenance for a given release can be found at: [wiki.ubuntu.com/SecurityTeam/ESM/](https://wiki.ubuntu.com/SecurityTeam/ESM/)
   2. Extended Security Maintenance is only included for 64-bit x86 AMD/Intel installations.
   3. Extended Security Maintenance does not provide:
     1. Bug fixes, unless a bug was created by an Extended Security Maintenance security update
@@ -58,8 +58,8 @@ When Ubuntu Advantage subscriptions are attached to all physical hosts in an Env
 As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infrastructure Advanced customer, you are entitled to all of the benefits and services described under the Subscriptions section above, and in addition are entitled to the following benefits and services:
 
 1. 24x5 (Standard) or 24x7 (Advanced) phone and ticket support.
-  1. Releases. Canonical will provide support for installation, configuration, maintenance, troubleshooting and usage of any standard release of Ubuntu when installed using official sources and within its product life cycle, including any applicable Extended Security Maintenance term. The life cycle for each version of Ubuntu is specified here: [https://www.ubuntu.com/about/release-cycle](https://www.ubuntu.com/about/release-cycle).
-  2. Hardware. Ubuntu Certified hardware has passed Canonical's extensive testing and review process. More information about the Ubuntu certification process and a list of certified hardware can be found on the Ubuntu Certification page: [http://www.ubuntu.com/certification/](http://www.ubuntu.com/certification/) The services apply only with respect to customer's hardware which has been certified. In the event a customer requests the services with respect to hardware which is not certified, Canonical will use reasonable efforts to provide support services, but may not adhere to the obligations described in this service description.
+  1. Releases. Canonical will provide support for installation, configuration, maintenance, troubleshooting and usage of any standard release of Ubuntu when installed using official sources and within its product life cycle, including any applicable Extended Security Maintenance term. The life cycle for each version of Ubuntu is specified here: [ubuntu.com/about/release-cycle](https://ubuntu.com/about/release-cycle).
+  2. Hardware. Ubuntu Certified hardware has passed Canonical's extensive testing and review process. More information about the Ubuntu certification process and a list of certified hardware can be found on the Ubuntu Certification page: [ubuntu.com/certified](https://ubuntu.com/certified) The services apply only with respect to customer's hardware which has been certified. In the event a customer requests the services with respect to hardware which is not certified, Canonical will use reasonable efforts to provide support services, but may not adhere to the obligations described in this service description.
   3. Packages. The service applies to:
     1. Packages found in the Ubuntu Main Repository, including the "proposed" and "backports" repository pockets
     2. Packages in the Ubuntu Cloud Archive
@@ -69,7 +69,7 @@ As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infra
   4. Kernels.
     1. The kernel provided initially in the release of a Long Term Support (LTS) version of Ubuntu is supported for the entire lifecycle of the LTS.
     2. Canonical releases Hardware enablement (HWE) kernels during the standard support period of an LTS version which provides support for newer hardware in an LTS releases. HWE kernels are supported until the next LTS point release.
-    3. More information and details about kernel support can be found at [https://www.ubuntu.com/about/release-cycle](https://www.ubuntu.com/about/release-cycle)
+    3. More information and details about kernel support can be found at [ubuntu.com/about/release-cycle](https://ubuntu.com/about/release-cycle)
     4. Access to Canonical Livepatch Service is included with all support offerings, unless otherwise noted.
   5. Landscape. All Landscape products, including Landscape on-premises (when purchased) are fully supported.
 2. [OpenStack](#term-openstack) & [Kubernetes](#term-kubernetes) Support. Canonical will provide the support set out in the section below:
@@ -107,13 +107,13 @@ As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infra
         1. [Deployment](#term-deployment) of [Charmed Kubernetes](#term-cdk) in at least the minimum deployment configuration, or a kubeadm-deployed cluster of unmodified upstream Kubernetes binaries as published by the CNCF deployed on Ubuntu as base OS validated by Canonical.
         2. Highly-Available control plane either deployed using Charms in the Charmed Kubernetes reference architecture or in a similar fashion using kubeadm.
         3. Support must be purchased for all nodes in the supported Kubernetes cluster.
-        4. Supported versions of Kubernetes include the current stable minor release and the two most recent minor releases in the stable release channel. Additional information can be found at: [https://ubuntu.com/kubernetes/docs/supported-versions](https://ubuntu.com/kubernetes/docs/supported-versions)
+        4. Supported versions of Kubernetes include the current stable minor release and the two most recent minor releases in the stable release channel. Additional information can be found at: [ubuntu.com/kubernetes/docs/supported-versions](https://ubuntu.com/kubernetes/docs/supported-versions)
         5. For any deployment of Charmed Kubernetes carried out by Canonical while under contract for a deployment, which result in the customisation of any Charms, the customisation will be supported for 90 days after completion of the deployment.
     2. Unless Full-Stack Support requirements are met, support is limited to:
         1. The software packages and Charms necessary for running Charmed Kubernetes.
         2. Kubernetes clusters deployed using kubeadm utilising the software packages available from apt.kubernetes.io.
         3. Bug-fix support in the supplied software artefacts by Canonical during the Ubuntu LTS.
-3. Ubuntu Legal Assurance programme. The customer is entitled to participate in the Ubuntu Assurance Programme, subject to its terms and conditions. Canonical may update the Assurance Programme and its terms periodically. The current Ubuntu Assurance Programme and its IP indemnification terms are available at Canonical's Ubuntu Assurance page:[ http://www.ubuntu.com/legal/ubuntu-advantage/assurance](http://www.ubuntu.com/legal/ubuntu-advantage/assurance)
+3. Ubuntu Legal Assurance programme. The customer is entitled to participate in the Ubuntu Assurance Programme, subject to its terms and conditions. Canonical may update the Assurance Programme and its terms periodically. The current Ubuntu Assurance Programme and its IP indemnification terms are available at Canonical's Ubuntu Assurance page: [ubuntu.com/legal/ubuntu-advantage/assurance](https://ubuntu.com/legal/ubuntu-advantage/assurance)
 
 <div class="p-top"><a href="#" class="p-top__link">Back to top</a></div>
 
@@ -174,7 +174,7 @@ As an Ubuntu Advantage for Infrastructure Standard or Ubuntu Advantage for Infra
 1. The Ubuntu Advantage for Infrastructure, Virtual services match those of the applicable Ubuntu Advantage for Infrastructure offering, subject to the exceptions listed below.
 2. The Ubuntu Advantage Infrastructure, Virtual services are provided for Ubuntu Server when installed and running as a guest in a virtualised environment either (1) in an Ubuntu Certified Public Cloud partner's environment, or (2) on a physical host, provided the guest is running on a [Covered Hypervisor](#term-hypervisor).<br /><br />
 Note: Only underlying technology is listed. These can be provided via a cloud like OpenStack. If hypervisor vendor provides a specific list of supported Ubuntu versions only those will be eligible for Ubuntu Advantage for Infrastructure, Virtual service.<br /><br />
-4. Certified Public Cloud partners can be found in the Ubuntu partner listing: [https://www.ubuntu.com/public-cloud](https://www.ubuntu.com/public-cloud)
+4. Certified Public Cloud partners can be found in the Ubuntu partner listing: [ubuntu.com/public-cloud](https://ubuntu.com/public-cloud)
 5. Kubernetes support is included as per definitions in the application section of Ubuntu Advantage for Infrastructure above.
 6. The Ubuntu Advantage for Infrastructure, Virtual service does not provide:
   1. Hypervisor support.
@@ -377,7 +377,7 @@ Add-Ons constitute additional support services available separately on a per-Nod
 - <strong id="term-node">Node</strong> means a Physical Node or Virtual Machine provided to Canonical (or paid for) by the Customer for the purposes of running the Environment.  Any further machines (whether virtual or container) created on top of a Node are not themselves considered to be Nodes.
 - <strong id="term-openstack">OpenStack</strong> means the cloud computing software known as "OpenStack" as distributed by Canonical with Ubuntu.
 - <strong id="term-openstack-packages">OpenStack Packages</strong> means packages relevant to OpenStack present in the Ubuntu Main repository of the Ubuntu Archive, including updates to those packages delivered in the Ubuntu Cloud Archive.
-This includes Charms listed at [https://wiki.ubuntu.com/OpenStack/OpenStackCharms](https://wiki.ubuntu.com/OpenStack/OpenStackCharms).
+This includes Charms listed at [wiki.ubuntu.com/OpenStack/OpenStackCharms](https://wiki.ubuntu.com/OpenStack/OpenStackCharms).
 - <strong>Physical Node</strong> means a single named/managed unit of physical compute infrastructure, essentially the shelf or rack unit. May contain multiple CPU sockets, cores, NICs, Storage controllers/devices.
 - <strong>Public Cloud</strong> means an Environment in which third parties (i.e. beyond just Canonical and the customer) are able to create and manage Guest or Container Instances.  
 - <strong>Region</strong> means a discrete OpenStack environment with dedicated API endpoints that typically shares only the Identity (Keystone) service with other Regions. An OpenStack Region must be contained within a single datacentre.

--- a/templates/managed/cassandra.html
+++ b/templates/managed/cassandra.html
@@ -666,6 +666,6 @@
 
     {% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-cassandra.html" data-form-id="3592" data-lp-id="3828" data-return-url="https://www.ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-cassandra.html" data-form-id="3592" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
     {% endblock content %}

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -705,7 +705,7 @@
 
 {% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-apps.html" data-form-id="3545" data-lp-id="3828" data-return-url="https://www.ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-apps.html" data-form-id="3545" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/managed/kafka.html
+++ b/templates/managed/kafka.html
@@ -703,6 +703,6 @@
 
     {% with first_item="_cloud_ubuntu_advantage", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-kafka.html" data-form-id="3592" data-lp-id="3828" data-return-url="https://www.ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/managed-kafka.html" data-form-id="3592" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
     {% endblock content %}

--- a/templates/masters-conference/_base-masters-conference.html
+++ b/templates/masters-conference/_base-masters-conference.html
@@ -6,6 +6,6 @@
     {% block content %}{% endblock %}
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/masters-conference" data-form-id="3476" data-lp-id="" data-return-url="https://www.ubuntu.com/masters-conference/thank-you" data-lp-url="https://www.ubuntu.com/masters-conference">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/masters-conference" data-form-id="3476" data-lp-id="" data-return-url="https://ubuntu.com/masters-conference/thank-you" data-lp-url="https://www.ubuntu.com/masters-conference">
     </div>
 {% endblock %}

--- a/templates/masters-conference/_base-masters-conference.html
+++ b/templates/masters-conference/_base-masters-conference.html
@@ -6,6 +6,6 @@
     {% block content %}{% endblock %}
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/masters-conference" data-form-id="3476" data-lp-id="" data-return-url="https://ubuntu.com/masters-conference/thank-you" data-lp-url="https://www.ubuntu.com/masters-conference">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/masters-conference" data-form-id="3476" data-lp-id="" data-return-url="https://ubuntu.com/masters-conference/thank-you" data-lp-url="https://ubuntu.com/masters-conference">
     </div>
 {% endblock %}

--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -430,7 +430,7 @@
 
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock %}

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -381,7 +381,7 @@
   {% with first_item="_cloud_bootstack", second_item="_cloud_rfp", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -776,7 +776,7 @@
 {% with first_item="_openstack_delivery", second_item="_openstack_documentation", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -854,7 +854,7 @@
   {% with first_item="_openstack_next_step", second_item="_openstack_documentation", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
   {% endblock content %}

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -1239,7 +1239,7 @@ $ echo "export PATH=$PATH:/snap/bin" >> .bashrc
 {% with first_item="_cloud_bootstack", second_item="_download_cloud_buy_landscape", third_item="_openstack_documentation" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -717,7 +717,7 @@
 {% with first_item="_k8s_managed", second_item="_openstack_documentation", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/openstack/tco-calculator.html
+++ b/templates/openstack/tco-calculator.html
@@ -243,7 +243,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 <script src="{{ versioned_static('js/dist/tco-calculator.js') }}"></script>

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -1,11 +1,18 @@
-{% extends "openstack/_base_openstack.html" %} {% block title %}What is
-OpenStack{% endblock %} {% block meta_description %}OpenStack is an open source
-private cloud platform designed to manage distributed compute, network and
+{% extends "openstack/_base_openstack.html" %}
+
+{% block title %}What is OpenStack{% endblock %}
+
+{% block meta_description %}
+OpenStack is an open source private cloud platform designed to manage distributed compute, network and
 storage resources in the data centre and enable on-demand virtual machines
-provisioning through a self-service portal.{% endblock meta_description %} {%
-block meta_copydoc
-%}https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit{%
-endblock meta_copydoc %} {% block content %}
+provisioning through a self-service portal.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit
+{% endblock meta_copydoc %}
+
+{% block content %}
 <section class="p-strip--suru-image is-bordered">
   <div class="row">
     <div class="col-7">
@@ -916,8 +923,7 @@ third_item="_openstack_further_reading", no_shadow="true" %}{% include
   data-form-location="/shared/forms/interactive/openstack"
   data-form-id="1251"
   data-lp-id="2086"
-  data-return-url="https://www.ubuntu.com/openstack/thank-you"
+  data-return-url="https://ubuntu.com/openstack/thank-you"
   data-lp-url="https://pages.ubuntu.com/things-contact-us.html"
 ></div>
-
 {% endblock content %}

--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -26,7 +26,7 @@
       <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button--neutral">
         Download the datasheet
       </a>
-      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">
+      <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive">
         Get in touch
       </a>
     </p>
@@ -50,7 +50,7 @@
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -841,7 +841,7 @@
 {% with colour="white", bordered="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock %}

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -79,7 +79,7 @@
 
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/pricing-infra" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/pricing-infra" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/public-cloud/_base_public-cloud.html
+++ b/templates/public-cloud/_base_public-cloud.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
     {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
 

--- a/templates/raspberry-pi/index.html
+++ b/templates/raspberry-pi/index.html
@@ -88,7 +88,7 @@
         Take the Pi to production with <a href="/server/">Ubuntu Server LTS</a> and <a href="/core">Ubuntu Core</a> with a decade of security updates.
       </p>
       <p>
-        <a target="blank" href="https://assets.ubuntu.com/v1/66fcd858-ubuntu-core-security-whitepaper.pdf?_ga=2.222811483.1572924598.1601997796-1689254820.1578926620" class="p-link--external">Read the Ubuntu Core security whitepaper</a>
+        <a target="blank" href="https://assets.ubuntu.com/v1/66fcd858-ubuntu-core-security-whitepaper.pdf"  class="p-link--external">Read the Ubuntu Core security whitepaper</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center">

--- a/templates/rfp/_base_rfp.html
+++ b/templates/rfp/_base_rfp.html
@@ -6,7 +6,7 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
     </div>
 
 

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -101,7 +101,7 @@
         <input type="hidden" name="subId" value="30" />
         <input type="hidden" name="lpurl" value="//pages.ubuntu.com/Contact_Us_Ubuntu_RFI_Contact-us-form.html?cr={creative}&kw={keyword}" />
         <input type="hidden" name="formid" value="3285" />
-        <input type="hidden" name="ret" value="https://www.ubuntu.com/openstack/thank-you?product=rfp" />
+        <input type="hidden" name="ret" value="https://ubuntu.com/openstack/thank-you?product=rfp" />
         <input type="hidden" name="munchkinId" value="066-EOV-335"/>
         <input type="hidden" name="kw" value=""/>
         <input type="hidden" name="cr" value=""/>

--- a/templates/security-series/_base-security-series.html
+++ b/templates/security-series/_base-security-series.html
@@ -6,6 +6,6 @@
     {% block content %}{% endblock %}
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-lp-id="" data-return-url="https://www.ubuntu.com/security-series/thank-you" data-lp-url="https://www.ubuntu.com/security-series">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-lp-id="" data-return-url="https://ubuntu.com/security-series/thank-you" data-lp-url="https://www.ubuntu.com/security-series">
     </div>
 {% endblock %}

--- a/templates/security-series/_base-security-series.html
+++ b/templates/security-series/_base-security-series.html
@@ -6,6 +6,6 @@
     {% block content %}{% endblock %}
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-lp-id="" data-return-url="https://ubuntu.com/security-series/thank-you" data-lp-url="https://www.ubuntu.com/security-series">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-lp-id="" data-return-url="https://ubuntu.com/security-series/thank-you" data-lp-url="https://ubuntu.com/security-series">
     </div>
 {% endblock %}

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -196,7 +196,7 @@
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -124,7 +124,7 @@
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="3785" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=docker" data-lp-url="https://www.ubuntu.com/security/contact-us?product=docker">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="3785" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=docker" data-lp-url="https://ubuntu.com/security/contact-us?product=docker">
 </div>
 
 {% endblock content %}

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -290,7 +290,7 @@
     {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
     <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/esm" data-form-id="3764" data-lp-id="" data-return-url="https://www.ubuntu.com/security/thank-you?product=esm" data-lp-url="">
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/esm" data-form-id="3764" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=esm" data-lp-url="">
     </div>
 
     {% endblock content %}

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -539,7 +539,7 @@
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -344,7 +344,7 @@
 {% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -224,7 +224,7 @@
 {% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1254" data-lp-id="2152" data-return-url="https://ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -468,7 +468,7 @@
 {% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1254" data-lp-id="2152" data-return-url="https://www.ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1254" data-lp-id="2152" data-return-url="https://ubuntu.com/server/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -27,9 +27,9 @@
         <input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/Opt-In_IoTNewsletters.html?cr={creative}&amp;kw={keyword}">
         <input type="hidden" name="source" class="mktoField  mktoFormCol" value="ubuntu.com">
         <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True">
-        <input type="hidden" name="returnURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
-        <input type="hidden" name="retURL" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
-        <input type="hidden" name="return_url" value="https://www.ubuntu.com/internet-of-things/thank-you?product=newsletter" />
+        <input type="hidden" name="returnURL" value="https://ubuntu.com/internet-of-things/thank-you?product=newsletter" />
+        <input type="hidden" name="retURL" value="https://ubuntu.com/internet-of-things/thank-you?product=newsletter" />
+        <input type="hidden" name="return_url" value="https://ubuntu.com/internet-of-things/thank-you?product=newsletter" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
       </li>

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -46,7 +46,7 @@
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -988,7 +988,7 @@
         </tr>
         <tr>
           <td>Systems management</td>
-          <td><a class="p-link--external" href="https://landscape.canonical.com/?_ga=2.268201288.772907711.1600674388-842710078.1584639728">Landscape</a></td>
+          <td><a class="p-link--external" href="https://landscape.canonical.com/" >Landscape</a></td>
           <td class="u-align--center">
             <div class="lazy-loaded">
               <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_16,h_16/https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg">
@@ -1247,7 +1247,7 @@
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://www.ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -1016,7 +1016,7 @@
 {% with first_item="_cloud_nfv", second_item="_cloud_newsletter", third_item="_telco_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/telco" data-form-id="3673" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/telco" data-form-id="3673" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -69,7 +69,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -92,7 +92,7 @@
           <dt class="p-inline-definition-list__title">Location</dt>
           <dd class="p-inline-definition-list__item">Your premises</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -125,7 +125,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -153,7 +153,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -178,7 +178,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -213,7 +213,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -237,7 +237,7 @@
           <dt class="p-inline-definition-list__title">Location</dt>
           <dd class="p-inline-definition-list__item">Your premises</dd>
         </dl>
-        <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -272,7 +272,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=kubeflow-training-onsite"  data-form-location="/shared/forms/interactive/kubeflow" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=kubeflow-training-onsite"  data-form-location="/shared/forms/interactive/kubeflow" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=kubeflow-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -307,7 +307,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -342,7 +342,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -377,7 +377,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=landscape-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=landscape-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=landscape-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -456,7 +456,7 @@
     <div class="col-7">
       <h2>Questions about training?</h2>
       <p>If you have a question about OpenStack training or want to register your interest for future training.</p>
-      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training">Contact us&nbsp;&rsaquo;</a></p>
+      <p><a href="/training/contact-us?product=openstack-training" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training">Contact us&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{
@@ -474,7 +474,7 @@
 </section>
 
 <!-- Set default Marketo information for contact form below -->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://www.ubuntu.com/training/thank-you" data-lp-url="https://www.ubuntu.com/training/thank-you">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1263" data-lp-id="2163" data-return-url="https://ubuntu.com/training/thank-you" data-lp-url="https://ubuntu.com/training/thank-you">
 </div>
 
 

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -397,7 +397,7 @@
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/wsl.html" data-form-id="3755" data-lp-id="" data-return-url="https://www.ubuntu.com/wsl/thank-you" data-lp-url="">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/wsl.html" data-form-id="3755" data-lp-id="" data-return-url="https://ubuntu.com/wsl/thank-you" data-lp-url="">
 </div>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Fix up a load of urls that have www, http, or /certification
- Removed the google analytics tracker from urls `?_ga(.*>)`
- Fixed up the UASD copy doc

## QA

- Check out this feature branch
- Read through the code and confirm changes look good

## Issue / Card

Fixes #9855


