### PR TITLE
Add free trial label to sticky footer if product is eligible

### DIFF
--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -161,6 +161,9 @@ function renderSummary(state) {
     // if the selection matches a product we populate the 'cart' section and show it
     const image = summarySection.querySelector("#summary-plan-image");
     const title = summarySection.querySelector("#summary-plan-name");
+    const freeTrialLabel = summarySection.querySelector(
+      "#summary-free-trial-label"
+    );
     const costElement = summarySection.querySelector(".js-summary-cost");
     const quantityElement = summarySection.querySelector(
       "#summary-plan-quantity"
@@ -171,6 +174,11 @@ function renderSummary(state) {
     quantityElement.innerHTML = `${quantity}x`;
     image.setAttribute("src", imgUrl[type]);
     title.innerHTML = state.product.name;
+    if (state.product.canBeTrialled) {
+      freeTrialLabel.classList.remove("u-hide");
+    } else {
+      freeTrialLabel.classList.add("u-hide");
+    }
     costElement.innerHTML = `${formatter.format((price / 100) * quantity)} / ${
       billing === "monthly" ? "month" : "year"
     }`;

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -23,7 +23,7 @@
           margin-left: 2.5rem;
         }
         > .p-label {
-          margin-top: 0rem;
+          margin-top: 0;
         }
       }
 

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -19,6 +19,10 @@
         }
       }
 
+      > .p-label {
+        align-self: center;
+      }
+
       > img {
         height: 35px;
         margin: 0 1rem;

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -13,8 +13,8 @@
       flex-wrap: wrap;
 
       > .p-label {
-        margin-top: 0.5rem;
         align-self: center;
+        margin-top: 0.5rem;
       }
 
       @media (min-width: $breakpoint-x-small) {

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -12,15 +12,19 @@
       display: flex;
       flex-wrap: wrap;
 
+      > .p-label {
+        margin-top: 0.5rem;
+        align-self: center;
+      }
+
       @media (min-width: $breakpoint-x-small) {
         flex-wrap: nowrap;
         > div {
           margin-left: 2.5rem;
         }
-      }
-
-      > .p-label {
-        align-self: center;
+        > .p-label {
+          margin-top: 0rem;
+        }
       }
 
       > img {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -75,6 +75,7 @@
         <span id="summary-plan-quantity">1x</span>
         <img id="summary-plan-image" src="${imageURL}" />
         <span id="summary-plan-name"></span>
+        <div id="summary-free-trial-label" class="p-label">1 month free trial</div>
         <div class="js-summary-billing">
           <select
             name="billing-period"


### PR DESCRIPTION
## Done

- Added a "Free trial" label in the sticky footer for eligible products

## QA

- Go to /advantage/subscribe?test_backend=true
- play with the selectors and check that it displays it for products that are eligible for a trial


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/68

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/125323039-a9bac800-e33e-11eb-8443-34cb439ca457.png)

