### PR TITLE
Override the defaultState values instead of trusting blindly the local state

### DIFF
--- a/static/js/src/utils/persitState.js
+++ b/static/js/src/utils/persitState.js
@@ -13,7 +13,8 @@ export function loadState(stateName, slice, defaultState) {
     if (serializedState === null) {
       return defaultState;
     }
-    return JSON.parse(serializedState)[slice];
+    const localState = JSON.parse(serializedState)[slice];
+    return { ...defaultState, ...localState };
   } catch (err) {
     return defaultState;
   }


### PR DESCRIPTION

## Done

Fix a bug where user who visited the site on a previous version would have a missing attribute in their localstorage state
