### PR TITLE
Add meta image to the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,7 @@
 {% extends "base_index.html" %}
 
+{% block meta_image %}https://assets.ubuntu.com/v1/df4cb5d8-Social+media+banner.jpg{% endblock meta_image %}
+
 {% block head_extra %}
 {% endblock %}
 
@@ -45,7 +47,7 @@
     %}
     {% include "takeovers/_template.html" %}
     {% endwith %}
-  {% endfor %}  
+  {% endfor %}
 {% endblock takeover_content %}
 
 {#


### PR DESCRIPTION
## Done
Add meta image to the homepage

## QA
- Go to https://www.opengraph.xyz/url/https:%2F%2Fubuntu-com-9890.demos.haus%2F/
- Check it looks better then https://www.opengraph.xyz/url/https:%2F%2Fubuntu.com/

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9864
