### PR TITLE
Add subscription notifications component

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import Notifications from "./Notifications";
+
+describe("Notifications", () => {
+  it("renders", () => {
+    const wrapper = shallow(<Notifications />);
+    expect(wrapper.find("Notification").exists()).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -1,4 +1,7 @@
-import { Notification, notificationTypes } from "@canonical/react-components";
+import {
+  Notification,
+  NotificationSeverity,
+} from "@canonical/react-components";
 import React from "react";
 
 import { useURLs } from "../../../hooks";
@@ -15,21 +18,21 @@ const Notifications = () => {
           subscriptions
         </>
       ),
-      status: "Payment method:",
-      type: notificationTypes.CAUTION,
+      title: "Payment method:",
+      severity: NotificationSeverity.CAUTION,
     },
     {
       children:
         'Select a subscripton, then "Renew subscription..." to renew it.',
-      status: "Your subscription is about to expire.",
-      type: notificationTypes.CAUTION,
+      title: "Your subscription is about to expire.",
+      severity: NotificationSeverity.CAUTION,
     },
   ];
 
   return (
     <>
       {notifications.map((props, i) => (
-        <Notification {...props} key={`notification-${i}`} />
+        <Notification inline {...props} key={`notification-${i}`} />
       ))}
     </>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -1,0 +1,38 @@
+import { Notification, notificationTypes } from "@canonical/react-components";
+import React from "react";
+
+import { useURLs } from "../../../hooks";
+
+const Notifications = () => {
+  const urls = useURLs();
+  const notifications = [
+    {
+      children: (
+        <>
+          You need to{" "}
+          <a href={urls.account.paymentMethods}>update your payment methods</a>{" "}
+          to ensure there is no interruption to your Ubuntu Advantage
+          subscriptions
+        </>
+      ),
+      status: "Payment method:",
+      type: notificationTypes.CAUTION,
+    },
+    {
+      children:
+        'Select a subscripton, then "Renew subscription..." to renew it.',
+      status: "Your subscription is about to expire.",
+      type: notificationTypes.CAUTION,
+    },
+  ];
+
+  return (
+    <>
+      {notifications.map((props, i) => (
+        <Notification {...props} key={`notification-${i}`} />
+      ))}
+    </>
+  );
+};
+
+export default Notifications;

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Notifications";

--- a/static/js/src/advantage/react/components/Subscriptions/Subscriptions.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Subscriptions.tsx
@@ -2,9 +2,11 @@ import { Strip } from "@canonical/react-components";
 import React from "react";
 
 import Content from "./Content";
+import Notifications from "./Notifications";
 
 const Subscriptions = () => (
   <Strip>
+    <Notifications />
     <Content />
   </Strip>
 );

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useLoadWindowData } from "./useLoadWindowData";
+export { useURLs } from "./useURLs";

--- a/static/js/src/advantage/react/hooks/useURLs.test.tsx
+++ b/static/js/src/advantage/react/hooks/useURLs.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import * as useURLsModule from "./useURLs";
+
+describe("useURLs", () => {
+  let getURLsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    getURLsSpy = jest.spyOn(useURLsModule, "getURLs");
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("can return the URLs without modification", async () => {
+    const { result } = renderHook(() => useURLsModule.useURLs());
+    expect(result.current).toStrictEqual(useURLsModule.APP_URLS);
+  });
+
+  it("can return the URLs with the test backend flag", async () => {
+    const { result } = renderHook(() => useURLsModule.useURLs(true));
+    expect(result.current.account.paymentMethods).toBe(
+      "/account/payment-methods?test_backend=true"
+    );
+  });
+
+  it("can append to a URL with existing query params", async () => {
+    const urls = {
+      ...useURLsModule.APP_URLS,
+    };
+    urls.account.paymentMethods = "/?existing=true";
+    getURLsSpy.mockReturnValue(urls);
+    const { result } = renderHook(() => useURLsModule.useURLs(true));
+    expect(result.current.account.paymentMethods).toBe(
+      "/?existing=true&test_backend=true"
+    );
+  });
+});

--- a/static/js/src/advantage/react/hooks/useURLs.ts
+++ b/static/js/src/advantage/react/hooks/useURLs.ts
@@ -1,0 +1,48 @@
+export type URLs = {
+  [path: string]: URLs | string;
+};
+
+export const APP_URLS = {
+  account: {
+    paymentMethods: "/account/payment-methods",
+  },
+};
+
+/**
+ * Fetch the URL definition via a function to make testing easier.
+ */
+export const getURLs = () => APP_URLS;
+
+/**
+ * Recursively append the test backend param. This function uses a generic to
+ * infer the shape of the object so that the types are not lost as it transfroms
+ * it.
+ */
+const appendTestBackend = <U extends URLs>(urls: U): U => {
+  Object.entries(urls).forEach(
+    ([key, pathOrSection]: [keyof U, URLs | string]) => {
+      let updatedPathOrSection = pathOrSection;
+      if (typeof pathOrSection === "string") {
+        const querySeparator = pathOrSection.includes("?") ? "&" : "?";
+        updatedPathOrSection = `${pathOrSection}${querySeparator}test_backend=true`;
+      } else {
+        // This is an object of URLs, so append the flag to the children of this
+        // section.
+        updatedPathOrSection = appendTestBackend(pathOrSection);
+      }
+      urls[key] = updatedPathOrSection as U[keyof U];
+    }
+  );
+  return urls;
+};
+
+/**
+ * This hook creates the URLS for the app with the test backend flag applied if
+ * it should be present.
+ */
+export const useURLs = (usingTestBackend = false) => {
+  const urls = getURLs();
+  // TODO: Update this to fetch `usingTestBackend` from the React Query store.
+  // https://github.com/canonical-web-and-design/commercial-squad/issues/136
+  return usingTestBackend ? appendTestBackend(urls) : urls;
+};


### PR DESCRIPTION
## Done

- Add notifications component to the subscriptions page.
- Add hook for appending the test backend flag to urls.

## QA

- Visit /advantage?test_backend=true
- You should see a couple of dummy notifications.


## Issue / Card

Fixes: canonical-web-and-design/commercial-squad#135.

## Screenshots

<img width="1085" alt="Screen Shot 2021-08-04 at 12 41 18 pm" src="https://user-images.githubusercontent.com/361637/128113824-c91d8bee-3339-43a9-b154-204fa908aa54.png">


