### PR TITLE
Fix `buyingFor` radio being ignored if an organisation name is entered

### DIFF
--- a/static/js/src/advantage/subscribe/react/APICalls/registerPaymentMethod.jsx
+++ b/static/js/src/advantage/subscribe/react/APICalls/registerPaymentMethod.jsx
@@ -13,6 +13,7 @@ const registerPaymentMethod = () => {
     const {
       name,
       organisation,
+      buyingFor,
       email,
       address,
       city,
@@ -51,7 +52,7 @@ const registerPaymentMethod = () => {
     if (!accountRes.accountID) {
       accountRes = await ensurePurchaseAccount({
         email: email,
-        accountName: organisation || name,
+        accountName: buyingFor === "myself" ? name : organisation,
         paymentMethodID: paymentMethod.id,
         country,
       });


### PR DESCRIPTION
## Done

- Check buyingFor value instead of the presence of an organisation name to decide what to pass to the backend.

## QA

- Go to https://ubuntu-com-10077.demos.haus/advantage/subscribe?test_backend=true as a guest
- select a product
- open the modal
- enter an organisation name then click Myself radio
- Check that the organisation name is ignored and the customer name is used instead as the account name


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/81

