### PR TITLE
Fix renewal dates

### DIFF
--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -189,8 +189,14 @@ export function getPaymentInformation(paymentMethod) {
 }
 
 export function getRenewalInformation(data) {
-  const startDate = new Date(data.renewalStart);
-  const endDate = new Date(data.renewalEnd);
+  const current = new Date();
+  let startDate = current;
+
+  if (current > startDate) {
+    startDate = new Date(data.newContractStart);
+  }
+
+  const endDate = add(startDate, { years: 1 });
 
   return {
     items: [

--- a/static/js/src/advantage/set-modal-info.js
+++ b/static/js/src/advantage/set-modal-info.js
@@ -190,12 +190,8 @@ export function getPaymentInformation(paymentMethod) {
 
 export function getRenewalInformation(data) {
   const current = new Date();
-  let startDate = current;
-
-  if (current > startDate) {
-    startDate = new Date(data.newContractStart);
-  }
-
+  const newContractStart = new Date(data.renewalNewContractStart);
+  const startDate = current > newContractStart ? current : newContractStart;
   const endDate = add(startDate, { years: 1 });
 
   return {

--- a/static/js/src/advantage/tests/fixtures/renewal-data.js
+++ b/static/js/src/advantage/tests/fixtures/renewal-data.js
@@ -8,8 +8,7 @@ export const advancedDesktop = {
   products: "['uai-advanced-desktop']",
   quantity: "5",
   renewalId: "rACmlqlrdX08yb4jK3_ldJBUVSY_Bkmubdq1ysGj65yU",
-  renewalStart: "2020-04-18T00:00:00Z",
-  renewalEnd: "2020-08-18T00:00:00Z",
+  renewalNewContractStart: "2030-04-18T00:00:00Z",
   unitPrice: "2500",
   total: "12500",
 };

--- a/static/js/src/advantage/tests/set-modal-info.test.js
+++ b/static/js/src/advantage/tests/set-modal-info.test.js
@@ -44,7 +44,7 @@ describe("getRenewalInformation", () => {
           {
             end: {
               label: "Ends:",
-              value: "18 August 2020",
+              value: "18 April 2031",
               extraClasses: "js-end-date",
             },
             plan: {
@@ -57,13 +57,26 @@ describe("getRenewalInformation", () => {
             },
             start: {
               label: "Continues from:",
-              value: "18 April 2020",
+              value: "18 April 2030",
             },
           },
         ],
         subtotal: "$125",
         total: "$125",
         vat: "$0",
+      });
+    });
+    it("should set start date to current", () => {
+      renewalData.advancedDesktop.renewalNewContractStart =
+        "2021-06-30T13:25:32.375Z";
+
+      const data = getRenewalInformation(renewalData.advancedDesktop);
+      const startDateData = data.items[0].start;
+      const expectedDate = format(new Date(), "dd MMMM yyyy");
+
+      expect(startDateData).toEqual({
+        label: "Continues from:",
+        value: expectedDate,
       });
     });
   });

--- a/templates/advantage/table/_renewal-actions.html
+++ b/templates/advantage/table/_renewal-actions.html
@@ -11,8 +11,7 @@
         data-name="{{ contract['contractInfo']['name']}}"
         data-quantity="{{ contract['renewal']['renewalItems'][0]['allowance']['value'] }}"
         data-renewal-id="{{ contract['renewal']['id']}}"
-        data-renewal-start="{{ contract['renewal']['start']}}"
-        data-renewal-end="{{ contract['renewal']['end']}}"
+        data-renewal-new-contract-start="{{ contract['renewal']['newContractStart']}}"
         {% if expired_renewable %}
           data-contract-end="{{ contract['contractInfo']['expired_restart_date']}}"
         {% else %}


### PR DESCRIPTION
## Done

- Use `renewal.newContractStart` to display the continue from date in the modal 

## QA

- Have a renewal (ask Albert for help)
- Go to  https://ubuntu-com-10040.demos.haus/advantage?test_backend=true
- Press the Renewal button, look at the start date, should be the `renewal.newContractDate`.

## Issue / Card

Fixes #78