### PR TITLE
/security/certifications copyupdate

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -206,7 +206,7 @@
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://www.ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -10,10 +10,10 @@
 <section class="p-strip--suru-topped">
  <div class="row u-equal-height u-vertically-center">
    <div class="col-8">
-     <h1>Security Certifications</h1>
-     <h2 class="p-heading--3">Deploy regulated and high security workloads</h2>
-     <p>Regulated and high security environments have complex requirements as they are designed to tackle many threats, known and unknown. Whatever path you have chosen in navigating compliance with a cybersecurity framework, such as the ones defined by ISO 27000, NIST, PCI or CIS Controls, Canonical provides you with a secure and easy to use operating system, that enables your compliance and reduces operational risk, whether on-premise or on a public cloud. We, at Canonical, are transparent on the security features we enable, provide access and automation to Industry accepted hardening and compliance profiles, such as CIS and DISA-STIG as well as present 3rd party attestation and certifications like FIPS 140-2 and Common Criteria.</p>
-     <p><a class="p-button--positive js-invoke-modal" href="/support/contact-us">Contact us</a></p>
+     <h1>Security Certifications & Hardening</h1>
+     <h2 class="p-heading--3">Run regulated and high security workloads on Ubuntu</h2>
+     <p>Whatever cybersecurity framework you have chosen, including ISO 27000, NIST, PCI or CIS Controls, <a href="/public-cloud">Ubuntu Pro</a> and <a href="/advantage">Ubuntu Advantage</a> enable your compliance and reduce your operational risk. Access automation for hardening and compliance profiles, such as CIS and DISA-STIG as well as the FIPS 140-2 and Common Criteria certifications.</p>
+     <p><a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a></p>
    </div>
    <div class="col-4 u-hide--small u-align--center">
      {{
@@ -35,33 +35,43 @@
  <div class="row p-divider">
    <div class="col-4 p-divider__block">
      <h3>Comply with established security baselines</h3>
-     <p>The default configuration of Ubuntu balances between usability and security. However, systems carrying dedicated workloads can be further hardened to reduce their attack surface. We work with DISA to ensure STIG guides available for Ubuntu, and we provide OpenSCAP tooling and automation for the Industry accepted CIS benchmark. Available with <a href="/advantage">Ubuntu Advantage</a> and <a href="/public-cloud">Ubuntu Pro</a>.</p>
+     <p>The default configuration of Ubuntu balances usability and security. However, systems carrying dedicated workloads can be further hardened to reduce their attack surface. Canonical works with DISA to ensure STIG guides are available for Ubuntu, and we provide OpenSCAP tooling and automation for the Industry accepted CIS benchmark. Available with <a href="/advantage">Ubuntu Advantage</a> and <a href="/public-cloud">Ubuntu Pro</a>.</p>
      <a class="p-button--neutral" href="#compliance-profiles">See our compliance profiles</a>
    </div>
    <div class="col-4 p-divider__block">
-     <h3>Transparency</h3>
-     <p>Canonical is transparent on the Security Features we enable on Ubuntu. We have a <a href="/security/notices">public vulnerability disclosure policy</a> and known vulnerabilities are disclosed in <a href="/security/oval">Machine readable OVAL</a> CVE output to be used by OpenSCAP and other 3rd party tools.</p>
+     <h3>Know your defenses</h3>
+     <p>Each Ubuntu release enables state of the art protection against vulnerability exploitation and malware and we <a class="p-link--external" href="https://wiki.ubuntu.com/Security/Features">publicly detail our choices</a>. Canonical has a <a href="/security/notices">public vulnerability disclosure policy</a> and vulnerabilities are not only fixed with automated security updates and <a href="/security/livepatch">livepatches</a> but also publicly disclosed with our <a href="/security/notices">security notices</a>. We further provide <a href="/security/oval">machine readable OVAL</a> CVE output to be used by OpenSCAP and other 3rd party vulnerability management tools.</p>
      <a class="p-button--neutral p-link--external" href="https://wiki.ubuntu.com/Security/Features">See our security features</a>
    </div>
    <div class="col-4 p-divider__block">
-     <h3>Security certification and 3rd party attestation</h3>
+     <h3>Access certifications for high security environments</h3>
      <p>Access to certification artifacts as well as the necessary tooling for regulated and high security environments. <a href="/advantage">Ubuntu Advantage</a> and <a href="/public-cloud">Ubuntu Pro</a> provide access to FIPS 140-2 certified cryptographic packages, allowing you to deploy workloads that need to operate under compliance regimes like FedRAMP, HIPAA, and PCI-DSS. Additionally, Ubuntu versions have been certified under Common Criteria, providing 3rd party attestation of the security mechanisms in the operating system.</p>
      <a class="p-button--neutral" href="#security-certifications">See our certifications</a>
    </div>
  </div>
 </section>
 
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2>FIPS certification and CIS compliance with Ubuntu</h2>
+      <p>Learn about Ubuntu CIS and FIPS certified components to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered in our upcoming webinar to ensure you and your team are, and remain, compliant.</p>
+      <p><a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip" id="compliance-profiles">
  <div class="u-fixed-width">
-   <h2>Ubuntu compliance profiles</h2>
-   <p class="u-sv2">The default configuration of Ubuntu LTS releases, as provided by Canonical, balances between usability, performance and security. However, non general purpose systems can be further hardened to reduce their attack surface. Reducing the attack surface is often part of the compliance with the organization’s cybersecurity framework, but is also a widely accepted security best practice. We recommend using the industry accepted benchmarks below. Click on each benchmark for more detailed information.</p>
+   <h2>Ubuntu compliance & hardening profiles</h2>
+   <p class="u-sv2">The default configuration of Ubuntu LTS releases, balances between usability, performance and security. However, non general purpose systems can be further hardened to reduce their attack surface. Reducing the attack surface is often part of the compliance with the organization’s cybersecurity framework, but is also a widely accepted security best practice. We recommend using the industry accepted benchmarks below. Click on each benchmark for more detailed information.</p>
    <table class="p-table--compliance-profiles">
      <thead>
        <th class="u-hide--small"></th>
        <th></th>
-       <th class="u-align--center">Ubuntu 16.04</th>
-       <th class="u-align--center">Ubuntu 18.04</th>
-       <th class="u-align--center">Ubuntu 20.04</th>
+       <th class="u-align--center">Ubuntu 16.04 LTS</th>
+       <th class="u-align--center">Ubuntu 18.04 LTS</th>
+       <th class="u-align--center">Ubuntu 20.04 LTS</th>
      </thead>
      <tbody>
        <tr>
@@ -107,15 +117,15 @@
    </table>
    <ul class="p-inline-list" aria-label="key">
      <li class="p-inline-list__item">
-      <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="Yes: Tooling and automation" style="height: 14px; vertical-align: middle; width: 14px;">
-       <small>Tooling & automation</small>
+       <i class="p-icon--success">Yes</i>
+       <small>Certified tooling & automation</small>
      </li>
      <li class="p-inline-list__item">
        <img src="https://assets.ubuntu.com/v1/2ccda8d7-tick-orange.svg" alt="Yes: STIG content" style="height: 14px; vertical-align: middle; width: 14px;">
-       <small> STIG content</small>
+       <small> STIG guide</small>
      </li>
    </ul>
-   <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+   <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
  </div>
 </section>
 
@@ -126,9 +136,9 @@
    <table class="p-table--security-certifications">
      <thead>
        <th></th>
-       <th class="u-align--center">16.04</th>
-       <th class="u-align--center">18.04</th>
-       <th class="u-align--center">20.04</th>
+       <th class="u-align--center">Ubuntu 16.04 LTS</th>
+       <th class="u-align--center">Ubuntu 18.04 LTS</th>
+       <th class="u-align--center">Ubuntu 20.04 LTS</th>
      </thead>
      <tbody>
        <tr>
@@ -139,26 +149,16 @@
            <div class="u-sv2">
              <i class="p-icon--success u-sv2">Yes: Tooling and automation</i>
            </div>
+         </td>
+         <td class="u-align--center">
            <div class="u-sv2">
-             <img src="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg" style="height: 32px; width: 53px;" alt="AWS logo">
-           </div>
-           <div class="u-sv2">
-             <img src="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg" style="height: 30px; width: 104px;" alt="Microsoft Azure logo">
+             <i class="p-icon--success">Yes: Tooling and automation</i>
            </div>
          </td>
          <td class="u-align--center">
            <div class="u-sv2">
              <i class="p-icon--success">Yes: Tooling and automation</i>
            </div>
-           <div class="u-sv2">
-             <img src="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg" style="height: 32px; width: 53px;" alt="AWS logo">
-           </div>
-           <div class="u-sv2">
-             <img src="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg" style="height: 30px; width: 104px;" alt="Microsoft Azure logo">
-           </div>
-         </td>
-         <td class="u-align--center">
-           <small><em>Under<br>validation</em></small>
          </td>
        </tr>
        <tr>
@@ -178,7 +178,7 @@
        <small>Tooling & automation</small>
      </li>
    </ul>
-   <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+   <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
  </div>
 </section>
 
@@ -190,7 +190,7 @@
    <h3>How do I comply with PCI-DSS?</h3>
    <p>PCI-DSS is a payment industry standard and any company that stores, processes or transmits payment card or cardholder information is required to comply with it. The standard is defined by the Payment Card Industry council and defines measures and processes to secure online financial transactions. The standard is about making business as usual processes like monitoring of security controls, timely response, review of environmental and organizational changes, as well as review of hardware and software being under support by its vendors. For companies with large volumes of transactions compliance with the standard is enforced by an audit of a Qualified Security Assessor (QSA).</p>
    <p>Achieving and maintaining compliance is a complex and costly process that involves business processes in addition to software requirements. Ubuntu by Canonical contains software and security controls, such as disk encryption, password settings configuration, <a href="/security/fips">cryptographic compliance with FIPS140-2</a>, CIS hardening as well as <a href="/advantage">a comprehensive Enterprise software maintenance program</a>, to achieve and maintain compliance with the standard.</p>
-   <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+   <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
  </div>
 </section>
 

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -40,7 +40,7 @@
    </div>
    <div class="col-4 p-divider__block">
      <h3>Know your defenses</h3>
-     <p>Each Ubuntu release enables state of the art protection against vulnerability exploitation and malware and we <a class="p-link--external" href="https://wiki.ubuntu.com/Security/Features">publicly detail our choices</a>. Canonical has a <a href="/security/notices">public vulnerability disclosure policy</a> and vulnerabilities are not only fixed with automated security updates and <a href="/security/livepatch">livepatches</a> but also publicly disclosed with our <a href="/security/notices">security notices</a>. We further provide <a href="/security/oval">machine readable OVAL</a> CVE output to be used by OpenSCAP and other 3rd party vulnerability management tools.</p>
+     <p>Each Ubuntu release enables state of the art protection against vulnerability exploitation and malware and we <a class="p-link--external" href="https://wiki.ubuntu.com/Security/Features">publicly detail our choices</a>. Canonical has a <a href="/security/disclosure-policy">public vulnerability disclosure policy</a> and vulnerabilities are not only fixed with automated security updates and <a href="/security/livepatch">livepatches</a> but also publicly disclosed with our <a href="/security/notices">security notices</a>. We further provide <a href="/security/oval">machine readable OVAL</a> CVE output to be used by OpenSCAP and other 3rd party vulnerability management tools.</p>
      <a class="p-button--neutral p-link--external" href="https://wiki.ubuntu.com/Security/Features">See our security features</a>
    </div>
    <div class="col-4 p-divider__block">
@@ -57,6 +57,14 @@
       <h2>FIPS certification and CIS compliance with Ubuntu</h2>
       <p>Learn about Ubuntu CIS and FIPS certified components to enable operating under compliance regimes like FedRAMP, HIPAA, PCI and ISO. Get all of your compliance questions answered in our upcoming webinar to ensure you and your team are, and remain, compliant.</p>
       <p><a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a></p>
+    </div>
+    <div class="col-6 u-hide--small u-align--center">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
+        <script class="jsBrightTALKEmbedConfig" type="application/json">
+          { "channelId" : 6793, "language": "en-US", "commId" : 432536, "displayMode" : "standalone", "height" : "250" }
+        </script>
+        <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -183,7 +183,7 @@
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3725">#3725</a>
           </td>
           <td>
-            <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3622">#3622</a>
+            <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3980">#3980</a>
           </td>
           <td>
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3966">#3966</a>
@@ -222,7 +222,7 @@
   <div class="u-fixed-width">
     <h2>Canonical patches vulnerabilities</h2>
     <p>Each FIPS 140 certificate is valid for 5 years, however vulnerabilities happen, and it is our intention to publish fixed packages quickly, irrespective of their certification status. We therefore provide two alternative options. An option to remain with the certified cryptographic packages (called the 'fips' option), and an option to use the certified packages but include security fixes (called the 'fips-updates' option) when available. Check <a class="p-link--external" href="https://security-certs.docs.ubuntu.com/en/fips">our security pages on how to enable these options</a>.</p>
-    <p>We recommend enabling the 'fips-updates' option that includes the security fixes. Our cloud images starting with 20.04 are pre-configured to enable security updates. The packages from 'fips-updates' option are updated to include high and critical security fixes during the whole product lifecycle including the <a href="/security/esm">Extended Security Maintenance phase</a>.</p>
+    <p>We recommend enabling the 'fips-updates' option that includes the security fixes. The packages from 'fips-updates' option are updated to include high and critical security fixes during the whole product lifecycle including the <a href="/security/esm">Extended Security Maintenance phase</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Updates copy on /security/certifications
- Last minute copy changes on fips.
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/certifications
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against certification [copydoc](https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit)
- Compare against fips [copydoc](https://docs.google.com/document/d/1moTJCAtFXKD7ZXrxB-EB7GPVyZRTSIdkP-0BhPZl69M/edit?ts=60f04150)
- Note: waiting on the link to the embedded video, see screenshot below.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4227

## Screenshots

Where the video should be:
![image](https://user-images.githubusercontent.com/58276363/125779151-b99a28be-1306-42c6-9c2a-fdfb5cfb045a.png)

