### PR TITLE
Fix html in /workstations-journey-to-ai

### DIFF
--- a/templates/workstations-journey-to-ai/index.html
+++ b/templates/workstations-journey-to-ai/index.html
@@ -27,7 +27,7 @@
 <section class="p-strip is-bordered">
     <div class="row">
         <div class="col-6">
-            <h4 class="p-muted-heading">Part 1 - On demand</p>
+            <h4 class="p-muted-heading">Part 1 - On demand</h4>
             <h2>Data Pipelines</h2>
             <p>Explore the best open source platforms and tools that help to work on large and varying datasets</p>
             <p>While new AI algorithms and training methods get all the hype, most analysts agree that data scientists spend up to 80% of their time on data: exploration, acquisition, ingestion, transformation and cleansing. This webinar will explore best open source platforms and tools that help to work on large and varying datasets, which is the first step of a four piece series on the AI Journey.</p>
@@ -56,7 +56,7 @@
 <section class="p-strip is-bordered">
     <div class="row">
         <div class="col-6">
-            <h4 class="p-muted-heading">Part 2 - June 8th | 11AM ET & 4PM BST</p>
+            <h4 class="p-muted-heading">Part 2 - June 8th | 11AM ET & 4PM BST</h4>
             <h2>Choosing your algorithm</h2>
             <p>In this session we will talk about statistical computer vision, NLP, predictions, segmentation</p>
             <a href="https://www.brighttalk.com/webcast/6793/480482" class="p-button--positive">Register</a>
@@ -67,7 +67,7 @@
 <section class="p-strip is-bordered">
     <div class="row">
         <div class="col-6">
-            <h4 class="p-muted-heading">Part 3 - August 10th | 11AM ET & 4PM BST</p>
+            <h4 class="p-muted-heading">Part 3 - August 10th | 11AM ET & 4PM BST</h4>
             <h2>Training on the workstation</h2>
             <p>In this session we will talk about, workstation vs server vs cloud, ephemeral environments, and GPU/acceleration</p>
             <a href="https://www.brighttalk.com/webcast/6793/480563" class="p-button--positive">Register</a>
@@ -78,7 +78,7 @@
 <section class="p-strip is-bordered">
     <div class="row">
         <div class="col-6">
-            <h4 class="p-muted-heading">Part 4 - Oct 12th | 11AM CT & 4PM BST</p>
+            <h4 class="p-muted-heading">Part 4 - Oct 12th | 11AM CT & 4PM BST</h4>
             <h2>Deployment anywhere</h2>
             <p>In this session we will talk about Inference engines deployment</p>
             <a href="https://www.brighttalk.com/webcast/6793/480564" class="p-button--positive">Register</a>


### PR DESCRIPTION
## Done

- fixed some malformed html I noticed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/workstations-journey-to-ai
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the h4's end properly
