### PR TITLE
Add free trial label on support section

### DIFF
--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -108,8 +108,8 @@
       }
 
       > small {
-        margin-top: 0.5rem;
         font-weight: normal;
+        margin-top: 0.5rem;
       }
     }
 

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -102,7 +102,13 @@
     > label {
       font-weight: 400;
 
+      > .p-label {
+        position: absolute;
+        right: 1rem;
+      }
+
       > small {
+        margin-top: 0.5rem;
         font-weight: normal;
       }
     }
@@ -134,21 +140,9 @@
     }
 
     .p-card__title {
-      &--is-new {
-        align-items: center;
-        display: flex;
-        justify-content: space-between;
-
-        &::after {
-          background-color: #0e8420;
-          border-radius: 2px;
-          color: white;
-          content: "New";
-          display: inline-block;
-          font-size: 1rem;
-          padding: 0 0.5rem;
-        }
-      }
+      align-items: baseline;
+      display: flex;
+      justify-content: space-between;
     }
 
     img {

--- a/templates/advantage/subscribe/form/_feature_coverage.html
+++ b/templates/advantage/subscribe/form/_feature_coverage.html
@@ -43,7 +43,11 @@
             value="apps"
           />
           <label for="feature_apps">
-            <h4 class="p-card__title--is-new">Apps</h4>
+            <div class="p-card__title">
+              <h4>Apps</h4>
+              <div class="p-label">New</div>
+            </div>
+
             <hr class="u-sv1">
             <ul class="p-list--ticked u-no-margin--left u-no-padding--left">
               <li class="p-list__item is-ticked">Security coverage for high and critical CVEs with extended  security maintenance for over 28,000 packages including:

--- a/templates/advantage/subscribe/form/_feature_coverage.html
+++ b/templates/advantage/subscribe/form/_feature_coverage.html
@@ -45,7 +45,7 @@
           <label for="feature_apps">
             <div class="p-card__title">
               <h4>Apps</h4>
-              <div class="p-label">New</div>
+              <div class="p-label--new">New</div>
             </div>
 
             <hr class="u-sv1">

--- a/templates/advantage/subscribe/form/_tech_support.html
+++ b/templates/advantage/subscribe/form/_tech_support.html
@@ -12,6 +12,7 @@
         />
         <label for="support_one">
           No, thanks<br />
+           <div class="p-label">Free trial</div>
           <small class="u-text-light">Software and security updates only</small>
         </label>
         {{ 


### PR DESCRIPTION
## Done

- Added a "free trial" label on no support option
- changed the Apps "new" label to grey so it doesn't look like a :christmas_tree: 

## QA

- go to /advantage/subscribe?test_backend=true
- Check that it looks good

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/67

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/125296529-ab789180-e326-11eb-8beb-76de98e155f2.png)

