### PR TITLE
Updates cube terms of service

### DIFF
--- a/templates/legal/terms-and-policies/cube-terms.html
+++ b/templates/legal/terms-and-policies/cube-terms.html
@@ -11,14 +11,14 @@ meta_copydoc %}
 <div class="p-strip row">
     <h1>CUBE Terms of Service</h1>
     <p class="p-heading--three">
-        Valid since March 2021
+        Valid since July 2021
     </p>
     <div class="col-8">
     <p>
-        These Terms of Service cover the provision of CUBE services (the “Service”) by Canonical Group Limited ("Canonical", "us", "our" or "we") to you ("you" or "your") subject to and in accordance with these Terms of Service.
+        These Terms of Service cover the provision of CUBE services (the “<b>Service</b>”) by Canonical Group Limited ("<b>Canonical</b>", "<b>us</b>", "<b>our</b>" or "<b>we</b>") to you ("<b>you</b>" or "<b>your</b>") subject to and in accordance with these Terms of Service.
     </p>
     <p>
-        Please read these Terms of Service carefully before you use the Service. By using the Service, you agree to become bound by these terms Terms of Service. You may not use the Service for illegal or unauthorised purposes or otherwise not in accordance with this Terms of Service.
+        Please read these Terms of Service carefully before you use the Service. By using the Service, you agree to become bound by these Terms of Service. You may not use the Service for illegal or unauthorised purposes or otherwise not in accordance with this Terms of Service.
     </p>
     <p>
         If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Service through the account, to these Terms of Service. “you” and “your” shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.
@@ -45,14 +45,14 @@ meta_copydoc %}
     <ul>
         <li>have a Service account;</li>
         <li>not use the Service for illegal or unauthorised purposes (or which encourage or permit illegal or authorised purposes), in infringement of a third party's’ rights or otherwise in accordance with these Terms of Service;</li>
-        <li>not use take any action or use the Service in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Service; </li>
+        <li>not use take any action or use the Service in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Service;</li>
         <li>not use the Service in any manner that might be libellous or defamatory, that contains threats or incites violence towards individuals or entities, or that violates the privacy rights of any third party.</li>
     </ul>
     <p>
         If you do not have an account you will need to create one. You are responsible for choosing an appropriate password for your accounts and for keeping such password secure. Canonical will not ask you for your password and you should not reveal it to anyone. You are responsible for keeping your account details up to date.
     </p>
     <p>
-        Note that by creating a Service account with Us you will automatically create an account on the edX platform provided by City Network, which is required to administer the CUBE exam materials. The edX privacy policy can be found here: <a href="https://www.edx.org/edx-privacy-policy">https://www.edx.org/edx-privacy-policy</a>.
+        Note that by creating a Service account with us you will automatically create an account on the edX platform provided by City Network, which is required to administer the CUBE exam materials. The edX privacy policy can be found here: <a href="https://www.edx.org/edx-privacy-policy">https://www.edx.org/edx-privacy-policy</a>.
     </p>
     <p>
         The creation of an edX account will be subject to the edX Terms of Service which can be found here: <a href="https://www.edx.org/edx-terms-service">https://www.edx.org/edx-terms-service</a>. Administration (including deletion) of the edX account will be carried out through your edX account directly.
@@ -65,7 +65,7 @@ meta_copydoc %}
         <li>The account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> records your username, password, and the name that you wish to appear on your earned CUBE credentials. The page also includes optional information fields that you may leave blank or fill out as desired.</li>
     </ul>
     <p>
-        You may cancel your CUBE account at any time through your account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> by clicking Delete My Account. Note that this does not delete your Ubuntu SSO account, since you might be using it for other Canonical services, neither does it automatically delete your edX account. To delete your Ubuntu SSO account, visit <a href="https://login.ubuntu.com/">https://login.ubuntu.com</a> and click Permanently delete account.
+        You may cancel your CUBE account at any time through your account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> by clicking <b>Delete My Account</b>. Note that this does not delete your Ubuntu SSO account, since you might be using it for other Canonical services, neither does it automatically delete your edX account. To delete your Ubuntu SSO account, visit <a href="https://login.ubuntu.com/">https://login.ubuntu.com</a> and click <b>Permanently delete account</b>.
     </p>
     <h2>3. Termination</h2>
     <p>
@@ -73,55 +73,72 @@ meta_copydoc %}
     </p>
     <h2>4. Changes</h2>
     <p>
-        We continually aim to improve the delivery and content of the Service and accordingly may make changes to the Service from time to time. 
+        We continually aim to improve the delivery and content of the Service and accordingly may make changes to the Service from time to time.
     </p>
     <p>
         New features may be added, but we may also modify or discontinue (temporarily or permanently) part of the Service, in part or in whole. We may also offer Services on a trial/beta basis, in which case your use of those Services will be limited to the period of your trial/beta and subject to the terms of the trial/beta.
     </p>
     <p>
-        In the event of a material change to the Service, we will notify you via the email associated with your account. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment. 	
+        In the event of a material change to the Service, we will notify you via the email associated with your account. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment.
     </p>
     <p>
         Similarly, we may occasionally make changes to these Terms of Service and will notify you of material changes via the email associated with your account. If Canonical does make changes to these Terms of Service, all changes will go into effect at the time we post the updated Terms of Service or as otherwise notified at that time.
     </p>
     <h2>5. Intellectual property and content</h2>
-    <h3>Intellectual property</h3>
+    <h3><u>Intellectual property</u></h3>
     <p>
         You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Service for such time as it is made available by us strictly in accordance with these Terms of Service.
     </p>
     <p>
         You will not acquire any rights to the Service (or the intellectual property rights contained therein) from your use of the Service, other than as set out in these Terms of Service.
     </p>
-    <h3>Content</h3>
+    <h3><u>Content</u></h3>
     <p>
         You are responsible for all content that you create or use through your account. All content provided by you or a third party are accessed at your sole discretion and risk.
     </p>
-    <h3>Third party content</h3>
+    <h3><u>Third party content</u></h3>
     <p>
-        You may use and access content provided by third parties (including without limitation third party edX) in your use of the Service. 	
+        You may use and access content provided by third parties (including without limitation third party edX) in your use of the Service.
     </p>
     <p>
         Canonical is not responsible for any content  provided by any third party. Should you reasonably believe that any third party content you access through the Services is in breach of any law, regulation or third party's rights, you should notify Canonical in writing at the address below. In doing so, please: (a) identify the material which you believe to be infringing; (b) identify what you believe this material infringes and why; (c) Provide your name, email address, address and telephone number; (d) confirm that you believe in good faith that this material is infringing a law or third party's rights and that, to the best of your knowledge, the information you are providing is correct; (e) identify if you are acting on behalf of the third party whose rights may have been infringed; and (f) provide your physical or electronic signature.
     </p>
-    <h2>6. Personal data</h2>
+    <h3><u>Licence</u></h3>
     <p>
-        In order to access and use the Service, you will be required to provide information about yourself such as your name and address, as well as optional information such as date of birth, nationality, gender, completed education, phone number, IP address and related information. Any such information you provide to Canonical must always be accurate, correct and up to date. 	
+        To the extent that the Service provided to you is not under an open source licence, Canonical grants to you a world-wide, non-exclusive, non-transferable licence for so long as we provide the Service to you, to use Canonical’s intellectual property rights in the Service (“Licensed IP”) in accordance with these Terms of Services. You may not use, copy, modify, disassemble, decompile, reverse engineer, or distribute the Licensed IP except as expressly permitted in these Terms of Service, or permit access to the Licensed IP to any third party other than those acting on your behalf except as expressly permitted in these Terms of Service.
+    </p>
+    <h2>6. Fees</h2>
+    <p>
+        Canonical will not charge you for use of any free use materials associated with the Service. Your use of paid content (“Study Labs”) will be charged as described below. Payment for Study Labs is due when you purchase access to Study Labs.
+    </p>
+    <p>
+        You will be asked to enter your credit card details and to confirm your acceptance of these Terms of Service. Fees are charged in the currency in which you make your purchase.
+    </p>
+    <p>
+        Payment is handled by a third party and your credit card statement may identify payments as made to “Canonical” or “Stripe”. You are responsible for any foreign transaction fees incurred by your bank. You must abide by any relevant terms and conditions or other legal agreement, whether with us or a third party, that governs your use of a given payment processing method. We may add or remove payment processing methods at our sole discretion and without notice to you.  Once your purchase is complete, we or our payment processor may charge your credit card or other form of payment, along with any additional applicable amounts (including any taxes). You are solely responsible for all amounts payable associated with purchases you make in accordance with these Terms of Service.
+    </p>
+    <p>
+        You are responsible for any Taxes (as defined below), and must pay for the Service without any reduction for Taxes. If Canonical is obliged to collect or pay Taxes, the Taxes will be charged to you. If you have a VAT ID please provide this with your credit card details when requested. "Taxes" means any duties, customs fees, or taxes (other than income tax) associated with the use of the Service or licensing of Software, including any related penalties or interest. You must comply with all applicable tax laws, including the reporting and payment of any taxes arising in connection with your use of the Services. The reporting and payment of any such applicable taxes are your responsibility.
+    </p>
+    <h2>7. Personal data</h2>
+    <p>
+        In order to access and use the Service, you will be required to provide information about yourself such as your name and address, as well as optional information such as date of birth, nationality, gender, completed education, phone number, IP address and related information. Any such information you provide to Canonical must always be accurate, correct and up to date. We may also ask you to participate in CUBE- related surveys, for feedback purposes. Participating in surveys is optional.
     </p>
     <p>
         Our Privacy Policy and CUBE Privacy Notice explain how we treat your personal data and protect your privacy when using our services. Canonical may need to provide limited personal data, such as your name and email address, to third parties for the purposes of providing you with the Service. By accessing and using the Service you are agreeing to the use of your personal data in this way.
     </p>
     <p>
-        We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical. 
+        We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.
     </p>
     <p>
         Canonical may disclose any or all personal data and contents you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of 	your personal data is subject to the Privacy Policy and applicable Privacy Notice.
     </p>
-    <h2>7. Liability</h2>
+    <h2>8. Liability</h2>
     <p>
         Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis without warranty of any kind.
     </p>
     <p>
-        In the case of the Service provided by Canonical, the Service is provided “as is” and, other than as expressly set out in these Terms of Service, all warranties (whether express, implied, statutory or otherwise) in respect of the Service are expressly excluded to the maximum extent permitted by law
+        In the case of the Service provided by Canonical, the Service is provided “as is” and, other than as expressly set out in these Terms of Service, all warranties (whether express, implied, statutory or otherwise) in respect of the Service are expressly excluded to the maximum extent permitted by law.
     </p>
     <p>
         Canonical will provide the Service with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Services, but makes no guarantee that the Service will be available without interruption or will be error-free.
@@ -135,9 +152,9 @@ meta_copydoc %}
     <p>
         Nothing in these Terms of Service will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.
     </p>
-    <h2>8. General</h2>
+    <h2>9. General</h2>
     <p>
-        These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England. 
+        These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.
     </p>
     <p>
         Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.
@@ -145,11 +162,11 @@ meta_copydoc %}
     <p>
         Any notices should be sent by registered post to:
     </p>
-    <p>Legal, Canonical<br>
-        5th Floor, Blue Fin Building<br>
-        110 Southwark Street<br>
-        London, SE1 0SU<br>
-        United Kingdom
+    <p>
+        Canonical Group Limited,<br>
+        5th Floor, Blue Fin Building,<br>
+        110 Southwark Street,<br>
+        London, SE1 0SU.<br>
     </p>
 </div>
 </div>

--- a/templates/legal/terms-and-policies/cube-terms.html
+++ b/templates/legal/terms-and-policies/cube-terms.html
@@ -8,166 +8,169 @@
 meta_copydoc %}
 
 {% block content %}
-<div class="p-strip row">
-    <h1>CUBE Terms of Service</h1>
-    <p class="p-heading--three">
-        Valid since July 2021
-    </p>
-    <div class="col-8">
-    <p>
-        These Terms of Service cover the provision of CUBE services (the “<b>Service</b>”) by Canonical Group Limited ("<b>Canonical</b>", "<b>us</b>", "<b>our</b>" or "<b>we</b>") to you ("<b>you</b>" or "<b>your</b>") subject to and in accordance with these Terms of Service.
-    </p>
-    <p>
-        Please read these Terms of Service carefully before you use the Service. By using the Service, you agree to become bound by these Terms of Service. You may not use the Service for illegal or unauthorised purposes or otherwise not in accordance with this Terms of Service.
-    </p>
-    <p>
-        If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Service through the account, to these Terms of Service. “you” and “your” shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.
-    </p>
-    <p>
-        You must be at least 13 years old to use the Service. If you are between age 13 and 18, you confirm that you have your parent's or legal guardian's consent to use the Service and that they have read and agreed to these Terms of Service.
-    </p>
-    <p>
-        Any change or update to the Services or Terms of Service will be made in accordance with section 6 below.
-    </p>
-    <h2>1. CUBE Services</h2>
-    <p>
-        CUBE is a certification program that grants the user the opportunity to earn professional credentials in various Ubuntu subject areas. To this end, CUBE provides the following services:
-    </p>
-    <ul>
-        <li>A platform for recording certification progress, purchasing access to CUBE materials, and sharing earned credentials online.</li>
-        <li>Access to purchased exams through the platform.</li>
-        <li>Access to purchased study labs through the platform.</li>
-    </ul>
-    <h2>2. Account</h2>
-    <p>
-        You will need an account to access and use the Service. We reserve the right to reject your request for an account or to immediately cancel or suspend your account and your use of the Service at any time if you do not comply with the following requirements. You must not attempt to create an account or use the Service if doing so would violate these Terms of Service. You must:
-    </p>
-    <ul>
-        <li>have a Service account;</li>
-        <li>not use the Service for illegal or unauthorised purposes (or which encourage or permit illegal or authorised purposes), in infringement of a third party's’ rights or otherwise in accordance with these Terms of Service;</li>
-        <li>not use take any action or use the Service in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Service;</li>
-        <li>not use the Service in any manner that might be libellous or defamatory, that contains threats or incites violence towards individuals or entities, or that violates the privacy rights of any third party.</li>
-    </ul>
-    <p>
-        If you do not have an account you will need to create one. You are responsible for choosing an appropriate password for your accounts and for keeping such password secure. Canonical will not ask you for your password and you should not reveal it to anyone. You are responsible for keeping your account details up to date.
-    </p>
-    <p>
-        Note that by creating a Service account with us you will automatically create an account on the edX platform provided by City Network, which is required to administer the CUBE exam materials. The edX privacy policy can be found here: <a href="https://www.edx.org/edx-privacy-policy">https://www.edx.org/edx-privacy-policy</a>.
-    </p>
-    <p>
-        The creation of an edX account will be subject to the edX Terms of Service which can be found here: <a href="https://www.edx.org/edx-terms-service">https://www.edx.org/edx-terms-service</a>. Administration (including deletion) of the edX account will be carried out through your edX account directly.
-    </p>
-    <p>
-        You will be provided with account pages at <a href="https://ubuntu.com/cube/microcerts">https://ubuntu.com/cube/microcerts</a> and <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a>:
-    </p>
-    <ul>
-        <li>The account page at <a href="https://ubuntu.com/cube/microcerts">https://ubuntu.com/cube/microcerts</a> records your progress through CUBE’s microcerts and allows you to purchase access to exams and study labs.</li>
-        <li>The account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> records your username, password, and the name that you wish to appear on your earned CUBE credentials. The page also includes optional information fields that you may leave blank or fill out as desired.</li>
-    </ul>
-    <p>
-        You may cancel your CUBE account at any time through your account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> by clicking <b>Delete My Account</b>. Note that this does not delete your Ubuntu SSO account, since you might be using it for other Canonical services, neither does it automatically delete your edX account. To delete your Ubuntu SSO account, visit <a href="https://login.ubuntu.com/">https://login.ubuntu.com</a> and click <b>Permanently delete account</b>.
-    </p>
-    <h2>3. Termination</h2>
-    <p>
-        We may cease to offer the services for any reason, in which case we will provide you with notice via the email associated with your account.
-    </p>
-    <h2>4. Changes</h2>
-    <p>
-        We continually aim to improve the delivery and content of the Service and accordingly may make changes to the Service from time to time.
-    </p>
-    <p>
-        New features may be added, but we may also modify or discontinue (temporarily or permanently) part of the Service, in part or in whole. We may also offer Services on a trial/beta basis, in which case your use of those Services will be limited to the period of your trial/beta and subject to the terms of the trial/beta.
-    </p>
-    <p>
-        In the event of a material change to the Service, we will notify you via the email associated with your account. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment.
-    </p>
-    <p>
-        Similarly, we may occasionally make changes to these Terms of Service and will notify you of material changes via the email associated with your account. If Canonical does make changes to these Terms of Service, all changes will go into effect at the time we post the updated Terms of Service or as otherwise notified at that time.
-    </p>
-    <h2>5. Intellectual property and content</h2>
-    <h3><u>Intellectual property</u></h3>
-    <p>
-        You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Service for such time as it is made available by us strictly in accordance with these Terms of Service.
-    </p>
-    <p>
-        You will not acquire any rights to the Service (or the intellectual property rights contained therein) from your use of the Service, other than as set out in these Terms of Service.
-    </p>
-    <h3><u>Content</u></h3>
-    <p>
-        You are responsible for all content that you create or use through your account. All content provided by you or a third party are accessed at your sole discretion and risk.
-    </p>
-    <h3><u>Third party content</u></h3>
-    <p>
-        You may use and access content provided by third parties (including without limitation third party edX) in your use of the Service.
-    </p>
-    <p>
-        Canonical is not responsible for any content  provided by any third party. Should you reasonably believe that any third party content you access through the Services is in breach of any law, regulation or third party's rights, you should notify Canonical in writing at the address below. In doing so, please: (a) identify the material which you believe to be infringing; (b) identify what you believe this material infringes and why; (c) Provide your name, email address, address and telephone number; (d) confirm that you believe in good faith that this material is infringing a law or third party's rights and that, to the best of your knowledge, the information you are providing is correct; (e) identify if you are acting on behalf of the third party whose rights may have been infringed; and (f) provide your physical or electronic signature.
-    </p>
-    <h3><u>Licence</u></h3>
-    <p>
-        To the extent that the Service provided to you is not under an open source licence, Canonical grants to you a world-wide, non-exclusive, non-transferable licence for so long as we provide the Service to you, to use Canonical’s intellectual property rights in the Service (“Licensed IP”) in accordance with these Terms of Services. You may not use, copy, modify, disassemble, decompile, reverse engineer, or distribute the Licensed IP except as expressly permitted in these Terms of Service, or permit access to the Licensed IP to any third party other than those acting on your behalf except as expressly permitted in these Terms of Service.
-    </p>
-    <h2>6. Fees</h2>
-    <p>
-        Canonical will not charge you for use of any free use materials associated with the Service. Your use of paid content (“Study Labs”) will be charged as described below. Payment for Study Labs is due when you purchase access to Study Labs.
-    </p>
-    <p>
-        You will be asked to enter your credit card details and to confirm your acceptance of these Terms of Service. Fees are charged in the currency in which you make your purchase.
-    </p>
-    <p>
-        Payment is handled by a third party and your credit card statement may identify payments as made to “Canonical” or “Stripe”. You are responsible for any foreign transaction fees incurred by your bank. You must abide by any relevant terms and conditions or other legal agreement, whether with us or a third party, that governs your use of a given payment processing method. We may add or remove payment processing methods at our sole discretion and without notice to you.  Once your purchase is complete, we or our payment processor may charge your credit card or other form of payment, along with any additional applicable amounts (including any taxes). You are solely responsible for all amounts payable associated with purchases you make in accordance with these Terms of Service.
-    </p>
-    <p>
-        You are responsible for any Taxes (as defined below), and must pay for the Service without any reduction for Taxes. If Canonical is obliged to collect or pay Taxes, the Taxes will be charged to you. If you have a VAT ID please provide this with your credit card details when requested. "Taxes" means any duties, customs fees, or taxes (other than income tax) associated with the use of the Service or licensing of Software, including any related penalties or interest. You must comply with all applicable tax laws, including the reporting and payment of any taxes arising in connection with your use of the Services. The reporting and payment of any such applicable taxes are your responsibility.
-    </p>
-    <h2>7. Personal data</h2>
-    <p>
-        In order to access and use the Service, you will be required to provide information about yourself such as your name and address, as well as optional information such as date of birth, nationality, gender, completed education, phone number, IP address and related information. Any such information you provide to Canonical must always be accurate, correct and up to date. We may also ask you to participate in CUBE- related surveys, for feedback purposes. Participating in surveys is optional.
-    </p>
-    <p>
-        Our Privacy Policy and CUBE Privacy Notice explain how we treat your personal data and protect your privacy when using our services. Canonical may need to provide limited personal data, such as your name and email address, to third parties for the purposes of providing you with the Service. By accessing and using the Service you are agreeing to the use of your personal data in this way.
-    </p>
-    <p>
-        We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.
-    </p>
-    <p>
-        Canonical may disclose any or all personal data and contents you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of 	your personal data is subject to the Privacy Policy and applicable Privacy Notice.
-    </p>
-    <h2>8. Liability</h2>
-    <p>
-        Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis without warranty of any kind.
-    </p>
-    <p>
-        In the case of the Service provided by Canonical, the Service is provided “as is” and, other than as expressly set out in these Terms of Service, all warranties (whether express, implied, statutory or otherwise) in respect of the Service are expressly excluded to the maximum extent permitted by law.
-    </p>
-    <p>
-        Canonical will provide the Service with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Services, but makes no guarantee that the Service will be available without interruption or will be error-free.
-    </p>
-    <p>
-        In the case of third party content, you acknowledge that such content is provided to you by the relevant third party pursuant to the relevant terms and conditions and Canonical will have no liability whatsoever in contract, tort or otherwise to you in respect of such content.
-    </p>
-    <p>
-        Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical’s total liability in contract, tort or otherwise for any claims is limited to £10.
-    </p>
-    <p>
-        Nothing in these Terms of Service will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.
-    </p>
-    <h2>9. General</h2>
-    <p>
-        These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.
-    </p>
-    <p>
-        Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.
-    </p>
-    <p>
-        Any notices should be sent by registered post to:
-    </p>
-    <p>
-        Canonical Group Limited,<br>
-        5th Floor, Blue Fin Building,<br>
-        110 Southwark Street,<br>
-        London, SE1 0SU.<br>
-    </p>
-</div>
-</div>
+<section class="p-strip">
+    <div class="row">
+        <div class="col-8">
+            <h1>CUBE Terms of Service</h1>
+            <p class="p-heading--three">
+                Valid since July 2021
+            </p>
+            <p>
+                These Terms of Service cover the provision of CUBE services (the "<strong>Service</strong>") by Canonical Group Limited ("<strong>Canonical</strong>", "<strong>us</strong>", "<strong>our</strong>" or "<strong>we</strong>") to you ("<strong>you</strong>" or "<strong>your</strong>") subject to and in accordance with these Terms of Service.
+            </p>
+            <p>
+                Please read these Terms of Service carefully before you use the Service. By using the Service, you agree to become bound by these Terms of Service. You may not use the Service for illegal or unauthorised purposes or otherwise not in accordance with this Terms of Service.
+            </p>
+            <p>
+                If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Service through the account, to these Terms of Service. "you" and "your" shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.
+            </p>
+            <p>
+                You must be at least 13 years old to use the Service. If you are between age 13 and 18, you confirm that you have your parent's or legal guardian's consent to use the Service and that they have read and agreed to these Terms of Service.
+            </p>
+            <p>
+                Any change or update to the Services or Terms of Service will be made in accordance with section 6 below.
+            </p>
+            <h2>1. CUBE Services</h2>
+            <p>
+                CUBE is a certification program that grants the user the opportunity to earn professional credentials in various Ubuntu subject areas. To this end, CUBE provides the following services:
+            </p>
+            <ul>
+                <li>A platform for recording certification progress, purchasing access to CUBE materials, and sharing earned credentials online.</li>
+                <li>Access to purchased exams through the platform.</li>
+                <li>Access to purchased study labs through the platform.</li>
+            </ul>
+            <h2>2. Account</h2>
+            <p>
+                You will need an account to access and use the Service. We reserve the right to reject your request for an account or to immediately cancel or suspend your account and your use of the Service at any time if you do not comply with the following requirements. You must not attempt to create an account or use the Service if doing so would violate these Terms of Service. You must:
+            </p>
+            <ul>
+                <li>have a Service account;</li>
+                <li>not use the Service for illegal or unauthorised purposes (or which encourage or permit illegal or authorised purposes), in infringement of a third party's rights or otherwise in accordance with these Terms of Service;</li>
+                <li>not use take any action or use the Service in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Service;</li>
+                <li>not use the Service in any manner that might be libellous or defamatory, that contains threats or incites violence towards individuals or entities, or that violates the privacy rights of any third party.</li>
+            </ul>
+            <p>
+                If you do not have an account you will need to create one. You are responsible for choosing an appropriate password for your accounts and for keeping such password secure. Canonical will not ask you for your password and you should not reveal it to anyone. You are responsible for keeping your account details up to date.
+            </p>
+            <p>
+                Note that by creating a Service account with us you will automatically create an account on the edX platform provided by City Network, which is required to administer the CUBE exam materials. The edX privacy policy can be found here: <a href="https://www.edx.org/edx-privacy-policy">https://www.edx.org/edx-privacy-policy</a>.
+            </p>
+            <p>
+                The creation of an edX account will be subject to the edX Terms of Service which can be found here: <a href="https://www.edx.org/edx-terms-service">https://www.edx.org/edx-terms-service</a>. Administration (including deletion) of the edX account will be carried out through your edX account directly.
+            </p>
+            <p>
+                You will be provided with account pages at <a href="https://ubuntu.com/cube/microcerts">https://ubuntu.com/cube/microcerts</a> and <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a>:
+            </p>
+            <ul>
+                <li>The account page at <a href="https://ubuntu.com/cube/microcerts">https://ubuntu.com/cube/microcerts</a> records your progress through CUBE's microcerts and allows you to purchase access to exams and study labs.</li>
+                <li>The account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> records your username, password, and the name that you wish to appear on your earned CUBE credentials. The page also includes optional information fields that you may leave blank or fill out as desired.</li>
+            </ul>
+            <p>
+                You may cancel your CUBE account at any time through your account page at <a href="https://cube.ubuntu.com/account/settings">https://cube.ubuntu.com/account/settings</a> by clicking <strong>Delete My Account</strong>. Note that this does not delete your Ubuntu SSO account, since you might be using it for other Canonical services, neither does it automatically delete your edX account. To delete your Ubuntu SSO account, visit <a href="https://login.ubuntu.com/">https://login.ubuntu.com</a> and click <strong>Permanently delete account</strong>.
+            </p>
+            <h2>3. Termination</h2>
+            <p>
+                We may cease to offer the services for any reason, in which case we will provide you with notice via the email associated with your account.
+            </p>
+            <h2>4. Changes</h2>
+            <p>
+                We continually aim to improve the delivery and content of the Service and accordingly may make changes to the Service from time to time.
+            </p>
+            <p>
+                New features may be added, but we may also modify or discontinue (temporarily or permanently) part of the Service, in part or in whole. We may also offer Services on a trial/beta basis, in which case your use of those Services will be limited to the period of your trial/beta and subject to the terms of the trial/beta.
+            </p>
+            <p>
+                In the event of a material change to the Service, we will notify you via the email associated with your account. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment.
+            </p>
+            <p>
+                Similarly, we may occasionally make changes to these Terms of Service and will notify you of material changes via the email associated with your account. If Canonical does make changes to these Terms of Service, all changes will go into effect at the time we post the updated Terms of Service or as otherwise notified at that time.
+            </p>
+            <h2>5. Intellectual property and content</h2>
+            <h3>Intellectual property</h3>
+            <p>
+                You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Service for such time as it is made available by us strictly in accordance with these Terms of Service.
+            </p>
+            <p>
+                You will not acquire any rights to the Service (or the intellectual property rights contained therein) from your use of the Service, other than as set out in these Terms of Service.
+            </p>
+            <h3>Content</h3>
+            <p>
+                You are responsible for all content that you create or use through your account. All content provided by you or a third party are accessed at your sole discretion and risk.
+            </p>
+            <h3>Third party content</h3>
+            <p>
+                You may use and access content provided by third parties (including without limitation third party edX) in your use of the Service.
+            </p>
+            <p>
+                Canonical is not responsible for any content  provided by any third party. Should you reasonably believe that any third party content you access through the Services is in breach of any law, regulation or third party's rights, you should notify Canonical in writing at the address below. In doing so, please: (a) identify the material which you believe to be infringing; (b) identify what you believe this material infringes and why; (c) Provide your name, email address, address and telephone number; (d) confirm that you believe in good faith that this material is infringing a law or third party's rights and that, to the best of your knowledge, the information you are providing is correct; (e) identify if you are acting on behalf of the third party whose rights may have been infringed; and (f) provide your physical or electronic signature.
+            </p>
+            <h3>Licence</h3>
+            <p>
+                To the extent that the Service provided to you is not under an open source licence, Canonical grants to you a world-wide, non-exclusive, non-transferable licence for so long as we provide the Service to you, to use Canonical's intellectual property rights in the Service ("Licensed IP") in accordance with these Terms of Services. You may not use, copy, modify, disassemble, decompile, reverse engineer, or distribute the Licensed IP except as expressly permitted in these Terms of Service, or permit access to the Licensed IP to any third party other than those acting on your behalf except as expressly permitted in these Terms of Service.
+            </p>
+            <h2>6. Fees</h2>
+            <p>
+                Canonical will not charge you for use of any free use materials associated with the Service. Your use of paid content ("Study Labs") will be charged as described below. Payment for Study Labs is due when you purchase access to Study Labs.
+            </p>
+            <p>
+                You will be asked to enter your credit card details and to confirm your acceptance of these Terms of Service. Fees are charged in the currency in which you make your purchase.
+            </p>
+            <p>
+                Payment is handled by a third party and your credit card statement may identify payments as made to "Canonical" or "Stripe". You are responsible for any foreign transaction fees incurred by your bank. You must abide by any relevant terms and conditions or other legal agreement, whether with us or a third party, that governs your use of a given payment processing method. We may add or remove payment processing methods at our sole discretion and without notice to you.  Once your purchase is complete, we or our payment processor may charge your credit card or other form of payment, along with any additional applicable amounts (including any taxes). You are solely responsible for all amounts payable associated with purchases you make in accordance with these Terms of Service.
+            </p>
+            <p>
+                You are responsible for any Taxes (as defined below), and must pay for the Service without any reduction for Taxes. If Canonical is obliged to collect or pay Taxes, the Taxes will be charged to you. If you have a VAT ID please provide this with your credit card details when requested. "Taxes" means any duties, customs fees, or taxes (other than income tax) associated with the use of the Service or licensing of Software, including any related penalties or interest. You must comply with all applicable tax laws, including the reporting and payment of any taxes arising in connection with your use of the Services. The reporting and payment of any such applicable taxes are your responsibility.
+            </p>
+            <h2>7. Personal data</h2>
+            <p>
+                In order to access and use the Service, you will be required to provide information about yourself such as your name and address, as well as optional information such as date of birth, nationality, gender, completed education, phone number, IP address and related information. Any such information you provide to Canonical must always be accurate, correct and up to date. We may also ask you to participate in CUBE- related surveys, for feedback purposes. Participating in surveys is optional.
+            </p>
+            <p>
+                Our Privacy Policy and CUBE Privacy Notice explain how we treat your personal data and protect your privacy when using our services. Canonical may need to provide limited personal data, such as your name and email address, to third parties for the purposes of providing you with the Service. By accessing and using the Service you are agreeing to the use of your personal data in this way.
+            </p>
+            <p>
+                We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.
+            </p>
+            <p>
+                Canonical may disclose any or all personal data and contents you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of 	your personal data is subject to the Privacy Policy and applicable Privacy Notice.
+            </p>
+            <h2>8. Liability</h2>
+            <p>
+                Your use of the Service is at your sole risk. The Service is provided on an "as is" and "as available" basis without warranty of any kind.
+            </p>
+            <p>
+                In the case of the Service provided by Canonical, the Service is provided "as is" and, other than as expressly set out in these Terms of Service, all warranties (whether express, implied, statutory or otherwise) in respect of the Service are expressly excluded to the maximum extent permitted by law.
+            </p>
+            <p>
+                Canonical will provide the Service with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Services, but makes no guarantee that the Service will be available without interruption or will be error-free.
+            </p>
+            <p>
+                In the case of third party content, you acknowledge that such content is provided to you by the relevant third party pursuant to the relevant terms and conditions and Canonical will have no liability whatsoever in contract, tort or otherwise to you in respect of such content.
+            </p>
+            <p>
+                Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical's total liability in contract, tort or otherwise for any claims is limited to £10.
+            </p>
+            <p>
+                Nothing in these Terms of Service will exclude or limit Canonical's liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.
+            </p>
+            <h2>9. General</h2>
+            <p>
+                These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.
+            </p>
+            <p>
+                Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.
+            </p>
+            <p>
+                Any notices should be sent by registered post to:
+            </p>
+            <p>
+                Canonical Group Limited,<br>
+                5th Floor, Blue Fin Building,<br>
+                110 Southwark Street,<br>
+                London, SE1 0SU.<br>
+            </p>
+        </div>
+    </div>
+</section>
+
 {% endblock %}


### PR DESCRIPTION
## Done

- Updates terms of service at /legal/terms-and-policies/cube-terms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/terms-and-policies/cube-terms
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against [copy-doc](https://docs.google.com/document/d/1vRtCO-FDMC8rqthi4sgI1Fn3ofT6zqcCpjHbOyiyhjY/edit#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4278
