### PR TITLE
Added the correct copy doc

### DIFF
--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -3,7 +3,7 @@
 {% block title %}Certified hardware{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 


### PR DESCRIPTION


## Done

Added https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit# to the meta_copydoc to https://ubuntu.com/certified?q=Dell

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the copy doc plugin opens to https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit# in https://ubuntu.com/certified?q=Dell
## Issue / Card

Fixes #9905 

