### PR TITLE
Copyupdate-4228

### DIFF
--- a/templates/security/cc.html
+++ b/templates/security/cc.html
@@ -11,11 +11,11 @@
 <section class="p-strip--suru-topped">
   <div class="row u-equal-height">
     <div class="col-8">
-      <h1 class="u-sv3">Common Criteria</h1>
-      <p class="p-heading--four u-sv3">Deploy regulated and high security workloads on Ubuntu</p>
-      <p>Developing and deploying open source workloads on regulated and high security environments can be challenging. There is a plethora of open source software following diverse development methods, and standards, but not always targeting a particular data protection standard. Canonical ensures that <a href="/public-cloud">Ubuntu Pro</a> and <a href="/advantage">Ubuntu Advantage</a> provide access to the necessary artifacts to comply with Common Criteria, an international (ISO/IEC 15408) computer security certification.</p>
+      <span class="u-sv3"><h1>Common Criteria</h1></span>
+      <span class="u-sv3"><p class="p-heading--four">Run high security workloads on the certified configuration of Ubuntu</p></span>
+      <p>Developing and deploying open source workloads on regulated and high security environments requires rigid certifications. <a href="/public-cloud">Ubuntu Pro</a> and <a href="/advantage">Ubuntu Advantage</a> provide access to the necessary artifacts to comply with Common Criteria, an international (ISO/IEC 15408) computer security certification for high security environments.</p>
       <p>
-        <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get the Common Criteria certified Ubuntu</a>
+        <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
       </p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
@@ -46,7 +46,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Where is Common Criteria accepted?</h2>
-      <p>Internationally a Common Criteria certification is accepted by members of the <a href="https://www.commoncriteriaportal.org/ccra/members/" class="p-link--external">CCRA</a> agreement and the EU <a href="https://www.sogis.eu/" class="p-link--external">SOGIS</a> members.</p>
+      <p>Internationally a Common Criteria certification is accepted by members of the <a href="https://www.commoncriteriaportal.org/ccra/members/" class="p-link--external">CCRA</a> agreement and the EU <a href="https://www.sogis.eu/" class="p-link--external">SOGIS</a> members. </p>
     </div>
   </div>
   <div class="u-fixed-width">
@@ -55,7 +55,7 @@
   <div class="row">
     <div class="col-8">
       <h2>What gets certified in Ubuntu under Common Criteria?</h2>
-      <p>Ubuntu 18.04 LTS and 16.04 LTS have both been evaluated to assurance level EAL2 through <a href="http://www.fmv.se/en/Our-activities/CSEC---The-Swedish-Certification-Body-for-IT-Security/" class="p-link--external">CSEC – The Swedish Certification Body for IT Security</a>. The evaluation testing was performed by atsec Information Security.  The following table provides a summary of the releases and platforms that have been certified.</p>
+      <p>Ubuntu 18.04 LTS and 16.04 LTS have both been evaluated to assurance level EAL2 through <a href="http://www.fmv.se/en/Our-activities/CSEC---The-Swedish-Certification-Body-for-IT-Security/" class="p-link--external">CSEC – The Swedish Certification Body for IT Security</a>. The evaluation testing was performed by atsec Information Security. The following table provides a summary of the releases and platforms that have been certified.</p>
     </div>
     <div class="col-4">
       {{ image (
@@ -87,7 +87,7 @@
           <td>Ubuntu 16.04 LTS</td>
           <td>x86_64, IBM Power8 and IBM Z</td>
           <td><a class="p-link--external" href="https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20Ubuntu%20LTS%2016.04.4.pdf">16.04.4</a></td>
-          <td><a class="p-link--external" href="https://security-certs.docs.ubuntu.com/en/cc">Installation instructions</a></td>
+          <td><a href="/security/certifications/docs/cc">Installation instructions</a></td>
         </tr>
       </t-body>
       <t-body>
@@ -95,12 +95,12 @@
           <td>Ubuntu 18.04 LTS</td>
           <td>x86_64 and IBM Z</td>
           <td><a class="p-link--external" href="https://www.commoncriteriaportal.org/files/epfiles/Certification%20Report%20-%20Canonical%20Ubuntu%20Server%2018.04%20LTS.pdf">18.04.4</a></td>
-          <td><a class="p-link--external" href="https://security-certs.docs.ubuntu.com/en/cc">Installation instructions</a></td>
+          <td><a href="/security/certifications/docs/cc">Installation instructions</a></td>
         </tr>
       </t-body>
     </table>
     <p>
-      <a class="p-button--positive js-invoke-modal" href="/support/get-in-touch">Contact us</a>
+      <a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updates copy on /security/cc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cc
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare https://ubuntu-com-10027.demos.haus/security/cc against [copy-doc](https://docs.google.com/document/d/1JLnHR9Xuuc1t6ojrnBuMWir5XABgf1L7WVpGGtlLaBo/edit#)
- I have set the links to the form to /security/contact-us as the links provided in the copy didn't make sense.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4228
