### PR TITLE
Add the OpenStack project chart to what is OpenStack page

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -574,13 +574,25 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
       </p>
     </div>
   </div>
-  <div class="row">
+  <div class="row u-hide--small">
     <div class="col-8">
       {{ image (
         url="https://assets.ubuntu.com/v1/ab82625a-Statista_figure1.svg",
         alt="Current usage of private cloud platform services running applications worldwide from 2017 to 2020, by service",
         width="680",
         height="256",
+        hi_def=True,
+        loading="lazy" ) |
+        safe }}
+    </div>
+  </div>
+  <div class="row u-hide u-show--small">
+    <div class="col-8">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/0ed9d1ff-Statista_figure1.svg",
+        alt="Current usage of private cloud platform services running applications worldwide from 2017 to 2020, by service",
+        width="768",
+        height="617",
         hi_def=True,
         loading="lazy" ) |
         safe }}

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -553,8 +553,8 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
     </div>
   </div>
   <div class="row">
-    <div class="col-4">
-      <p>
+    <div class="col-8 u-sv3">
+      <p class="u-sv3">
         According to the
         <a
           class="p-link--external"
@@ -573,12 +573,14 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
         source private cloud platform and its adoption continues to grow.
       </p>
     </div>
+  </div>
+  <div class="row">
     <div class="col-8">
       {{ image (
-        url="https://assets.ubuntu.com/v1/0ed9d1ff-Statista_figure1.svg",
+        url="https://assets.ubuntu.com/v1/ab82625a-Statista_figure1.svg",
         alt="Current usage of private cloud platform services running applications worldwide from 2017 to 2020, by service",
-        width="768",
-        height="617",
+        width="680",
+        height="256",
         hi_def=True,
         loading="lazy" ) |
         safe }}

--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -549,7 +549,11 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h2>How big is the OpenStack project?</h2>
+      <h2 class="u-sv3">How big is the OpenStack project?</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4">
       <p>
         According to the
         <a
@@ -568,6 +572,16 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
         participate in OpenStack development. It is also the most popular open
         source private cloud platform and its adoption continues to grow.
       </p>
+    </div>
+    <div class="col-8">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/0ed9d1ff-Statista_figure1.svg",
+        alt="Current usage of private cloud platform services running applications worldwide from 2017 to 2020, by service",
+        width="768",
+        height="617",
+        hi_def=True,
+        loading="lazy" ) |
+        safe }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
Add the OpenStack project chart to what is OpenStack page

## QA
- Open the demo
- Go to /openstack/what-is-openstack
- Jump to the "How big is the OpenStack project?" section
- See the OpenStack chart

## Issue / Card
Fixes #10052 

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/126338641-f07e8551-6fed-4e78-ae6b-4c9eb57ced41.png)
