### PR TITLE
Fix 404 certification link

### DIFF
--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -114,7 +114,7 @@
     <div class="col-6">
       <h2>Ubuntu Desktop certified hardware</h2>
       <p>To offer top performance on Ubuntu, manufacturers are pre-loading devices with an Ubuntu Certified image. This ensures driver integration and superior device performance.  Canonical is committed to working closely with with the world's leading manufacturers to optimise and certify Ubuntu on their laptops and PCs.</p>
-      <p><a href="/certified/certification/">Learn more about Ubuntu Certified hardware</a></p>
+      <p><a href="/certified">Learn more about Ubuntu Certified hardware</a></p>
     </div>
     <div class="col-6 u-vertically-center">
       {{


### PR DESCRIPTION
## Done

- Fix 404 on certification link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop/partners
- Link `Learn more about Ubuntu Certified hardware` (at the bottom of the page) shouldn't 404
