### PR TITLE
Update enterprise and developer menus with CUBE

### DIFF
--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -12,22 +12,17 @@
             <a href="/desktop/developers">Develop on Ubuntu&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item">GCC, CLANG</li>
+            <!--<li class="p-list__item">GCC, CLANG</li>
             <li class="p-list__item">Go</li>
             <li class="p-list__item">Python, Ruby, Node.js</li>
-            <li class="p-list__item"><a href="https://flutter.dev">Flutter</a></li>
+            <li class="p-list__item"><a href="https://flutter.dev">Flutter</a></li>-->
             <li class="p-list__item"><a href="/about/packages">Deb, snap, and charm packages</a></li>
-            <li class="p-list__item">Android development</li>
-            <li class="p-list__item">Architectures and ISAs</li>
-            <li class="p-list__item">
-              <a href="/kernel">Kernel selection &amp; lifecycle&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://multipass.run/">Multipass&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/wsl">Ubuntu on WSL&nbsp;&rsaquo;</a>
-            </li>
+            <!--<li class="p-list__item">Android development</li>
+            <li class="p-list__item">Architectures and ISAs</li>-->
+            <li class="p-list__item"><a href="/kernel">Kernel selection &amp; lifecycle</a></li>
+            <li class="p-list__item"><a href="https://multipass.run/">Multipass</a></li>
+            <li class="p-list__item"><a href="/wsl">Ubuntu on WSL</a></li>
+            <li class="p-list__item"><a href="/cube">Become a Certified Ubuntu Engineer</a></li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/desktop/developers">Develop with Ubuntu</a></p>
         </div>
@@ -42,24 +37,14 @@
               <a href="https://snapcraft.io/">Publish apps&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item">
-              <a href="https://snapcraft.io/store">Browse the snap store&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://docs.snapcraft.io/core/usage">The snap command line interface&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://build.snapcraft.io/">Auto-build service for snaps&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://docs.snapcraft.io/">Snap documentation&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://docs.snapcraft.io/reference/channels">Snap channels - track/risk/branch&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">Cross-distro testing of snaps</li>
+            <li class="p-list__item"><a href="https://snapcraft.io/store">Browse the snap store</a></li>
+            <li class="p-list__item"><a href="https://docs.snapcraft.io/core/usage">The snap command line interface</a></li>
+            <li class="p-list__item"><a href="https://build.snapcraft.io/">Auto-build service for snaps</a></li>
+            <li class="p-list__item"><a href="https://docs.snapcraft.io/">Snap documentation</a></li>
+            <li class="p-list__item"><a href="https://docs.snapcraft.io/reference/channels">Snap channels - track/risk/branch</a></li>
+            <!--<li class="p-list__item">Cross-distro testing of snaps</li>
             <li class="p-list__item">Rigorous snap security model</li>
-            <li class="p-list__item">Integration between snaps</li>
+            <li class="p-list__item">Integration between snaps</li>-->
           </ul>
           <p><a class="p-button--positive p-button--small" href="https://snapcraft.io/">Publish with Snapcraft</a></p>
         </div>
@@ -70,30 +55,14 @@
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">Devops</h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item">
-              <a href="/public-cloud">Ubuntu images on public clouds&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/blog/minimal-ubuntu-released">Minimal Ubuntu for containers&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://cloud-init.io/">Cloud-init - customise cloud instances&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://jaas.ai/">Juju for standardised operations&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/kubernetes">Charmed Kubernetes&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://microk8s.io/">MicroK8s - single node k8s for devs&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://maas.io/">MAAS - fast server provisioning&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="https://multipass.run/">Multipass - Ubuntu on macOS&nbsp;&rsaquo;</a>
-            </li>
+            <li class="p-list__item"><a href="/public-cloud">Ubuntu images on public clouds</a></li>
+            <li class="p-list__item"><a href="/blog/minimal-ubuntu-released">Minimal Ubuntu for containers</a></li>
+            <li class="p-list__item"><a href="https://cloud-init.io/">Cloud-init - customise cloud instances</a></li>
+            <li class="p-list__item"><a href="https://jaas.ai/">Juju for standardised operations</a></li>
+            <li class="p-list__item"><a href="/kubernetes">Charmed Kubernetes</a></li>
+            <li class="p-list__item"><a href="https://microk8s.io/">MicroK8s - single node k8s for devs</a></li>
+            <li class="p-list__item"><a href="https://maas.io/">MAAS - fast server provisioning</a></li>
+            <li class="p-list__item"><a href="https://multipass.run/">Multipass - Ubuntu on macOS</a></li>
           </ul>
         </div>
         <div class="col-medium-2 col-3 p-card--navigation">
@@ -107,24 +76,12 @@
             <a href="/internet-of-things">Make devices&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item">
-              <a href="/core">Secure, embedded Ubuntu Core&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/internet-of-things/robotics">Make robots with app stores&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/internet-of-things/gateways">Industrial gateways and controllers&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/tutorials/graphical-snaps">Build a secure Ubuntu based kiosk&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/internet-of-things/digital-signage">The leading OS for digital signage&nbsp;&rsaquo;</a>
-            </li>
-            <li class="p-list__item">
-              <a href="/appliance">Free appliance images for your PC or Raspberry Pi&nbsp;&rsaquo;</a>
-            </li>
+            <li class="p-list__item"><a href="/core">Secure, embedded Ubuntu Core</a></li>
+            <li class="p-list__item"><a href="/internet-of-things/robotics">Make robots with app stores</a></li>
+            <li class="p-list__item"><a href="/internet-of-things/gateways">Industrial gateways and controllers</a></li>
+            <li class="p-list__item"><a href="/tutorials/graphical-snaps">Build a secure Ubuntu based kiosk</a></li>
+            <li class="p-list__item"><a href="/internet-of-things/digital-signage">The leading OS for digital signage</a></li>
+            <li class="p-list__item"><a href="/appliance">Free appliance images for your PC or Raspberry Pi</a></li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/internet-of-things/contact-us">Accelerate to market</a></p>
         </div>
@@ -142,15 +99,9 @@
           <div>
             <p class="p-p--small">Ubuntu delivers hardware acceleration on Nvidia for all clouds and bare metal.</p>
             <ul class="p-text-list--small is-bordered">
-              <li class="p-list__item">
-                <a href="/ai/what-is-kubeflow">What is Kubeflow&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="https://charmed-kubeflow.io">Easy Kubeflow operations&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="https://charmed-kubeflow.io/docs/install">Install Kubeflow in 5 min&nbsp;&rsaquo;</a>
-              </li>
+              <li class="p-list__item"><a href="/ai/what-is-kubeflow">What is Kubeflow</a></li>
+              <li class="p-list__item"><a href="https://charmed-kubeflow.io">Easy Kubeflow operations</a></li>
+              <li class="p-list__item"><a href="https://charmed-kubeflow.io/docs/install">Install Kubeflow in 5 min</a></li>
             </ul>
             <p><a class="p-button--positive p-button--small" href="/ai">Develop with AI/ML</a></p>
           </div>
@@ -170,19 +121,11 @@
           </h4>
           <div>
             <ul class="p-text-list--small is-bordered">
-              <li class="p-list__item">
-                <a href="/kubernetes">Kubernetes on Ubuntu&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="https://microk8s.io/">Install K8s &ndash; workstations&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                <a href="/kubernetes/install">Install K8s &ndash; clouds and clusters&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">
-                  <a href="https://linuxcontainers.org/">Run pre-K8s apps in LXD containers&nbsp;&rsaquo;</a>
-              </li>
-              <li class="p-list__item">Test CentOS apps on Ubuntu with LXD</li>
+              <li class="p-list__item"><a href="/kubernetes">Kubernetes on Ubuntu</a></li>
+              <li class="p-list__item"><a href="https://microk8s.io/">Install K8s &ndash; workstations</a></li>
+              <li class="p-list__item"><a href="/kubernetes/install">Install K8s &ndash; clouds and clusters</a></li>
+              <li class="p-list__item"><a href="https://linuxcontainers.org/">Run pre-K8s apps in LXD containers</a></li>
+              <!-- <li class="p-list__item">Test CentOS apps on Ubuntu with LXD</li>-->
             </ul>
           </div>
         </div>
@@ -191,9 +134,7 @@
           <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">
-              <li class="p-list__item">
-                <a href="/tutorials/tutorial-guidelines">How to write a tutorial&nbsp;&rsaquo;</a>
-              </li>
+              <li class="p-list__item"><a href="/tutorials/tutorial-guidelines">How to write a tutorial</a></li>
             </ul>
           </div>
         </div>
@@ -207,23 +148,17 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a href="/download/desktop">Ubuntu Desktop</a>
-          </li>
+            <a href="/download/desktop">Ubuntu Desktop</a></li>
           <li class="p-inline-list__item">
-            <a href="/download/server">Ubuntu Server</a>
-          </li>
+            <a href="/download/server">Ubuntu Server</a></li>
           <li class="p-inline-list__item">
-            <a href="/download/iot">IoT</a>
-          </li>
+            <a href="/download/iot">IoT</a></li>
           <li class="p-inline-list__item">
-            <a href="/download/cloud">Cloud</a>
-          </li>
+            <a href="/download/cloud">Cloud</a></li>
           <li class="p-inline-list__item">
-            <a href="/download/alternative-downloads">Alternative downloads</a>
-          </li>
+            <a href="/download/alternative-downloads">Alternative downloads</a></li>
           <li class="p-inline-list__item">
-            <a href="/download/flavours">Flavours</a>
-          </li>
+            <a href="/download/flavours">Flavours</a></li>
         </ul>
       </div>
     </div>
@@ -235,26 +170,19 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a href="https://docs.ubuntu.com/">Docs</a>
-          </li>
+            <a href="https://docs.ubuntu.com/">Docs</a></li>
           <li class="p-inline-list__item">
-            <a href="https://ubuntuforums.org/">Forum</a>
-          </li>
+            <a href="https://ubuntuforums.org/">Forum</a></li>
           <li class="p-inline-list__item">
-            <a href="/tutorials/">Tutorials</a>
-          </li>
+            <a href="/tutorials/">Tutorials</a></li>
           <li class="p-inline-list__item">
-            <a href="https://www.youtube.com/user/celebrateubuntu">Videos</a>
-          </li>
+            <a href="https://www.youtube.com/user/celebrateubuntu">Videos</a></li>
           <li class="p-inline-list__item">
-            <a href="https://www.brighttalk.com/search?q=Canonical">Webinars</a>
-          </li>
+            <a href="https://www.brighttalk.com/search?q=Canonical">Webinars</a></li>
           <li class="p-inline-list__item">
-            <a href="/blog?category=white-papers#posts-list">Whitepapers</a>
-          </li>
+            <a href="/blog?category=white-papers#posts-list">Whitepapers</a></li>
           <li class="p-inline-list__item">
-            <a href="/blog">Blog</a>
-          </li>
+            <a href="/blog">Blog</a></li>
         </ul>
       </div>
     </div>
@@ -266,20 +194,15 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a href="https://docs.ubuntu.com/">Read the docs</a>
-          </li>
+            <a href="https://docs.ubuntu.com/">Read the docs</a></li>
           <li class="p-inline-list__item">
-            <a href="https://askubuntu.com/">Ask Ubuntu</a>
-          </li>
+            <a href="https://askubuntu.com/">Ask Ubuntu</a></li>
           <li class="p-inline-list__item">
-            <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC Channels</a>
-          </li>
+            <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC Channels</a></li>
           <li class="p-inline-list__item">
-            <a href="https://help.ubuntu.com/community/CommunityHelpWiki">Help</a>
-          </li>
+            <a href="https://help.ubuntu.com/community/CommunityHelpWiki">Help</a></li>
           <li class="p-inline-list__item">
-            <a href="/support">Commercial Support</a>
-          </li>
+            <a href="/support">Commercial Support</a></li>
         </ul>
       </div>
     </div>
@@ -291,21 +214,16 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item">
-            <a href="/security">Security</a>
-          </li>
+            <a href="/security">Security</a></li>
           <li class="p-inline-list__item">
-            <a href="/security/certifications">Certifications</a>
-          </li>
+            <a href="/security/certifications">Certifications</a></li>
           <li class="p-inline-list__item">
-            <a href="/security/notices">Notices</a>
-          </li>
+            <a href="/security/notices">Notices</a></li>
           <!-- Hidden for soft launch -->
           <!-- <li class="p-inline-list__item">
-            <a href="/security/cve">CVEs</a>
-          </li> -->
+            <a href="/security/cve">CVEs</a></li> -->
           <li class="p-inline-list__item">
-            <a href="/esm">Extended Security Maintenance</a>
-          </li>
+            <a href="/esm">Extended Security Maintenance</a></li>
         </ul>
       </div>
     </div>
@@ -318,20 +236,15 @@
         <div class="col-9">
           <ul class="p-inline-list--middot is-x-dense">
             <li class="p-inline-list__item">
-              <a href="https://cloud-init.io/">cloud-init</a>
-            </li>
+              <a href="https://cloud-init.io/">cloud-init</a></li>
             <li class="p-inline-list__item">
-              <a href="https://jujucharms.com/">Juju</a>
-            </li>
+              <a href="https://jujucharms.com/">Juju</a></li>
             <li class="p-inline-list__item">
-              <a href="https://snapcraft.io/">Snapcraft</a>
-            </li>
+              <a href="https://snapcraft.io/">Snapcraft</a></li>
             <li class="p-inline-list__item">
-              <a href="http://linuxcontainers.org/">LXD</a>
-            </li>
+              <a href="http://linuxcontainers.org/">LXD</a></li>
             <li class="p-inline-list__item">
-              <a href="https://multipass.run/">Multipass</a>
-            </li>
+              <a href="https://multipass.run/">Multipass</a></li>
           </ul>
         </div>
       </div>

--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -12,15 +12,9 @@
             <a href="/desktop/developers">Develop on Ubuntu&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <!--<li class="p-list__item">GCC, CLANG</li>
-            <li class="p-list__item">Go</li>
-            <li class="p-list__item">Python, Ruby, Node.js</li>
-            <li class="p-list__item"><a href="https://flutter.dev">Flutter</a></li>-->
             <li class="p-list__item"><a href="/about/packages">Deb, snap, and charm packages</a></li>
-            <!--<li class="p-list__item">Android development</li>
-            <li class="p-list__item">Architectures and ISAs</li>-->
             <li class="p-list__item"><a href="/kernel">Kernel selection &amp; lifecycle</a></li>
-            <li class="p-list__item"><a href="https://multipass.run/">Multipass</a></li>
+            <li class="p-list__item"><a href="https://multipass.run">Multipass</a></li>
             <li class="p-list__item"><a href="/wsl">Ubuntu on WSL</a></li>
             <li class="p-list__item"><a href="/cube">Become a Certified Ubuntu Engineer</a></li>
           </ul>
@@ -29,24 +23,21 @@
         <div class="col-medium-2 col-3 p-card--navigation">
           <div class="u-hide--small">
             <h4 class="is-dense">
-              <a href="https://snapcraft.io/">Publish apps&nbsp;&rsaquo;</a>
+              <a href="https://snapcraft.io">Publish apps&nbsp;&rsaquo;</a>
             </h4>
             <p class="p-p--small">Deliver your app to millions of Ubuntu users, servers and devices.</p>
           </div>
           <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
-              <a href="https://snapcraft.io/">Publish apps&nbsp;&rsaquo;</a>
+              <a href="https://snapcraft.io">Publish apps&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item"><a href="https://snapcraft.io/store">Browse the snap store</a></li>
             <li class="p-list__item"><a href="https://docs.snapcraft.io/core/usage">The snap command line interface</a></li>
-            <li class="p-list__item"><a href="https://build.snapcraft.io/">Auto-build service for snaps</a></li>
-            <li class="p-list__item"><a href="https://docs.snapcraft.io/">Snap documentation</a></li>
+            <li class="p-list__item"><a href="https://build.snapcraft.io">Auto-build service for snaps</a></li>
+            <li class="p-list__item"><a href="https://docs.snapcraft.io">Snap documentation</a></li>
             <li class="p-list__item"><a href="https://docs.snapcraft.io/reference/channels">Snap channels - track/risk/branch</a></li>
-            <!--<li class="p-list__item">Cross-distro testing of snaps</li>
-            <li class="p-list__item">Rigorous snap security model</li>
-            <li class="p-list__item">Integration between snaps</li>-->
           </ul>
-          <p><a class="p-button--positive p-button--small" href="https://snapcraft.io/">Publish with Snapcraft</a></p>
+          <p><a class="p-button--positive p-button--small" href="https://snapcraft.io">Publish with Snapcraft</a></p>
         </div>
         <div class="col-medium-2 col-3 p-card--navigation">
           <div class="u-hide--small">
@@ -57,12 +48,12 @@
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item"><a href="/public-cloud">Ubuntu images on public clouds</a></li>
             <li class="p-list__item"><a href="/blog/minimal-ubuntu-released">Minimal Ubuntu for containers</a></li>
-            <li class="p-list__item"><a href="https://cloud-init.io/">Cloud-init - customise cloud instances</a></li>
-            <li class="p-list__item"><a href="https://jaas.ai/">Juju for standardised operations</a></li>
+            <li class="p-list__item"><a href="https://cloud-init.io">Cloud-init - customise cloud instances</a></li>
+            <li class="p-list__item"><a href="https://jaas.ai">Juju for standardised operations</a></li>
             <li class="p-list__item"><a href="/kubernetes">Charmed Kubernetes</a></li>
-            <li class="p-list__item"><a href="https://microk8s.io/">MicroK8s - single node k8s for devs</a></li>
-            <li class="p-list__item"><a href="https://maas.io/">MAAS - fast server provisioning</a></li>
-            <li class="p-list__item"><a href="https://multipass.run/">Multipass - Ubuntu on macOS</a></li>
+            <li class="p-list__item"><a href="https://microk8s.io">MicroK8s - single node k8s for devs</a></li>
+            <li class="p-list__item"><a href="https://maas.io">MAAS - fast server provisioning</a></li>
+            <li class="p-list__item"><a href="https://multipass.run">Multipass - Ubuntu on macOS</a></li>
           </ul>
         </div>
         <div class="col-medium-2 col-3 p-card--navigation">
@@ -108,11 +99,11 @@
         </div>
         <div class="col-3">
           <h4 class="p-muted-heading">
-            <a href="https://jujucharms.com/store">Cloud packages&nbsp;&rsaquo;</a>
+            <a href="https://charmhub.io">Cloud packages&nbsp;&rsaquo;</a>
           </h4>
           <div>
             <p class="p-p--small">A standard way to deploy and operate cloud software like Hadoop, Spark, OpenStack and Kubernetes.</p>
-            <p><a class="p-button--positive p-button--small" href="https://jujucharms.com/">Discover Charm Packages</a></p>
+            <p><a class="p-button--positive p-button--small" href="https://charmhub.io">Discover Charm Packages</a></p>
           </div>
         </div>
         <div class="col-3">
@@ -122,15 +113,15 @@
           <div>
             <ul class="p-text-list--small is-bordered">
               <li class="p-list__item"><a href="/kubernetes">Kubernetes on Ubuntu</a></li>
-              <li class="p-list__item"><a href="https://microk8s.io/">Install K8s &ndash; workstations</a></li>
+              <li class="p-list__item"><a href="https://microk8s.io">Install K8s &ndash; workstations</a></li>
               <li class="p-list__item"><a href="/kubernetes/install">Install K8s &ndash; clouds and clusters</a></li>
-              <li class="p-list__item"><a href="https://linuxcontainers.org/">Run pre-K8s apps in LXD containers</a></li>
+              <li class="p-list__item"><a href="https://linuxcontainers.org">Run pre-K8s apps in LXD containers</a></li>
               <!-- <li class="p-list__item">Test CentOS apps on Ubuntu with LXD</li>-->
             </ul>
           </div>
         </div>
         <div class="col-3">
-          <h4 class="p-muted-heading"><a href="/tutorials/">Tutorials&nbsp;&rsaquo;</a></h4>
+          <h4 class="p-muted-heading"><a href="/tutorials">Tutorials&nbsp;&rsaquo;</a></h4>
           <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">
@@ -147,18 +138,12 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
-          <li class="p-inline-list__item">
-            <a href="/download/desktop">Ubuntu Desktop</a></li>
-          <li class="p-inline-list__item">
-            <a href="/download/server">Ubuntu Server</a></li>
-          <li class="p-inline-list__item">
-            <a href="/download/iot">IoT</a></li>
-          <li class="p-inline-list__item">
-            <a href="/download/cloud">Cloud</a></li>
-          <li class="p-inline-list__item">
-            <a href="/download/alternative-downloads">Alternative downloads</a></li>
-          <li class="p-inline-list__item">
-            <a href="/download/flavours">Flavours</a></li>
+          <li class="p-inline-list__item"><a href="/download/desktop">Ubuntu Desktop</a></li>
+          <li class="p-inline-list__item"><a href="/download/server">Ubuntu Server</a></li>
+          <li class="p-inline-list__item"><a href="/download/iot">IoT</a></li>
+          <li class="p-inline-list__item"><a href="/download/cloud">Cloud</a></li>
+          <li class="p-inline-list__item"><a href="/download/alternative-downloads">Alternative downloads</a></li>
+          <li class="p-inline-list__item"><a href="/download/flavours">Flavours</a></li>
         </ul>
       </div>
     </div>
@@ -169,20 +154,13 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
-          <li class="p-inline-list__item">
-            <a href="https://docs.ubuntu.com/">Docs</a></li>
-          <li class="p-inline-list__item">
-            <a href="https://ubuntuforums.org/">Forum</a></li>
-          <li class="p-inline-list__item">
-            <a href="/tutorials/">Tutorials</a></li>
-          <li class="p-inline-list__item">
-            <a href="https://www.youtube.com/user/celebrateubuntu">Videos</a></li>
-          <li class="p-inline-list__item">
-            <a href="https://www.brighttalk.com/search?q=Canonical">Webinars</a></li>
-          <li class="p-inline-list__item">
-            <a href="/blog?category=white-papers#posts-list">Whitepapers</a></li>
-          <li class="p-inline-list__item">
-            <a href="/blog">Blog</a></li>
+          <li class="p-inline-list__item"><a href="https://docs.ubuntu.com">Docs</a></li>
+          <li class="p-inline-list__item"><a href="https://ubuntuforums.org">Forum</a></li>
+          <li class="p-inline-list__item"><a href="/tutorials">Tutorials</a></li>
+          <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Videos</a></li>
+          <li class="p-inline-list__item"><a href="https://www.brighttalk.com/search?q=Canonical">Webinars</a></li>
+          <li class="p-inline-list__item"><a href="/blog?category=white-papers#posts-list">Whitepapers</a></li>
+          <li class="p-inline-list__item"><a href="/blog">Blog</a></li>
         </ul>
       </div>
     </div>
@@ -193,16 +171,11 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
-          <li class="p-inline-list__item">
-            <a href="https://docs.ubuntu.com/">Read the docs</a></li>
-          <li class="p-inline-list__item">
-            <a href="https://askubuntu.com/">Ask Ubuntu</a></li>
-          <li class="p-inline-list__item">
-            <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC Channels</a></li>
-          <li class="p-inline-list__item">
-            <a href="https://help.ubuntu.com/community/CommunityHelpWiki">Help</a></li>
-          <li class="p-inline-list__item">
-            <a href="/support">Commercial Support</a></li>
+          <li class="p-inline-list__item"><a href="https://docs.ubuntu.com">Read the docs</a></li>
+          <li class="p-inline-list__item"><a href="https://askubuntu.com">Ask Ubuntu</a></li>
+          <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC Channels</a></li>
+          <li class="p-inline-list__item"><a href="https://help.ubuntu.com/community/CommunityHelpWiki">Help</a></li>
+          <li class="p-inline-list__item"><a href="/support">Commercial Support</a></li>
         </ul>
       </div>
     </div>
@@ -213,17 +186,11 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
-          <li class="p-inline-list__item">
-            <a href="/security">Security</a></li>
-          <li class="p-inline-list__item">
-            <a href="/security/certifications">Certifications</a></li>
-          <li class="p-inline-list__item">
-            <a href="/security/notices">Notices</a></li>
-          <!-- Hidden for soft launch -->
-          <!-- <li class="p-inline-list__item">
-            <a href="/security/cve">CVEs</a></li> -->
-          <li class="p-inline-list__item">
-            <a href="/esm">Extended Security Maintenance</a></li>
+          <li class="p-inline-list__item"><a href="/security">Security</a></li>
+          <li class="p-inline-list__item"><a href="/security/certifications">Certifications</a></li>
+          <li class="p-inline-list__item"><a href="/security/notices">Notices</a></li>
+          <li class="p-inline-list__item"><a href="/security/cve">CVEs</a></li>
+          <li class="p-inline-list__item"><a href="/esm">Extended Security Maintenance</a></li>
         </ul>
       </div>
     </div>
@@ -235,16 +202,11 @@
         </div>
         <div class="col-9">
           <ul class="p-inline-list--middot is-x-dense">
-            <li class="p-inline-list__item">
-              <a href="https://cloud-init.io/">cloud-init</a></li>
-            <li class="p-inline-list__item">
-              <a href="https://jujucharms.com/">Juju</a></li>
-            <li class="p-inline-list__item">
-              <a href="https://snapcraft.io/">Snapcraft</a></li>
-            <li class="p-inline-list__item">
-              <a href="http://linuxcontainers.org/">LXD</a></li>
-            <li class="p-inline-list__item">
-              <a href="https://multipass.run/">Multipass</a></li>
+            <li class="p-inline-list__item"><a href="https://cloud-init.io">cloud-init</a></li>
+            <li class="p-inline-list__item"><a href="https://charmhub.io">Juju</a></li>
+            <li class="p-inline-list__item"><a href="https://snapcraft.io">Snapcraft</a></li>
+            <li class="p-inline-list__item"><a href="http://linuxcontainers.org">LXD</a></li>
+            <li class="p-inline-list__item"><a href="https://multipass.run">Multipass</a></li>
           </ul>
         </div>
       </div>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -119,6 +119,7 @@
             <li class="p-list__item"><a href="/certified">Hardware certification</a></li>
             <li class="p-list__item"><a href="/aws">Get Ubuntu Pro on AWS</a></li>
             <li class="p-list__item"><a href="/azure">Get Ubuntu Pro on Azure</a></li>
+            <li class="p-list__item"><a href="/cube">Become a Certified Ubuntu Engineer</a></li>
           </ul>
         </div>
       </div>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -25,8 +25,8 @@
             <li class="p-list__item"><a href="/openstack/features">OpenStack features</a></li>
             <li class="p-list__item"><a href="/engage/vmware-to-openstack">Migrate from VMware</a></li>
             <li class="p-list__item"><a href="/telco">NFVi and Edge solutions</a></li>
-            <li class="p-list__item"><a href="https://microstack.run/" title="Visit Microstack.run - external site">Multi-node OpenStack for workstations and edge / IoT</a></li>
-            <li class="p-list__item"><a href="https://charmed-osm.com/" title="Visit charmed-osm.com - external site">NFV Management and Orchestration (MANO)</a></li>
+            <li class="p-list__item"><a href="https://microstack.run" title="Visit Microstack.run - external site">Multi-node OpenStack for workstations and edge / IoT</a></li>
+            <li class="p-list__item"><a href="https://charmed-osm.com" title="Visit charmed-osm.com - external site">NFV Management and Orchestration (MANO)</a></li>
             <li class="p-list__item"><a href="/training">OpenStack training</a></li>
             <li class="p-list__item"><a href="/pricing/infra">Support and pricing</a></li>
             <li class="p-list__item"><a href="/openstack/tco-calculator">TCO calculator</a></li>
@@ -111,7 +111,7 @@
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/livepatch">Livepatch security updates</a></li>
             <li class="p-list__item"><a href="/esm">Extended Security Maintenance</a></li>
-            <li class="p-list__item"><a href="https://landscape.canonical.com/">Landscape remote management</a></li>
+            <li class="p-list__item"><a href="https://landscape.canonical.com">Landscape remote management</a></li>
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/managed">Managed Apps</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>
@@ -140,7 +140,7 @@
         <h4 class="p-muted-heading"><a href="/containers" title="Visit the containers pages">Containers&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="/kubernetes">Install and operate Kubernetes</a></li>
-          <li class="p-list__item"><a href="https://linuxcontainers.org/" title="Visit the LXD website - external site">Run legacy apps in LXD containers</a></li>
+          <li class="p-list__item"><a href="https://linuxcontainers.org" title="Visit the LXD website - external site">Run legacy apps in LXD containers</a></li>
         </ul>
       </div>
       <!-- Data centre -->
@@ -152,7 +152,7 @@
           <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
           <li class="p-list__item"><a href="/certified/server" title="Visit certification - external site">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>
-          <li class="p-list__item"><a href="https://anbox-cloud.io/" title="Visit Anbox Cloud">Anbox Cloud - Android in the cloud</a></li>
+          <li class="p-list__item"><a href="https://anbox-cloud.io" title="Visit Anbox Cloud">Anbox Cloud - Android in the cloud</a></li>
         </ul>
       </div>
       <!-- AI and ML -->
@@ -202,7 +202,7 @@
           <li class="p-inline-list__item"><a href="/openstack/managed">OpenStack</a></li>
           <li class="p-inline-list__item"><a href="/kubernetes/managed">Kubernetes</a></li>
           <li class="p-inline-list__item"><a href="/managed-apps">Managed apps</a></li>
-          <li class="p-inline-list__item"><a href="https://anbox-cloud.io/" title="Visit Anbox Cloud">Anbox Cloud</a></li>
+          <li class="p-inline-list__item"><a href="https://anbox-cloud.io" title="Visit Anbox Cloud">Anbox Cloud</a></li>
           <li class="p-inline-list__item"><a href="/core/smartstart">Smart Start for IoT</a></li>
         </ul>
       </div>
@@ -215,7 +215,7 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/blog?category=webinars#posts-list">Webinars</a></li>
-          <li class="p-inline-list__item"><a href="/tutorials/" title="Visit the Tutorials - external site">Tutorials</a></li>
+          <li class="p-inline-list__item"><a href="/tutorials" title="Visit the Tutorials - external site">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
           <li class="p-inline-list__item"><a href="/blog?category=case-studies#posts-list">Case studies</a></li>
           <li class="p-inline-list__item"><a href="/blog?category=white-papers#posts-list">White papers</a></li>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -215,7 +215,7 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/blog?category=webinars#posts-list">Webinars</a></li>
-          <li class="p-inline-list__item"><a href="/tutorials" title="Visit the Tutorials - external site">Tutorials</a></li>
+          <li class="p-inline-list__item"><a href="/tutorials" title="Visit our tutorials">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
           <li class="p-inline-list__item"><a href="/blog?category=case-studies#posts-list">Case studies</a></li>
           <li class="p-inline-list__item"><a href="/blog?category=white-papers#posts-list">White papers</a></li>


### PR DESCRIPTION
## Done

- Added 'Become a Certified Ubunut Engineer' links on the Enterprise and Developer menu
- Removed all the extra '>' on the Developer menu
- Removed all the non-link list items as a test... need to remove the comments later

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/#enterprise http://0.0.0.0:8001/#developer
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the copy docs [enterprise](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit?disco=AAAANcZBZ5M&ts=60edf8d8&usp_dm=true) and [developer](https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit?disco=AAAANCbL7X8&ts=60edf89f&usp_dm=true)

## Issue / Card

Fixes #10023
