### PR TITLE
[Certified improvements] - add functionality to toggle filter lists

### DIFF
--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -6,6 +6,9 @@
   }
 
   .p-certification-results {
+    th {
+      padding-top: 0.6rem;
+    }
     th,
     td {
       &:nth-child(1) {
@@ -28,5 +31,38 @@
   .p-update-results {
     margin-left: 0.5rem;
     width: fit-content;
+  }
+
+  //hide <hr> after each group - moved to after each tab title
+  .p-accordion__group--certified {
+    &::after {
+      display: none;
+    }
+  }
+
+  .p-certification-header {
+    font-size: 0.863rem;
+    font-weight: 400;
+    line-height: 1rem;
+    text-transform: uppercase;
+  }
+
+  .is-dense {
+    padding-left: 1rem;
+  }
+
+  .is-collapsed {
+    overflow: hidden;
+    &__vendors {
+      @extend .is-collapsed;
+
+      max-height: 11.5rem;
+    }
+
+    &__versions {
+      @extend .is-collapsed;
+
+      max-height: 10rem;
+    }
   }
 }

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -38,41 +38,28 @@
          <div>
            <aside class="p-accordion" data-multiple-expanded="true">
              <ul class="p-accordion__list">
-               <li class="p-accordion__group">
+               <li class="p-accordion__group--certified">
                  <div role="heading" aria-level="2" class="p-accordion__heading">
-                   <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Category</button>
+                   <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true" ><span class="p-certification-header">Category</span></button>
                  </div>
-                 <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab1">
+                 <hr>
+                 <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
                    {% for category_filter in category_filters %}
-                   <label class="p-checkbox">
-                     <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input" id="category_filter" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
-                     <div class="p-checkbox__label" id="{{ category_filter }}">
-                       <span>{{ category_filter }}</span>
-                     </div>
-                   </label>
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input" id="category_filter" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
+                      <div class="p-checkbox__label" id="{{ category_filter }}">
+                        <span>{{ category_filter }}</span>
+                      </div>
+                    </label>
                    {% endfor %}
                  </section>
                </li>
-               <li class="p-accordion__group">
+               <li class="p-accordion__group--certified" id="vendor-section">
                  <div role="heading" aria-level="2" class="p-accordion__heading">
-                   <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="true">Certified Ubuntu release</button>
+                   <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="true"><span class="p-certification-header">Vendor</span></button>
                  </div>
-                 <section class="p-accordion__panel" id="tab2-section" aria-hidden="false" style="padding-left: 1rem;" aria-labelledby="tab2">
-                   {% for release_filter in release_filters %}
-                   <label class="p-checkbox">
-                     <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                     <div class="p-checkbox__label" id="{{ release_filter }}">
-                       <span>{{ release_filter }}</span>
-                     </div>
-                   </label>
-                   {% endfor %}
-                 </section>
-               </li>
-               <li class="p-accordion__group">
-                 <div role="heading" aria-level="2" class="p-accordion__heading">
-                   <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Vendor</button>
-                 </div>
-                 <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" style="padding-left: 1rem;" aria-labelledby="tab3">
+                 <hr>
+                 <section class="p-accordion__panel is-collapsed__vendors is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
                    {% for vendor_filter in vendor_filters %}
                    <label class="p-checkbox">
                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
@@ -83,6 +70,30 @@
                    </label>
                    {% endfor %}
                  </section>
+                 <span class="js-toggle-links">
+                  <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
+                  <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
+                </span>
+               </li>
+               <li class="p-accordion__group--certified" id="version-section">
+                 <div role="heading" aria-level="2" class="p-accordion__heading">
+                   <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true"><span class="p-certification-header">Certified Ubuntu release</span></button>
+                 </div>
+                 <hr>
+                 <section class="p-accordion__panel is-collapsed__versions is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
+                   {% for release_filter in release_filters %}
+                   <label class="p-checkbox">
+                     <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
+                     <div class="p-checkbox__label" id="{{ release_filter }}">
+                       <span>{{ release_filter }}</span>
+                     </div>
+                   </label>
+                   {% endfor %}
+                 </section>
+                 <span class="js-toggle-links">
+                  <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
+                  <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
+                </span>
                </li>
              </ul>
            </aside>
@@ -96,6 +107,7 @@
          <thead>
            <tr>
              <th>
+               <span class="p-certification-header">
                {% if total_results and total_results > 1 %}
                  {{ offset + 1 }}
                  &ndash;
@@ -107,9 +119,10 @@
                  of
                {% endif %}
                {{ total_results }} result{% if total_results != 1 %}s{% endif %}
+              </span>
              </th>
-             <th>Vendor</th>
-             <th>Category</th>
+             <th><span class="p-certification-header">Vendor</span></th>
+             <th><span class="p-certification-header">Category</span></th>
            </tr>
          </thead>
          <tbody>
@@ -146,6 +159,54 @@
 </form>
 
 <script>
+
+  function toggleVendorsList() {
+    const vendorSection = document.querySelector("#vendor-section");
+    const vendorPanel = vendorSection.querySelector(".p-accordion__panel");
+    const toggleVendorButtons = document.querySelectorAll(".p-reveal-vendors");
+    toggleVendorButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        window.scrollTo(0, 360);
+        vendorPanel.classList.toggle("is-collapsed__vendors");
+        toggleVendorButtons.forEach((button) => {
+          button.classList.toggle("u-hide");
+        });
+      });
+    });
+  }
+  toggleVendorsList();
+  
+  function toggleVersionsList() {
+    const versionSection = document.querySelector("#version-section");
+    const versionPanel = versionSection.querySelector(".p-accordion__panel");
+    const toggleVersionButtons = document.querySelectorAll(".p-reveal-versions");
+    toggleVersionButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        versionPanel.classList.toggle("is-collapsed__versions");
+        toggleVersionButtons.forEach((button) => {
+          button.classList.toggle("u-hide");
+        });
+      });
+    });
+  }
+  toggleVersionsList();
+  
+  //hides "show all .." and "show fewer" links when the accordion is closed
+  function toggleLinks() {
+    const filterSections = document.querySelectorAll(
+      ".p-accordion__group--certified"
+    );
+    filterSections.forEach((filterSection) => {
+      const tab = filterSection.querySelector(".p-accordion__tab");
+      tab.addEventListener("click", () => {
+        const links = filterSection.querySelector(".js-toggle-links");
+        if (links) {
+          links.classList.toggle("u-hide");
+        }
+      });
+    });
+  }
+  toggleLinks();
 
 function toggleDrawer(sideNavigation, show) {
   if (sideNavigation) {


### PR DESCRIPTION
## Done

- Add "See all vendors" and "See all versions" links
- Add functionality to expand and collapse the filter lists
- Ensure the links are hidden when accordions are closed
- Following [design](https://app.zeplin.io/project/60c1ca887b99f18a380e57e9/screen/60f169f4009bd51281d0a3ff) increase size of headings, and add `<hr>` to after tab title instead of before

## QA

- View page at: https://ubuntu-com-10071.demos.haus/certified?q=dell
- Check the links in the filter list work as expected by expanding and collapsing list of filters.
- Check the links aren't present when the accordions are closed
- This PR is addressing the show and reveal functionality - the buttons, pagination and table will be updated in future PRs. 


## Issue / Card

Fixes [#4249](https://github.com/canonical-web-and-design/web-squad/issues/4249)

## Screenshots

![Screenshot 2021-07-26 at 15 20 21](https://user-images.githubusercontent.com/58959073/127004589-b652831e-7b95-4022-b2b4-74b3d24064ca.png)

