### PR TITLE
Add button to add another instance type

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -293,58 +293,55 @@ import { assignMarketoBackgroundSubmit } from "./bg-form-submit";
           }
 
           inputs.forEach(function (input) {
-            if (input.value) {
-              switch (input.type) {
-                case "radio":
-                  if (input.checked) {
-                    message += comma + input.value;
-                    comma = ", ";
+            switch (input.type) {
+              case "radio":
+                if (input.checked) {
+                  message += comma + input.value + "\r\n\r\n";
+                  comma = ", ";
+                }
+                break;
+              case "checkbox":
+                if (input.checked) {
+                  var subSectionText = "";
+                  var subSection = input
+                    .closest('[class*="col-"]')
+                    .querySelector(".js-sub-section");
+                  if (subSection) {
+                    subSectionText = subSection.innerText + ": ";
                   }
-                  break;
-                case "checkbox":
-                  if (input.checked) {
-                    var subSectionText = "";
-                    var subSection = input
-                      .closest('[class*="col-"]')
-                      .querySelector(".js-sub-section");
-                    if (subSection) {
-                      subSectionText = subSection.innerText + ": ";
-                    }
 
-                    var label = formField.querySelector(
-                      "label[for=" + input.id + "]"
-                    );
-                    if (label) {
-                      label = subSectionText + label.innerText;
-                    } else {
-                      label = input.id;
-                    }
-                    message += comma + label;
-                    comma = ", ";
+                  var label = formField.querySelector(
+                    "label[for=" + input.id + "]"
+                  );
+                  if (label) {
+                    label = subSectionText + label.innerText;
+                  } else {
+                    label = input.id;
                   }
-                  break;
-                case "text":
-                  if (input.value !== "") {
-                    message += comma + input.value;
-                    comma = ", ";
-                  }
-                  break;
-                case "number":
-                  if (input.value !== "") {
-                    message += comma + input.value;
-                    comma = ", ";
-                  }
-                  break;
-                case "textarea":
-                  if (input.value !== "") {
-                    message += comma + input.value;
-                    comma = ", ";
-                  }
-                  break;
-              }
+                  message += comma + label + "\r\n\r\n";
+                  comma = ", ";
+                }
+                break;
+              case "text":
+                if (input.value !== "") {
+                  message += comma + input.value + "\r\n\r\n";
+                  comma = ", ";
+                }
+                break;
+              case "number":
+                if (input.value !== "") {
+                  message += comma + input.value + "\r\n\r\n";
+                  comma = ", ";
+                }
+                break;
+              case "textarea":
+                if (input.value !== "") {
+                  message += comma + input.value + "\r\n\r\n";
+                  comma = ", ";
+                }
+                break;
             }
           });
-          message += "\r\n\r\n";
         });
 
         return message;

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -288,56 +288,60 @@ import { assignMarketoBackgroundSubmit } from "./bg-form-submit";
           var comma = "";
           var fieldTitle = formField.querySelector(".p-heading--five");
           var inputs = formField.querySelectorAll("input, textarea");
-          message += fieldTitle.innerText + "\r\n";
+          if (fieldTitle) {
+            message += fieldTitle.innerText + "\r\n";
+          }
 
           inputs.forEach(function (input) {
-            switch (input.type) {
-              case "radio":
-                if (input.checked) {
-                  message += comma + input.value;
-                  comma = ", ";
-                }
-                break;
-              case "checkbox":
-                if (input.checked) {
-                  var subSectionText = "";
-                  var subSection = input
-                    .closest('[class*="col-"]')
-                    .querySelector(".js-sub-section");
-                  if (subSection) {
-                    subSectionText = subSection.innerText + ": ";
+            if (input.value) {
+              switch (input.type) {
+                case "radio":
+                  if (input.checked) {
+                    message += comma + input.value;
+                    comma = ", ";
                   }
+                  break;
+                case "checkbox":
+                  if (input.checked) {
+                    var subSectionText = "";
+                    var subSection = input
+                      .closest('[class*="col-"]')
+                      .querySelector(".js-sub-section");
+                    if (subSection) {
+                      subSectionText = subSection.innerText + ": ";
+                    }
 
-                  var label = formField.querySelector(
-                    "label[for=" + input.id + "]"
-                  );
-                  if (label) {
-                    label = subSectionText + label.innerText;
-                  } else {
-                    label = input.id;
+                    var label = formField.querySelector(
+                      "label[for=" + input.id + "]"
+                    );
+                    if (label) {
+                      label = subSectionText + label.innerText;
+                    } else {
+                      label = input.id;
+                    }
+                    message += comma + label;
+                    comma = ", ";
                   }
-                  message += comma + label;
-                  comma = ", ";
-                }
-                break;
-              case "text":
-                if (input.value !== "") {
-                  message += comma + input.value;
-                  comma = ", ";
-                }
-                break;
-              case "number":
-                if (input.value !== "") {
-                  message += comma + input.value;
-                  comma = ", ";
-                }
-                break;
-              case "textarea":
-                if (input.value !== "") {
-                  message += comma + input.value;
-                  comma = ", ";
-                }
-                break;
+                  break;
+                case "text":
+                  if (input.value !== "") {
+                    message += comma + input.value;
+                    comma = ", ";
+                  }
+                  break;
+                case "number":
+                  if (input.value !== "") {
+                    message += comma + input.value;
+                    comma = ", ";
+                  }
+                  break;
+                case "textarea":
+                  if (input.value !== "") {
+                    message += comma + input.value;
+                    comma = ", ";
+                  }
+                  break;
+              }
             }
           });
           message += "\r\n\r\n";

--- a/templates/openstack/pricing-calculator.html
+++ b/templates/openstack/pricing-calculator.html
@@ -133,18 +133,16 @@ const addAnotherInstance = () => {
     const button = document.querySelector("#add-another-instance");
     button.addEventListener("click", () => {
       const instanceTypes = Array.from(
-        document.querySelectorAll("#instance-type")
+        document.querySelectorAll(".js-instance-type") 
       );
       const length = instanceTypes.length;
       for (let i = 0; i < length; i++) {
         if (instanceTypes[i].classList.contains("u-hide")) {
           instanceTypes[i].classList.remove("u-hide");
           //when new instance is added add p-heading--five class to h3s for inputs only to capture values in comment.
-          const inputTitles = instanceTypes[i].querySelectorAll("h3")
+          const inputTitles = instanceTypes[i].querySelectorAll("h4")
           inputTitles.forEach(inputTitle => {
-            if(!inputTitle.classList.contains("p-heading--four")) {
-              inputTitle.classList.add("p-heading--five")
-            }
+            inputTitle.classList.add("p-heading--five")
           })
           if (i === length - 1) {
             button.setAttribute("disabled", "true")

--- a/templates/openstack/pricing-calculator.html
+++ b/templates/openstack/pricing-calculator.html
@@ -139,6 +139,13 @@ const addAnotherInstance = () => {
       for (let i = 0; i < length; i++) {
         if (instanceTypes[i].classList.contains("u-hide")) {
           instanceTypes[i].classList.remove("u-hide");
+          //when new instance is added add p-heading--five class to h3s for inputs only to capture values in comment.
+          const inputTitles = instanceTypes[i].querySelectorAll("h3")
+          inputTitles.forEach(inputTitle => {
+            if(!inputTitle.classList.contains("p-heading--four")) {
+              inputTitle.classList.add("p-heading--five")
+            }
+          })
           if (i === length - 1) {
             button.setAttribute("disabled", "true")
           }

--- a/templates/openstack/pricing-calculator.html
+++ b/templates/openstack/pricing-calculator.html
@@ -103,7 +103,6 @@
 <script src="{{ versioned_static('js/dist/costCalculator.js') }}" type="module" defer></script>
 
 <script>
-
 const updateFormFields = () => {
   document.addEventListener("contactModalLoaded", (event) => {
     const container = document.querySelector(`#cost-calculator-section`);
@@ -129,6 +128,27 @@ const updateFormFields = () => {
 };
 updateFormFields();
 
+const addAnotherInstance = () => {
+  document.addEventListener("contactModalLoaded", (event) => {
+    const button = document.querySelector("#add-another-instance");
+    button.addEventListener("click", () => {
+      const instanceTypes = Array.from(
+        document.querySelectorAll("#instance-type")
+      );
+      const length = instanceTypes.length;
+      for (let i = 0; i < length; i++) {
+        if (instanceTypes[i].classList.contains("u-hide")) {
+          instanceTypes[i].classList.remove("u-hide");
+          if (i === length - 1) {
+            button.setAttribute("disabled", "true")
+          }
+          return;
+        }
+      }
+    });
+  });
+};
+addAnotherInstance();
 </script> 
 
 {% endblock content %}

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -6,125 +6,125 @@
     </header>
     <div class="js-pagination js-pagination--1">
       <p>Tell us more about your needs here and we will send you a detailed report including the required number of nodes for your private cloud and estimated private cloud pricing, including initial CapEx and recurring OpEx costs. We will also help you find the cloud architecture that best suits your requirements.</p>
-      <div id="instance-type">
+      <div class="js-instance-type">
         <h3 class="p-heading--four">Instance type 1</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">vCPUs</h3>
+              <h4 class="p-heading--five">vCPUs</h4>
               <input type="number" id="instance-type-vcpus" min="1" max="116" value="2" aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">RAM [GB]</h3>
+              <h4 class="p-heading--five">RAM [GB]</h4>
               <input type="number" id="instance-type-ram" min="1" max="1824" value="8" aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <h4 class="p-heading--five">Ephemeral storage [GB]</h4>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" value="8" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <h4 class="p-heading--five">Persistent storage [GB]</h4>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" value="80" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Number of instances</h3>
+              <h4 class="p-heading--five">Number of instances</h4>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" value="1000" aria-label="Instance type: Number of instances">
             </div>
           </div>
         </div>
       </div>
-      <div class="u-hide" id="instance-type">
+      <div class="u-hide js-instance-type">
         <h3 class="p-heading--four">Instance type 2</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>vCPUs</h3>
+              <h4>vCPUs</h4>
               <input type="number" id="instance-type-vcpus" min="1" max="116" aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3>RAM [GB]</h3>
+              <h4>RAM [GB]</h4>
               <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>Ephemeral storage [GB]</h3>
+              <h4>Ephemeral storage [GB]</h4>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3>Persistent storage [GB]</h3>
+              <h4>Persistent storage [GB]</h4>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>Number of instances</h3>
+              <h4>Number of instances</h4>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
             </div>
           </div>
         </div>
       </div>
-      <div class="u-hide" id="instance-type">
+      <div class="u-hide js-instance-type">
         <h3 class="p-heading--four">Instance type 3</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>vCPUs</h3>
+              <h4>vCPUs</h4>
               <input type="number" id="instance-type-vcpus" min="1" max="116" aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3>RAM [GB]</h3>
+              <h4>RAM [GB]</h4>
               <input type="number" id="instance-type-ram" min="1" max="1824" aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>Ephemeral storage [GB]</h3>
+              <h4>Ephemeral storage [GB]</h4>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3>Persistent storage [GB]</h3>
+              <h4>Persistent storage [GB]</h4>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>Number of instances</h3>
+              <h4>Number of instances</h4>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
             </div>
           </div>
         </div>
       </div>
-      <div class="u-hide" id="instance-type">
+      <div class="u-hide js-instance-type">
         <h3 class="p-heading--four">Instance type 4</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>vCPUs</h3>
+              <h4>vCPUs</h4>
               <input type="number" id="instance-type-vcpus" min="1" max="116"  aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3>RAM [GB]</h3>
+              <h4>RAM [GB]</h4>
               <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>Ephemeral storage [GB]</h3>
+              <h4>Ephemeral storage [GB]</h4>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144"  aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3>Persistent storage [GB]</h3>
+              <h4>Persistent storage [GB]</h4>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3>Number of instances</h3>
+              <h4>Number of instances</h4>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
             </div>
           </div>
@@ -140,7 +140,7 @@
 
     <div class="js-pagination js-pagination--2 u-hide">
       <div class="js-formfield">
-        <h3 class="p-heading--five">Support level</h3>
+        <h4 class="p-heading--five">Support level</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <input type="radio" id="support-level-fully-managed" name="support-level" value="fully-managed" checked>
@@ -155,36 +155,36 @@
       <div class="row u-no-padding">
         <div class="col-4 u-sv3">
           <div class="js-formfield">
-            <h3 class="p-heading--five">Operations team size [FTEs]</h3>
+            <h4 class="p-heading--five">Operations team size [FTEs]</h3>
             <input type="number" id="operations-team-size" min="0" max="1000" value="12" aria-label="Operations team Size [FTEs]">
           </div>
           <div class="js-formfield">
-            <h3 class="p-heading--five">Operations team average annual staff salary [USD]</h3>
+            <h4 class="p-heading--five">Operations team average annual staff salary [USD]</h3>
             <input type="number" id="operations-team-annual-staff-salary" min="0" max="1000000" value="125000">
           </div>
         </div>
         <div class="col-4 u-sv3">
           <div class="js-formfield">
-            <h3 class="p-heading--five"> CPU overcommitment ratio</h3>
+            <h4 class="p-heading--five"> CPU overcommitment ratio</h3>
             <input type="number" id="cpu-overcommitment-ratio" min="1" max="16" value="2" aria-label="CPU overcommitment ratio">
           </div>
           <div class="js-formfield">
-            <h3 class="p-heading--five">RAM overcommitment ratio</h3>
+            <h4 class="p-heading--five">RAM overcommitment ratio</h3>
             <input type="number" id="ram-overcommitment-ratio" min="1" max="1.5" value="1" aria-label="RAM overcommitment ratio">
           </div>
         </div>
         <div class="col-4 u-sv3">
           <div class="js-formfield">
-            <h3 class="p-heading--five">Storage replication factor</h3>
+            <h4 class="p-heading--five">Storage replication factor</h3>
             <input type="number" id="storage-replication-factor" min="1" max="5" value="3" aria-label="Storage replication factor">
           </div>
           <div class="js-formfield">
-            <h3 class="p-heading--five">Desired cloud utilisation ratio [%]</h3>
+            <h4 class="p-heading--five">Desired cloud utilisation ratio [%]</h3>
             <input type="number" id="desired-cloud-utilised-ratio" min="1" max="100" value="75" aria-label="Desired cloud utilisation ratio [%]">
           </div>
         </div>
         <div class="js-formfield">
-          <h3 class="p-heading--five">Cloud architecture</h3>
+          <h4 class="p-heading--five">Cloud architecture</h3>
           <div class="row u-no-padding">
             <div class="col-4 u-sv3">
               <input type="radio" id="cloud-architecture-reference" name="cloud-achitecture" value="reference" checked>
@@ -207,25 +207,25 @@
       <div class="row u-no-padding">
         <div class="col-4 u-sv3">
           <div class="js-formfield">
-            <h3 class="p-heading--five">Hardware renewal period [years]</h3>
+            <h4 class="p-heading--five">Hardware renewal period [years]</h3>
             <input type="number" id="hardware-renewal-period" min="1" max="5" value="3" aria-label="Hardware renewal period [years]">
           </div>
           <div class="js-formfield">
-            <h3 class="p-heading--five">Annual per-node hosting rent and electricity cost [USD]</h3>
+            <h4 class="p-heading--five">Annual per-node hosting rent and electricity cost [USD]</h3>
             <input type="number" id="annual-per-node-hosting-rent-and-electricity-cost" min="0" max="1000000" value="4500" aria-label="Annual per-node hosting rent and electricity cost [USD]">
           </div>
           <div class="js-formfield">
-            <h3 class="p-heading--five">Annual per-node hardware installation and maintenance cost [USD]</h3>
+            <h4 class="p-heading--five">Annual per-node hardware installation and maintenance cost [USD]</h3>
             <input type="number" id="annual-per-node-hardware-installation-and-maintencance-cost" min="1" max="1000000" value="1000" aria-label="Annual per-node hardware installation and maintenance cost [USD]">
           </div>
         </div>
         <div class="col-4 u-sv3">
           <div class="js-formfield">
-            <h3 class="p-heading--five">External network bandwidth</h3>
+            <h4 class="p-heading--five">External network bandwidth</h3>
             <input type="number" id="external-network-bandwidth" min="0" max="1000000" value="125000" aria-label="External network bandwidth">
           </div>
           <div class="js-formfield">
-            <h3 class="p-heading--five">Annual per-Gbps hosting external network cost</h3>
+            <h4 class="p-heading--five">Annual per-Gbps hosting external network cost</h3>
             <input type="number" id="annual-per-gbps-hosting-external-network-cost" min="0" max="1000000" value="6000" aria-label="Annual per-Gbps hosting external network cost">
           </div>
         </div>

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -338,5 +338,3 @@
     </div>
   </div>
 </div>
-
-<script>console.log("hello")</script>

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -6,35 +6,133 @@
     </header>
     <div class="js-pagination js-pagination--1">
       <p>Tell us more about your needs here and we will send you a detailed report including the required number of nodes for your private cloud and estimated private cloud pricing, including initial CapEx and recurring OpEx costs. We will also help you find the cloud architecture that best suits your requirements.</p>
-      <h3 class="p-heading--four">Instance type</h3>
+      <div id="instance-type">
+        <h3 class="p-heading--four">Instance type 1</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">vCPUs</h3>
+              <input type="number" id="instance-type-vcpus" min="1" max="116" value="2" aria-label="Instance type: vCPUs">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">RAM [GB]</h3>
+              <input type="number" id="instance-type-ram" min="1" max="1824" value="8" aria-label="Instance type: RAM [GB]">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" value="8" aria-label="Instance type: Ephemeral storage">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221" value="80" aria-label="Instance type: Persistent storage">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Number of instances</h3>
+              <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" value="1000" aria-label="Instance type: Number of instances">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="u-hide" id="instance-type">
+        <h3 class="p-heading--four">Instance type 2</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">vCPUs</h3>
+              <input type="number" id="instance-type-vcpus" min="1" max="116" aria-label="Instance type: vCPUs">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">RAM [GB]</h3>
+              <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Number of instances</h3>
+              <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="u-hide" id="instance-type">
+        <h3 class="p-heading--four">Instance type 3</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">vCPUs</h3>
+              <input type="number" id="instance-type-vcpus" min="1" max="116" aria-label="Instance type: vCPUs">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">RAM [GB]</h3>
+              <input type="number" id="instance-type-ram" min="1" max="1824" aria-label="Instance type: RAM [GB]">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Number of instances</h3>
+              <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="u-hide" id="instance-type">
+        <h3 class="p-heading--four">Instance type 4</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">vCPUs</h3>
+              <input type="number" id="instance-type-vcpus" min="1" max="116"  aria-label="Instance type: vCPUs">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">RAM [GB]</h3>
+              <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144"  aria-label="Instance type: Ephemeral storage">
+            </div>
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h3 class="p-heading--five">Number of instances</h3>
+              <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="row u-no-padding">
-        <div class="col-4 u-sv3">
-          <div class="js-formfield">
-            <h3 class="p-heading--five">vCPUs</h3>
-            <input type="number" id="instance-type-vcpus" min="1" max="116" value="2" aria-label="Instance type: vCPUs">
-          </div>
-          <div class="js-formfield">
-            <h3 class="p-heading--five">RAM [GB]</h3>
-            <input type="number" id="instance-type-ram" min="1" max="1824" value="8" aria-label="Instance type: RAM [GB]">
-          </div>
-        </div>
-        <div class="col-4 u-sv3">
-          <div class="js-formfield">
-            <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
-            <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" value="8" aria-label="Instance type: Ephemeral storage">
-          </div>
-          <div class="js-formfield">
-            <h3 class="p-heading--five">Persistent storage [GB]</h3>
-            <input type="number" id="instance-type-persistent-storage" min="0" max="221" value="80" aria-label="Instance type: Persistent storage">
-          </div>
-        </div>
-        <div class="col-4 u-sv3">
-          <div class="js-formfield">
-            <h3 class="p-heading--five">Number of instances</h3>
-            <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" value="1000" aria-label="Instance type: Number of instances">
-          </div>
-        </div>
         <div class="pagination">
+          <button class="p-button--netural" id="add-another-instance">Add another instance</button>
           <a class="p-button--positive pagination__link--next" href="">Next</a>
         </div>
       </div>
@@ -240,3 +338,5 @@
     </div>
   </div>
 </div>
+
+<script>console.log("hello")</script>

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -42,27 +42,27 @@
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">vCPUs</h3>
+              <h3>vCPUs</h3>
               <input type="number" id="instance-type-vcpus" min="1" max="116" aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">RAM [GB]</h3>
+              <h3>RAM [GB]</h3>
               <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <h3>Ephemeral storage [GB]</h3>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <h3>Persistent storage [GB]</h3>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Number of instances</h3>
+              <h3>Number of instances</h3>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
             </div>
           </div>
@@ -73,27 +73,27 @@
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">vCPUs</h3>
+              <h3>vCPUs</h3>
               <input type="number" id="instance-type-vcpus" min="1" max="116" aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">RAM [GB]</h3>
+              <h3>RAM [GB]</h3>
               <input type="number" id="instance-type-ram" min="1" max="1824" aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <h3>Ephemeral storage [GB]</h3>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <h3>Persistent storage [GB]</h3>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Number of instances</h3>
+              <h3>Number of instances</h3>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
             </div>
           </div>
@@ -104,27 +104,27 @@
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">vCPUs</h3>
+              <h3>vCPUs</h3>
               <input type="number" id="instance-type-vcpus" min="1" max="116"  aria-label="Instance type: vCPUs">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">RAM [GB]</h3>
+              <h3>RAM [GB]</h3>
               <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Ephemeral storage [GB]</h3>
+              <h3>Ephemeral storage [GB]</h3>
               <input type="number" id="instance-type-ephemeral-storage" min="4" max="144"  aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
-              <h3 class="p-heading--five">Persistent storage [GB]</h3>
+              <h3>Persistent storage [GB]</h3>
               <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
             <div class="js-formfield">
-              <h3 class="p-heading--five">Number of instances</h3>
+              <h3>Number of instances</h3>
               <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
             </div>
           </div>


### PR DESCRIPTION
## Done

- Added an option to add another instance type (up to 4) on pricing calculator contact form

## QA

- Visit page at: https://ubuntu-com-10054.demos.haus/openstack/pricing-calculator
- Click on the "Get cost estimates" button
- Click the "Add another instance" button
- Check Instance Type 2 appears. Then 3, then 4, then the button to add another instance should be disabled


## Issue / Card

Fixes #10049 

## Screenshots

![Screenshot 2021-07-20 at 15 19 08](https://user-images.githubusercontent.com/58959073/126340160-cceefd20-4350-43e5-ab0c-aafa190f5465.png)

