### PR TITLE
Add extra copy on logged out advantage

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -65,6 +65,28 @@
     </div>
   </section>
 
+ <section class="p-strip is-shallow">
+    <div class="row">
+      <h2>Introducing a free trial of ESM Apps</h2>
+      <p>Security coverage for high and critical CVEs with extended security maintenance for over 28,000 packages including: NodeJS, Django, NGINX, Redis, Kafka, ROS.</p>
+      <p>Try ESM Apps Essential for 1 month, free of charge with no commitment and no payment card.</p>
+      <p>
+      <a 
+        href="/advantage/subscribe?free_trial=uaa-essential&quantity=1{% if is_test_backend %}&test_backend=true{% endif %}" 
+        class="p-button--positive"   
+        onclick="dataLayer.push({
+          'event' : 'GAEvent',
+          'eventCategory' : 'Advantage',
+          'eventAction' : 'free-trial',
+          'eventLabel' : 'Try ESM Apps Free',
+          'eventValue' : 5
+        });">
+          Try ESM Apps Free
+      </a>
+      </p>
+    </div>
+  </section>
+
   <section class="p-strip is-shallow is-bordered">
     <div class="row">
       <h2>Plans for enterprise use</h2>

--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -65,11 +65,11 @@
     </div>
   </section>
 
- <section class="p-strip is-shallow">
+ <section class="p-strip u-no-padding--bottom">
     <div class="row">
       <h2>Introducing a free trial of ESM Apps</h2>
-      <p>Security coverage for high and critical CVEs with extended security maintenance for over 28,000 packages including: NodeJS, Django, NGINX, Redis, Kafka, ROS.</p>
-      <p>Try ESM Apps Essential for 1 month, free of charge with no commitment and no payment card.</p>
+      <p>Security coverage for high and critical CVEs with extended security maintenance for over 30,000 packages including: NodeJS, Django, NGINX, Redis, Kafka, ROS.</p>
+      <p>Try Ubuntu Pro Essential for 1 month, free of charge with no commitment and no payment card.</p>
       <p>
       <a 
         href="/advantage/subscribe?free_trial=uaa-essential&quantity=1{% if is_test_backend %}&test_backend=true{% endif %}" 


### PR DESCRIPTION
## Done

- Added free trial paragraph to logged out /advantage
- Added a button to a pre-filled product selector

## QA

- go to https://ubuntu-com-10014.demos.haus/advantage?test_backend=true
-  Click the button and see that it brings you to a modal where you can start the trial


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/125313622-b1c23a00-e335-11eb-9625-922fcdcdc76f.png)
