### PR TITLE
Don't show the modal for prepopulated free trial

### DIFF
--- a/static/js/src/advantage/subscribe/reducers/ui-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/ui-reducer.js
@@ -1,8 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { loadState } from "../../../utils/persitState";
 
-const params = new URLSearchParams(window.location.search);
-
 const initialUIState = {
   otherVersionsModal: {
     show: false,
@@ -14,9 +12,7 @@ const initialUIState = {
 
 const UISlice = createSlice({
   name: "ui",
-  initialState: params.has("free_trial")
-    ? { ...initialUIState, purchaseModal: { show: true } }
-    : loadState("ua-subscribe-state", "ui", initialUIState),
+  initialState: loadState("ua-subscribe-state", "ui", initialUIState),
   reducers: {
     toggleOtherVersionsModal(state) {
       state.otherVersionsModal.show = !state.otherVersionsModal.show;


### PR DESCRIPTION
## Done

- Stopped auto-opening the modal when a user lands on /subscribe after having clicked the free trial button
## QA

- go to /advantage (logged out)
- click Try ESM Apps free
- See that you land on / subscribe with Physical Apps and essential pre-selected but the modal is closed


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/75

