### PR TITLE
Only run prettier against source SCSS and JavaScript files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test-python": "python3 -m unittest discover tests",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "format-python": "black --line-length 79 webapp tests",
-    "format-js": "prettier -w '**/*.js'",
+    "format-js": "prettier -w 'static/js/src/**/*.{js,jsx,ts,tsx}'",
     "lint-scss": "stylelint 'static/sass/**/*.scss'",
     "lint-js": "eslint static/js/src/**/*.js 'static/js/src/**/*.jsx'",
     "test-js": "NODE_ICU_DATA=node_modules/full-icu jest",
@@ -23,7 +23,7 @@
     "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch-css' 'yarn run watch-js' 'yarn run serve'",
     "cypress:run": "cypress run --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}",
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://$(hostname -I | awk '{print $1;}'):${PORT}",
-    "check-prettier": "prettier -c '**/*.{scss,js}'"
+    "check-prettier": "prettier -c 'static/js/src/**/*.{js,jsx,ts,tsx}' 'static/sass/**/*.scss'"
   },
   "keywords": [
     "website",


### PR DESCRIPTION
## Done

- Update `check-prettier` and `format-js` to only run against source files.

## QA

- Check out this branch.
- Run `check-prettier` or `format-js`.
- It should run much faster and you shouldn't see warnings about dist or .venv files.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10087.

## Screenshots

[If relevant, please include a screenshot.]
