### PR TITLE
Fix VAT problems

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -551,6 +551,10 @@ def post_anonymised_customer_info(**kwargs):
     address = kwargs.get("address")
     tax_id = kwargs.get("tax_id")
 
+    tax_id["value"] = tax_id["value"].replace(" ", "")
+    if tax_id["value"] == "":
+        tax_id["delete"] = True
+
     advantage = UAContractsAPI(
         session, token, token_type=token_type, api_url=api_url
     )
@@ -635,6 +639,10 @@ def post_customer_info(**kwargs):
     address = kwargs.get("address")
     name = kwargs.get("name")
     tax_id = kwargs.get("tax_id")
+
+    tax_id["value"] = tax_id["value"].replace(" ", "")
+    if tax_id["value"] == "":
+        tax_id["delete"] = True
 
     advantage = UAContractsAPI(
         session, token, token_type=token_type, api_url=api_url


### PR DESCRIPTION
## Done

- Not providing VAT will correctly remove your VAT from your customer info
- Delete spaces from VAT number. It's causing problems.

## QA

1. Back-end error fixed:
- Be logged out
- Go to https://ubuntu.com/advantage/subscribe?test_backend=true
- Insert card, customer info including VAT number
- Press continue
- Hit change details
- Insert same VAT number again you will get the error:
`{"errors":"{"code":"resource_already_exists"}.....}`
- Go to: https://ubuntu-com-10124.demos.haus/advantage?test_backend=true
- Do the same steps from above
- It will not error out

2. VAT left blank gets deleted now:
- Be logged in
- Go to: https://ubuntu-com-10124.demos.haus/advantage/subscribe?test_backend=true
- Select item, reach the modal
- Select UK give a VAT number press continue
- Go a CURL request of your account info:
```
# Find out your account ID
# Token can be found on https://ubuntu-com-10124.demos.haus/account.json once you log in
# Make sure you do not choose your free token account_id (it's usually the first one)
curl -H "Authorization: Macaroon <token>" https://contracts.staging.canonical.com/v1/accounts

curl -H "Authorization: Macaroon <token>" https://contracts.staging.canonical.com/v1/accounts/<account_id>/customer-info/stripe
```
- Check your info. You should see the country as `GB` and the tax_id info
- Go back to the modal, you should be on the step 2; press change details
- Select a non VAT country and press continue
- Fetch you contract info now. You should not have a `taxId` anymore
- Before your country would change to a non VAT country, but your taxID would stay there

## Issue / Card

Fixes #