### PR TITLE
Fix newsletter form with formVid

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -70,6 +70,7 @@
 
         <input name="lpurl" value="https://pages.canonical.com/Insights-Subscription_Insights-Subscription-test.html?cr={creative}&amp;kw={keyword}" type="hidden">
         <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+        <input value="1212" class="mktoField mktoFieldDescriptor" name="formVid" type="hidden">
         <input type="hidden" name="ret" value="{{request.build_absolute_uri}}?newsletter=true" />
         <input value="066-EOV-335" class="mktoField mktoFieldDescriptor" name="munchkinId" type="hidden">
         <input name="kw" value="" type="hidden">


### PR DESCRIPTION
## Done

- Add `formVid` to newsletter form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- Fill in the newsletter form
- In the insprector, see that you get a 200, not a 403 from marketo

## Issue / Card

Fixes #10038
