### PR TITLE
Replace copydocs links with correct links

### DIFF
--- a/templates/certified/base_certification.html
+++ b/templates/certified/base_certification.html
@@ -1,6 +1,6 @@
 {% extends "templates/base.html" %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1vIf1vC1mg72JbzmahrcKCaRZN-qMLCgin_i9iqjUxpM/edit#heading=h.urf3keoh6w6k{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/certified/component-details.html
+++ b/templates/certified/component-details.html
@@ -3,7 +3,6 @@
 {% block title %}Ubuntu certified component: {{ component.vendor_name }} {{ component.model }}{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--suru-topped">

--- a/templates/certified/hardware-details.html
+++ b/templates/certified/hardware-details.html
@@ -3,7 +3,6 @@
 {% block title %} {{ vendor }} {{ model }} certified with Ubuntu {{ release }}{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -3,7 +3,6 @@
 {% block title %}Certified hardware{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit#{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -3,7 +3,6 @@
 {% block title %} {{ vendor }} {{ model }} certified with Ubuntu{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -3,7 +3,6 @@
 {% block title %}Certified hardware{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit{% endblock meta_copydoc %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

- Some pages were using cube copydocs
- Since there is one copydocs for this section, use the index one on the template

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified
- Check copydocs
