### PR TITLE
[CUBE] - Remove custom authorization from cube pages

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -64,12 +64,6 @@ env:
       key: client-secret
       name: cube-edx
 
-  - name: CUBE_AUTHORIZED_USERS
-    configMapKeyRef:
-      key: cube-authorized-users
-      name: ubuntu-com
-      optional: true
-
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
@@ -166,12 +160,6 @@ production:
           secretKeyRef:
             key: client-secret
             name: cube-edx
-
-        - name: CUBE_AUTHORIZED_USERS
-          configMapKeyRef:
-            key: cube-authorized-users
-            name: ubuntu-com
-            optional: true
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -331,12 +319,6 @@ staging:
           secretKeyRef:
             key: client-secret
             name: cube-edx
-
-        - name: CUBE_AUTHORIZED_USERS
-          configMapKeyRef:
-            key: cube-authorized-users
-            name: ubuntu-com
-            optional: true
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -86,43 +86,10 @@ class TestCube(VCRTestCase):
             "no-store",
         )
 
-    def test_microcerts_403_authenticated_non_canonical_user(self):
-        with self.client.session_transaction() as session:
-            session["authentication_token"] = "test_token"
-            session["openid"] = {
-                "fullname": "Cube Engineer",
-                "email": "cube@ubuntu.com",
-            }
-
+    def test_microcerts_login_required(self):
         response = self.client.get("/cube/microcerts")
-        self.assertEqual(response.status_code, 403)
-
-    def test_home_login_required(self):
-        response = self.client.get("/cube")
         self.assertEqual(response.status_code, 302)
 
-    def test_home_authenticated(self):
-        with self.client.session_transaction() as session:
-            session["authentication_token"] = "test_token"
-            session["openid"] = {
-                "fullname": "Cube Engineer",
-                "email": "cube@canonical.com",
-            }
-
-        response = self.client.get("/cube")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.headers.get("Cache-Control"),
-            "no-store",
-        )
-
-    def test_home_403_non_canonical_user(self):
-        with self.client.session_transaction() as session:
-            session["authentication_token"] = "test_token"
-            session["openid"] = {
-                "fullname": "Cube Engineer",
-                "email": "cube@ubuntu.com",
-            }
-
-        response = self.client.get("/cube")
-        self.assertEqual(response.status_code, 403)
+    def test_study_login_required(self):
+        response = self.client.get("/cube/study")
+        self.assertEqual(response.status_code, 302)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -45,7 +45,6 @@ from webapp.cube.views import (
     cube_home,
     cube_microcerts,
     cube_study_labs_button,
-    is_authorized,
 )
 
 from webapp.views import (
@@ -823,9 +822,6 @@ def cube_require_login_cube_study():
         user = user_info(flask.session)
         if not user:
             return flask.redirect("/login?next=" + flask.request.path)
-
-        if not is_authorized(user):
-            flask.abort(403)
 
 
 @app.after_request


### PR DESCRIPTION
## Done

- Remove login requirement from `/cube`
- Remove custom authorization from `/cube/microcerts` and `/cube/study` so it's open to anyone with an Ubuntu ONE SSO account (not only users with `@canonical.com` emails)
- Update tests

## QA

- Clear session so you aren't logged in to SSO
- View cube homepage page at: https://ubuntu-com-10055.demos.haus/cube - the page should be visible
- Go to: `/cube/microcerts` and `/cube/study` (still not logged in), you should be asked to log in to SSO. 
- log into SSO with an email that doesn't end in `@canonical.com`. Check you are authorized to view both `/cube/microcerts` and `/cube/study`


## Issue / Card

Fixes #10051 
