### PR TITLE
Remove arrow on selected version

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -207,36 +207,6 @@
     h4 {
       margin: 0;
     }
-
-    &.is-selected {
-      background-color: $color-light;
-      overflow: visible;
-      position: relative;
-
-      // Arrow
-      @media (min-width: $breakpoint-medium) {
-        &::after {
-          background: $color-light;
-          border-left: solid 1px $color-mid-light;
-          border-top: solid 1px $color-mid-light;
-          bottom: -41px;
-          content: "";
-          display: block;
-          height: 2rem;
-          left: calc(50% - 1rem);
-          pointer-events: none;
-          position: absolute;
-          transform: rotate(45deg) skew(-10deg, -10deg);
-          width: 2rem;
-          z-index: 5;
-        }
-      }
-      @media (min-width: $breakpoint-x-large) {
-        &::after {
-          bottom: -46px;
-        }
-      }
-    }
   }
 
   .p-card--radio--feature {


### PR DESCRIPTION
## Done

- Removed arrows from selected Ubuntu version input

## QA

- go to https://ubuntu-com-9986.demos.haus/advantage/subscribe and check that the arrows are gone

## Issue / Card

Fixes #9840

## Screenshots
![image](https://user-images.githubusercontent.com/11927929/124444061-82805b80-dd7e-11eb-80c4-8972f63d15c9.png)

