### PR TITLE
Allow NODE_ENV to be set by the environment.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -139,3 +139,9 @@ CUBE_CONTENT = yaml.load(
     Path("webapp/cube/content/cube-qa.yaml").read_text(), Loader=yaml.Loader
 )
 ```
+
+### JavaScript
+
+Parts of this site use [React Query](https://react-query.tanstack.com/overview) to manage data from the API.
+
+To enable the React Query devtools you need to add `NODE_ENV="development"` to your `.env.local` file or run: `dotrun -e NODE_ENV="development"`.

--- a/build.js
+++ b/build.js
@@ -31,7 +31,14 @@ for (const [key, value] of Object.entries(entries)) {
     sourcemap: true,
     outfile: "static/js/dist/" + key + ".js",
     target: ["chrome58", "firefox57", "safari11", "edge16"],
-    define: { "process.env.NODE_ENV": '"production"' },
+    define: {
+      "process.env.NODE_ENV":
+        // Explicitly check for 'development' so that this defaults to
+        // 'production' in all other cases.
+        process && process.env && process.env.NODE_ENV === "development"
+          ? '"development"'
+          : '"production"',
+    },
   };
 
   esbuild.build(options).then((result) => {

--- a/static/js/src/advantage/subscribe/react/app.jsx
+++ b/static/js/src/advantage/subscribe/react/app.jsx
@@ -21,15 +21,6 @@ const queryClient = new QueryClient({
   },
 });
 
-/*
- *
- * This app is using react query (https://react-query.tanstack.com/overview) to manage data from the API
- * This library has built in devtools which are really helpful.
- * To enable them you need to replace "production" by "development" in "/build.js"
- * If you do so, please make sure to revert the change before you merge your changes.
- *
- */
-
 function App() {
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Done

- Update the `esbuild` config to allow the environment to set `NODE_ENV`.

## QA

- Check out this branch.
- Either add `NODE_ENV="development"` to your `.env.local` file and then run `dotrun` or run: `dotrun -e NODE_ENV="development"`.
- Visit `/advantage/subscribe`, fill out the form and then click "Buy now".
- You should see the devtools flower in the bottom left of the screen.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/124.
