### PR TITLE
K8sDocs Charm deploy updates

### DIFF
--- a/templates/kubernetes/docs/1.16/charm-containerd.md
+++ b/templates/kubernetes/docs/1.16/charm-containerd.md
@@ -87,7 +87,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.16/charm-containerd.md
+++ b/templates/kubernetes/docs/1.16/charm-containerd.md
@@ -87,7 +87,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.16/charm-flannel.md
+++ b/templates/kubernetes/docs/1.16/charm-flannel.md
@@ -34,10 +34,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/1.16/charm-keepalived.md
+++ b/templates/kubernetes/docs/1.16/charm-keepalived.md
@@ -47,7 +47,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -81,7 +81,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```

--- a/templates/kubernetes/docs/1.17/charm-containerd.md
+++ b/templates/kubernetes/docs/1.17/charm-containerd.md
@@ -87,7 +87,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.17/charm-containerd.md
+++ b/templates/kubernetes/docs/1.17/charm-containerd.md
@@ -87,7 +87,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.17/charm-flannel.md
+++ b/templates/kubernetes/docs/1.17/charm-flannel.md
@@ -34,10 +34,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/1.17/charm-keepalived.md
+++ b/templates/kubernetes/docs/1.17/charm-keepalived.md
@@ -47,7 +47,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -81,7 +81,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```

--- a/templates/kubernetes/docs/1.18/charm-containerd.md
+++ b/templates/kubernetes/docs/1.18/charm-containerd.md
@@ -85,7 +85,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.18/charm-containerd.md
+++ b/templates/kubernetes/docs/1.18/charm-containerd.md
@@ -85,7 +85,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.18/charm-easyrsa.md
+++ b/templates/kubernetes/docs/1.18/charm-easyrsa.md
@@ -27,9 +27,7 @@ This charm delivers the EasyRSA application to act as a Certificate Authority
 To deploy EasyRSA:
 
 ```
-juju deploy easyrsa
-juju deploy tls-client
-juju add-relation easyrsa tls-client
+juju deploy cs:~containers/easyrsa
 ```
 
 ## Using the EasyRSA charm

--- a/templates/kubernetes/docs/1.18/charm-flannel.md
+++ b/templates/kubernetes/docs/1.18/charm-flannel.md
@@ -35,10 +35,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/1.18/charm-keepalived.md
+++ b/templates/kubernetes/docs/1.18/charm-keepalived.md
@@ -48,7 +48,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -82,7 +82,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```

--- a/templates/kubernetes/docs/1.19/charm-containerd.md
+++ b/templates/kubernetes/docs/1.19/charm-containerd.md
@@ -85,7 +85,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.19/charm-containerd.md
+++ b/templates/kubernetes/docs/1.19/charm-containerd.md
@@ -85,7 +85,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.19/charm-easyrsa.md
+++ b/templates/kubernetes/docs/1.19/charm-easyrsa.md
@@ -27,9 +27,7 @@ This charm delivers the EasyRSA application to act as a Certificate Authority
 To deploy EasyRSA:
 
 ```
-juju deploy easyrsa
-juju deploy tls-client
-juju add-relation easyrsa tls-client
+juju deploy cs:~containers/easyrsa
 ```
 
 ## Using the EasyRSA charm

--- a/templates/kubernetes/docs/1.19/charm-flannel.md
+++ b/templates/kubernetes/docs/1.19/charm-flannel.md
@@ -35,10 +35,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/1.19/charm-keepalived.md
+++ b/templates/kubernetes/docs/1.19/charm-keepalived.md
@@ -48,7 +48,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -82,7 +82,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```

--- a/templates/kubernetes/docs/1.20/charm-containerd.md
+++ b/templates/kubernetes/docs/1.20/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.20/charm-containerd.md
+++ b/templates/kubernetes/docs/1.20/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.20/charm-easyrsa.md
+++ b/templates/kubernetes/docs/1.20/charm-easyrsa.md
@@ -26,9 +26,7 @@ This charm delivers the EasyRSA application to act as a Certificate Authority
 To deploy EasyRSA:
 
 ```
-juju deploy easyrsa
-juju deploy tls-client
-juju add-relation easyrsa tls-client
+juju deploy cs:~containers/easyrsa
 ```
 
 ## Using the EasyRSA charm

--- a/templates/kubernetes/docs/1.20/charm-flannel.md
+++ b/templates/kubernetes/docs/1.20/charm-flannel.md
@@ -34,10 +34,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/1.20/charm-keepalived.md
+++ b/templates/kubernetes/docs/1.20/charm-keepalived.md
@@ -47,7 +47,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -81,7 +81,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```

--- a/templates/kubernetes/docs/1.21/charm-containerd.md
+++ b/templates/kubernetes/docs/1.21/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.21/charm-containerd.md
+++ b/templates/kubernetes/docs/1.21/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.21/charm-easyrsa.md
+++ b/templates/kubernetes/docs/1.21/charm-easyrsa.md
@@ -26,9 +26,7 @@ This charm delivers the EasyRSA application to act as a Certificate Authority
 To deploy EasyRSA:
 
 ```
-juju deploy easyrsa
-juju deploy tls-client
-juju add-relation easyrsa tls-client
+juju deploy cs:~containers/easyrsa
 ```
 
 ## Using the EasyRSA charm

--- a/templates/kubernetes/docs/1.21/charm-flannel.md
+++ b/templates/kubernetes/docs/1.21/charm-flannel.md
@@ -34,10 +34,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/1.21/charm-keepalived.md
+++ b/templates/kubernetes/docs/1.21/charm-keepalived.md
@@ -47,7 +47,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -81,7 +81,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```

--- a/templates/kubernetes/docs/charm-containerd.md
+++ b/templates/kubernetes/docs/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/charm-containerd.md
+++ b/templates/kubernetes/docs/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/charm-easyrsa.md
+++ b/templates/kubernetes/docs/charm-easyrsa.md
@@ -26,9 +26,7 @@ This charm delivers the EasyRSA application to act as a Certificate Authority
 To deploy EasyRSA:
 
 ```
-juju deploy easyrsa
-juju deploy tls-client
-juju add-relation easyrsa tls-client
+juju deploy cs:~containers/easyrsa
 ```
 
 ## Using the EasyRSA charm

--- a/templates/kubernetes/docs/charm-flannel.md
+++ b/templates/kubernetes/docs/charm-flannel.md
@@ -34,10 +34,10 @@ This charm will require a principal charm that implements the `kubernetes-cni`
 interface in order to properly deploy.
 
 ```
-juju deploy flannel
-juju deploy etcd
-juju deploy kubernetes-master
-juju deploy kubernetes-worker
+juju deploy cs:~containers/flannel
+juju deploy cs:~containers/etcd
+juju deploy cs:~containers/kubernetes-master
+juju deploy cs:~containers/kubernetes-worker
 juju add-relation flannel etcd
 juju add-relation flannel kubernetes-master
 juju add-relation flannel kubernetes-worker

--- a/templates/kubernetes/docs/charm-keepalived.md
+++ b/templates/kubernetes/docs/charm-keepalived.md
@@ -47,7 +47,7 @@ point of failure.
 # juju deploy charmed-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info
@@ -81,7 +81,7 @@ This changes kubelet and kubectl to use the VIP to reach the Kubernetes API serv
 
 ### Using with HA Proxy
 ```
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 juju add-relation haproxy keepalived
 
 ```


### PR DESCRIPTION
## Done

- Various charm docs needed to be updated to namespace charms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

