### PR TITLE
Add count to closed accordion

### DIFF
--- a/build.js
+++ b/build.js
@@ -21,6 +21,7 @@ let entries = {
   openstackChart: "./static/js/src/openstack-chart.js",
   uaSubscribe: "./static/js/src/advantage/subscribe/react/app.jsx",
   "cloud-price-slider": "./static/js/src/cloud-price-slider.js",
+  "certification-results": "./static/js/src/certification-results.js",
 };
 
 for (const [key, value] of Object.entries(entries)) {

--- a/build.js
+++ b/build.js
@@ -21,7 +21,7 @@ let entries = {
   openstackChart: "./static/js/src/openstack-chart.js",
   uaSubscribe: "./static/js/src/advantage/subscribe/react/app.jsx",
   "cloud-price-slider": "./static/js/src/cloud-price-slider.js",
-  "certification-results": "./static/js/src/certification-results.js",
+  "certified-search-results": "./static/js/src/certified-search-results.js",
 };
 
 for (const [key, value] of Object.entries(entries)) {

--- a/static/js/src/certification-results.js
+++ b/static/js/src/certification-results.js
@@ -1,0 +1,133 @@
+function enableApplyFilters() {
+  const filtersSelected = [];
+  const filters = document.querySelectorAll(".js-enable-apply-filters");
+  filters.forEach((filter) => {
+    filter.addEventListener("change", () => {
+      if (!filtersSelected.includes(filter)) {
+        filtersSelected.push(filter);
+      } else {
+        const index = filtersSelected.indexOf(filter);
+        filtersSelected.splice(index, 1);
+      }
+      const button = document.querySelector(".js-apply-filters");
+      if (filtersSelected.length) {
+        button.removeAttribute("disabled");
+      } else {
+        button.disabled = true;
+      }
+    });
+  });
+
+  function displayFilterCount() {
+    const accordion = document.querySelector(".js-filter-count");
+    const accordionTabs = accordion.querySelectorAll(".p-accordion__tab");
+    accordionTabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        let categoryFilterCount = 0;
+        let vendorFilterCount = 0;
+        let releaseFilterCount = 0;
+        filtersSelected.forEach((filter) => {
+          if (filter.id === "category-filter") {
+            categoryFilterCount++;
+          } else if (filter.id === "vendor-filter") {
+            vendorFilterCount++;
+          } else if (filter.id === "release-filter") {
+            releaseFilterCount++;
+          }
+        });
+        const chip = tab.querySelector(".p-round-chip");
+        chip.classList.toggle("u-hide");
+
+        const categoryChipValue = tab.querySelector("#category-count");
+        if (categoryChipValue) {
+          categoryChipValue.innerHTML = categoryFilterCount;
+        }
+        const vendorChipValue = tab.querySelector("#vendor-count");
+        if (vendorChipValue) {
+          vendorChipValue.innerHTML = vendorFilterCount;
+        }
+        const releaseChipValue = tab.querySelector("#release-count");
+        if (releaseChipValue) {
+          releaseChipValue.innerHTML = releaseFilterCount;
+        }
+
+        // Add line break in title to keep chip on same line
+        const header = tab.querySelector(".p-certification-header");
+        if (header.innerHTML.includes("Certified")) {
+          if (!chip.classList.contains("u-hide")) {
+            header.innerHTML = "Certified Ubuntu <br> release";
+          } else {
+            header.innerHTML = "Certified Ubuntu release";
+          }
+        }
+      });
+    });
+  }
+  displayFilterCount();
+}
+
+enableApplyFilters();
+
+//function to ensure only the option which has been changed is appended to the URL
+function updateResultsPerPage() {
+  let resultsDropdowns = document.querySelectorAll(".p-results-per-page");
+  resultsDropdowns.forEach((resultsDropdown) => {
+    const options = resultsDropdown.querySelectorAll("option");
+    options.forEach((option) => {
+      if (option.selected) {
+        if (option.value === resultsDropdown.dataset.limit) {
+          resultsDropdown.name = "";
+        }
+        searchResults.submit();
+      }
+    });
+  });
+}
+
+function toggleVendorsList() {
+  const vendorSection = document.querySelector("#vendor-section");
+  const vendorPanel = vendorSection.querySelector(".p-accordion__panel");
+  const toggleVendorButtons = document.querySelectorAll(".js-reveal-vendors");
+  toggleVendorButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      window.scrollTo(0, 360);
+      vendorPanel.classList.toggle("is-collapsed__vendors");
+      toggleVendorButtons.forEach((button) => {
+        button.classList.toggle("u-hide");
+      });
+    });
+  });
+}
+toggleVendorsList();
+
+function toggleVersionsList() {
+  const versionSection = document.querySelector("#version-section");
+  const versionPanel = versionSection.querySelector(".p-accordion__panel");
+  const toggleVersionButtons = document.querySelectorAll(".js-reveal-versions");
+  toggleVersionButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      versionPanel.classList.toggle("is-collapsed__versions");
+      toggleVersionButtons.forEach((button) => {
+        button.classList.toggle("u-hide");
+      });
+    });
+  });
+}
+toggleVersionsList();
+
+//hides "show all .." and "show fewer" links when the accordion is closed
+function toggleShowAllLinks() {
+  const filterSections = document.querySelectorAll(
+    ".p-accordion__group--certified"
+  );
+  filterSections.forEach((filterSection) => {
+    const tab = filterSection.querySelector(".p-accordion__tab");
+    tab.addEventListener("click", () => {
+      const links = filterSection.querySelector(".js-toggle-links");
+      if (links) {
+        links.classList.toggle("u-hide");
+      }
+    });
+  });
+}
+toggleShowAllLinks();

--- a/static/js/src/certification-results.js
+++ b/static/js/src/certification-results.js
@@ -40,14 +40,23 @@ function enableApplyFilters() {
 
         const categoryChipValue = tab.querySelector("#category-count");
         if (categoryChipValue) {
+          if (categoryFilterCount === 0) {
+            chip.classList.toggle("u-hide");
+          }
           categoryChipValue.innerHTML = categoryFilterCount;
         }
         const vendorChipValue = tab.querySelector("#vendor-count");
         if (vendorChipValue) {
+          if (vendorFilterCount === 0) {
+            chip.classList.toggle("u-hide");
+          }
           vendorChipValue.innerHTML = vendorFilterCount;
         }
         const releaseChipValue = tab.querySelector("#release-count");
         if (releaseChipValue) {
+          if (releaseFilterCount === 0) {
+            chip.classList.toggle("u-hide");
+          }
           releaseChipValue.innerHTML = releaseFilterCount;
         }
 

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -64,32 +64,20 @@ function enableApplyFilters() {
           }
           releaseChipValue.innerHTML = releaseFilterCount;
         }
-
-        // Add line break in title to keep chip on same line
-        const header = tab.querySelector(".p-certification-header");
-        if (header.innerHTML.includes("Certified")) {
-          if (!chip.classList.contains("u-hide")) {
-            header.innerHTML = "Certified Ubuntu <br> release";
-          } else {
-            header.innerHTML = "Certified Ubuntu release";
-          }
-        }
       });
     });
   }
   displayFilterCount();
 }
 
-//function to ensure only the option which has been changed is appended to the URL
+// function to ensure only the option which has been changed is appended to the URL
 function updateResultsPerPage() {
+  const searchResults = document.querySelector(".js-search-results");
   let resultsDropdowns = document.querySelectorAll(".p-results-per-page");
   resultsDropdowns.forEach((resultsDropdown) => {
     const options = resultsDropdown.querySelectorAll("option");
     options.forEach((option) => {
       if (option.selected) {
-        if (option.value === resultsDropdown.dataset.limit) {
-          resultsDropdown.name = "";
-        }
         searchResults.submit();
       }
     });
@@ -99,11 +87,11 @@ function updateResultsPerPage() {
 function toggleVendorsList() {
   const vendorSection = document.querySelector("#vendor-section");
   const vendorPanel = vendorSection.querySelector(".p-accordion__panel");
-  const toggleVendorButtons = document.querySelectorAll(".js-reveal-vendors");
+  const toggleVendorButtons = document.querySelectorAll(".p-reveal-vendors");
   toggleVendorButtons.forEach((button) => {
     button.addEventListener("click", () => {
       window.scrollTo(0, 360);
-      vendorPanel.classList.toggle("is-collapsed__vendors");
+      vendorPanel.classList.toggle("is-collapsed");
       toggleVendorButtons.forEach((button) => {
         button.classList.toggle("u-hide");
       });
@@ -114,10 +102,10 @@ function toggleVendorsList() {
 function toggleVersionsList() {
   const versionSection = document.querySelector("#version-section");
   const versionPanel = versionSection.querySelector(".p-accordion__panel");
-  const toggleVersionButtons = document.querySelectorAll(".js-reveal-versions");
+  const toggleVersionButtons = document.querySelectorAll(".p-reveal-versions");
   toggleVersionButtons.forEach((button) => {
     button.addEventListener("click", () => {
-      versionPanel.classList.toggle("is-collapsed__versions");
+      versionPanel.classList.toggle("is-collapsed");
       toggleVersionButtons.forEach((button) => {
         button.classList.toggle("u-hide");
       });

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -1,3 +1,8 @@
+function clearFilters() {
+  location.assign(`/certified?q=`);
+  return false;
+}
+
 function enableApplyFilters() {
   const filtersSelected = [];
   const filters = document.querySelectorAll(".js-enable-apply-filters");
@@ -75,8 +80,6 @@ function enableApplyFilters() {
   displayFilterCount();
 }
 
-enableApplyFilters();
-
 //function to ensure only the option which has been changed is appended to the URL
 function updateResultsPerPage() {
   let resultsDropdowns = document.querySelectorAll(".p-results-per-page");
@@ -107,7 +110,6 @@ function toggleVendorsList() {
     });
   });
 }
-toggleVendorsList();
 
 function toggleVersionsList() {
   const versionSection = document.querySelector("#version-section");
@@ -122,7 +124,6 @@ function toggleVersionsList() {
     });
   });
 }
-toggleVersionsList();
 
 //hides "show all .." and "show fewer" links when the accordion is closed
 function toggleShowAllLinks() {
@@ -139,4 +140,8 @@ function toggleShowAllLinks() {
     });
   });
 }
+
+enableApplyFilters();
+toggleVersionsList();
+toggleVendorsList();
 toggleShowAllLinks();

--- a/static/sass/_pattern_accordion.scss
+++ b/static/sass/_pattern_accordion.scss
@@ -42,17 +42,6 @@
           );
         }
       }
-
-      .p-checkbox {
-        width: 100%;
-      }
-
-      .p-checkbox__label {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        width: calc(98%);
-      }
     }
   }
 }

--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -60,4 +60,17 @@
     padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
+  .p-accordion__tab {
+    &:hover {
+      .p-round-chip {
+        $base-background-opacity-amount: 0.1;
+        $color-background-base: adjust-color(
+          $color-x-dark,
+          $lightness: 100% * (1 - $base-background-opacity-amount)
+        );
+
+        background-color: $color-background-base;
+      }
+    }
+  }
 }

--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -51,4 +51,13 @@
     max-width: 5.3rem;
     min-width: 5.3rem;
   }
+
+  .p-round-chip {
+    @extend .p-chip;
+
+    float: right;
+    margin-top: 0;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
 }

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -140,7 +140,7 @@
                </li>
              </ul>
            </aside>
-           <button href="#" class="p-button--positive p-update-results" id="apply-filters" type=submit disabled>Apply filters</button>
+           <button href="#" class="p-button--positive p-update-results js-apply-filters" type=submit disabled>Apply filters</button>
            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
          </div>
        </nav>
@@ -207,6 +207,7 @@
  </section>
 </form>
 
+
 <script>
 
  function clearFilters() {
@@ -214,175 +215,8 @@
    return false
  }
 
-  function enableApplyFilters() {
-    const filtersSelected = [];
-    const filters = document.querySelectorAll(".js-enable-apply-filters")
-    filters.forEach(filter => {
-      filter.addEventListener("change", () => {
-        if(!filtersSelected.includes(filter)) {
-          filtersSelected.push(filter)
-        } else {
-          const index = filtersSelected.indexOf(filter)
-          filtersSelected.splice(index, 1)
-        }
-        const button = document.querySelector("#apply-filters");
-        if(filtersSelected.length) {
-          button.removeAttribute("disabled")
-        } else {
-          button.disabled = true
-        }
-      })
-    })
-  
-    function displayFilterCount() {
-      const accordion = document.querySelector(".js-filter-count")
-      const accordionTabs = accordion.querySelectorAll(".p-accordion__tab")
-      accordionTabs.forEach(tab => {
-        tab.addEventListener("click", () => {
-          let vendorFilterCount = 0; 
-          let categoryFilterCount = 0;
-          let releaseFilterCount = 0;
-          filtersSelected.forEach(filter => {
-            if(filter.id === "vendor-filter") {
-              vendorFilterCount++;
-            } else if (filter.id === "category-filter") {
-              categoryFilterCount++;
-            } else {
-              releaseFilterCount++;
-            }
-          })
-          const chip = tab.querySelector(".p-round-chip")
-          chip.classList.toggle("u-hide")
-          
-          const categoryChipValue = tab.querySelector("#category-count")
-          if(categoryChipValue) {
-            categoryChipValue.innerHTML = categoryFilterCount
-          }
-          const vendorChipValue = tab.querySelector("#vendor-count")
-          if(vendorChipValue) {
-            vendorChipValue.innerHTML = vendorFilterCount
-          }
-          const releaseChipValue = tab.querySelector("#release-count")
-          if(releaseChipValue) {
-            releaseChipValue.innerHTML = releaseFilterCount
-          }
-          
-          // Add line break in title to keep chip on same line
-          const header = tab.querySelector(".p-certification-header")
-          if(header.innerHTML.includes("Certified")) {
-            if(!chip.classList.contains("u-hide")) {
-              header.innerHTML = "Certified Ubuntu <br> release"
-            } else {
-              header.innerHTML = "Certified Ubuntu release"
-            }
-          }
-        })
-      })
-    }
-    displayFilterCount()
-  }
-
-  enableApplyFilters()
-
-  //function to ensure only the option which has been changed is appended to the URL
-  function updateResultsPerPage() {
-    let resultsDropdowns = document.querySelectorAll(".p-results-per-page");
-    resultsDropdowns.forEach((resultsDropdown) => {
-      const options = resultsDropdown.querySelectorAll("option");
-      options.forEach((option) => {
-        if (option.selected) {
-          if (option.value === resultsDropdown.dataset.limit) {
-            resultsDropdown.name = "";
-          }
-          searchResults.submit();
-        }
-      });
-    });
-  }
-
-  function toggleVendorsList() {
-    const vendorSection = document.querySelector("#vendor-section");
-    const vendorPanel = vendorSection.querySelector(".p-accordion__panel");
-    const toggleVendorButtons = document.querySelectorAll(".js-reveal-vendors");
-    toggleVendorButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        window.scrollTo(0, 360);
-        vendorPanel.classList.toggle("is-collapsed");
-        toggleVendorButtons.forEach((button) => {
-          button.classList.toggle("u-hide");
-        });
-      });
-    });
-  }
-  toggleVendorsList();
-  
-  function toggleVersionsList() {
-    const versionSection = document.querySelector("#version-section");
-    const versionPanel = versionSection.querySelector(".p-accordion__panel");
-    const toggleVersionButtons = document.querySelectorAll(".js-reveal-versions");
-    toggleVersionButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        versionPanel.classList.toggle("is-collapsed");
-        toggleVersionButtons.forEach((button) => {
-          button.classList.toggle("u-hide");
-        });
-      });
-    });
-  }
-  toggleVersionsList();
-  
-  //hides "show all .." and "show fewer" links when the accordion is closed
-  function toggleShowAllLinks() {
-    const filterSections = document.querySelectorAll(
-      ".p-accordion__group--certified"
-    );
-    filterSections.forEach((filterSection) => {
-      const tab = filterSection.querySelector(".p-accordion__tab");
-      tab.addEventListener("click", () => {
-        const links = filterSection.querySelector(".js-toggle-links");
-        if (links) {
-          links.classList.toggle("u-hide");
-        }
-      });
-    });
-  }
-  toggleShowAllLinks();
-
-function toggleDrawer(sideNavigation, show) {
-  if (sideNavigation) {
-    if (show) {
-      sideNavigation.classList.remove('is-collapsed');
-      sideNavigation.classList.add('is-expanded');
-    } else {
-      sideNavigation.classList.remove('is-expanded');
-      sideNavigation.classList.add('is-collapsed');
-    }
-  }
-}
-
-function setupSideNavigation(sideNavigation) {
-  var toggles = [].slice.call(sideNavigation.querySelectorAll('.js-drawer-toggle'));
-
-  toggles.forEach(function (toggle) {
-    toggle.addEventListener('click', function (event) {
-      event.preventDefault();
-      var sideNav = document.getElementById(toggle.getAttribute('aria-controls'));
-
-      if (sideNav) {
-        toggleDrawer(sideNav, !sideNav.classList.contains('is-expanded'));
-      }
-    });
-  });
-}
-
-function setupSideNavigations(sideNavigationSelector) {
-  var sideNavigations = [].slice.call(document.querySelectorAll(sideNavigationSelector));
-
-  sideNavigations.forEach(setupSideNavigation);
-}
-
-setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
-
 </script>
+
+<script src="{{ versioned_static('js/src/certification-results.js') }}" type="module" defer></script>
 
 {% endblock content %}

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -9,15 +9,7 @@
 <form name="searchResults">
  <section class="p-strip--suru-topped">
    <div class="u-fixed-width">
-     <h1 class="u-sv3">Ubuntu certified
-       {% if category == "Desktop" %} desktops
-       {% elif category == "Laptop" %} laptops
-       {% elif category == "Device" %} devices
-       {% elif category == "Server" %} servers
-       {% elif category == "SoC" %} SoCs
-       {% else %} hardware {% endif %}
-       {% if vendors and vendors|length == 1 %} from {{ vendors [0] }} {% endif %}
-     </h1>
+     <h1 class="u-sv3">Ubuntu certified hardware</h1>
    </div>
    <div class="u-fixed-width">
      <div class="p-search-box">
@@ -73,17 +65,22 @@
            </a>
          </div>
          <div>
-           <aside class="p-accordion" data-multiple-expanded="true">
+           <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
              <ul class="p-accordion__list">
                <li class="p-accordion__group--certified">
-                 <div role="heading" aria-level="2" class="p-accordion__heading">
-                   <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true" ><span class="p-certification-header">Category</span></button>
+                 <div role="heading" aria-level="2">
+                  <button type="button" class="p-accordion__tab u-no-padding--right" id="tab1" aria-controls="tab1-section" aria-expanded="true">
+                    <span class="p-certification-header">Category</span>
+                    <div class="p-round-chip u-hide">
+                      <span class="p-chip__value" id="category-count"></span>
+                    </div>
+                  </button>
                  </div>
                  <hr>
                  <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
                    {% for category_filter in category_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input js-enable-apply-filters" id="category_filter" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
+                      <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input js-enable-apply-filters" id="category-filter" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
                       <div class="p-checkbox__label" id="{{ category_filter }}">
                         <span>{{ category_filter }}</span>
                       </div>
@@ -92,8 +89,13 @@
                  </section>
                </li>
                <li class="p-accordion__group--certified" id="vendor-section">
-                 <div role="heading" aria-level="2" class="p-accordion__heading">
-                   <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="true"><span class="p-certification-header">Vendor</span></button>
+                 <div role="heading" aria-level="2">
+                   <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
+                     <span class="p-certification-header">Vendor</span>
+                     <div class="p-round-chip u-hide">
+                      <span class="p-chip__value" id="vendor-count">1</span>
+                    </div>
+                    </button>
                  </div>
                  <hr>
                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
@@ -107,13 +109,18 @@
                    {% endfor %}
                  </section>
                  <span class="js-toggle-links">
-                  <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                  <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
+                  <p class="js-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
+                  <p class="js-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                 </span>
                </li>
                <li class="p-accordion__group--certified" id="version-section">
-                 <div role="heading" aria-level="2" class="p-accordion__heading">
-                   <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true"><span class="p-certification-header">Certified Ubuntu release</span></button>
+                 <div role="heading" aria-level="2">
+                   <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
+                     <span class="p-certification-header">Certified Ubuntu release</span>
+                     <div class="p-round-chip u-hide">
+                      <span class="p-chip__value" id="release-count">1</span>
+                    </div>
+                    </button>
                  </div>
                  <hr>
                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
@@ -127,8 +134,8 @@
                    {% endfor %}
                  </section>
                  <span class="js-toggle-links">
-                  <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                  <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
+                  <p class="js-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
+                  <p class="js-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                 </span>
                </li>
              </ul>
@@ -212,22 +219,71 @@
     const filters = document.querySelectorAll(".js-enable-apply-filters")
     filters.forEach(filter => {
       filter.addEventListener("change", () => {
-        if(!filtersSelected.includes(filter.value)) {
-          filtersSelected.push(filter.value)
+        if(!filtersSelected.includes(filter)) {
+          filtersSelected.push(filter)
         } else {
-          const index = filtersSelected.indexOf(filter.value)
+          const index = filtersSelected.indexOf(filter)
           filtersSelected.splice(index, 1)
         }
+        const button = document.querySelector("#apply-filters");
         if(filtersSelected.length) {
-          document.querySelector("#apply-filters").removeAttribute("disabled")
+          button.removeAttribute("disabled")
         } else {
-          document.querySelector("#apply-filters").disabled = true
+          button.disabled = true
         }
       })
     })
+  
+    function displayFilterCount() {
+      const accordion = document.querySelector(".js-filter-count")
+      const accordionTabs = accordion.querySelectorAll(".p-accordion__tab")
+      accordionTabs.forEach(tab => {
+        tab.addEventListener("click", () => {
+          let vendorFilterCount = 0; 
+          let categoryFilterCount = 0;
+          let releaseFilterCount = 0;
+          filtersSelected.forEach(filter => {
+            if(filter.id === "vendor-filter") {
+              vendorFilterCount++;
+            } else if (filter.id === "category-filter") {
+              categoryFilterCount++;
+            } else {
+              releaseFilterCount++;
+            }
+          })
+          const chip = tab.querySelector(".p-round-chip")
+          chip.classList.toggle("u-hide")
+          
+          const categoryChipValue = tab.querySelector("#category-count")
+          if(categoryChipValue) {
+            categoryChipValue.innerHTML = categoryFilterCount
+          }
+          const vendorChipValue = tab.querySelector("#vendor-count")
+          if(vendorChipValue) {
+            vendorChipValue.innerHTML = vendorFilterCount
+          }
+          const releaseChipValue = tab.querySelector("#release-count")
+          if(releaseChipValue) {
+            releaseChipValue.innerHTML = releaseFilterCount
+          }
+          
+          // Add line break in title to keep chip on same line
+          const header = tab.querySelector(".p-certification-header")
+          if(header.innerHTML.includes("Certified")) {
+            if(!chip.classList.contains("u-hide")) {
+              header.innerHTML = "Certified Ubuntu <br> release"
+            } else {
+              header.innerHTML = "Certified Ubuntu release"
+            }
+          }
+        })
+      })
+    }
+    displayFilterCount()
   }
 
   enableApplyFilters()
+
   //function to ensure only the option which has been changed is appended to the URL
   function updateResultsPerPage() {
     let resultsDropdowns = document.querySelectorAll(".p-results-per-page");
@@ -247,7 +303,7 @@
   function toggleVendorsList() {
     const vendorSection = document.querySelector("#vendor-section");
     const vendorPanel = vendorSection.querySelector(".p-accordion__panel");
-    const toggleVendorButtons = document.querySelectorAll(".p-reveal-vendors");
+    const toggleVendorButtons = document.querySelectorAll(".js-reveal-vendors");
     toggleVendorButtons.forEach((button) => {
       button.addEventListener("click", () => {
         window.scrollTo(0, 360);
@@ -263,7 +319,7 @@
   function toggleVersionsList() {
     const versionSection = document.querySelector("#version-section");
     const versionPanel = versionSection.querySelector(".p-accordion__panel");
-    const toggleVersionButtons = document.querySelectorAll(".p-reveal-versions");
+    const toggleVersionButtons = document.querySelectorAll(".js-reveal-versions");
     toggleVersionButtons.forEach((button) => {
       button.addEventListener("click", () => {
         versionPanel.classList.toggle("is-collapsed");
@@ -276,7 +332,7 @@
   toggleVersionsList();
   
   //hides "show all .." and "show fewer" links when the accordion is closed
-  function toggleLinks() {
+  function toggleShowAllLinks() {
     const filterSections = document.querySelectorAll(
       ".p-accordion__group--certified"
     );
@@ -290,7 +346,7 @@
       });
     });
   }
-  toggleLinks();
+  toggleShowAllLinks();
 
 function toggleDrawer(sideNavigation, show) {
   if (sideNavigation) {

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -6,205 +6,201 @@
 
 {% block content %}
 
-<form name="searchResults">
- <section class="p-strip--suru-topped">
-   <div class="u-fixed-width">
-     <h1 class="u-sv3">Ubuntu certified hardware</h1>
-   </div>
-   <div class="u-fixed-width">
-     <div class="p-search-box">
-       <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
-       <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
-     </div>
-   </div>
-   <div class="row">
-     <div class="col-3">
-       <h2 class="p-heading--4">Filter</h2>
-     </div>
-     <div class="col-4">
-      <h2 class="p-heading--4">
-        {% if total_results %}
-        {% if total_results and total_results > 1 %}
-        {{ offset + 1 }}
-        &ndash;
-        {% if offset + limit > total_results %}
+<form class="js-search-results">
+  <section class="p-strip--suru-topped">
+    <div class="u-fixed-width">
+      <h1 class="u-sv3">Ubuntu certified hardware</h1>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-search-box">
+        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
+        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-3">
+        <h2 class="p-heading--4">Filter</h2>
+      </div>
+      <div class="col-4">
+        <h2 class="p-heading--4">
+          {% if total_results %}
+          {% if total_results and total_results > 1 %}
+          {{ offset + 1 }}
+          &ndash;
+          {% if offset + limit > total_results %}
           {{ total_results }}
-        {% else %}
+          {% else %}
           {{ offset + limit }}
+          {% endif %}
+          of
+          {% endif %}
+          {{ total_results }} result{% if total_results != 1 %}s{% endif %}
+          {% endif %}
+        </h2>
+      </div>
+      <div class="col-5 u-align--right">
+        {% if total_results > 0 %}
+        <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
+        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+          <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
+          {% if total_results > 20 %}
+          <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
+          {% endif %}
+          {% if total_results > 40 %}
+          <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
+          {% endif %}
+          <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
+        </select>
         {% endif %}
-        of
-      {% endif %}
-      {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-      {% endif %}
-      </h2>
+      </div>
     </div>
-    <div class="col-5 u-align--right">
-    {% if total_results > 0 %}
-    <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-      <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
-        <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
-        {% if total_results > 20 %}
-        <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
-        {% endif %}
-        {% if total_results > 40 %}
-        <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
-        {% endif %}
-        <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
-      </select>
-    {% endif %}
-    </div>
-   </div>
-   <div class="row">
-     <div class="col-3 p-side-navigation" id="drawer">
-       <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-       <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-       <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-         <div class="p-side-navigation__drawer-header">
-           <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-             Toggle filters
-           </a>
-         </div>
-         <div>
-           <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
-             <ul class="p-accordion__list">
-               <li class="p-accordion__group--certified">
-                 <div role="heading" aria-level="2">
-                  <button type="button" class="p-accordion__tab u-no-padding--right" id="tab1" aria-controls="tab1-section" aria-expanded="true">
-                    <span class="p-certification-header">Category</span>
-                    <div class="p-round-chip u-hide">
-                      <span class="p-chip__value" id="category-count"></span>
-                    </div>
-                  </button>
-                 </div>
-                 <hr>
-                 <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
-                   {% for category_filter in category_filters %}
+    <div class="row">
+      <div class="col-3 p-side-navigation" id="drawer">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
+          <div class="p-side-navigation__drawer-header">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle filters
+            </a>
+          </div>
+          <div>
+            <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
+              <ul class="p-accordion__list">
+                <li class="p-accordion__group--certified">
+                  <div role="heading" aria-level="2">
+                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab1" aria-controls="tab1-section" aria-expanded="true">
+                      <span class="p-certification-header">Category</span>
+                      <div class="p-round-chip u-hide">
+                        <span class="p-chip__value" id="category-count"></span>
+                      </div>
+                    </button>
+                  </div>
+                  <hr class="u-no-margin--bottom">
+                  <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
+                    {% for category_filter in category_filters %}
                     <label class="p-checkbox">
                       <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input js-enable-apply-filters" id="category-filter" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
-                      <div class="p-checkbox__label" id="{{ category_filter }}">
-                        <span>{{ category_filter }}</span>
-                      </div>
+                      <span class="p-checkbox__label" id="{{ category_filter }}">{{ category_filter }}</span>
                     </label>
-                   {% endfor %}
-                 </section>
-               </li>
-               <li class="p-accordion__group--certified" id="vendor-section">
-                 <div role="heading" aria-level="2">
-                   <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                     <span class="p-certification-header">Vendor</span>
-                     <div class="p-round-chip u-hide">
-                      <span class="p-chip__value" id="vendor-count">1</span>
-                    </div>
+                    {% endfor %}
+                  </section>
+                </li>
+                <li class="p-accordion__group--certified" id="vendor-section">
+                  <div role="heading" aria-level="2">
+                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
+                      <span class="p-certification-header">Vendor</span>
+                      <div class="p-round-chip u-hide">
+                        <span class="p-chip__value" id="vendor-count">1</span>
+                      </div>
                     </button>
-                 </div>
-                 <hr>
-                 <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
-                   {% for vendor_filter in vendor_filters %}
-                   <label class="p-checkbox">
-                     <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                     <div class="p-checkbox__label" id="{{ vendor_filter }}">
-                       <span>{{ vendor_filter }}</span>
-                     </div>
-                   </label>
-                   {% endfor %}
-                 </section>
-                 <span class="js-toggle-links">
-                  <p class="js-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                  <p class="js-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
-                </span>
-               </li>
-               <li class="p-accordion__group--certified" id="version-section">
-                 <div role="heading" aria-level="2">
-                   <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                     <span class="p-certification-header">Certified Ubuntu release</span>
-                     <div class="p-round-chip u-hide">
-                      <span class="p-chip__value" id="release-count">1</span>
-                    </div>
+                  </div>
+                  <hr class="u-no-margin--bottom">
+                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
+                    {% for vendor_filter in vendor_filters %}
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
+                    </label>
+                    {% endfor %}
+                  </section>
+                  <span class="js-toggle-links">
+                    <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
+                    <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
+                  </span>
+                </li>
+                <li class="p-accordion__group--certified" id="version-section">
+                  <div role="heading" aria-level="2">
+                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
+                      <span class="p-certification-header">Certified Ubuntu
+                        <div class="p-round-chip u-hide">
+                          <span class="p-chip__value" id="release-count">1</span>
+                        </div>
+                        <br> release
+                      </span>
                     </button>
-                 </div>
-                 <hr>
-                 <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
-                   {% for release_filter in release_filters %}
-                   <label class="p-checkbox">
-                     <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                     <div class="p-checkbox__label" id="{{ release_filter }}">
-                       <span>{{ release_filter }}</span>
-                     </div>
-                   </label>
-                   {% endfor %}
-                 </section>
-                 <span class="js-toggle-links">
-                  <p class="js-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                  <p class="js-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
-                </span>
-               </li>
-             </ul>
-           </aside>
-           <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-           <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-         </div>
-       </nav>
-     </div>
-     {% if total_results > 0 %}
-     <div class="col-9">
-       <table class="p-certification-results">
-         <thead>
-           <tr>
-             <th><span class="p-certification-header">Vendor</span></th>
-             <th><span class="p-certification-header">Model</span></th>
-             <th><span class="p-certification-header">Category</span></th>
-           </tr>
-         </thead>
-         <tbody>
-           {% for result in results %}
-           <tr>
-             <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
-             <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-             <td>{{ result.category }}</td>
-           </tr>
-           {% endfor %}
-         </tbody>
-       </table>
-       <div class="row">
-         <div class="col-5">
-          {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-          {% include "security/cve/_pagination.html" %}
-          {% endwith %}
-         </div>
-         <div class="col-4 u-align--right">
-          {% if total_results > 0 %}
-          <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-          <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
-            <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
-            {% if total_results > 20 %}
-            <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
+                  </div>
+                  <hr class="u-no-margin--bottom">
+                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
+                    {% for release_filter in release_filters %}
+                    <label class="p-checkbox">
+                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
+                    </label>
+                    {% endfor %}
+                  </section>
+                  <span class="js-toggle-links">
+                    <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
+                    <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
+                  </span>
+                </li>
+              </ul>
+            </aside>
+            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
+            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
+          </div>
+        </nav>
+      </div>
+      {% if total_results > 0 %}
+      <div class="col-9">
+        <table class="p-certification-results">
+          <thead>
+            <tr>
+              <th><span class="p-certification-header">Vendor</span></th>
+              <th><span class="p-certification-header">Model</span></th>
+              <th><span class="p-certification-header">Category</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for result in results %}
+            <tr>
+              <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
+              <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
+              <td>{{ result.category }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <div class="row">
+          <div class="col-5">
+            {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
+            {% include "security/cve/_pagination.html" %}
+            {% endwith %}
+          </div>
+          <div class="col-4 u-align--right">
+            {% if total_results > 0 %}
+            <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
+            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+              <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
+              {% if total_results > 20 %}
+              <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
+              {% endif %}
+              {% if total_results > 40 %}
+              <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
+              {% endif %}
+              <option value="{{ total_results }}" name="all">All</option>
+            </select>
             {% endif %}
-            {% if total_results > 40 %}
-            <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
-            {% endif %}
-            <option value="{{ total_results }}" name="all">All</option>
-          </select>
-        {% endif %}
-         </div>
-       </div>
-     </div>
-     {% else %}
-     <div class="col-9">
-       <h3 class="p-heading--4">No results - why not try widening your search?</h3>
-       <p>You can do this by:</p>
-       <ul class="p-list">
-         <li class="p-list__item is-ticked u-sv1">
-           Adding alternative words or phrases
-         </li>
-         <li class="p-list__item is-ticked  u-sv1">
-           Using individual words instead of phrases
-         </li>
-         <li class="p-list__item is-ticked">Trying a different spelling</li>
-       </ul>
-     </div>
-     {% endif %}
-   </div>
- </section>
+          </div>
+        </div>
+      </div>
+      {% else %}
+      <div class="col-9">
+        <h3 class="p-heading--4">No results - why not try widening your search?</h3>
+        <p>You can do this by:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked u-sv1">
+            Adding alternative words or phrases
+          </li>
+          <li class="p-list__item is-ticked  u-sv1">
+            Using individual words instead of phrases
+          </li>
+          <li class="p-list__item is-ticked">Trying a different spelling</li>
+        </ul>
+      </div>
+      {% endif %}
+    </div>
+  </section>
 </form>
 
 <script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -140,7 +140,7 @@
                </li>
              </ul>
            </aside>
-           <button href="#" class="p-button--positive p-update-results js-apply-filters" type=submit disabled>Apply filters</button>
+           <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
          </div>
        </nav>
@@ -207,16 +207,6 @@
  </section>
 </form>
 
-
-<script>
-
- function clearFilters() {
-  location.assign(`/certified?q=`)
-   return false
- }
-
-</script>
-
-<script src="{{ versioned_static('js/src/certification-results.js') }}" type="module" defer></script>
+<script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Add counter to accordion tab when the accordion is closed
- Move javascript functionality into it's own file

## QA

- View page at: https://ubuntu-com-10125.demos.haus/certified?q=
- Select filters on the LHS and close the accordion - check the chip is visible on each section with the correct number of filters applied. 
- Check when there are no filters applied the chip isn't visible. 


## Issue / Card

Fixes [#4250](https://github.com/canonical-web-and-design/web-squad/issues/4250)

## Screenshots

![Screenshot 2021-08-04 at 11 20 40](https://user-images.githubusercontent.com/58959073/128165128-aed149d9-002b-4852-a71b-dd31be8ec4e6.png)

