### PR TITLE
add link to survey

### DIFF
--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -24,7 +24,7 @@ Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because 
     </div>
     <div class="col-3 p-divider__block">
       <h3>What's new</h3>
-      <p><a href="/kubernetes/docs/release-notes">Version 1.21 released&nbsp;&rsaquo;</a></p>
+      <p>How Devs, DevOps and businesses <em>really</em> use Kubernetes: <a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">Read the latest industry report</a>
     </div>
     <div class="col-3 p-divider__block">
       <h3>Tutorials</h3>

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -24,7 +24,7 @@ Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because 
     </div>
     <div class="col-3 p-divider__block">
       <h3>What's new</h3>
-      <p>How Devs, DevOps and businesses <em>really</em> use Kubernetes: <a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">Read the latest industry report</a>
+      <p>How Devs, DevOps and businesses <em>really</em> use Kubernetes: <a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">Read the latest industry report</a></p>
     </div>
     <div class="col-3 p-divider__block">
       <h3>Tutorials</h3>


### PR DESCRIPTION
## Done

Adds a link from Kubernetes docs to survey report.
Alex wants this link to go live by/on 29th June

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

