### PR TITLE
move is-dense accordion modifier to accordion

### DIFF
--- a/static/sass/_pattern_accordion.scss
+++ b/static/sass/_pattern_accordion.scss
@@ -1,0 +1,58 @@
+@mixin ubuntu-p-accordion {
+  .p-accordion {
+    .is-dense {
+      padding-left: 1rem;
+    }
+
+    .is-collapsed {
+      // when an accordion is collapsed we want a specific number of filters to still be visible,
+      // so we need to work out the height of the each filter, and multiply that by however many
+      // rows we want to be visible.
+      $visible-rows: 5;
+
+      // a label's height is made up of line height and top padding
+      // line heights are taken from default line height applied in Vanilla
+      // https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_base_typography.scss#L23
+      $label-line-height: map-get($line-heights, default-text);
+      $label-x-large-line-height: map-get($line-heights, default-text) *
+        $font-size-ratio--largescreen;
+
+      // label top padding is taken from
+      // https://github.com/canonical-web-and-design/vanilla-framework/blob/master/scss/_base_forms.scss#L100
+      $label-top-padding: map-get($nudges, nudge--p);
+
+      // total height:
+      $label-height: $label-line-height + $label-top-padding;
+      $label-x-large-height: $label-x-large-line-height + $label-top-padding;
+
+      // we also need to account for the bottom margin of one label
+      // as all but the first label's margin collapses into the padding of
+      // the label above it.
+      $label-margin-nudge: $spv-outer--small-scaleable - $spv-nudge;
+
+      max-height: calc(
+        #{$label-height} * #{$visible-rows} + #{$label-margin-nudge}
+      );
+      overflow: hidden;
+
+      @if ($increase-font-size-on-larger-screens) {
+        @media (min-width: $breakpoint-x-large) {
+          max-height: calc(
+            #{$label-x-large-height} * #{$visible-rows} + #{$label-margin-nudge}
+          );
+        }
+      }
+
+      .p-checkbox {
+        width: 100%;
+      }
+
+      .p-checkbox__label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: calc(98%);
+      }
+    }
+  }
+}

--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -47,25 +47,6 @@
     text-transform: uppercase;
   }
 
-  .is-dense {
-    padding-left: 1rem;
-  }
-
-  .is-collapsed {
-    overflow: hidden;
-    &__vendors {
-      @extend .is-collapsed;
-
-      max-height: 11.5rem;
-    }
-
-    &__versions {
-      @extend .is-collapsed;
-
-      max-height: 10rem;
-    }
-  }
-
   .p-results-per-page {
     max-width: 5.3rem;
     min-width: 5.3rem;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -30,6 +30,7 @@ $font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen
 $color-shadow: rgba(0, 0, 0, 0.5) !default;
 
 // import site specific patterns and overrides
+@import "pattern_accordion";
 @import "pattern_active-reveal";
 @import "pattern_blog-featured";
 @import "pattern_blog-list";
@@ -93,6 +94,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include blog-p-strips-suru;
 @include blog-u-crop;
 @include blog-p-topic;
+@include ubuntu-p-accordion;
 @include ubuntu-p-active-reveal;
 @include ubuntu-p-buttons;
 @include ubuntu-p-calculator;

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -96,13 +96,12 @@
                    <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="true"><span class="p-certification-header">Vendor</span></button>
                  </div>
                  <hr>
-                 <section class="p-accordion__panel is-collapsed__vendors is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
+                 <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
                    {% for vendor_filter in vendor_filters %}
                    <label class="p-checkbox">
                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
                      <div class="p-checkbox__label" id="{{ vendor_filter }}">
                        <span>{{ vendor_filter }}</span>
-                       </p>
                      </div>
                    </label>
                    {% endfor %}
@@ -117,7 +116,7 @@
                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true"><span class="p-certification-header">Certified Ubuntu release</span></button>
                  </div>
                  <hr>
-                 <section class="p-accordion__panel is-collapsed__versions is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
+                 <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
                    {% for release_filter in release_filters %}
                    <label class="p-checkbox">
                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
@@ -252,7 +251,7 @@
     toggleVendorButtons.forEach((button) => {
       button.addEventListener("click", () => {
         window.scrollTo(0, 360);
-        vendorPanel.classList.toggle("is-collapsed__vendors");
+        vendorPanel.classList.toggle("is-collapsed");
         toggleVendorButtons.forEach((button) => {
           button.classList.toggle("u-hide");
         });
@@ -267,7 +266,7 @@
     const toggleVersionButtons = document.querySelectorAll(".p-reveal-versions");
     toggleVersionButtons.forEach((button) => {
       button.addEventListener("click", () => {
-        versionPanel.classList.toggle("is-collapsed__versions");
+        versionPanel.classList.toggle("is-collapsed");
         toggleVersionButtons.forEach((button) => {
           button.classList.toggle("u-hide");
         });


### PR DESCRIPTION
Co-authored-by: Beth Collins <bethcollinsliv92@gmail.com>

## Done

- Moved `is-dense` and `is-collapsed` accordion modifiers to `p-accordion` class scope
- Drive by: added calculation for determining exact height of accordion section when collapsed, so that it shows 5 rows exactly.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the mega nav, see that "Open Stack" heading is not indented (compare to live site)
- See that the accordion filters on the left side of the page still work, and look good


## Issue / Card

Fixes #10111 
