### PR TITLE
Copy update removed SCAP 20.04

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -168,7 +168,7 @@
       </p>
       <ul class="p-list">
         <li class="p-list__item"><a class="p-link--external" href="https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux">STIG checklist for Ubuntu 16.04 LTS, 18.04 LTS and 20.04 LTS</a></li>
-        <li class="p-list__item"><a class="p-link--external" href="https://public.cyber.mil/stigs/scap/">SCAP content for Ubuntu 16.04 LTS, 18.04 LTS and 20.04 LTS</a></li>
+        <li class="p-list__item"><a class="p-link--external" href="https://public.cyber.mil/stigs/scap/">SCAP content for Ubuntu 16.04 LTS and 18.04 LTS</a></li>
       </ul>
     </div>
     <div class="col-4 u-align--center u-hide--small">


### PR DESCRIPTION
## Done

- Copy update removed SCAP 20.04
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check against [copy doc](https://docs.google.com/document/d/1CiF-dPqG1Y--h4FWfgKB1ft4G3nC2Boa8NT_JG7D6dQ/edit?ts=60dc11c8#
)

Fixes #4212
