### PR TITLE
Fix renewal dates

### DIFF
--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -189,10 +189,8 @@ export function getPaymentInformation(paymentMethod) {
 }
 
 export function getRenewalInformation(data) {
-  const startDate = add(new Date(data.contractEnd), { days: 1 });
-  const endDate = add(new Date(data.contractEnd), {
-    months: parseInt(data.months),
-  });
+  const startDate = new Date(data.renewalStart);
+  const endDate = new Date(data.renewalEnd);
 
   return {
     items: [

--- a/static/js/src/advantage/tests/fixtures/renewal-data.js
+++ b/static/js/src/advantage/tests/fixtures/renewal-data.js
@@ -8,6 +8,8 @@ export const advancedDesktop = {
   products: "['uai-advanced-desktop']",
   quantity: "5",
   renewalId: "rACmlqlrdX08yb4jK3_ldJBUVSY_Bkmubdq1ysGj65yU",
+  renewalStart: "2020-04-18T00:00:00Z",
+  renewalEnd: "2020-08-18T00:00:00Z",
   unitPrice: "2500",
   total: "12500",
 };

--- a/static/js/src/advantage/tests/set-modal-info.test.js
+++ b/static/js/src/advantage/tests/set-modal-info.test.js
@@ -44,7 +44,7 @@ describe("getRenewalInformation", () => {
           {
             end: {
               label: "Ends:",
-              value: "20 May 2021",
+              value: "18 August 2020",
               extraClasses: "js-end-date",
             },
             plan: {
@@ -57,7 +57,7 @@ describe("getRenewalInformation", () => {
             },
             start: {
               label: "Continues from:",
-              value: "21 May 2020",
+              value: "18 April 2020",
             },
           },
         ],

--- a/templates/advantage/table/_renewal-actions.html
+++ b/templates/advantage/table/_renewal-actions.html
@@ -11,6 +11,8 @@
         data-name="{{ contract['contractInfo']['name']}}"
         data-quantity="{{ contract['renewal']['renewalItems'][0]['allowance']['value'] }}"
         data-renewal-id="{{ contract['renewal']['id']}}"
+        data-renewal-start="{{ contract['renewal']['start']}}"
+        data-renewal-end="{{ contract['renewal']['end']}}"
         {% if expired_renewable %}
           data-contract-end="{{ contract['contractInfo']['expired_restart_date']}}"
         {% else %}


### PR DESCRIPTION
## Done

- Fix renewal dates
- Renewal modal shows incorrect start and end date of the renewal
- The logic before was to look at the contract end and add X amount of months
- Now we use the start and end dates of the renewal

## QA

- Have a renewal (ask for help)
- Click the renew button
- Confirm that the dates match the renewal dates

## Issue / Card

Fixes #9920
