### PR TITLE
K8sDocs-azure/upgrade additions

### DIFF
--- a/templates/kubernetes/docs/1.19/upgrading.md
+++ b/templates/kubernetes/docs/1.19/upgrading.md
@@ -278,7 +278,7 @@ Minimally, secrets for the following users should be listed:
 With secrets verified, the charm can be configured to select the desired **Kubernetes** channel, which takes the form `Major.Minor/risk-level`. This is then passed as a configuration option to the charm. So, for example, to select the stable 1.19 version of **Kubernetes**, you would enter:
 
 ```bash
-juju config kubernetes-master channel=1.20/stable
+juju config kubernetes-master channel=1.19/stable
 ```
 
 If you wanted to try a release candidate for 1.20, the channel would be `1.20/candidate`.
@@ -336,7 +336,7 @@ juju upgrade-charm kubernetes-worker
 Next, run the command to configure the workers for the version of Kubernetes you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.12/stable
+juju config kubernetes-worker channel=1.19/stable
 ```
 
 Now add additional units of the kubernetes-worker. You should add as many units as you are replacing. For example, to add three additional units:
@@ -388,7 +388,7 @@ juju upgrade-charm kubernetes-worker
 Next, run the command to configure the workers for the version of **Kubernetes** you wish to run (as you did previously for the master units). For example:
 
 ```bash
-juju config kubernetes-worker channel=1.12/stable
+juju config kubernetes-worker channel=1.19/stable
 ```
 
 All the units can now be upgraded by running the `upgrade` action on each one:

--- a/templates/kubernetes/docs/azure-integration.md
+++ b/templates/kubernetes/docs/azure-integration.md
@@ -42,8 +42,8 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ['azure-integrator', 'kubernetes-master']
-  - ['azure-integrator', 'kubernetes-worker']
+  - ['azure-integrator', 'kubernetes-master:azure']
+  - ['azure-integrator', 'kubernetes-worker:azure']
   ```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified
@@ -156,7 +156,7 @@ EOY
 Charmed Kubernetes can make use of additional types of storage - for more
 information see the [storage documentation][storage].
 
-## Azure load-balancers
+## Azure load-balancers for services
 
 The following commands start the 'hello-world' pod behind an Azure-backed
 load-balancer.
@@ -184,6 +184,17 @@ You can then verify this works by loading the described IP address (on port
 
 For more configuration options and details of the permissions which the integrator uses,
 please see the [azure charm page][azure-integrator].
+
+## Azure load-balancers for the control plane
+
+With revision 1015 and later of the `kubernetes-master` charm, Charmed
+Kubernetes can also use Azure native load balancers in front of the control
+plane, replacing the need to deploy the `kubeapi-load-balancer` charm. The
+`kubernetes-master` charm supports two relation endpoints, `loadbalancer-external`
+for a publicly accessible load balancer which can be used by external clients as
+well as the control plane, and `loadbalancer-internal` for a non-public load
+balancer which can only be used by the rest of the control plane but not by
+external clients.
 
 <!-- LINKS -->
 

--- a/templates/kubernetes/docs/charm-azure-integrator.md
+++ b/templates/kubernetes/docs/charm-azure-integrator.md
@@ -151,6 +151,24 @@ kubectl expose deployment hello-world --type=LoadBalancer --name=hello --port=80
 watch kubectl get svc hello -o wide
 ```
 
+### Providing load-balancers to other charms
+
+Any charm which supports the `loadbalancer` interface can request an Azure-backed
+load-balancer. For example, you can use an Azure LB to run Vault in HA mode with this:
+
+```yaml
+applications:
+  vault:
+    charm: cs:vault
+    num_units: 3
+  azure-integrator:
+    charm: cs:azure-integrator
+    num_units: 1
+    trust: true
+relations:
+  - ["vault:lb-provider", "azure-integrator"]
+```
+
 ## Configuration
 
 <!-- CONFIG STARTS -->


### PR DESCRIPTION
## Done

- small fix for upgrade page
-  added details of new azure relations
- added instructions for using Azure LB

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


