### PR TITLE
TCO calc - Fix incorrect range and default values

### DIFF
--- a/static/js/src/openstack/react/components/CostCalculatorForm.jsx
+++ b/static/js/src/openstack/react/components/CostCalculatorForm.jsx
@@ -104,7 +104,7 @@ const CostCalculatorForm = () => {
                   onChange={onChangeHandler}
                   type="number"
                   min="4"
-                  max="114"
+                  max="6114"
                   name="ephemeralStorage"
                   value={formState.ephemeralStorage.value}
                   error={formState.ephemeralStorage.error}
@@ -140,7 +140,7 @@ const CostCalculatorForm = () => {
                   onChange={onChangeHandler}
                   type="number"
                   min="0"
-                  max="221"
+                  max="221184"
                   name="persistentStorage"
                   value={formState.persistentStorage.value}
                   error={formState.persistentStorage.error}

--- a/templates/openstack/pricing-calculator.html
+++ b/templates/openstack/pricing-calculator.html
@@ -16,6 +16,7 @@
       <p>
         While leading public cloud providers continue lowering their prices, private clouds remain a cost-efficient extension to the public cloud infrastructure. Get the following report for free to learn how cloud pricing differs across leading public and private cloud platforms, including AWS, Azure, Google, VMware and OpenStack.
       </p>
+      <a href="/engage/cloud-pricing-report-2021" class="p-button--positive">Get the free report</a>
     </div>
   </div>
 </section>
@@ -56,6 +57,7 @@
       <h2>Cloud pricing comparison</h2>
       <h3 class="p-heading--4">Choose a cloud platform based on economics</h3>
       <p>In most cases, the decision of which cloud platform to use is driven by economics. Use cost-per-resource metrics or total cost of ownership (TCO) calculators to estimate and  compare costs between various cloud platforms.</p>
+      <a href="/engage/cloud-pricing-report-2021">Learn more about TCO calculators&nbsp;&rsaquo;</a>
     </div>
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
       {{ image (

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -22,11 +22,11 @@
           <div class="col-4 u-sv3">
             <div class="js-formfield">
               <h4 class="p-heading--five">Ephemeral storage [GB]</h4>
-              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" value="8" aria-label="Instance type: Ephemeral storage">
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="6144" value="8" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
               <h4 class="p-heading--five">Persistent storage [GB]</h4>
-              <input type="number" id="instance-type-persistent-storage" min="0" max="221" value="80" aria-label="Instance type: Persistent storage">
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221184" value="80" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
@@ -53,11 +53,11 @@
           <div class="col-4 u-sv3">
             <div class="js-formfield">
               <h4>Ephemeral storage [GB]</h4>
-              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="6144" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
               <h4>Persistent storage [GB]</h4>
-              <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221184" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
@@ -84,11 +84,11 @@
           <div class="col-4 u-sv3">
             <div class="js-formfield">
               <h4>Ephemeral storage [GB]</h4>
-              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144" aria-label="Instance type: Ephemeral storage">
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="6144" aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
               <h4>Persistent storage [GB]</h4>
-              <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221184" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
@@ -115,11 +115,42 @@
           <div class="col-4 u-sv3">
             <div class="js-formfield">
               <h4>Ephemeral storage [GB]</h4>
-              <input type="number" id="instance-type-ephemeral-storage" min="4" max="144"  aria-label="Instance type: Ephemeral storage">
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="6144"  aria-label="Instance type: Ephemeral storage">
             </div>
             <div class="js-formfield">
               <h4>Persistent storage [GB]</h4>
-              <input type="number" id="instance-type-persistent-storage" min="0" max="221" aria-label="Instance type: Persistent storage">
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221184" aria-label="Instance type: Persistent storage">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h4>Number of instances</h4>
+              <input type="number" id="instance-type-number-of-instances" min="1" max="1000000" aria-label="Instance type: Number of instances">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="u-hide js-instance-type">
+        <h3 class="p-heading--four">Instance type 5</h3>
+        <div class="row u-no-padding">
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h4>vCPUs</h4>
+              <input type="number" id="instance-type-vcpus" min="1" max="116"  aria-label="Instance type: vCPUs">
+            </div>
+            <div class="js-formfield">
+              <h4>RAM [GB]</h4>
+              <input type="number" id="instance-type-ram" min="1" max="1824"  aria-label="Instance type: RAM [GB]">
+            </div>
+          </div>
+          <div class="col-4 u-sv3">
+            <div class="js-formfield">
+              <h4>Ephemeral storage [GB]</h4>
+              <input type="number" id="instance-type-ephemeral-storage" min="4" max="6144"  aria-label="Instance type: Ephemeral storage">
+            </div>
+            <div class="js-formfield">
+              <h4>Persistent storage [GB]</h4>
+              <input type="number" id="instance-type-persistent-storage" min="0" max="221184" aria-label="Instance type: Persistent storage">
             </div>
           </div>
           <div class="col-4 u-sv3">
@@ -221,11 +252,11 @@
         </div>
         <div class="col-4 u-sv3">
           <div class="js-formfield">
-            <h4 class="p-heading--five">External network bandwidth</h3>
-            <input type="number" id="external-network-bandwidth" min="0" max="1000000" value="125000" aria-label="External network bandwidth">
+            <h4 class="p-heading--five">External network bandwidth [Gbps]</h3>
+            <input type="number" id="external-network-bandwidth" min="1" max="1000000" value="1" aria-label="External network bandwidth">
           </div>
           <div class="js-formfield">
-            <h4 class="p-heading--five">Annual per-Gbps hosting external network cost</h3>
+            <h4 class="p-heading--five">Annual per-Gbps hosting external network cost [USD]</h3>
             <input type="number" id="annual-per-gbps-hosting-external-network-cost" min="0" max="1000000" value="6000" aria-label="Annual per-Gbps hosting external network cost">
           </div>
         </div>


### PR DESCRIPTION
## Done

- Updated default values and fixed incorrect range values
- Added another instance option to contact form to give the option of 5 instances instead of 4 as per [comment](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit?disco=AAAAMvOaL-I)

## QA

- View page at: https://ubuntu-com-10083.demos.haus/openstack/pricing-calculator
- Check max range for Ephemeral storage is 6144 and for persistent storage is 221184 on both calculator and in "Get cost estimates" form
- Check default value for RAM is 2 on calculator and form as per [comment](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit?disco=AAAAIqPYt3U) 
- on the "Get cost estimates" form, check default value for "External network bandwidth" is 1 as per [comment](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit?disco=AAAAIqPYt6E). Also check the [Gbps] is included. Also check [USD] is included on "Annual per-Gbps hosting external network cost"
- On the form check there is the ability to add up to 5 instances.
- Check both links "Get the free report" and "Learn more about TCO calculators" - requested [here](https://github.com/canonical-web-and-design/web-squad/issues/4281#issuecomment-887400583)

## Issue / Card

Fixes [#4281](https://github.com/canonical-web-and-design/web-squad/issues/4281#issuecomment-887400583)
