### PR TITLE
Add abbr for LMA on /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -12,7 +12,7 @@
     <div class="col-8">
       <h1>Ubuntu Advantage</h1>
       <h4>Security, support and managed open source for enterprises</h4>
-      <p>Future-proof the full stack, from the data centre to containers to the database, LMA, server and cloud-native applications with open source software support from Canonical.</p>
+      <p>Future-proof the full stack, from the data centre to containers to the database, <abbr title="Logging, Monitoring and Aggregation services">LMA</abbr>, server and cloud-native applications with open source software support from Canonical.</p>
       <p>Ubuntu Advantage is a single, per-node package of the most comprehensive enterprise security and support for open source infrastructure and applications, with managed service offerings available.</p>
       <p>
         <a href="/support/contact-us?product=support-overview" class="p-button--positive js-invoke-modal">Contact us</a>
@@ -173,7 +173,7 @@
   <div class="row p-divider u-equal-height u-vertically-spaced">
     <div class="col-6 p-divider__block">
       <h4>Applications</h4>
-      <p>Security and support for open source database, LMA, server and cloud-native apps.</p>
+      <p>Security and support for open source database, <abbr title="Logging, Monitoring and Aggregation services">LMA</abbr>, server and cloud-native apps.</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Security patching for over 28,000 packages in Ubuntu Universe and Main repositories</li>
         <li class="p-list__item is-ticked">Up to 10 years of Linux support for Ubuntu LTS releases</li>


### PR DESCRIPTION
## Done

- Add abbr for LMA on /support

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support
- See that there is a abbr for the acronym LMA twice on the page


## Issue / Card

Fixes #10074
