### PR TITLE
Prepare buttons on cube microcerts now link the the courseware

### DIFF
--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -11,28 +11,19 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 js-hero-content">
       {% if certified_badge %}
-
         <h1>CUBE 2020 complete</h1>
         <p class="p-heading--4">You have completed all {{ modules|length }} microcerts, proving your Ubuntu expertise. You are now a Certified Ubuntu Engineer.</p>
-
       {% elif has_enrollments %}
-
-      <h1>Your road to CUBE</h1>
+        <h1>Your road to CUBE</h1>
         {% if passed_courses > 0 %}
         <p class="p-heading--4">You have completed {{ passed_courses }} microcerts.</br>Complete {{ (modules|length - passed_courses) }} more microcerts to attain CUBE.</p>
         {% else %}
         <p class="p-heading--4">Complete {{ modules|length }} microcerts to attain CUBE.</p>
         {% endif %}
-
       {% else %}
-
         <h1>The road to CUBE</h1>
         <p class="p-heading--4">The path to certification is clear and convenient. Complete 15 microcerts to attain CUBE.</p>
-          <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a></br>
-          {% if not user %}
-          <a href="/login" class="p-link--inverted">Sign in&nbsp;&rsaquo;</a>
-          {% endif %}
-
+        <a href="/cube/contact-us" class="p-button--positive js-invoke-modal">Apply for access</a></br>
       {% endif %}
     </div>
     <div class="col-6 p-cube-progression u-hide--medium u-hide--small">
@@ -115,8 +106,8 @@
       <h2>Refresh your knowledge</h2>
       <p><strong>Be prepared for every microcert</strong></p>
       <p class="u-sv2">Check your baseline understanding of Ubuntu fundamentals and preview the exam experience in a practice environment.</p>
-      {% if has_prepare_material %}
-      <a href="{{ prepare_material_url }}" class="p-button--positive">Prepare</a>
+      {% if has_study_labs %}
+      <a href="{{ study_labs_url }}" class="p-button--positive">Prepare</a>
       {% else %}
       <a href="/cube/contact-us" class="p-button--positive cube-access js-invoke-modal">Apply for access</a>
       {% endif %}
@@ -280,8 +271,8 @@
           {% elif module.status == "enrolled" %}
           <td>
             <div class="p-table--cube__contents u-align--right">
-              {% if has_prepare_material %}
-              <a class="p-button--neutral u-no-margin--right" href="{{ prepare_material_url }}">Prepare</a>
+              {% if has_study_labs %}
+              <a class="p-button--neutral u-no-margin--right" href="{{ module.study_lab }}">Prepare</a>
               {% endif %}
               <a style = "margin-left: 1rem;" class="p-button--positive" href="{{ module.take_url }}">Take</a>
             </div>

--- a/webapp/cube/content/cube-qa.yaml
+++ b/webapp/cube/content/cube-qa.yaml
@@ -4,7 +4,7 @@
 
 badgr-issuer: "36ZEJnXdTjqobw93BJElog"
 certified-badge: "x9kzmcNhSSyqYhZcQGz0qg"
-prepare-course: "course-v1:ubuntu+cubereview+coursecommandsdev"
+study-labs: "course-v1:ubuntu+cubereview+coursecommandsdev"
 
 courses:
   -

--- a/webapp/cube/content/cube.yaml
+++ b/webapp/cube/content/cube.yaml
@@ -4,7 +4,7 @@
 
 badgr-issuer: "eTedPNzMTuqy1SMWJ05UbA"
 certified-badge: "hs8gVorCRgyO2mNUfeXaLw"
-prepare-course: "course-v1:CUBE+study_labs_2020+alpha"
+study-labs: "course-v1:CUBE+study_labs+2020"
 
 courses:
   -

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -97,6 +97,7 @@ def cube_microcerts():
             certified_badge["image"] = assertion["image"]
             certified_badge["share_url"] = assertion["openBadgeId"]
 
+    study_labs = CUBE_CONTENT["study-labs"]
     courses = copy.deepcopy(CUBE_CONTENT["courses"])
     for course in courses:
         attempts = []
@@ -119,16 +120,18 @@ def cube_microcerts():
         elif course["id"] in enrollments:
             course["status"] = "enrolled"
 
-        take_path = quote_plus(
-            f"/courses/{course['id']}/courseware/2020/start/?child=first"
-        )
-        course["take_url"] = f"{edx_url}{take_path}"
+        course_id = course["id"]
+        courseware_name = course_id.split("+")[1]
 
-    prepare_material_path = quote_plus(
-        f"/courses/{CUBE_CONTENT['prepare-course']}/course/"
-    )
-    prepare_material_url = f"{edx_url}{prepare_material_path}"
-    has_prepare_material = CUBE_CONTENT["prepare-course"] in enrollments
+        course["take_url"] = edx_url + quote_plus(
+            f"/courses/{course_id}/courseware/2020/start/?child=first"
+        )
+
+        course["study_lab"] = edx_url + quote_plus(
+            f"/courses/{study_labs}/courseware/{courseware_name}/?child=first"
+        )
+
+    study_labs_url = edx_url + quote_plus(f"/courses/{study_labs}/course/")
 
     return flask.render_template(
         "cube/microcerts.html",
@@ -140,8 +143,8 @@ def cube_microcerts():
             "modules": courses,
             "passed_courses": passed_courses,
             "has_enrollments": len(enrollments) > 0,
-            "has_prepare_material": has_prepare_material,
-            "prepare_material_url": prepare_material_url,
+            "has_study_labs": study_labs in enrollments,
+            "study_labs_url": study_labs_url,
         },
     )
 


### PR DESCRIPTION
## Done
Prepare buttons on cube microcerts now link the the courseware

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the prepare buttons link to the appropriate sections of the study labs course(see #9953)

## Issue / Card

Fixes #9953 