### PR TITLE
show form factor for certified models

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -11,7 +11,7 @@
   <div class="row u-sv3">
     <div class="col-7">
       <h1>{{ vendor }} {{ name }}</h1>
-      <p class="p-heading--4"> {{ category }} system certified with Ubuntu</p>
+      <p class="p-heading--4"> {{ form_factor }} system certified with Ubuntu</p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
       {% if category == "Desktop" or category == "Laptop" %}


### PR DESCRIPTION
Fixes #9921

## Done

Updated the template to use form_factor instead of category.

## QA

Verify that this shows _Industrial PC system certified with Ubuntu_ and not _Ubuntu Core_.

https://ubuntu-com-9922.demos.haus/certified/202103-28845
