### PR TITLE
Fix onclick endless requests

### DIFF
--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -120,6 +120,7 @@ let progressTimer3;
 let progressTimer4;
 
 let isCustomerInfoSet = false;
+let isCustomerInfoSetFailed = false;
 
 function attachCTAevents() {
   document.addEventListener("click", (e) => {
@@ -136,7 +137,12 @@ function attachCTAevents() {
       }
     }
 
-    if (currentTransaction.accountId && !isCustomerInfoSet && !guestPurchase) {
+    if (
+      currentTransaction.accountId &&
+      !isCustomerInfoSet &&
+      !isCustomerInfoSetFailed &&
+      !guestPurchase
+    ) {
       fetchCustomerInfo(currentTransaction.accountId);
     }
 
@@ -474,8 +480,12 @@ function fetchCustomerInfo(accountId) {
       customerInfo = { ...res.customerInfo, name, address };
       setFormElements();
       isCustomerInfoSet = true;
+      isCustomerInfoSetFailed = false;
     })
-    .catch((e) => console.error(e));
+    .catch((e) => {
+      isCustomerInfoSetFailed = true;
+      console.error(e);
+    });
 }
 
 function setFormElements() {


### PR DESCRIPTION
## Done

- If you have an account with a renewal but you have no customer stripe account 
- You press on the renew button
- Everywhere you click after will trigger an `get-customer-anon` request

## QA

- Have an account without a stripe customer account and a renewal
- Open the console
- Click on the renew button
- Close the modal
- No more `get-customer-anon` requests get made onclick

## Issue / Card

Fixes #41