### PR TITLE
Remove Certification reference section

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -229,38 +229,4 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="u-fixed-width">
-    <h2>Certification reference</h2>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <ul class="p-list">
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/2a2ee894-Checkbox-snappyTutorial.pdf" class="p-link--external">Running Checkbox on Ubuntu Core</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/f1f2fc8e-MAAS_Advanced_Network_Installation_And_Configuration.pdf" class="p-link--external">MAAS advanced network installation and configuration</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/8561bb98-PlatformConfigCert.pdf" class="p-link--external">OEM partner programme definitions</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/e6e61575-ReferenceDeviceTP.pdf" class="p-link--external">IoT reference device test plans</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/4a65f316-TestCaseGuide2004.pdf" class="p-link--external">Ubuntu 20.04 client certification tests</a></li>
-      </ul>
-    </div>
-    <div class="col-4">
-      <ul class="p-list">
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/bae83a86-UC18Coverage.pdf" class="p-link--external">Ubuntu Core 18 certified hardware<br>coverage</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/afc699d1-UbuntuCoreCertifiedHardwareCoverageforSeries16SmartDevices.pdf" class="p-link--external">Ubuntu Core 16 certified hardware<br>coverage</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/6c8e9c5f-Ubuntu_Desktop_Certified_Hardware_Self-Testing_Guide.pdf" class="p-link--external">Ubuntu Desktop certified hardware self-testing guide</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/44871442-Ubuntu_Server_Hardware_Certification_Coverage_18.04.pdf" class="p-link--external">Ubuntu Server 18.04 LTS hardware certification converage</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/74830270-Ubuntu_Server_Hardware_Certification_Coverage_20.04.pdf" class="p-link--external">Ubuntu Server 20.04 LTS hardware certification converage</a></li>
-      </ul>
-    </div>
-    <div class="col-4">
-      <ul class="p-list">
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/7b7982d7-Ubuntu_Server_Hardware_Certification_Overview.pdf" class="p-link--external">Ubuntu Server hardware certification overview</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/d05795f9-Ubuntu_Server_Hardware_Certification_Policy_Guide.pdf" class="p-link--external">Ubuntu Server hardware certification<br>policies</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/02ca9ede-Ubuntu_Server_Hardware_Certification_Self-Testing_Guide-compressed.pdf" class="p-link--external">Ubuntu Server certified hardware self-testing guide (20.04 LTS)</a></li>
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/94d2994f-Ubuntu_Server_Hardware_Certification_Test_Cases_Guide_18.04.pdf" class="p-link--external">Ubuntu Server hardware certification test case guide (16.04 LTS)</a></li>
-      </ul>
-    </div>
-  </div>
-</section>
-
 {% endblock content%}


### PR DESCRIPTION
Fixes #9944

This removes the reference section from /certified.

## QA

Navigate to https://ubuntu-com-9945.demos.haus/certified and verify that the reference section has been removed.