### PR TITLE
Homepage accessibility improvements

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -29,10 +29,6 @@
       padding-top: 0;
     }
 
-    p:last-of-type {
-      margin-bottom: 0 !important;
-    }
-
     .u-align--left-medium {
       @media (max-width: $breakpoint-medium) {
         justify-content: left !important;

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -14,7 +14,7 @@
   <div class="row p-takeover-animation" id="takeover-animaition">
     <div class="col-7 u-vertically-center">
       <h1 id="takeover-title">What's new in<br>Ubuntu {{ releases.latest.short_version }}?</h1>
-      <h4 id="takeover-subtitle">Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds.</h4>
+      <p class="p-heading--four" id="takeover-subtitle">Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds.</p>
       <div id="takeover-ctas">
         <p><a id="takeover-primary-url" href="/download" class="p-button--positive">Get Ubuntu {{ releases.latest.short_version }}</a></p>
         <p>
@@ -34,8 +34,8 @@
   <div class="row">
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
-        <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="CentOS users, 6 things to know when considering a migration to Ubuntu LTS" class="p-heading-icon__img" >
-        <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOS users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></h4>
+        <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="" class="p-heading-icon__img" >
+        <p class="p-heading--four p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOS users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -116,7 +116,7 @@
     <div class="col-4 u-vertically-center u-align--left u-hide--small">
       <div>
         <p>
-          <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">
+          <a class="p-link--external" href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf" aria-label="Visit the PDF file for 2020 HackerEarth Developer Survey">
             The 2020 HackerEarth Developer Survey
           </a>
         </p>
@@ -1479,8 +1479,12 @@
     takeover.className += classNameString;
 
     // Set language attributes
-    takeover.setAttribute("lang", selectedTakeover.lang);
-    takeover.setAttribute("lang-skip", selectedTakeover.lang_skip);
+    if (selectedTakeover.lang) {
+      takeover.setAttribute("lang", selectedTakeover.lang);
+    }
+    if (selectedTakeover.lang_skip) {
+      takeover.setAttribute("lang-skip", selectedTakeover.lang_skip);
+    }
 
     // Set takeover content
     title.textContent = selectedTakeover.title;

--- a/templates/shared/_notice_default.html
+++ b/templates/shared/_notice_default.html
@@ -2,7 +2,7 @@
   <div class="u-fixed-width">
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
-        {% if icon %}<img src="{{icon}}" alt="{{text}}" class="p-heading-icon__img" />{% endif %}
+        {% if icon %}<img src="{{icon}}" alt="" class="p-heading-icon__img" />{% endif %}
         <h4 class="p-heading-icon__title" style="padding-top:0.4rem"><a href="{{url}}" {%if "http" in url%}class="p-link--external">{{text}}{% else %}>{{text}}&nbsp;&rsaquo;{% endif %}</a></h4>
       </div>
     </div>


### PR DESCRIPTION
## Done
- Only render the `lang` attr on the takeover if it's setting a difference lang
- Remove redundant alt contents. If the contents match sibling text the alt is redundant.
- Switching some skip level headings to paragraphs with heading classes

## QA
- Install Waves the browser extension
- Go to https://ubuntu.com and run it.
- Open the demo in a different tab and run Waves. 
- See there are no errors and less alerts in the demo

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9915
