### PR TITLE
Fix lost renewal bug

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -767,7 +767,7 @@ def _make_renewal(advantage, contract_info):
         return None
 
     sorted_renewals = sorted(
-        (r for r in renewals if r["status"] != "closed"),
+        (r for r in renewals if r["status"] not in ["lost", "closed"]),
         key=lambda renewal: parse(renewal["start"]),
     )
 


### PR DESCRIPTION
## Done

- Fix lost renewal bug

## QA

- Go to https://ubuntu-com-9896.demos.haus?email=email@address.com
- The email address should have an account with both `lost` and `active` renewals