### PR TITLE
Update ceph copy doc

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Ceph storage on Ubuntu{% endblock %}
 {% block meta_description %}Ceph storage on Ubuntu  reduces your costs of running software-defined storage clusters at scale on commodity hardware. {% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/17VnBygL00hXjLSECXMo3bF7KOCT5oZGFBLo6Qd6rF3A{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1gpEjTcdJor2yTGfMz7T_xIfs7BtV6rbBPFYfNZFe52Y/edit{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip u-no-padding--top u-no-padding--bottom is-bordered">
@@ -10,7 +10,7 @@
     <div class="row u-equal-height">
       <div class="col-7 col-medium-4">
         <h1>Ceph storage on Ubuntu</h1>
-        <h2 class="p-heading--four">Ceph provides a flexible open source storage option for OpenStack, Kubernetes or as stand-alone storage cluster.</h2>
+        <h2 class="p-heading--four">Ceph provides a flexible open source storage option for OpenStack, Kubernetes or as a stand-alone storage cluster.</h2>
         <p>Use Ceph on Ubuntu to reduce the costs of running storage clusters at scale on commodity hardware. Get access to a proven storage technology solution and 24x7 support with Ubuntu Advantage for Infrastructure.</p>
         <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a>
         <p>


### PR DESCRIPTION
## Done

- Created a new ceph copy doc
- Update ceph copy doc meta data
- Add the an 'a' to the opening h4

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the new [copy doc](https://docs.google.com/document/d/1gpEjTcdJor2yTGfMz7T_xIfs7BtV6rbBPFYfNZFe52Y/edit#heading=h.vnx6txk2yt47) is linked
