### PR TITLE
Align the navigation height with the new Vanilla styling

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -92,18 +92,18 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
     }
 
     & &__link-anchor {
-      @include vf-animation(all, brisk, in);
+      @include vf-animation(all, snap, in);
 
       color: $color-light;
       display: block;
 
       @media (max-width: $breakpoint-navigation-threshold) {
-        padding: $spv-inner--medium $grid-margin-width $spv-inner--medium
+        padding: $spv-inner--large $grid-margin-width $spv-inner--large
           $grid-margin-width;
       }
 
       @media (min-width: $breakpoint-navigation-threshold + 1) {
-        padding: $spv-inner--medium 2rem $spv-inner--medium $sph-inner;
+        padding: $spv-inner--large 2rem $spv-inner--large $sph-inner;
       }
 
       &:focus,
@@ -229,7 +229,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
 
     &__logo {
       background: $color-brand;
-      height: 3rem;
+      height: 3.5rem;
     }
 
     &__search {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -92,10 +92,9 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;
     }
 
     & &__link-anchor {
-      @include vf-animation(all, snap, in);
-
       color: $color-light;
       display: block;
+      line-height: 1.5rem;
 
       @media (max-width: $breakpoint-navigation-threshold) {
         padding: $spv-inner--large $grid-margin-width $spv-inner--large

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -33,16 +33,16 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__items u-hide js-show-nav" role="menu">
-        <li class="p-navigation__dropdown-link" role="menuitem" id="enterprise" onmouseover="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content'); this.onmouseover = null;">
+        <li class="p-navigation__item p-navigation__dropdown-link" role="menuitem" id="enterprise" onmouseover="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content'); this.onmouseover = null;">
           <a class="p-navigation__link-anchor" href="#enterprise-content" onfocus="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content');">Enterprise</a>
         </li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="developer" onmouseover="fetchDropdown('/templates/navigation-developer-h', 'developer-content'); this.onmouseover = null;">
+        <li class="p-navigation__item p-navigation__dropdown-link" role="menuitem" id="developer" onmouseover="fetchDropdown('/templates/navigation-developer-h', 'developer-content'); this.onmouseover = null;">
           <a class="p-navigation__link-anchor" href="#developer-content" onfocus="fetchDropdown('/templates/navigation-developer-h', 'developer-content');">Developer</a>
         </li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="community" onmouseover="fetchDropdown('/templates/navigation-community-h', 'community-content'); this.onmouseover = null;">
+        <li class="p-navigation__item p-navigation__dropdown-link" role="menuitem" id="community" onmouseover="fetchDropdown('/templates/navigation-community-h', 'community-content'); this.onmouseover = null;">
           <a class="p-navigation__link-anchor" href="#community-content" onfocus="fetchDropdown('/templates/navigation-community-h', 'community-content');">Community</a>
         </li>
-        <li class="p-navigation__dropdown-link" role="menuitem" id="download" onmouseover="fetchDropdown('/templates/navigation-download-h', 'download-content'); this.onmouseover = null;">
+        <li class="p-navigation__item p-navigation__dropdown-link" role="menuitem" id="download" onmouseover="fetchDropdown('/templates/navigation-download-h', 'download-content'); this.onmouseover = null;">
           <a class="p-navigation__link-anchor" href="#download-content" onfocus="fetchDropdown('/templates/navigation-download-h', 'download-content');">Download</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done
- Increase the height of the navigation to 56px to match the latest in Vanilla
- Removed the duration of the animation of the links to make it feel faster

## QA
- Open the demo
- Check the header is 56px height
- Check live is shallower
- Check the dropdowns work
- Check the user menu aligns when open

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9865

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/121557455-aadd9a00-ca0c-11eb-94e5-f7f9a44f0612.png)

