### PR TITLE
Add link in navigation to k8s report

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -49,6 +49,7 @@
             <a href="/kubernetes">Kubernetes&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item"><a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">Industry report</a></li>
             <li class="p-list__item"><a href="/kubernetes/what-is-kubernetes">What is Kubernetes</a></li>
             <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>


### PR DESCRIPTION
## Done
Added a link to the Juju k8s report

## QA
- Go to https://ubuntu-com-9939.demos.haus/#enterprise
- Open the enterprise navigation
- Click the "Industry report" link
- Check that it takes you to https://juju.is/cloud-native-kubernetes-usage-report-2021