### PR TITLE
Hide expiration date

### DIFF
--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -45,13 +45,6 @@
     {% if not mobile %}
       <hr />
     {% endif %}
-    {% if not monthly_information['is_auto_renewal_enabled'] %}
-      <div class="p-notification--caution">
-        <p class="p-notification__response" role="status">
-          <span class="p-notification__status">End in {{contract["contractInfo"]["daysTillExpiry"] }} days.</span>Auto-renewal disabled.
-        </p>
-      </div>
-    {% endif %}
     <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
     <div class="panel-input-wrapper">
       <input 


### PR DESCRIPTION
## Done

- Number of days to expiry can be flawed if a product was purchased both from a monthly and a yearly subscription, so we will hide it for now

## QA

- Have a monthly subscription on your testing account
- Login to https://ubuntu.com/advantage/subscribe?test_backend=true
- Disable auto-renewal for your account
- Take a look at your monthly product -> Click change subscription
- You will see a notification telling you how many days until expiry
- Go to: https://ubuntu-com-10037.demos.haus/advantage?test_backend=true
- Take a look at your monthly product -> Click change subscription
- You will **_NOT_** see a notification telling you how many days until expiry

## Issue / Card

Fixes #74