### PR TITLE
Fix links and number in product selector

### DIFF
--- a/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoAnon.jsx
+++ b/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoAnon.jsx
@@ -22,21 +22,25 @@ const usePostCustomerInfoAnon = () => {
       state: country === "US" ? usState : caProvince,
     };
 
-    const res = await postCustomerInfoForPurchasePreview(
-      window.accountId,
-      name,
-      addressObject,
-      {
-        type: "eu_vat",
-        value: VATNumber,
-      }
-    );
+    if (VATNumber) {
+      const res = await postCustomerInfoForPurchasePreview(
+        window.accountId,
+        name,
+        addressObject,
+        {
+          type: "eu_vat",
+          value: VATNumber,
+        }
+      );
 
-    if (res.errors) {
-      throw new Error(JSON.parse(res.errors).code);
+      if (res.errors) {
+        throw new Error(JSON.parse(res.errors).code);
+      }
+
+      return res;
     }
 
-    return res;
+    throw new Error("VAT is missing");
   });
 
   return mutation;

--- a/templates/advantage/subscribe/form/_feature_coverage.html
+++ b/templates/advantage/subscribe/form/_feature_coverage.html
@@ -3,8 +3,7 @@
   <div class="row">
     <div class="col-12 subscribe-section">
       <p>
-        Essential features are already included in your subscription.<br />
-        You can add Infrastructure and Application features to your plan.
+        Essential features are already included in your subscription. <a href="/support">See what is included with Applications coverage.</a>
       </p>
       <div class="radio-wrapper--stacking">
         <div class="p-card--radio--feature js-radio">
@@ -16,7 +15,7 @@
             value="infra"
           />
           <label for="feature_infra">
-            <h4 class="p-card__title">Infrastructure</h4>
+            <h4 class="p-card__title">Infra</h4>
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
               <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 2.000 packages including:
@@ -29,7 +28,7 @@
               </li>
               <li class="p-list__item is-ticked">Optional tech support for Ubuntu OS and the underlying infrastructure as specified above</li>
             </ul>
-            <span>Select Infrastructure only</span>
+            <span>Select Infra only</span>
           </label>
         </div>
 
@@ -42,7 +41,7 @@
             value="apps"
           />
           <label for="feature_apps">
-            <h4 class="p-card__title--is-new">Applications</h4>
+            <h4 class="p-card__title--is-new">Apps</h4>
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
               <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 28.000 packages including:
@@ -55,9 +54,9 @@
                   ROS.
                  </h5>
               </li>
-              <li class="p-list__item is-ticked">Optional tech support for Ubuntu OS and <a href="/support">selected open source applications</a></li>
+              <li class="p-list__item is-ticked">Optional tech support for Ubuntu OS and selected open source applications</li>
             </ul>
-            <span>Select Applications only</span>
+            <span>Select Apps only</span>
           </label>
         </div>
 
@@ -70,7 +69,7 @@
             value="infra+apps"
           />
           <label for="feature_infra+apps">
-            <h4 class="p-card__title">Apps + Infra</h4>
+            <h4 class="p-card__title">Infra + Apps</h4>
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
               <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 30.000 packages including:
@@ -79,9 +78,9 @@
                   Applications.
                 </h5>
               </li>
-              <li class="p-list__item is-ticked">Optional tech support for Ubuntu OS, the underlying infrastructure and <a href="/support">selected open source applications</a></li>
+              <li class="p-list__item is-ticked">Optional tech support for Ubuntu OS, the underlying infrastructure and selected open source applications</li>
             </ul>
-            <span>Select Apps + Infra</span>
+            <span>Select Infra + Apps</span>
           </label>
         </div>
       </div>

--- a/templates/advantage/subscribe/form/_feature_coverage.html
+++ b/templates/advantage/subscribe/form/_feature_coverage.html
@@ -18,7 +18,7 @@
             <h4 class="p-card__title">Infra</h4>
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
-              <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 2.000 packages including:
+              <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 2,000 packages including:
                  <h5> 
                   OpenStack,
                   Ceph raw storage,
@@ -44,7 +44,7 @@
             <h4 class="p-card__title--is-new">Apps</h4>
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
-              <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 28.000 packages including:
+              <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 28,000 packages including:
                  <h5>  
                   NodeJS,
                   Django,
@@ -72,7 +72,7 @@
             <h4 class="p-card__title">Infra + Apps</h4>
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
-              <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 30.000 packages including:
+              <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 30,000 packages including:
                 <h5>   
                   Infrastructure,
                   Applications.

--- a/templates/advantage/subscribe/form/_feature_coverage.html
+++ b/templates/advantage/subscribe/form/_feature_coverage.html
@@ -3,7 +3,9 @@
   <div class="row">
     <div class="col-12 subscribe-section">
       <p>
-        Essential features are already included in your subscription. <a href="/support">See what is included with Applications coverage.</a>
+        Essential features are already included in your subscription.
+        <br />
+        <a href="/support">See what is included with Applications coverage.</a>
       </p>
       <div class="radio-wrapper--stacking">
         <div class="p-card--radio--feature js-radio">


### PR DESCRIPTION
## Done

- Took the link out of the cards and put it in the section's subtitle
- Renamed cards to Infra, Apps and Infra + Apps
- replaced periods in number by commas

## QA

- go to https://ubuntu-com-9994.demos.haus/advantage/subscribe?test_backend=true&esm_apps=true
- check that it matches the [design](https://user-images.githubusercontent.com/5436686/124556647-d485b780-de38-11eb-8baf-ed450413c3bc.png)

## Issue / Card

Fixes #9961

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/124599794-58a26400-de66-11eb-9051-46a1e0d04ec1.png)

