### PR TITLE
Move label to the right of the select period select

### DIFF
--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -15,6 +15,7 @@
       > .p-label {
         align-self: center;
         margin-top: 0.5rem;
+        margin-left: 0.5rem;
       }
 
       @media (min-width: $breakpoint-x-small) {
@@ -23,7 +24,9 @@
           margin-left: 2.5rem;
         }
         > .p-label {
-          margin-top: 0;
+          align-self: flex-start;
+          margin-top: calc(0.4rem - 1px);
+          margin-left: 1rem;
         }
       }
 

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -17,6 +17,9 @@
         margin-left: 0.5rem;
         margin-top: 0.5rem;
       }
+      select {
+        margin-top: 0.5rem;
+      }
 
       @media (min-width: $breakpoint-x-small) {
         flex-wrap: nowrap;
@@ -27,6 +30,9 @@
           align-self: flex-start;
           margin-left: 1rem;
           margin-top: calc(0.4rem - 1px);
+        }
+        select {
+          margin-top: 0rem;
         }
       }
 

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -32,7 +32,7 @@
           margin-top: calc(0.4rem - 1px);
         }
         select {
-          margin-top: 0rem;
+          margin-top: 0;
         }
       }
 

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -14,8 +14,8 @@
 
       > .p-label {
         align-self: center;
-        margin-top: 0.5rem;
         margin-left: 0.5rem;
+        margin-top: 0.5rem;
       }
 
       @media (min-width: $breakpoint-x-small) {
@@ -25,8 +25,8 @@
         }
         > .p-label {
           align-self: flex-start;
-          margin-top: calc(0.4rem - 1px);
           margin-left: 1rem;
+          margin-top: calc(0.4rem - 1px);
         }
       }
 

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -75,7 +75,6 @@
         <span id="summary-plan-quantity">1x</span>
         <img id="summary-plan-image" src="${imageURL}" />
         <span id="summary-plan-name"></span>
-        <div id="summary-free-trial-label" class="p-label">1 month free trial</div>
         <div class="js-summary-billing">
           <select
             name="billing-period"
@@ -91,6 +90,7 @@
             <strong>Switch to annual billing and save over 15%</strong>
           </p>
         </div>
+        <div id="summary-free-trial-label" class="p-label">1 month free trial</div>
       </div>
       <div class="col-4 p-shop-cart__buy">
         <span>


### PR DESCRIPTION
## Done

- Move label to the right of the period select
- tweak spacing

## QA

- Go to /advantage/subscribe and play with different free trials options
- or check screenshots


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/76

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/125766451-a8ba811a-05f7-48ff-8953-8af99793dc0e.png)
![image](https://user-images.githubusercontent.com/11927929/125766487-7f84ba07-1b13-4b38-9609-06dd2bac9db7.png)
![image](https://user-images.githubusercontent.com/11927929/125766538-7edff6ac-5c9f-4e8f-9d0e-692d0e0734bd.png)
![image](https://user-images.githubusercontent.com/11927929/125766558-5b4fb80a-f316-4289-ac75-5385a41244b5.png)
![image](https://user-images.githubusercontent.com/11927929/125766603-a7c6003f-bd59-465c-9f8f-38a72211043d.png)
![image](https://user-images.githubusercontent.com/11927929/125766686-eeec6ea7-61a2-4d80-b964-5d1a20d98423.png)

