### PR TITLE
Update payment methods page

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -269,7 +269,7 @@ export async function postCustomerInfoForPurchasePreview(
 export async function setPaymentMethod(accountID, paymentMethodId) {
   const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
 
-  let response = await fetch(`/advantage/payment-method${queryString}`, {
+  let response = await fetch(`/account/payment-methods${queryString}`, {
     method: "POST",
     cache: "no-store",
     credentials: "include",

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -991,11 +991,16 @@ body {
   opacity: 0.33;
 }
 
-.card-management-section {
+.p-strip-account-page {
   height: 600px;
+
   @media (max-width: $breakpoint-small) {
     height: auto;
+  }
+}
 
+.card-management-section {
+  @media (max-width: $breakpoint-small) {
     #card-element {
       margin-bottom: 1rem;
     }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -991,37 +991,6 @@ body {
   opacity: 0.33;
 }
 
-#payment-modal-form {
-  > .row {
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  #card-element {
-    background-color: #fff;
-    border: 1px solid rgba(0, 0, 0, 0.56);
-    border-radius: 0;
-    box-shadow: inset 0 1px 1px rgb(0 0 0 / 12%);
-    padding: calc(0.4rem - 1px) 0.5rem;
-
-    &.StripeElement--focus {
-      outline: 0.1875rem solid #2e96ff;
-      outline-offset: -0.1875rem;
-
-      &.StripeElement--invalid {
-        outline-color: $color-negative;
-      }
-    }
-
-    &.StripeElement--invalid {
-      background-image: url("#{$assets-path}4b0cd7fc-icon-error.svg");
-      background-position: calc(100% - 0.5rem) 50%;
-      background-repeat: no-repeat;
-      border-color: $color-negative;
-    }
-  }
-}
-
 .card-management-section {
   height: 600px;
   @media (max-width: $breakpoint-small) {
@@ -1053,6 +1022,37 @@ body {
 
   #card-element {
     margin: 0.5rem 0;
+  }
+}
+
+#payment-modal-form {
+  > .row {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  #card-element {
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.56);
+    border-radius: 0;
+    box-shadow: inset 0 1px 1px rgb(0 0 0 / 12%);
+    padding: calc(0.4rem - 1px) 0.5rem;
+
+    &.StripeElement--focus {
+      outline: 0.1875rem solid #2e96ff;
+      outline-offset: -0.1875rem;
+
+      &.StripeElement--invalid {
+        outline-color: $color-negative;
+      }
+    }
+
+    &.StripeElement--invalid {
+      background-image: url("#{$assets-path}4b0cd7fc-icon-error.svg");
+      background-position: calc(100% - 0.5rem) 50%;
+      background-repeat: no-repeat;
+      border-color: $color-negative;
+    }
   }
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1024,7 +1024,6 @@ body {
 
 .card-management-section {
   height: 600px;
-
   @media (max-width: $breakpoint-small) {
     height: auto;
 
@@ -1050,6 +1049,10 @@ body {
     border-radius: 2px;
     height: 1.7rem;
     margin-right: 0.5rem;
+  }
+
+  #card-element {
+    margin: 0.5rem 0;
   }
 }
 

--- a/templates/account/index.html
+++ b/templates/account/index.html
@@ -8,7 +8,7 @@
 
 {% block outer_content %}
 
-  <section class="p-strip--suru-topped">
+  <section class="p-strip--suru-topped p-strip-account-page">
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -9,24 +9,20 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped u-no-padding--bottom">
+<section class="p-strip--suru-topped p-strip-account-page">
   <div class="row">
     <div class="col-12">
       <h1>Invoices</h1>
     </div>
   </div>
-</section>
-<section class="p-strip is-shallow">
   <div class="row">
-    <div class="col-3">
+    <div class="col-3" style="padding: 0.75rem 0">
       <select name="marketplace" id="marketplace-dropdown">
         <option value="">All invoices</option>
         <option value="canonical-ua" {% if marketplace == 'canonical-ua' %}selected{% endif %}>Canonical UA</option>
       </select>
     </div>
   </div>
-</section>
-<section class="p-strip is-deep u-no-padding--top">
   <div class="row">
     <div class="col-12">
       {% if invoices %}

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -77,7 +77,4 @@
 </script>
 <script src="{{ versioned_static('js/dist/ua-payment-methods.js') }}" type="module" defer></script>
 
-
-{% with first_item="_ua_got_questions", second_item="_ua_legal", third_item="_ua_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
 {% endblock content %}

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped card-management-section">
+<section class="p-strip--suru-topped p-strip-account-page card-management-section">
   <div class="row">
     <div class="col-12">
 

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -1,71 +1,53 @@
 {% extends "advantage/base_advantage.html" %}
 
-{% block title %}Ubuntu Advantage for Infrastructure{% endblock %}
-{% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1K65n3NpZCh7EWDXKLhG31seGJ2jKbW6lqw3BwV2mlnU/edit#heading=h.nleu1cdig11l{% endblock meta_copydoc %}
+{% block title %}Canonical payment method{% endblock %}
+{% block meta_description %}Mange your payment method for your Canonical services.{% endblock %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex, nofollow">
+{% endblock %}
 
 {% block content %}
 
-{% if user_info %}
-  <section class="p-strip--suru-topped">
-    <div class="row">
-      <div class="col-12">
-        <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
+<section class="p-strip--suru-topped card-management-section">
+  <div class="row">
+    <div class="col-12">
 
-        <p>You are signed in as {{ user_info.fullname }} ({{ user_info.email }})
-          <span class="u-hide--large u-hide--medium"><br/></br/></span>
-          <a href="/logout?return_to={{ request.host_url }}advantage" class="p-button--neutral is-inline is-dense u-no-margin--bottom" onclick="dataLayer.push({
-            'event' : 'GAEvent',
-            'eventCategory' : 'Advantage',
-            'eventAction' : 'Authentication',
-            'eventLabel' : 'Sign out',
-            'eventValue' : undefined
-          });">Sign out</a>
+      <div id="payment-success" class="p-notification--positive u-hide">
+        <p class="p-notification__response">
+          <span class="p-notification__message"></span>
         </p>
       </div>
-    </div>
-  </section>
 
-  <hr></hr>
+      <div id="payment-errors" class="p-notification--negative u-hide">
+        <p class="p-notification__response">
+          <span class="p-notification__message"></span>
+        </p>
+      </div>
 
-  <section class="p-strip card-management-section">
-    <div class="row">
-      <div class="col-12">
+      <div id="payment-warnings" class="p-notification--caution u-hide">
+        <p class="p-notification__response">
+          <span class="p-notification__message">
+            You have one or more pending payments. Use your saved card to <a class="p-notification__action" id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
+        </p>
+      </div>
 
-        <div id="payment-success" class="p-notification--positive u-hide">
-          <p class="p-notification__response">
-            <span class="p-notification__message"></span>
-          </p>
-        </div>
+      <h1>Payment methods</h1>
 
-        <div id="payment-errors" class="p-notification--negative u-hide">
-          <p class="p-notification__response">
-            <span class="p-notification__message"></span>
-          </p>
-        </div>
-
-        <div id="payment-warnings" class="p-notification--caution u-hide">
-          <p class="p-notification__response">
-            <span class="p-notification__message">
-              You have one or more pending payments. Use your saved card to <a class="p-notification__action" id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
-          </p>
-        </div>
-
-        <h2>Payment methods</h2>
-
-        <div id="default-payment-method-section" class="row {% if not default_payment_method["id"] %}u-hide{% endif %}" style="margin-top: 2rem;">
-          <div class="col-4 current-payment-method">
-            {% with brand=default_payment_method["brand"] %}
-              {% include "account/payment-methods/_card-logo.html" %}
-            {% endwith %}
-            <p><span style="text-transform: capitalize;">{{default_payment_method["brand"]}}</span> ending in {{default_payment_method["last4"]}}</p>
-            </div>
-          <p class="col-4 u-text--muted">Default payment method</p>
-          <div class="col-4 u-align--right">
-            <button class="p-button--neutral" id="edit-payment-details">Edit</button>
+      <div id="default-payment-method-section" class="row {% if not default_payment_method["id"] %}u-hide{% endif %}" style="margin-top: 2rem;">
+        <div class="col-4 current-payment-method">
+          {% with brand=default_payment_method["brand"] %}
+            {% include "account/payment-methods/_card-logo.html" %}
+          {% endwith %}
+          <p><span style="text-transform: capitalize;">{{default_payment_method["brand"]}}</span> ending in {{default_payment_method["last4"]}}</p>
           </div>
+        <p class="col-4 u-text--muted">Default payment method</p>
+        <div class="col-4 u-align--right">
+          <button class="p-button--neutral" id="edit-payment-details">Edit</button>
         </div>
+      </div>
 
+      {% if default_payment_method %}
         <div id="edit-payment-method-section" class="row {% if default_payment_method["id"] %}u-hide{% endif %}" style="margin-top: 2rem;">
           <div class="col-8">
               <div id="card-element"></div>
@@ -79,35 +61,12 @@
           </div>
         </div>
         <hr></hr>
-
-
-      </div>
+      {% else %}
+        <p>No card added yet.</p>
+      {% endif %}
     </div>
-  </section>
-{% else %}
-  <section class="p-strip--suru-topped">
-    <div class="row">
-      <div class="col-12">
-        <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
-        <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
-        <p>Sign in to access your personal or paid subscriptions.</p>
-        <p>
-          <a href="{% if get_test_backend %}/login?test_backend=true{% else %}/login{% endif %}" class="p-button--neutral"
-            onclick="dataLayer.push({
-              'event' : 'GAEvent',
-              'eventCategory' : 'Advantage',
-              'eventAction' : 'Authentication',
-              'eventLabel' : 'Sign in',
-              'eventValue' : undefined
-            });">
-            Sign in
-          </a>
-          <a href="/advantage/subscribe" class="p-button--neutral">Buy a subscription</a>
-        </p>
-      </div>
-    </div>
-  </section>
-{% endif %}
+  </div>
+</section>
 
 
 <script src="https://js.stripe.com/v3/"></script>

--- a/webapp/advantage/api.py
+++ b/webapp/advantage/api.py
@@ -121,6 +121,9 @@ class UAContractsAPI:
                     raise UAContractsAPIAuthErrorView(error)
                 raise UAContractsAPIAuthError(error)
 
+            if error.response.status_code == 404:
+                raise UAContractsUserHasNoAccount(error)
+
             if self.is_for_view:
                 raise UAContractsAPIErrorView(error)
 

--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -51,7 +51,7 @@ post_anonymised_customer_info = {
     "tax_id": Nested(TaxIdSchema, allow_none=True),
 }
 
-post_payment_method = {
+post_payment_methods = {
     "account_id": String(required=True),
     "payment_method_id": String(required=True),
 }

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -19,7 +19,6 @@ from webapp.advantage.api import (
     UnauthorizedError,
     UAContractsUserHasNoAccount,
     UAContractsAPIError,
-    UAContractsAPIErrorView,
 )
 
 from webapp.advantage.schemas import (
@@ -28,8 +27,8 @@ from webapp.advantage.schemas import (
     cancel_advantage_subscriptions,
     post_customer_info,
     ensure_purchase_account,
-    post_payment_method,
     invoice_view,
+    post_payment_methods,
 )
 
 
@@ -370,6 +369,10 @@ def payment_methods_view(**kwargs):
     stripe_publishable_key = kwargs["stripe_publishable_key"]
     api_url = kwargs.get("api_url")
     token = kwargs.get("token")
+    account = None
+    default_payment_method = None
+    account_id = ""
+    pending_purchase_id = ""
 
     advantage = UAContractsAPI(
         session, token, api_url=api_url, is_for_view=True
@@ -377,31 +380,40 @@ def payment_methods_view(**kwargs):
 
     try:
         account = advantage.get_purchase_account()
-    except UAContractsUserHasNoAccount as error:
-        raise UAContractsAPIErrorView(error)
+    except UAContractsUserHasNoAccount:
+        # No Stripe account
 
-    subscriptions = advantage.get_account_subscriptions(
-        account_id=account["id"],
-        marketplace="canonical-ua",
-        filters={"status": "locked"},
-    )
+        pass
 
-    pending_purchase_id = ""
-    for subscription in subscriptions:
-        if subscription.get("pendingPurchases"):
-            pending_purchase_id = subscription.get("pendingPurchases")[0]
-            break
+    if account:
+        account_id = account["id"]
 
-    account_info = advantage.get_customer_info(account["id"])
-    customer_info = account_info["customerInfo"]
-    default_payment_method = customer_info.get("defaultPaymentMethod")
+        subscriptions = advantage.get_account_subscriptions(
+            account_id=account_id,
+            marketplace="canonical-ua",
+            filters={"status": "locked"},
+        )
+
+        for subscription in subscriptions:
+            if subscription.get("pendingPurchases"):
+                pending_purchase_id = subscription.get("pendingPurchases")[0]
+                break
+
+        try:
+            account_info = advantage.get_customer_info(account_id)
+            customer_info = account_info["customerInfo"]
+            default_payment_method = customer_info.get("defaultPaymentMethod")
+        except UAContractsUserHasNoAccount:
+            # User has no stripe account
+
+            pass
 
     return flask.render_template(
         "account/payment-methods/index.html",
         stripe_publishable_key=stripe_publishable_key,
         default_payment_method=default_payment_method,
         pending_purchase_id=pending_purchase_id,
-        account_id=account["id"],
+        account_id=account_id,
     )
 
 
@@ -561,8 +573,8 @@ def post_anonymised_customer_info(**kwargs):
 
 
 @advantage_checks(check_list=["need_user"])
-@use_kwargs(post_payment_method, location="json")
-def post_payment_method(**kwargs):
+@use_kwargs(post_payment_methods, location="json")
+def post_payment_methods(**kwargs):
     api_url = kwargs.get("api_url")
     token = kwargs.get("token")
     account_id = kwargs.get("account_id")
@@ -570,7 +582,16 @@ def post_payment_method(**kwargs):
 
     advantage = UAContractsAPI(session, token, api_url=api_url)
 
-    return advantage.put_payment_method(account_id, payment_method_id)
+    try:
+        response = advantage.put_payment_method(account_id, payment_method_id)
+    except UAContractsUserHasNoAccount:
+        name = flask.session["openid"]["fullname"]
+
+        response = advantage.put_customer_info(
+            account_id, payment_method_id, None, name, None
+        )
+
+    return response
 
 
 @advantage_checks(check_list=["need_user"])

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -83,7 +83,7 @@ from webapp.advantage.views import (
     get_renewal,
     post_advantage_subscriptions,
     post_anonymised_customer_info,
-    post_payment_method,
+    post_payment_methods,
     post_auto_renewal_settings,
     post_customer_info,
     post_stripe_invoice_id,
@@ -286,6 +286,11 @@ app.add_url_rule("/account.json", view_func=account_query)
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)
+app.add_url_rule(
+    "/account/payment-methods",
+    view_func=post_payment_methods,
+    methods=["POST"],
+)
 app.add_url_rule("/account/invoices", view_func=invoices_view)
 app.add_url_rule(
     "/account/invoices/download/<period>/<purchase_id>",
@@ -317,11 +322,6 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/customer-info-anon",
     view_func=post_anonymised_customer_info,
-    methods=["POST"],
-)
-app.add_url_rule(
-    "/advantage/payment-method",
-    view_func=post_payment_method,
     methods=["POST"],
 )
 app.add_url_rule(


### PR DESCRIPTION
## Done

With the release of `/account/invoices`, I took the time to look at `/account/payment-methods` and bring them in line with each other. `/payment-methods` was originally intended to be part of the `/advantage` domain. Now it's part of the `/account` pages, making it a higher level page, independent of product names.

**At the moment this page allows only editing existing card information. It does not allow for adding a card, if you do not already have one set.**

## Changes include:
### Front-end/Visual changes:
1) Updating the meta title and description.
2) Removing the Ubuntu Advantage title
![image](https://user-images.githubusercontent.com/6387619/128331375-cc0b532c-a145-4b83-99e6-cac65117161e.png)
3) Removing the "You are signed in as". That was forgotten there. It's been remove already from all other pages.
4) Making the Payment methods title an h1. Similar to the title on /invoices.
5) Mini fix CSS to bring the Update button in line with the card input field
6) Remove front-end `user_info` checks. Back-end forbids access to `/payment-methods` for guest users.

### Back-end changes:
1) Fixing errors with people with Stripe accounts or Stripe account customer info reach the page.
- If a user with no Stripe account reaches `/payment-methods`. They get the 500 page.
- If a user with a Stripe account, but no Stripe customer info reaches `/payment-methods` page they will get see page, but will get a 500 if they try to provide a card. That is because the API expects name, address info to be submitted together with the card info.
Instead of a 500 we show this:
![image](https://user-images.githubusercontent.com/6387619/128332805-6131074f-5572-400b-bb21-89aa3394b069.png)

2) Update the POST `/advantage/payment-method` link to `/account/payment-methods`

## QA

1. Accessing /account/payment-methods without stripe account
- Have a Ubuntu One account without a stripe account; You can achieve this the easiest by creating a new UO account and log in with it then go to `/account/payment-methods`
- Log in with your UO account
- Go to https://ubuntu-com-10106.demos.haus/account/payment-methods?test_backend=true
- You will see the page showing you no cards set

2. Accessing /account/payment-methods without default payment method:
- Have an account attached to your UO user but default payment method set yet; You should be able to reproduce if you use your main canonical account on production. You will have the company UA account attached, but no payment methods attached to it. 
- Log in with your UO account
- Go to https://ubuntu-com-10106.demos.haus/account/payment-methods?test_backend=true
- You will see the page showing you no cards set

3. Accessing the /account/payment-methods with everything you need:
- Have a stripe account
- Log in with your UO account
- Go to https://ubuntu-com-10106.demos.haus/account/payment-methods?test_backend=true
- You will see your card
- Update your card
- It should work

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/123