### PR TITLE
Add components for the subscription details content

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.test.tsx
@@ -8,7 +8,7 @@ describe("SubscriptionCancel", () => {
   it("handles closing the modal", () => {
     const onClose = jest.fn();
     const wrapper = shallow(<SubscriptionCancel onClose={onClose} />);
-    wrapper.find(Modal).invoke("close")();
+    wrapper.find(Modal).invoke("close")!();
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import DetailsContent from "./DetailsContent";
+
+describe("DetailsContent", () => {
+  it("renders", () => {
+    const wrapper = shallow(<DetailsContent />);
+    expect(wrapper.find("DetailsTabs").exists()).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -50,7 +50,7 @@ const DetailsContent = () => {
           },
         ])}
       </Row>
-      <h5 className="u-no-padding--top p-subscribe__details-small-title">
+      <h5 className="u-no-padding--top p-subscription__details-small-title">
         Subscription
       </h5>
       <CodeSnippet

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -1,11 +1,16 @@
-import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
-import { CodeSnippetBlockAppearance } from "@canonical/react-components/dist/components/CodeSnippet";
+import {
+  CodeSnippet,
+  CodeSnippetBlockAppearance,
+  Col,
+  ColProps,
+  Row,
+} from "@canonical/react-components";
 import React from "react";
 
 import DetailsTabs from "../DetailsTabs";
 
 type Feature = {
-  size?: number;
+  size?: ColProps["size"];
   title: string;
   value: string | number;
 };
@@ -50,7 +55,7 @@ const DetailsContent = () => {
           },
         ])}
       </Row>
-      <h5 className="u-no-padding--top p-subscription__details-small-title">
+      <h5 className="u-no-padding--top p-subscriptions__details-small-title">
         Subscription
       </h5>
       <CodeSnippet

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -1,0 +1,70 @@
+import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
+import { CodeSnippetBlockAppearance } from "@canonical/react-components/dist/components/CodeSnippet";
+import React from "react";
+
+import DetailsTabs from "../DetailsTabs";
+
+type Feature = {
+  size?: number;
+  title: string;
+  value: string | number;
+};
+
+const generateFeatures = (features: Feature[]) =>
+  features.map(({ size = 3, title, value }) => (
+    <Col key={title} size={size}>
+      <p className="u-text--muted u-no-margin--bottom">{title}</p>
+      {value}
+    </Col>
+  ));
+
+const DetailsContent = () => {
+  return (
+    <>
+      <Row className="u-sv4">
+        {generateFeatures([
+          {
+            title: "Created",
+            value: "12.02.2021",
+          },
+          {
+            title: "Expires",
+            value: "23.04.2022",
+          },
+          {
+            size: 2,
+            title: "Billing",
+            value: "Annual",
+          },
+          {
+            title: "Cost",
+            value: "$25,000 USD/yr",
+          },
+          {
+            title: "Machine type",
+            value: "Virtual",
+          },
+          {
+            title: "Machines",
+            value: "10",
+          },
+        ])}
+      </Row>
+      <h5 className="u-no-padding--top p-subscribe__details-small-title">
+        Subscription
+      </h5>
+      <CodeSnippet
+        blocks={[
+          {
+            appearance: CodeSnippetBlockAppearance.URL,
+            code: "C2439dskds4efni0923u22q4234",
+          },
+        ]}
+        className="u-sv4 u-no-margin--bottom"
+      />
+      <DetailsTabs />
+    </>
+  );
+};
+
+export default DetailsContent;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DetailsContent";

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { mount, shallow } from "enzyme";
+
+import DetailsTabs from "./DetailsTabs";
+
+describe("DetailsTabs", () => {
+  it("defaults to the features tab", () => {
+    const wrapper = shallow(<DetailsTabs />);
+    expect(wrapper.find("[data-test='features-content']").exists()).toBe(true);
+  });
+
+  it("can change tabs", () => {
+    const wrapper = mount(<DetailsTabs />);
+    expect(wrapper.find("[data-test='docs-content']").exists()).toBe(false);
+    wrapper.find("[data-test='docs-tab']").simulate("click");
+    wrapper.update();
+    expect(wrapper.find("[data-test='docs-content']").exists()).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -16,7 +16,7 @@ type ListItem = {
 
 const generateList = (title: string, items: ListItem[]) => (
   <>
-    <h5 className="u-no-padding--top p-subscribe__details-small-title">
+    <h5 className="u-no-padding--top p-subscription__details-small-title">
       {title}
     </h5>
     <List

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -16,7 +16,7 @@ type ListItem = {
 
 const generateList = (title: string, items: ListItem[]) => (
   <>
-    <h5 className="u-no-padding--top p-subscription__details-small-title">
+    <h5 className="u-no-padding--top p-subscriptions__details-small-title">
       {title}
     </h5>
     <List

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -1,0 +1,127 @@
+import { Col, Icon, List, Row, Tabs } from "@canonical/react-components";
+import React, { HTMLProps, useState } from "react";
+import type { ReactNode } from "react";
+
+enum ActiveTab {
+  DOCUMENTATION = "documentation",
+  FEATURES = "features",
+}
+
+type Props = HTMLProps<HTMLDivElement>;
+
+type ListItem = {
+  icon?: string;
+  label: ReactNode;
+};
+
+const generateList = (title: string, items: ListItem[]) => (
+  <>
+    <h5 className="u-no-padding--top p-subscribe__details-small-title">
+      {title}
+    </h5>
+    <List
+      items={items.map(({ label, icon }) => ({
+        className: "u-no-padding--bottom",
+        content: (
+          <>
+            {icon ? (
+              <>
+                <Icon name={icon} />
+                &emsp;
+              </>
+            ) : null}
+            {label}
+          </>
+        ),
+      }))}
+    />
+  </>
+);
+
+const DetailsTabs = (wrapperProps: Props) => {
+  const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.FEATURES);
+  let content: ReactNode | null;
+  switch (activeTab) {
+    case ActiveTab.DOCUMENTATION:
+      content = (
+        <div data-test="docs-content">
+          {generateList("Documentation & tutorials", [
+            {
+              label: <a href="#">Getting started / UA client</a>,
+            },
+            {
+              label: <a href="#">Attaching machines</a>,
+            },
+            {
+              label: <a href="#">ESM Infra & ESM Apps</a>,
+            },
+            {
+              label: <a href="#">Livepatch</a>,
+            },
+            {
+              label: <a href="#">Certification</a>,
+            },
+          ])}
+        </div>
+      );
+      break;
+    case ActiveTab.FEATURES:
+    default:
+      content = (
+        <>
+          <Row className="u-sv1" data-test="features-content">
+            <Col size={4}>
+              {generateList("Included", [
+                {
+                  icon: "success",
+                  label: "ESM Infra",
+                },
+                {
+                  icon: "success",
+                  label: "24/5 support",
+                },
+                {
+                  icon: "success",
+                  label: "Livepatch",
+                },
+              ])}
+            </Col>
+            <Col size={4}>
+              {generateList("Not included", [
+                {
+                  icon: "error",
+                  label: "ESM Apps",
+                },
+              ])}
+            </Col>
+          </Row>
+          <a href="#">Service description &rsaquo;</a>
+        </>
+      );
+      break;
+  }
+  return (
+    <div {...wrapperProps}>
+      <Tabs
+        className="p-tabs--brand"
+        links={[
+          {
+            active: activeTab === ActiveTab.FEATURES,
+            "data-test": "features-tab",
+            label: "Features",
+            onClick: () => setActiveTab(ActiveTab.FEATURES),
+          },
+          {
+            active: activeTab === ActiveTab.DOCUMENTATION,
+            "data-test": "docs-tab",
+            label: "Documentation",
+            onClick: () => setActiveTab(ActiveTab.DOCUMENTATION),
+          },
+        ]}
+      />
+      {content}
+    </div>
+  );
+};
+
+export default DetailsTabs;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DetailsTabs";

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,22 +1,7 @@
-import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
-import { CodeSnippetBlockAppearance } from "@canonical/react-components/dist/components/CodeSnippet";
+import { Button } from "@canonical/react-components";
 import React from "react";
 
-import DetailsTabs from "./DetailsTabs";
-
-type Feature = {
-  size?: number;
-  title: string;
-  value: string | number;
-};
-
-const generateFeatures = (features: Feature[]) =>
-  features.map(({ size = 3, title, value }) => (
-    <Col key={title} size={size}>
-      <p className="u-text--muted u-no-margin--bottom">{title}</p>
-      {value}
-    </Col>
-  ));
+import DetailsContent from "./DetailsTabs";
 
 const SubscriptionDetails = () => {
   return (
@@ -35,48 +20,7 @@ const SubscriptionDetails = () => {
           Edit subscription&hellip;
         </Button>
       </div>
-      <Row className="u-sv4">
-        {generateFeatures([
-          {
-            title: "Created",
-            value: "12.02.2021",
-          },
-          {
-            title: "Expires",
-            value: "23.04.2022",
-          },
-          {
-            size: 2,
-            title: "Billing",
-            value: "Annual",
-          },
-          {
-            title: "Cost",
-            value: "$25,000 USD/yr",
-          },
-          {
-            title: "Machine type",
-            value: "Virtual",
-          },
-          {
-            title: "Machines",
-            value: "10",
-          },
-        ])}
-      </Row>
-      <h5 className="u-no-padding--top p-subscribe__details-small-title">
-        Subscription
-      </h5>
-      <CodeSnippet
-        blocks={[
-          {
-            appearance: CodeSnippetBlockAppearance.URL,
-            code: "C2439dskds4efni0923u22q4234",
-          },
-        ]}
-        className="u-sv4 u-no-margin--bottom"
-      />
-      <DetailsTabs />
+      <DetailsContent />
     </div>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@canonical/react-components";
 import React from "react";
 
-import DetailsContent from "./DetailsTabs";
+import DetailsContent from "./DetailsContent";
 
 const SubscriptionDetails = () => {
   return (
-    <div className="p-subscribe__details">
+    <div className="p-subscriptions__details">
       <h4>UA Infra Essential (Virtual)</h4>
       <div className="u-sv4">
         <Button

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,21 +1,84 @@
+import { Button, CodeSnippet, Col, Row } from "@canonical/react-components";
+import { CodeSnippetBlockAppearance } from "@canonical/react-components/dist/components/CodeSnippet";
 import React from "react";
 
-import SubscriptionEdit from "../SubscriptionEdit";
+import DetailsTabs from "./DetailsTabs";
 
-const SubscriptionDetails = () => (
-  <div className="p-subscriptions__details">
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <p>Details</p>
-    <SubscriptionEdit />
-  </div>
-);
+type Feature = {
+  size?: number;
+  title: string;
+  value: string | number;
+};
+
+const generateFeatures = (features: Feature[]) =>
+  features.map(({ size = 3, title, value }) => (
+    <Col key={title} size={size}>
+      <p className="u-text--muted u-no-margin--bottom">{title}</p>
+      {value}
+    </Col>
+  ));
+
+const SubscriptionDetails = () => {
+  return (
+    <div className="p-subscribe__details">
+      <h4>UA Infra Essential (Virtual)</h4>
+      <div className="u-sv4">
+        <Button
+          appearance="positive"
+          className="u-no-margin--bottom"
+          element="a"
+          href="https://support.canonical.com/"
+        >
+          Support portal
+        </Button>
+        <Button appearance="neutral" className="u-no-margin--bottom">
+          Edit subscription&hellip;
+        </Button>
+      </div>
+      <Row className="u-sv4">
+        {generateFeatures([
+          {
+            title: "Created",
+            value: "12.02.2021",
+          },
+          {
+            title: "Expires",
+            value: "23.04.2022",
+          },
+          {
+            size: 2,
+            title: "Billing",
+            value: "Annual",
+          },
+          {
+            title: "Cost",
+            value: "$25,000 USD/yr",
+          },
+          {
+            title: "Machine type",
+            value: "Virtual",
+          },
+          {
+            title: "Machines",
+            value: "10",
+          },
+        ])}
+      </Row>
+      <h5 className="u-no-padding--top p-subscribe__details-small-title">
+        Subscription
+      </h5>
+      <CodeSnippet
+        blocks={[
+          {
+            appearance: CodeSnippetBlockAppearance.URL,
+            code: "C2439dskds4efni0923u22q4234",
+          },
+        ]}
+        className="u-sv4 u-no-margin--bottom"
+      />
+      <DetailsTabs />
+    </div>
+  );
+};
 
 export default SubscriptionDetails;

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -38,7 +38,7 @@
     padding: $card-padding;
   }
 
-  .p-subscribe__details-small-title {
+  .p-subscription__details-small-title {
     margin-bottom: $spv-outer--small;
   }
 

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -38,6 +38,10 @@
     padding: $card-padding;
   }
 
+  .p-subscribe__details-small-title {
+    margin-bottom: $spv-outer--small;
+  }
+
   .p-subscriptions__list-group {
     // Add extra space between groups. Padding is used instead of margin
     // otherwise it'll be collapsed with the bottom margin from the previous

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -38,7 +38,7 @@
     padding: $card-padding;
   }
 
-  .p-subscription__details-small-title {
+  .p-subscriptions__details-small-title {
     margin-bottom: $spv-outer--small;
   }
 

--- a/static/sass/_pattern_tabs.scss
+++ b/static/sass/_pattern_tabs.scss
@@ -83,4 +83,30 @@
       padding: 1.5rem;
     }
   }
+
+  // Override the highlighted tab colour for pages that need to use the brand
+  // colour.
+  .p-tabs--brand .p-tabs__link {
+    $color-tabs-active-bar: $color-brand;
+
+    %focus-visible {
+      // Display the highlight when focussing (in combination with the parent
+      // states) in modern browsers that support focus-visible.
+      &:focus:not(:focus-visible) {
+        @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+      }
+    }
+
+    &:active,
+    &[aria-selected="true"] {
+      @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+      @extend %focus-visible;
+    }
+
+    // Display the highlight when focussing in modern browsers that support
+    // focus-visible.
+    &:focus:not(:focus-visible) {
+      @include vf-highlight-bar($color-tabs-active-bar, bottom, false);
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Add subscription details components.
- Add subscription tabs component.

## QA

- Visit /advantage?test_backend=true.
- You should see the layout of the subscription content (all dummy content at this point).
- You should be able to switch Features and Documentation tabs.


## Issue / Card

Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/108.
Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/110.

## Screenshots

[If relevant, please include a screenshot.]
