### PR TITLE
Fix KeyError on cube_study_labs_button view

### DIFF
--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -174,10 +174,10 @@ def cube_study_labs_button():
     text = "Purchase study labs access"
     redirect_url = "/cube/microcerts"
 
-    if CUBE_CONTENT["prepare-course"] in enrollments:
+    if CUBE_CONTENT["study-labs"] in enrollments:
         text = "Access study labs"
         prepare_materials_path = quote_plus(
-            f"/courses/{CUBE_CONTENT['prepare-course']}/course/"
+            f"/courses/{CUBE_CONTENT['study-labs']}/course/"
         )
         redirect_url = (
             f"{edx_api.base_url}/auth/login/tpa-saml/"


### PR DESCRIPTION
The key that holds the study labs course ID was updated on the YAML config file so we need to update the view to get the right key.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to `/cube/study` and make sure you get a button rather than an error message.


## Issue / Card

Fixes #10031 
