### PR TITLE
Fix missing grid-margin-width in Vanilla 2.32

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -1,3 +1,7 @@
+// Vanilla 2.32 removes internal $grid-margin-width variable,
+// $grid-margin-widths map should be used instead
+$grid-margin-width: map-get($grid-margin-widths, large);
+
 $ubuntu-logo-svg-width: 5rem; // width in rems
 $ubuntu-logo-width--desktop: $ubuntu-logo-svg-width + 2 * $grid-margin-width;
 $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph-inner;


### PR DESCRIPTION
## Done

- Replaces deprecated variable with correct use for Vanilla 2.32


This should fix Vanilla build errors when updating to v2.32 in #9937


## QA

- Check out this feature branch or use [demo](https://ubuntu-com-9993.demos.haus)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure navigation renders as expected


