### PR TITLE
Make test flag consistent

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1163,6 +1163,8 @@ account:
   path: /account
 
   children:
+    - title: Overview
+      path: /account
     - title: Invoices
       path: /account/invoices
     - title: Payment methods

--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -172,9 +172,13 @@ const PurchaseModal = () => {
         if (request.readyState === 4) {
           //redirect
           if (window.isGuest) {
+            const queryString = window.location.search;
+            const testBackend = queryString.includes("test_backend=true")
+              ? "&test_backend=true"
+              : "";
             location.href = `/advantage/subscribe/thank-you?email=${encodeURIComponent(
               pendingPurchase?.invoice?.customerEmail
-            )}`;
+            )}${testBackend}`;
           } else {
             location.pathname = "/advantage";
           }

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -197,26 +197,28 @@ if (accountContainer && accountContainerSmall) {
   fetch("/account.json")
     .then((response) => response.json())
     .then((data) => {
+      const queryString = window.location.search.includes("test_backend=true")
+        ? "?test_backend=true"
+        : "";
+
       if (data.account === null) {
-        accountContainerSmall.innerHTML =
-          '<a href="/login" class="p-navigation__link-anchor">Sign in</a>';
-        accountContainer.innerHTML =
-          '<a href="/login" class="p-navigation__link-anchor" style="padding-right: 1rem;">Sign in</a>';
+        accountContainerSmall.innerHTML = `<a href="/login${queryString}" class="p-navigation__link-anchor">Sign in</a>`;
+        accountContainer.innerHTML = `<a href="/login${queryString}" class="p-navigation__link-anchor" style="padding-right: 1rem;">Sign in</a>`;
       } else {
-        accountContainerSmall.innerHTML = `<span class="p-navigation__link-anchor">${data.account.fullname} (<a href="/logout" class="p-link--inverted">logout</a>)</span>`;
+        accountContainerSmall.innerHTML = `<span class="p-navigation__link-anchor">${data.account.fullname} (<a href="/logout${queryString}" class="p-link--inverted">logout</a>)</span>`;
         accountContainer.innerHTML = `<div class="p-navigation__dropdown-link p-subnav">
             <a href="" class="p-navigation__link-anchor p-subnav__toggle" aria-controls="user-menu" aria-expanded="false" aria-haspopup="true">${data.account.fullname}</a>
             <ul class="p-subnav__items--right" id="user-menu" aria-hidden="true">
-              <li><a href="/advantage" class="p-subnav__item">UA subscriptions</a></li>
+              <li><a href="/advantage${queryString}" class="p-subnav__item">UA subscriptions</a></li>
               <li>
                 <hr class="u-no-margin--bottom">
-                <a href="/account/invoices" class="p-subnav__item">Invoices & Payments</a>
+                <a href="/account/invoices${queryString}" class="p-subnav__item">Invoices & Payments</a>
               </li>
               <li>
                 <a href="https://login.ubuntu.com/" class="p-subnav__item p-link--external">Account settings</a>
               </li>
               <li>
-                <a href="/logout" class="p-subnav__item">Logout</a>
+                <a href="/logout${queryString}" class="p-subnav__item">Logout</a>
               </li>
             </ul>
           </div>`;

--- a/static/js/src/ua-payment-modal.js
+++ b/static/js/src/ua-payment-modal.js
@@ -972,14 +972,19 @@ function processStripePayment() {
 }
 
 function reloadPage() {
+  const queryString = window.location.search;
+  const testBackend = queryString.includes("test_backend=true")
+    ? "&test_backend=true"
+    : "";
+
   if (currentTransaction.type === "renewal") {
-    location.search = `?subscription=${currentTransaction.contractId}`;
+    location.search = `?subscription=${currentTransaction.contractId}${testBackend}`;
   } else if (currentTransaction.type === "purchase" && !guestPurchase) {
     location.pathname = "/advantage";
   } else if (currentTransaction.type === "purchase" && guestPurchase) {
     location.href = `/advantage/subscribe/thank-you?email=${encodeURIComponent(
       customerInfo.email
-    )}`;
+    )}${testBackend}`;
   }
 }
 

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -53,7 +53,7 @@
                 </td>
                 <td aria-label="Download PDF">
                   {% if invoice.download_link %}
-                    <a href="{{ invoice.download_link }}{% if is_test_backend %}?test_backend=true{% endif %}" target="_blank">{{ invoice.download_file_name }}</a>
+                    <a href="{{ invoice.download_link }}{% if get_test_backend %}?test_backend=true{% endif %}" target="_blank">{{ invoice.download_file_name }}</a>
                   {% else %}
                     No invoice available
                   {% endif %}

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -92,7 +92,7 @@
         <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
         <p>Sign in to access your personal or paid subscriptions.</p>
         <p>
-          <a href="{% if is_test_backend %}/login?test_backend=true{% else %}/login{% endif %}" class="p-button--neutral"
+          <a href="{% if get_test_backend %}/login?test_backend=true{% else %}/login{% endif %}" class="p-button--neutral"
             onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage',

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -241,7 +241,7 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <a class="p-button--neutral" href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}"
+        <a class="p-button--neutral" href="/advantage/subscribe{% if get_test_backend %}?test_backend=true{% endif %}"
           >Buy a subscription</a
         >
       </p>

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -241,7 +241,7 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <a class="p-button--neutral" href="/advantage/subscribe"
+        <a class="p-button--neutral" href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}"
           >Buy a subscription</a
         >
       </p>

--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -11,7 +11,7 @@
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
         <h5>
-          <a href="/login{% if is_test_backend %}?test_backend=true{% endif %}" class="p-link"
+          <a href="/login{% if get_test_backend %}?test_backend=true{% endif %}" class="p-link"
              onclick="dataLayer.push({
                 'event' : 'GAEvent',
                 'eventCategory' : 'Advantage',
@@ -31,7 +31,7 @@
         <p>Enterprises choose Ubuntu Advantage for extended security, certified compliance and 24x7support.</p>
         <p>
           <a 
-            href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}" 
+            href="/advantage/subscribe{% if get_test_backend %}?test_backend=true{% endif %}"
             class="p-button--positive"   
             onclick="dataLayer.push({
               'event' : 'GAEvent',
@@ -50,7 +50,7 @@
         <h3>Free for personal use</h3>
         <p>Anyone can use UA-I Essential for free on up to 3 machines, or 50 if you are an <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">official Ubuntu Community member</a>.</p>
         <p class="u-no-margin--bottom">
-          <a href="/login{% if is_test_backend %}?test_backend=true{% endif %}" class="p-button--positive" onclick="dataLayer.push({
+          <a href="/login{% if get_test_backend %}?test_backend=true{% endif %}" class="p-button--positive" onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage',
               'eventAction' : 'Authentication',

--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -11,7 +11,7 @@
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
         <h5>
-          <a href="{% if is_test_backend %}/login?test_backend=true{% else %}/login{% endif %}" class="p-link"
+          <a href="/login{% if is_test_backend %}?test_backend=true{% endif %}" class="p-link"
              onclick="dataLayer.push({
                 'event' : 'GAEvent',
                 'eventCategory' : 'Advantage',
@@ -50,7 +50,7 @@
         <h3>Free for personal use</h3>
         <p>Anyone can use UA-I Essential for free on up to 3 machines, or 50 if you are an <a href="https://wiki.ubuntu.com/Membership" class="p-link--external">official Ubuntu Community member</a>.</p>
         <p class="u-no-margin--bottom">
-          <a href="/login" class="p-button--positive" onclick="dataLayer.push({
+          <a href="/login{% if is_test_backend %}?test_backend=true{% endif %}" class="p-button--positive" onclick="dataLayer.push({
               'event' : 'GAEvent',
               'eventCategory' : 'Advantage',
               'eventAction' : 'Authentication',

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -29,7 +29,7 @@
   <div class="row">
     <div class="p-notification--caution">
       <p class="p-notification__response" role="status">
-        <span class="p-notification__status">Payment method:</span>You need to <a href="/account/payment-methods{% if is_test_backend %}?test_backend=true{% endif %}">update your payment methods</a> to ensure there is no interruption to your Ubuntu Advantage subscriptions
+        <span class="p-notification__status">Payment method:</span>You need to <a href="/account/payment-methods{% if get_test_backend %}?test_backend=true{% endif %}">update your payment methods</a> to ensure there is no interruption to your Ubuntu Advantage subscriptions
       </p>
     </div>
   </div>
@@ -188,7 +188,7 @@
           {% endfor %}
         </div>
           <a
-            href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}"
+            href="/advantage/subscribe{% if get_test_backend %}?test_backend=true{% endif %}"
             class="p-button--positive"
             onclick="dataLayer.push({
               'event' : 'GAEvent',
@@ -322,7 +322,7 @@
         </div>
         <div class="col-12 u-align--right">
           <a
-            href="/advantage/subscribe{% if is_test_backend %}?test_backend=true{% endif %}"
+            href="/advantage/subscribe{% if get_test_backend %}?test_backend=true{% endif %}"
             class="p-button--positive u-align--right"
             onclick="dataLayer.push({
               'event' : 'GAEvent',

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -15,7 +15,7 @@
         <p>
           If you have existing subscriptions or sales offers,
           <a
-            href="{% if is_test_backend %}/login?test_backend=true{% else %}/login{% endif %}"
+            href="{% if get_test_backend %}/login?test_backend=true{% else %}/login{% endif %}"
             onclick="dataLayer.push({ 'event' : 'GAEvent', 'eventCategory' : 'Advantage subscribe', 'eventAction' : 'Authentication', 'eventLabel' : 'Sign in', 'eventValue' : undefined });" 
           >
             sign in

--- a/templates/advantage/subscribe/thank-you.html
+++ b/templates/advantage/subscribe/thank-you.html
@@ -18,7 +18,7 @@
         {% endif %}
 
         <p>To start using Ubuntu Advantage, you need to set up an Ubuntu One account{% if email %} with that address{% endif %}.</p>
-        <a href="/login{% if is_test_backend %}?test_backend=true{% endif %}" class="p-button--positive">Register/Sign in...</a>
+        <a href="/login{% if get_test_backend %}?test_backend=true{% endif %}" class="p-button--positive">Register/Sign in...</a>
       </div>
     </div>
   </section>

--- a/templates/advantage/subscribe/thank-you.html
+++ b/templates/advantage/subscribe/thank-you.html
@@ -18,7 +18,7 @@
         {% endif %}
 
         <p>To start using Ubuntu Advantage, you need to set up an Ubuntu One account{% if email %} with that address{% endif %}.</p>
-        <a href="/login" class="p-button--positive">Register/Sign in...</a>
+        <a href="/login{% if is_test_backend %}?test_backend=true{% endif %}" class="p-button--positive">Register/Sign in...</a>
       </div>
     </div>
   </section>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -17,7 +17,7 @@
         {% endif %}
         {% if breadcrumbs %}
         <h5 class="p-navigation--secondary__logo u-hide--nav-threshold-up">
-          <a class="p-navigation--secondary__banner" href="{{ breadcrumbs.section.path }}">
+          <a class="p-navigation--secondary__banner" href="{{ breadcrumbs.section.path }}{% if get_test_backend %}?test_backend=true{% endif %}">
             {{ breadcrumbs.section.title }}
           </a>
         </h5>
@@ -92,7 +92,7 @@
 <nav class="p-navigation--secondary">
   <div class="row">
     <div class="col-12 u-equal-height">
-      <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="{{ breadcrumbs.section.path }}">
+      <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="{{ breadcrumbs.section.path }}{% if get_test_backend %}?test_backend=true{% endif %}">
         <h5 class="p-navigation--secondary__logo">
           {{ breadcrumbs.section.title | replace(" ", "&nbsp;") | safe }}
         </h5>

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -10,6 +10,11 @@
           <script>performance.mark("Logo rendered")</script>
         </a>
 
+        {% if get_test_backend %}
+          <div class="u-hide u-show--small" style="padding: 15px 0 15px 10px">
+            <div class="p-label--new">Testing</div>
+          </div>
+        {% endif %}
         {% if breadcrumbs %}
         <h5 class="p-navigation--secondary__logo u-hide--nav-threshold-up">
           <a class="p-navigation--secondary__banner" href="{{ breadcrumbs.section.path }}">
@@ -32,6 +37,11 @@
       <span class="u-off-screen">
         <a href="#main-content">Jump to main content</a>
       </span>
+      {% if get_test_backend %}
+        <div class="u-hide--small" style="margin-right: -75px; padding: 15px 0 15px 10px">
+          <div class="p-label--new">Testing</div>
+        </div>
+      {% endif %}
       <ul class="p-navigation__items u-hide js-show-nav" role="menu">
         <li class="p-navigation__item p-navigation__dropdown-link" role="menuitem" id="enterprise" onmouseover="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content'); this.onmouseover = null;">
           <a class="p-navigation__link-anchor" href="#enterprise-content" onfocus="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content');">Enterprise</a>
@@ -104,7 +114,7 @@
           </li>
           {% elif child.path != '/blog/archives' and child.path != '/blog/upcoming' %}
           <li class="breadcrumbs__item">
-            <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}">{{ child.title }}</a>
+            <a class="breadcrumbs__link {% if child.active %}p-link--active{% else %}p-link--soft{% endif %}" href="{{ child.path }}{% if get_test_backend %}?test_backend=true{% endif %}">{{ child.title }}</a>
           </li>
           {% endif %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -44,7 +44,7 @@
   <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}">
   <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M">
 
-  {% if is_test_backend %}<meta name="robots" content="noindex" />{% endif %}
+  {% if get_test_backend %}<meta name="robots" content="noindex" />{% endif %}
 
   {% if self.title() %}
   <meta name="twitter:title" content="{{ self.title() }} | Ubuntu">

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -755,7 +755,6 @@ def account_view(**kwargs):
 @advantage_checks(check_list=["is_maintenance", "view_need_user"])
 @use_kwargs(invoice_view, location="query")
 def invoices_view(**kwargs):
-    is_test_backend = kwargs.get("test_backend")
     token = kwargs.get("token")
     api_url = kwargs.get("api_url")
     email = kwargs.get("email", "").strip()
@@ -819,7 +818,6 @@ def invoices_view(**kwargs):
         "account/invoices/index.html",
         invoices=total_payments,
         marketplace=marketplace,
-        is_test_backend=is_test_backend,
     )
 
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -54,7 +54,6 @@ SERVICES = {
 @advantage_checks(check_list=["is_maintenance", "view_need_user"])
 @use_kwargs({"subscription": String(), "email": String()}, location="query")
 def advantage_view(**kwargs):
-    is_test_backend = kwargs.get("test_backend")
     api_url = kwargs.get("api_url")
     stripe_publishable_key = kwargs["stripe_publishable_key"]
     token = kwargs.get("token")
@@ -296,13 +295,11 @@ def advantage_view(**kwargs):
         open_subscription=open_subscription,
         new_subscription_id=new_subscription_id,
         stripe_publishable_key=stripe_publishable_key,
-        is_test_backend=is_test_backend,
     )
 
 
 @advantage_checks(check_list=["is_maintenance"])
 def advantage_shop_view(**kwargs):
-    is_test_backend = kwargs.get("test_backend")
     api_url = kwargs.get("api_url")
     stripe_publishable_key = kwargs.get("stripe_publishable_key")
     token = kwargs.get("token")
@@ -361,7 +358,6 @@ def advantage_shop_view(**kwargs):
 
     return flask.render_template(
         "advantage/subscribe/index.html",
-        is_test_backend=is_test_backend,
         stripe_publishable_key=stripe_publishable_key,
         account=account,
         previous_purchase_ids=previous_purchase_ids,
@@ -371,7 +367,6 @@ def advantage_shop_view(**kwargs):
 
 @advantage_checks(check_list=["is_maintenance", "view_need_user"])
 def payment_methods_view(**kwargs):
-    is_test_backend = kwargs.get("test_backend")
     stripe_publishable_key = kwargs["stripe_publishable_key"]
     api_url = kwargs.get("api_url")
     token = kwargs.get("token")
@@ -404,7 +399,6 @@ def payment_methods_view(**kwargs):
     return flask.render_template(
         "account/payment-methods/index.html",
         stripe_publishable_key=stripe_publishable_key,
-        is_test_backend=is_test_backend,
         default_payment_method=default_payment_method,
         pending_purchase_id=pending_purchase_id,
         account_id=account["id"],
@@ -417,7 +411,6 @@ def advantage_thanks_view(**kwargs):
     return flask.render_template(
         "advantage/subscribe/thank-you.html",
         email=kwargs.get("email"),
-        is_test_backend=kwargs.get("test_backend"),
     )
 
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -411,17 +411,13 @@ def payment_methods_view(**kwargs):
     )
 
 
-@advantage_checks(check_list=["is_maintenance"])
+@advantage_checks(check_list=["is_maintenance", "view_need_guest"])
 @use_kwargs({"email": String()}, location="query")
 def advantage_thanks_view(**kwargs):
-    email = kwargs.get("email")
-
-    if user_info(flask.session):
-        return flask.redirect("/advantage")
-
     return flask.render_template(
         "advantage/subscribe/thank-you.html",
-        email=email,
+        email=kwargs.get("email"),
+        is_test_backend=kwargs.get("test_backend"),
     )
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -259,6 +259,7 @@ def context():
         "month_name": month_name,
         "months_list": months_list,
         "get_navigation": get_navigation,
+        "get_test_backend": flask.request.args.get("test_backend", ""),
         "product": flask.request.args.get("product", ""),
         "request": flask.request,
         "releases": releases(),

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -62,12 +62,25 @@ def advantage_checks(check_list=None):
 
             if "view_need_user" in check_list and not user_info(flask.session):
                 if flask.request.path != "/advantage":
-                    return flask.redirect("/advantage")
+                    go_to = (
+                        "/advantage?test_backend=true"
+                        if is_test_backend
+                        else "/advantage"
+                    )
+                    return flask.redirect(go_to)
 
                 return flask.render_template(
                     "advantage/index-no-login.html",
                     is_test_backend=is_test_backend,
                 )
+
+            if "view_need_guest" in check_list and user_info(flask.session):
+                go_to = (
+                    "/advantage?test_backend=true"
+                    if is_test_backend
+                    else "/advantage"
+                )
+                return flask.redirect(go_to)
 
             if "need_user" in check_list:
                 if not user_info(flask.session):

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -110,6 +110,7 @@ def after_login(resp):
 
 
 def logout():
+    is_test_backend = flask.request.args.get("test_backend", False)
     return_to = flask.request.args.get("return_to") or flask.request.path
 
     # Protect against redirect loop if return_to is logout
@@ -117,5 +118,8 @@ def logout():
         return_to = "/"
 
     empty_session(flask.session)
+
+    if is_test_backend:
+        return_to = f"{return_to}?test_backend=true"
 
     return flask.redirect(return_to)


### PR DESCRIPTION
## Done

- Make test flag consistent
- We now have `{% if get_test_backend %}` everywhere in the front-end to check the environment

## QA

1. Logout keeps does not lose the flag
- Go to https://ubuntu-com-10093.demos.haus?test_backend=true
- Login using the link in the nav bar
- Logout using the link in the nav bar
- You will still have the flag

2. Login without flag still works
- Go to https://ubuntu-com-10093.demos.haus
- Login using the link in the nav bar
- Logout using the link in the nav bar
- You not have the flag

3. Flag shows up in both nav dropdown, subnab and all links on the page
- Go to https://ubuntu-com-10093.demos.haus/advantage?test_backend=true
- Login
- Check the urls in the nav dropdown, subnab and all links on the page, you will have the flag

4. No flag for both nav dropdown, subnab  and all links on the page shows no flag urls
- Go to https://ubuntu-com-10093.demos.haus/advantage
- Login
- Check the urls in the nav dropdown, subnab and all links on the page, you will not have the flag

5. Thank you page does not lose the flag
- Make a purchase with a proper email: https://ubuntu-com-10093.demos.haus/advantage/subscribe?test_backend=true
- Reach the thank you page, it should still have the flag
- Click the "Login/Sign in..." button and go through that flow
- You should reach /advantage?test_backend=true
- You did not lose the flag

6. Thank you only allows only guest users and redirects without losing the flag
- Login in without flag
- Go to https://ubuntu-com-10093.demos.haus/advantage/subscribe/thank-you 
- You will be redirected to /advantage
- Logout
- Login with the flag on
- Go to https://ubuntu-com-10093.demos.haus/advantage/subscribe/thank-you?test_backend=true
- You should reach /advantage?test_backend=true
- You did not lose the flag
- Logout
- Go to https://ubuntu-com-10093.demos.haus/advantage/subscribe/thank-you
- You will see the thank you page

## Issue / Card

Fixes #126
