### PR TITLE
Change UA cert text

### DIFF
--- a/templates/advantage/shared/_certifications-info.html
+++ b/templates/advantage/shared/_certifications-info.html
@@ -1,11 +1,7 @@
 <div class="row">
   <div class="row col-start-large-2 col-10">
     <div class="advantage-table-section">
-      <h5>FIPS 140-2 Level 1 certified packages use older software versions</h5>
-      <p class="u-no-margin--bottom">
-        Use them only if your organisation requires it.
-      </p>
-      <p></p>
+      <h5>FIPS 140-2 Level 1 certified packages</h5>
       <div class="advantage-table-instruction">
         <span>Available on</span>
         <p>Ubuntu 16.04 ESM, 18.04 LTS</p>
@@ -21,11 +17,7 @@
     </div>
 
     <div class="advantage-table-section">
-      <h5>CC-EAL2 certified packages use older software versions</h5>
-      <p class="u-no-margin--bottom">
-        Use them only if your organisation requires it.
-      </p>
-      <p></p>
+      <h5>CC-EAL2 certified packages and configuration</h5>
       <div class="advantage-table-instruction">
         <span>Available on</span>
         <p>Ubuntu 16.04 ESM</p>


### PR DESCRIPTION
## Done

- Change UA cert text

## QA

- check that the texts in the certification tab on https://ubuntu-com-9959.demos.haus/advantage have the changes described here: https://github.com/canonical-web-and-design/ubuntu.com/issues/9607


## Issue / Card

Fixes #9607