### PR TITLE
Clean titles for certified pages

### DIFF
--- a/templates/certified/hardware-details.html
+++ b/templates/certified/hardware-details.html
@@ -1,6 +1,6 @@
 {% extends "certified/base_certification.html" %}
 
-{% block title %} {{ vendor }} {{ model }} certified with Ubuntu {{ release }} | Ubuntu{% endblock %}
+{% block title %} {{ vendor }} {{ model }} certified with Ubuntu {{ release }}{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -1,6 +1,6 @@
 {% extends "certified/base_certification.html" %}
 
-{% block title %} {{ vendor }} {{ model }} certified with Ubuntu | Ubuntu{% endblock %}
+{% block title %} {{ vendor }} {{ model }} certified with Ubuntu{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}


### PR DESCRIPTION
## Done

- Clean ducplicate `| Ubuntu`
- The `| Ubuntu` is added by default by the base template

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified/201811-26620 
- Page title should only have one `| Ubuntu`
