### PR TITLE
New language for "Further preparation" section

### DIFF
--- a/templates/cube/study/index.md
+++ b/templates/cube/study/index.md
@@ -15,7 +15,7 @@ Note that these study materials are not intended as a training program. Rather, 
 
 ## Further preparation
 
-For additional practise, enroll in Canonical’s Study Labs. The labs feature virtual Ubuntu terminals for a hands-on study experience that simulates working with the real thing.
+For additional practise, enroll in Canonical’s Study Labs. The labs enhance the free study materials, adding new interactive exercises that feature virtual Ubuntu terminals. They offer a hands-on study experience that simulates working with the real thing.
 
 A single purchase grants 90 days of access to the full set of Study Labs.
 

--- a/templates/cube/study/index.md
+++ b/templates/cube/study/index.md
@@ -15,9 +15,11 @@ Note that these study materials are not intended as a training program. Rather, 
 
 ## Further preparation
 
-For additional practise, enroll in Canonical’s Study Labs. The labs enhance the free study materials, adding new interactive exercises that feature virtual Ubuntu terminals. They offer a hands-on study experience that simulates working with the real thing.
+For additional practise, enroll in Canonical’s Study Labs. The labs enhance the free study materials, adding new interactive exercises that feature virtual Ubuntu terminals. They offer a hands-on study experience that simulates working with the real thing. No more worrying about experimenting on your personal computer; use our simulated ones to avoid altering your own files. 
 
-A single purchase grants 90 days of access to the full set of Study Labs.
+Our study labs provide terminal access via your browser and are formatted similarly to what you will see during exams.
+
+A single purchase grants 90 days of access to the full set of Study Labs for every microcertification.
 
 <a class="p-button--positive js-study-button u-hide"></a>
 <div class="p-notification--negative js-study-notification u-hide">


### PR DESCRIPTION
## Done

Made it more explicit that the Study Labs are an enhanced version of the free materials, per Marketing's request.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the content on `/cube/study`
