### PR TITLE
Fix rich data training page

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -48,48 +48,52 @@
       <h2>OpenStack Fundamentals</h2>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <hr />
-    <h3>On-site Ubuntu Openstack cloud training</h3>
-  </div>
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A three-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
-      <p><a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">On-site Ubuntu Openstack cloud training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">3 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A three-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
+        <p><a href="https://assets.ubuntu.com/v1/8408628d-OpenStack+Fundamentals+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">3 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>High Availability Architecture add-on training</h3>
-  </div>
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>This half day add-on course is bundled with our OpenStack Fundamentals training. It provides key instruction on High Availability for OpenStack for up to 15 students at your premises.</p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">High Availability Architecture add-on training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">4.5 hrs (half day)</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">This half day add-on course is bundled with our OpenStack Fundamentals training. It provides key instruction on High Availability for OpenStack for up to 15 students at your premises.</p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">4.5 hrs (half day)</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="2000">2,000 </span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -100,76 +104,82 @@
       <h2>OpenStack Operations</h2>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <hr />
-    <h3>On-site training: how to operate Ubuntu OpenStack</h3>
-  </div>
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A five-day hands-on course at your premises for up to 15 people that guides you through all aspects of performing effective operations on your Ubuntu OpenStack cloud. A follow-up course to OpenStack Fundamentals, it guides you through operational tasks such as monitoring, troubleshooting, patching, scaling, and upgrading, while keeping your cloud available and performing.</p>
-      <p><a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">On-site training: how to operate Ubuntu OpenStack</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">5 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="29500">29,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A five-day hands-on course at your premises for up to 15 people that guides you through all aspects of performing effective operations on your Ubuntu OpenStack cloud. A follow-up course to OpenStack Fundamentals, it guides you through operational tasks such as monitoring, troubleshooting, patching, scaling, and upgrading, while keeping your cloud available and performing.</p>
+        <p><a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">5 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="29500">29,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
 
 <section class="p-strip--light is-bordered">
-  <div class="u-fixed-width">
-    <h2>Ubuntu Server Administration</h2>
-    <h3>Basic on-site Ubuntu Server training</h3>
-  </div>
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A three-day hands-on course at your premises for up to 15 students, that teaches you how to install and administer Ubuntu Server.</p>
-      <p><a href="https://assets.ubuntu.com/v1/f2dbacb1-Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <h2>Ubuntu Server Administration</h2>
+      <h3 itemprop="name">Basic on-site Ubuntu Server training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">3 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A three-day hands-on course at your premises for up to 15 students, that teaches you how to install and administer Ubuntu Server.</p>
+        <p><a href="https://assets.ubuntu.com/v1/f2dbacb1-Training_basic-Ubuntu-server-administration.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">3 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <hr />
-    <h3>Advanced on-site Ubuntu Server training</h3>
-  </div>
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>You've been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive three-day hands-on course in which you will learn and use advanced techniques.</p>
-      <p><a href="https://assets.ubuntu.com/v1/bb64a38e-Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">Advanced on-site Ubuntu Server training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">3 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">You've been using Ubuntu Server for a while and want to advance your skills. The Ubuntu Advanced Server course is an intensive three-day hands-on course in which you will learn and use advanced techniques.</p>
+        <p><a href="https://assets.ubuntu.com/v1/bb64a38e-Training_Advanced-server-administration_02.17.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">3 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -181,50 +191,54 @@
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>On-site training</h3>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">On-site training</h3>
+    </div>
+
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A three-day hands-on course at your premises for up to 15 people that guides you through Charmed Kubernetes. You will learn about Kubernetes, how to deploy it and configure it, as well as how to perform operational actions such as live upgrades.</p>
+        <p><a href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">3 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
   </div>
 
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A three-day hands-on course at your premises for up to 15 people that guides you through Charmed Kubernetes. You will learn about Kubernetes, how to deploy it and configure it, as well as how to perform operational actions such as live upgrades.</p>
-      <p><a href="https://assets.ubuntu.com/v1/bdff2205-Kubernetes+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">Bare Metal add-on training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">3 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>Bare Metal add-on training</h3>
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>This is an add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students.</p>
-    </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">1 day</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="6500">6,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">This is an add-on course that is offered as an extension to the Kubernetes Explorer. It focuses on managing your bare metal in an automated way with MAAS so that you can deploy Kubernetes easily and effortlessly. It takes place at your premises for up to 15 students.</p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">1 day</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="6500">6,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -236,28 +250,30 @@
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>Modelling and Operations training</h3>
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A four-day workshop-like course at your premises for up to 15 people that guides you through all aspects of performing effective Machine Learning and Deep Learning automation on your Kubeflow cluster. A follow-up course to Kubernetes Explorer, it guides you through common tasks such as creating Pipelines, working with Notebooks, training models, visualizing results, model serving, and troubleshooting, as well as introducing MLOps practices for streamlined data science using containerized frameworks and infrastructure.</p>
-      <p><a href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">Modelling and Operations training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">4 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">29,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=kubeflow-training-onsite"  data-form-location="/shared/forms/interactive/kubeflow" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A four-day workshop-like course at your premises for up to 15 people that guides you through all aspects of performing effective Machine Learning and Deep Learning automation on your Kubeflow cluster. A follow-up course to Kubernetes Explorer, it guides you through common tasks such as creating Pipelines, working with Notebooks, training models, visualizing results, model serving, and troubleshooting, as well as introducing MLOps practices for streamlined data science using containerized frameworks and infrastructure.</p>
+        <p><a href="https://assets.ubuntu.com/v1/ee5a96f3-Kubeflow+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">4 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">29,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=kubeflow-training-onsite"  data-form-location="/shared/forms/interactive/kubeflow" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -269,28 +285,30 @@
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>Deployment and Operations training</h3>
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A two-day hands-on course at your premises for up to 15 people that guides you through MAAS and how to treat your bare metal estate as a cloud. The aim of this training is to help users understand MAAS components, installing and configuring them, as well on-going MAAS operations for physical and virtual machines (KVM), network configuration and image management.</p>
-      <p><a href="https://assets.ubuntu.com/v1/dc6e1ec3-Canonical_training-MAAS_Deployment_and_Operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">Deployment and Operations training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">2 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">14,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A two-day hands-on course at your premises for up to 15 people that guides you through MAAS and how to treat your bare metal estate as a cloud. The aim of this training is to help users understand MAAS components, installing and configuring them, as well on-going MAAS operations for physical and virtual machines (KVM), network configuration and image management.</p>
+        <p><a href="https://assets.ubuntu.com/v1/dc6e1ec3-Canonical_training-MAAS_Deployment_and_Operations.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">2 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">14,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -302,28 +320,30 @@
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>Deployment and Operations training</h3>
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A three-day hands-on course at your premises for up to 15 people that focuses on Ceph storage. The aim of this training is to educate users on Ceph, practice deployment, perform operations and optimisations of Ceph storage, as well as troubleshooting.</p>
-      <p><a href="https://assets.ubuntu.com/v1/28ca49c8-Ceph+Operations+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">Deployment and Operations training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">3 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises or remote</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A three-day hands-on course at your premises for up to 15 people that focuses on Ceph storage. The aim of this training is to educate users on Ceph, practice deployment, perform operations and optimisations of Ceph storage, as well as troubleshooting.</p>
+        <p><a href="https://assets.ubuntu.com/v1/28ca49c8-Ceph+Operations+Training+Curriculum.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">3 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500">19,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises or remote</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -335,28 +355,30 @@
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <hr />
-    <h3>Deployment and Operations training</h3>
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-7 p-divider__block">
-      <p>A two-day hands-on course at your premises for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.</p>
-      <p><a href="https://assets.ubuntu.com/v1/d55c5afe-Landscape+Deployment+and+Operations+Canonical+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+  <div itemscope itemtype="https://schema.org/Product">
+    <div class="u-fixed-width">
+      <hr />
+      <h3 itemprop="name">Deployment and Operations training</h3>
     </div>
-    <div class="col-5 p-divider__block">
-      <dl class="p-inline-definition-list" itemscope itemtype="https://schema.org/Product">
-        <dt class="p-inline-definition-list__title">Duration</dt>
-        <dd class="p-inline-definition-list__item">2 days</dd>
-        <dt class="p-inline-definition-list__title">Cost</dt>
-        <dd class="p-inline-definition-list__item">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
-        <dt class="p-inline-definition-list__title">Location</dt>
-        <dd class="p-inline-definition-list__item">Your premises or remote</dd>
-        <dt class="p-inline-definition-list__title">Availability</dt>
-        <dd class="p-inline-definition-list__item">Private groups only</dd>
-      </dl>
-      <p><a href="/training/contact-us?product=landscape-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A two-day hands-on course at your premises for up to 15 people that focuses on Landscape. The aim of this training is to educate users on the deployment, administration and operation of Landscape. Each section contains a theory session presented by the instructor, followed by a practical lab.</p>
+        <p><a href="https://assets.ubuntu.com/v1/d55c5afe-Landscape+Deployment+and+Operations+Canonical+Training.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">2 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500">14,500</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Your premises or remote</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=landscape-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Fix rich data on training page
- The google search console was signaling this page as failing (see: https://search.google.com/test/rich-results?id=XI6RL64zVxpqUekTbJ4xUQ )

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Get HTML and paste it on the code tab: https://search.google.com/test/rich-results
- Or get the demo link directly: https://search.google.com/test/rich-results?id=yLUA_7IuL3HSO3R-4gDHsg