### PR TITLE
Check for defaultPaymentMethod instead of customerId to decide which step to show

### DIFF
--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -57,7 +57,9 @@ const PurchaseModal = () => {
   } = useStripeCustomerInfo();
   const { isLoading: isPreviewLoading } = usePreview();
   const { isLoading: isProductLoading } = useProduct();
-  const [step, setStep] = useState(window.accountId ? 2 : 1);
+  const [step, setStep] = useState(
+    userInfo?.customerInfo?.defaultPaymentMethod ? 2 : 1
+  );
   const queryClient = useQueryClient();
 
   const {


### PR DESCRIPTION
## Done

- Display the second step of the form only if there is a default payment method

## QA

- Go to https://ubuntu-com-9985.demos.haus/advantage/subscribe?test_backend=true 
- log in with an account that has no payment method set
- open the modal and check that you see the form
- log out
- Log in with an account with a payment method
- open the modal and  check that you see the summary + pay button


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/43

