### PR TITLE
Replace the newletter contextual footer from OpenStack

### DIFF
--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -426,7 +426,7 @@
   </div>
 </section>
 
-{% with first_item="_private_cloud_contact_us", second_item="_cloud_newsletter", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_private_cloud_contact_us", second_item="_openstack_documentation", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 
 <!-- Set default Marketo information for contact form below-->

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -773,7 +773,7 @@
   </div>
 </section>
 
-{% with first_item="_openstack_delivery", second_item="_cloud_newsletter", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_openstack_delivery", second_item="_openstack_documentation", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -852,7 +852,7 @@
 
   <script src="{{ versioned_static('js/dist/cloud-price-slider.js') }}" defer></script>
 
-  {% with first_item="_openstack_next_step", second_item="_cloud_newsletter", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+  {% with first_item="_openstack_next_step", second_item="_openstack_documentation", third_item="_openstack_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -714,7 +714,7 @@
   </div>
 </section>
 
-{% with first_item="_k8s_managed", second_item="_cloud_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_k8s_managed", second_item="_openstack_documentation", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/bootstack" data-form-id="1128" data-lp-id="1646" data-return-url="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -11,7 +11,7 @@
     <div class="col-7">
       <h1>What is OpenStack?</h1>
       <p>Imagine a data centre. Hundreds of physical machines, racked, powered and connected to each other. One tool turns this data centre into a cloud and enables on-demand resource provisioning through a self-service portal. That’s OpenStack!</p>
-      <p class="">
+      <p>
         <a class="p-button--positive" href="/openstack">Learn more</a>
       </p>
       <p>
@@ -727,7 +727,7 @@
   </div>
 </section>
 
-{% with first_item="_cloud_costs_increasing", second_item="_cloud_newsletter", third_item="_openstack_further_reading", no_shadow="true" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_cloud_costs_increasing", second_item="_openstack_documentation", third_item="_openstack_further_reading", no_shadow="true" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://www.ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/shared/contextual_footers/_openstack_documentation.html
+++ b/templates/shared/contextual_footers/_openstack_documentation.html
@@ -2,17 +2,17 @@
   <h3 class="p-heading--four">Detailed documentation</h3>
 
   <ul class="p-list">
-    <li><a
+    <li class="p-list__item"><a
         href="https://microstack.run"
         class="p-link--external"
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'openstack documentation', 'eventLabel' : 'MicroStack', 'eventValue' : undefined });">MicroStack website</a>
     </li>
-    <li><a
+    <li class="p-list__item"><a
         href="https://docs.openstack.org/charm-guide/latest/"
         class="p-link--external"
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'openstack documentation', 'eventLabel' : 'OpenStack Charms documentation', 'eventValue' : undefined });">OpenStack Charms documentation</a>
     </li>
-    <li><a
+    <li class="p-list__item"><a
         href="https://jaas.ai/openstack"
         class="p-link--external"
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'openstack documentation', 'eventLabel' : 'Charmed OpenStack', 'eventValue' : undefined });">Charmed OpenStack</a>


### PR DESCRIPTION
## Done
Replace the newsletter contextual footer from OpenStack

## QA
- Open then demo
- Go to /openstack#get-in-touch
- Go to the last stage and click the label "I agree to receive information about Canonical's products and services." and check it works.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9958
