### PR TITLE
Add link to the study labs from the study materials index page

### DIFF
--- a/templates/cube/study/index.md
+++ b/templates/cube/study/index.md
@@ -19,4 +19,29 @@ For additional practise, enroll in Canonical’s Study Labs. The labs feature vi
 
 A single purchase grants 90 days of access to the full set of Study Labs.
 
-<a class="p-button--positive">Purchase Study Lab access</a>
+<a class="p-button--positive js-study-button u-hide"></a>
+<div class="p-notification--negative js-study-notification u-hide">
+  <p class="p-notification__response" role="status">
+    <span class="p-notification__status">Error:</span>We could not verify if you have access to the study labs.
+  </p>
+</div>
+
+<script>
+  const button = document.querySelector(".js-study-button");
+  const notification = document.querySelector(".js-study-notification");
+  fetch("/cube/study/labs")
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Response was not ok');
+      }
+      return response.json()
+    })
+    .then((json) => {
+      button.href = json.redirect_url;
+      button.text = json.text;
+      button.classList.toggle("u-hide")
+    })
+    .catch(() => {
+      notification.classList.toggle("u-hide")
+    });
+</script>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,7 +41,12 @@ from webapp.context import (
 )
 
 from webapp.advantage.parser import UAContractsValidationError
-from webapp.cube.views import cube_home, cube_microcerts, is_authorized
+from webapp.cube.views import (
+    cube_home,
+    cube_microcerts,
+    cube_study_labs_button,
+    is_authorized,
+)
 
 from webapp.views import (
     BlogCustomGroup,
@@ -744,6 +749,7 @@ core_als_autils_docs.init_app(app)
 # Cube docs
 app.add_url_rule("/cube", view_func=cube_home)
 app.add_url_rule("/cube/microcerts", view_func=cube_microcerts)
+app.add_url_rule("/cube/study/labs", view_func=cube_study_labs_button)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(


### PR DESCRIPTION
## Done
Add link to the study labs from the study materials index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to `/study/materials`
- Click the purchase study labs button and:
  - If you have the enrolment you should be redirected to the course in the EDX platform.
  - If you don't have the enrolment you should be redirected to `/cube/microcerts` which is where the purchase will be done from in the future.

## Issue / Card

Fixes #9867
Fixes #9913

