### PR TITLE
Remove outdated copy on /advantage

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -358,7 +358,7 @@
       </div>
 
       <div class="col-12 u-hide--small">
-        <p>Anyone can use UA Infra Essential for free on up to 3 machines. And if you're a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it's free on up to 50 machines.</p>      <p>Initially, this free subscription is available for Ubuntu 14.04 ESM and 16.04 ESM.</p>
+        <p>Anyone can use UA Infra Essential for free on up to 3 machines. And if you're a recognised <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">Ubuntu community member</a>, it's free on up to 50 machines.</p>
 
         <span class="p-contextual-menu--left p-contextual-menu--advantage">
           <a href="#" class="p-contextual-menu__toggle p-button--neutral" data-trigger="click" aria-controls="#free-sub" aria-expanded="false" aria-haspopup="true">Get your free token&nbsp;<i class="p-icon--contextual-menu">Open</i></a>


### PR DESCRIPTION
## Done

- removed "Initially, this free subscription is available for Ubuntu 14.04 ESM and 16.04 ESM." for free users

## QA

- got to https://ubuntu-com-10069.demos.haus/advantage?test_backend=true
- login
- see that the Free personal subscription section doesn't mention eligible ubuntu versions anymore.


## Issue / Card

Fixes #10041

