### PR TITLE
Fix centered classname on certified

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -14,7 +14,7 @@
       <p class="p-heading--4">Find machines you can trust with Ubuntu</p>
       <p>Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to jointly make Ubuntu available on a wide range of desktops, laptops, servers, IoT, and SoC hardware.</p>
     </div>
-    <div class="col-5 u-hide--small u-align-center">
+    <div class="col-5 u-hide--small u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/a491f87c-Ubuntu+Certified+Hardware.svg",
         alt="",


### PR DESCRIPTION
## Done
Fix centered classname on ccertified

## QA
- Open the demo and go to /certified
- Check the hero image is centered in the `col-5`
