### PR TITLE
Add missing name for Product schema

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -383,14 +383,14 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light is-bordered" itemscope itemtype="https://schema.org/Product">
   <div class="row">
     <div class="col-7">
-      <h2>Juju Administrator</h2>
+      <h2 itemprop="name">Juju Administrator</h2>
     </div>
   </div>
 
-  <div itemscope itemtype="https://schema.org/Product">
+  <div>
     <div class="u-fixed-width">
       <hr />
     </div>
@@ -417,14 +417,14 @@
   </div>
 </section>
 
-<section class="p-strip is-bordered">
+<section class="p-strip is-bordered" itemscope itemtype="https://schema.org/Product">
   <div class="row">
     <div class="col-7">
-      <h2>Charm Developer</h2>
+      <h2 itemprop="name">Charm Developer</h2>
     </div>
   </div>
 
-  <div itemscope itemtype="https://schema.org/Product">
+  <div>
     <div class="u-fixed-width">
       <hr />
     </div>


### PR DESCRIPTION
## Done

- Fix missing name issue from new product added from https://github.com/canonical-web-and-design/ubuntu.com/pull/9976
- See: https://search.google.com/test/rich-results?id=1gW1vYru48TDbSsic0_wEg

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/training
- Make sure it still works and that the content of the Juju Administrator and Charm Developer are still well formatted (last 2 products)
- Use demo link and test on https://search.google.com/test/rich-results (or look at this result: https://search.google.com/test/rich-results?id=eJeash2iZOTwxkKM5KITvw )