### PR TITLE
Fix organisation name not being saved correctly

### DIFF
--- a/static/js/src/advantage/subscribe/react/APICalls/registerPaymentMethod.jsx
+++ b/static/js/src/advantage/subscribe/react/APICalls/registerPaymentMethod.jsx
@@ -12,7 +12,7 @@ const registerPaymentMethod = () => {
   const mutation = useMutation(async (formData) => {
     const {
       name,
-      organisation,
+      organisationName,
       email,
       address,
       city,
@@ -51,7 +51,7 @@ const registerPaymentMethod = () => {
     if (!accountRes.accountID) {
       accountRes = await ensurePurchaseAccount({
         email: email,
-        accountName: organisation || name,
+        accountName: organisationName || name,
         paymentMethodID: paymentMethod.id,
         country,
       });


### PR DESCRIPTION
## Done

- Fix a typo in a variable name causing the organisation name not to be saved correctly for new customers

## QA

- go to /advantage/subscribe?test_backend=true as a guest
- make a new purchase 'for an organisation'
- check that the organisation name is passed correctly to the backend


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/80

