### PR TITLE
Adding a temp form for blender support

### DIFF
--- a/templates/contact-us/form/index.html
+++ b/templates/contact-us/form/index.html
@@ -16,6 +16,17 @@
     {% include "shared/_cloud-contact-us-form.html" %}
   {% endwith %}
 
+{% elif product == 'blender-support' %}
+
+    {% with h1="Let's get in touch",
+      intro_text="Blender has partnered with Canonical to offer enterprise-grade support for the Blender LTS application suite. We can help you unleash more capabilities and supply the right level of support you need to have the best, hassle-free experience.",
+      formid="4052",
+      lpId="",
+      returnURL="https://ubuntu.com/contact-us/form/thank-you?product=blender-support" %}
+      {% include "shared/_cloud-contact-us-form.html" %}
+    {% endwith %}
+
+
 {% elif product == 'ossa' %}
 
   {% with h1="Contact us about the Open Source Security Assessment",

--- a/templates/contact-us/form/thank-you.html
+++ b/templates/contact-us/form/thank-you.html
@@ -9,9 +9,21 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="col-8">
+    <div class="col-7">
       <h1>Thanks for getting in touch</h1>
       <h2 class="p-heading--three">A member of our team will be in touch within <br/><strong>one working day</strong>.</h2>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+          alt="",
+          height="200",
+          width="200",
+          loading="auto",
+          hi_def=True
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Adding a temp form for blender support

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/contact-us/form?product=blender-support
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the form uses formid 4052 and returns you to https://ubuntu.com/contact-us/form/thank-you?product=blender-support

