### PR TITLE
K*sDocs-1.21+ck3 updates

### DIFF
--- a/templates/kubernetes/docs/1.21/release-notes.md
+++ b/templates/kubernetes/docs/1.21/release-notes.md
@@ -13,6 +13,16 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.21+ck3 Bugfix release
+
+### August 02, 2021 - [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck3).
+
+
 # 1.21+ck2 Bugfix release
 
 ### May 28, 2021 - [charmed-kubernetes-679](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-679/archive/bundle.yaml)

--- a/templates/kubernetes/docs/charm-containerd.md
+++ b/templates/kubernetes/docs/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/charm-containerd.md
+++ b/templates/kubernetes/docs/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  [{"url": "https://my.registry:port", "username": "user", "password": "pass"}]
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.21.x    | [charmed-kubernetes-679](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-679/archive/bundle.yaml) |
+| 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
 | 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -38,15 +38,15 @@ along with the following overlay file ([download it here][monitoring-pgt-overlay
 applications:
   prometheus:
     series: bionic
-    charm: cs:prometheus2-11
+    charm: cs:prometheus2
     constraints: "mem=4G root-disk=16G"
     num_units: 1
   grafana:
-    charm: cs:grafana-37
+    charm: cs:grafana
     expose: true
     num_units: 1
   telegraf:
-    charm: cs:telegraf-36
+    charm: cs:telegraf
 relations:
   - [prometheus:grafana-source, grafana:grafana-source]
   - [telegraf:prometheus-client, prometheus:target]
@@ -182,7 +182,7 @@ install time, and can be retrieved by running:
 juju ssh nagios/0 sudo cat /var/lib/juju/nagios.passwd
 ```
 
-![nagios dashboard image][https://assets.ubuntu.com/v1/4b109895-CDK-nagios.png]
+![nagios dashboard image](https://assets.ubuntu.com/v1/4b109895-CDK-nagios.png)
 
 ### Using an existing Nagios service
 

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -14,6 +14,16 @@ toc: False
 ---
 
 
+# 1.21+ck3 Bugfix release
+
+### August 02, 2021 - [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck3).
+
+
 # 1.21+ck2 Bugfix release
 
 ### May 28, 2021 - [charmed-kubernetes-679](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-679/archive/bundle.yaml)

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -57,7 +57,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.21.x    | [charmed-kubernetes-679](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-679/archive/bundle.yaml) |
+| 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |
 | 1.18.x    | [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml) |


### PR DESCRIPTION
## Done

- Update references for bundles
- Add release notes for 1.21ck3
- Changes to monitoring page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
