### PR TITLE
Add copy for open badges to /cube

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -33,6 +33,12 @@
       <h2>Certification at your convenience</h2>
       <p class="p-heading--four">Earn your qualification one topic at a time, at your own pace, in any order.</p>
       <p class="u-sv3">The CUBE curriculum is perfectly portioned to accommodate your busy schedule. It consists of 15 separate microcerts, each covering a specific subject area, that can be taken in any order and at any time.</p>
+      <p>All CUBE badges follow <a class="p-link--external" href="https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/index.html">Open Badge specifications</a>.</p>
+      <p>
+        <a class="p-link--external" href="https://openbadges.org/about">
+          Learn more about Open Badges
+        </a>
+      </p>
     </div>
     <div class="col-4 col-start-large-9 u-hide--small">
       {{ image (
@@ -50,7 +56,7 @@
 
 <div class="row p-floating-image u-hide--small">
   <div class="col-12">
-    {{ 
+    {{
       image (
       url="https://assets.ubuntu.com/v1/129dac00-cubes-left.svg",
       alt="CUBE image",
@@ -81,7 +87,7 @@
       <p><strong>Onwards and upwards</strong></p>
     </div>
     <div class="col-6">
-      <p>Show current and prospective employers how you stand out from the rest. Individualised CUBE badges can be shared on social media, meaning that your successes will always remain visible and tied to you.</p>    
+      <p>Show current and prospective employers how you stand out from the rest. Individualised CUBE badges can be shared on social media, meaning that your successes will always remain visible and tied to you.</p>
     </div>
     <hr class="p-separator">
   </div>
@@ -108,7 +114,7 @@
 
 <div class="row p-floating-image u-hide--small">
   <div class="col-12">
-    {{ 
+    {{
       image (
       url="https://assets.ubuntu.com/v1/d1374dcc-cubes-right.svg",
       alt="CUBE image",
@@ -127,7 +133,7 @@
   <h2 class="u-sv2">Complete CUBE Syllabus &ndash; at a glance</h2>
     <ul class="p-matrix">
       <li class="p-matrix__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/9ef4a092-Architecture.svg",
             alt="Architecture badge",
@@ -146,7 +152,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/c19e9931-Packages.svg",
             alt="Packages badge",
@@ -165,7 +171,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/43f7d2a3-Commands.svg",
           alt="Commands badge",
@@ -182,7 +188,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/093b57b6-Devices+%26+files.svg",
           alt="Devices and files badge",
@@ -201,7 +207,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/30af430c-bash.svg",
           alt="bash badge",
@@ -218,7 +224,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/7bf909cc-Admin.svg",
           alt="Admin badge",
@@ -235,7 +241,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/09d0b73a-Services.svg",
           alt="Services badge",
@@ -254,7 +260,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/f59674b7-Networking.svg",
           alt="Networking badge",
@@ -273,7 +279,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/2291952a-Security.svg",
           alt="Security badge",
@@ -292,7 +298,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg",
           alt="Kernel badge",
@@ -311,7 +317,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/cd7785d1-Storage.svg",
           alt="Storage badge",
@@ -330,7 +336,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/64422ff3-Virtualisation.svg",
           alt="Virtualisation badge",
@@ -349,7 +355,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/1812ec49-MicroK8s.svg",
           alt="MicroK8s badge",
@@ -368,7 +374,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/8e0dd19e-MAAS.svg",
           alt="MAAS badge",
@@ -387,7 +393,7 @@
         </div>
       </li>
       <li class="p-matrix__item">
-        {{ 
+        {{
           image (
           url="https://assets.ubuntu.com/v1/5be7daa5-Juju.svg",
           alt="Juju badge",


### PR DESCRIPTION
## Done

- Add copy for open badges to /cube

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit?ts=60c8af8f)


## Issue / Card

Fixes [#4183](https://github.com/canonical-web-and-design/web-squad/issues/4183)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/122727085-90a68600-d26e-11eb-955c-68e10f3b4662.png)

