### PR TITLE
Pre-fill the product selector with a free trial

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Summary.jsx
+++ b/static/js/src/advantage/subscribe/react/components/Summary.jsx
@@ -85,7 +85,7 @@ function Summary() {
           <div className="u-text-light">Plan type:</div>
         </Col>
         <Col size="8">
-          <div>{product?.name}</div>
+          <div dangerouslySetInnerHTML={{ __html: product?.name }} />
         </Col>
       </Row>
       <Row className="u-no-padding u-sv1">

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -117,7 +117,7 @@ function getProduct(state) {
 
 const getFreeTrialState = () => {
   const productId = params.get("free_trial");
-  const quantity = params.get("quantity");
+  const quantity = Number(params.get("quantity")) || 1;
 
   var freeTrialState = initialFormState;
 

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -7,6 +7,8 @@ const isSmallVP =
 
 const productsArray = Object.entries(window.productList);
 
+const params = new URLSearchParams(window.location.search);
+
 const initialFormState = {
   type: "physical",
   version: "18.04",
@@ -113,9 +115,48 @@ function getProduct(state) {
   };
 }
 
+const getFreeTrialState = () => {
+  const productId = params.get("free_trial");
+  const quantity = params.get("quantity");
+
+  var freeTrialState = initialFormState;
+
+  freeTrialState.quantity = quantity;
+
+  if (productId.includes("virtual")) {
+    freeTrialState.type = "virtual";
+  } else if (productId.includes("desktop")) {
+    freeTrialState.type = "desktop";
+  } else {
+    freeTrialState.type = "physical";
+  }
+
+  if (productId.includes("uaia")) {
+    freeTrialState.feature = "infra+apps";
+  } else if (productId.includes("uaa")) {
+    freeTrialState.feature = "apps";
+  } else {
+    freeTrialState.feature = "infra";
+  }
+
+  if (productId.includes("essential")) {
+    freeTrialState.support = "essential";
+  } else if (productId.includes("standard")) {
+    freeTrialState.support = "standard";
+  } else {
+    freeTrialState.support = "advanced";
+  }
+
+  freeTrialState.product = getProduct(freeTrialState);
+
+  return freeTrialState;
+};
+
 const formSlice = createSlice({
   name: "form",
-  initialState: loadState("ua-subscribe-state", "form", initialFormState),
+  initialState: params.has("free_trial")
+    ? getFreeTrialState()
+    : loadState("ua-subscribe-state", "form", initialFormState),
   reducers: {
     changeType(state, action) {
       state.type = action.payload;

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -121,7 +121,7 @@ const getFreeTrialState = () => {
 
   var freeTrialState = initialFormState;
 
-  freeTrialState.quantity = quantity;
+  freeTrialState.quantity = Math.min(Math.max(1, quantity), 1000);
 
   if (productId.includes("virtual")) {
     freeTrialState.type = "virtual";

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -139,12 +139,12 @@ const getFreeTrialState = () => {
     freeTrialState.feature = "infra";
   }
 
-  if (productId.includes("essential")) {
-    freeTrialState.support = "essential";
+  if (productId.includes("advanced")) {
+    freeTrialState.support = "advanced";
   } else if (productId.includes("standard")) {
     freeTrialState.support = "standard";
   } else {
-    freeTrialState.support = "advanced";
+    freeTrialState.support = "essential";
   }
 
   freeTrialState.product = getProduct(freeTrialState);

--- a/static/js/src/advantage/subscribe/reducers/ui-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/ui-reducer.js
@@ -1,6 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { loadState } from "../../../utils/persitState";
 
+const params = new URLSearchParams(window.location.search);
+
 const initialUIState = {
   otherVersionsModal: {
     show: false,
@@ -12,7 +14,9 @@ const initialUIState = {
 
 const UISlice = createSlice({
   name: "ui",
-  initialState: loadState("ua-subscribe-state", "ui", initialUIState),
+  initialState: params.has("free_trial")
+    ? { ...initialUIState, purchaseModal: { show: true } }
+    : loadState("ua-subscribe-state", "ui", initialUIState),
   reducers: {
     toggleOtherVersionsModal(state) {
       state.otherVersionsModal.show = !state.otherVersionsModal.show;


### PR DESCRIPTION
## Done

- Added the ability to prepop the wizard with a query param

## QA

- go here https://ubuntu-com-9963.demos.haus/advantage/subscribe?test_backend=true&esm_apps=true&free_trial=uai-essential-physical&quantity=222
- experiment with different ids and quantities in the url
- check that the selected product and quantity matches

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9493

## List of product IDs you can use
`uaa-essential`
`uaa-essential-virtual`
`uaia-essential-physical`
`uaia-essential-virtual`
`uaa-advanced`
`uaa-advanced-virtual`
`uaa-essential-desktop`
`uaa-standard`
`uaa-standard-virtual`
`uaia-advanced-physical`
`uaia-advanced-virtual`
`uai-advanced-desktop`
`uai-advanced-physical`
`uai-advanced-virtual`
`uaia-standard-physical`
`uaia-standard-virtual`
`uai-essential-desktop`
`uai-essential-physical`
`uai-essential-virtual`
`uai-standard-desktop`
`uai-standard-physical`
`uai-standard-virtual`
