### PR TITLE
Remove noindex on subscribe page and s390x page

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -5,8 +5,6 @@
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit{% endblock meta_copydoc %}
 
-{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
-
 {% block content %}
 
 <section class="p-strip--suru-topped js-shop-hero u-no-padding--bottom">

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -3,7 +3,6 @@
 {% block title %}Ubuntu Server LTS for IBM Z and LinuxONE{% endblock %}
 {% block meta_description %}Ubuntu for IBM LinuxONE and IBM Z brings the Ubuntu Server and Ubuntu Server for cloud with the OpenStack, KVM and LXD ecosystem to IBM's premium platform.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit{% endblock meta_copydoc %}
-{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
 <div class="p-strip--suru-topped is-bordered">


### PR DESCRIPTION
## Done

- Remove noindex on subscribe page 
- Remove noindex on s390x download page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server/s390x
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Make sure those 2 pages don't have a noindex tag (in the header)
