### PR TITLE
Corrects the URL to prevent recursive links

### DIFF
--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -46,7 +46,7 @@
     <div class="col-6">
       <h2>Free for personal use</h2>
       <p>All you need is an Ubuntu One account. Free for 3 machines.</p>
-      <p><a class="p-button--positive"  href="https://ubuntu.com/advantage/">Get Livepatch now</a></p>
+      <p><a class="p-button--positive"  href="/advantage">Get Livepatch now</a></p>
     </div>
     <div class="col-6">
       <h2>Part of Ubuntu Advantage</h2>

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -46,7 +46,7 @@
     <div class="col-6">
       <h2>Free for personal use</h2>
       <p>All you need is an Ubuntu One account. Free for 3 machines.</p>
-      <p><a class="p-button--positive"  href="https://auth.livepatch.canonical.com/">Get Livepatch now</a></p>
+      <p><a class="p-button--positive"  href="https://ubuntu.com/advantage/">Get Livepatch now</a></p>
     </div>
     <div class="col-6">
       <h2>Part of Ubuntu Advantage</h2>


### PR DESCRIPTION
## Done

- This is a minor fix that updates the way to get a free token to prevent a recursive link when connecting to the now deprecated auth.livepatch.canonical.com

Resolves #9891
