### PR TITLE
Fix components table releases

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -156,9 +156,8 @@
         {% for component in components%}
         <tr>
           <th aria-label="Component"><a href="/certified/component/{{ component.id }}">{{ component.vendor_name }} {{ component.model }}</a></th>
-          {% for lts_release, details in component.lts_releases.items() %}
-            {% if lts_release == '14.04 ESM' %}
-              {% if details[0].third_party_driver == True %}
+            {% if '14.04 ESM' in component.lts_releases %}
+              {% if component.lts_releases['14.04 ESM'][0].third_party_driver %}
               <td aria-label="14.04 ESM">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
@@ -170,16 +169,16 @@
                   ) | safe
                 }}
               </td>
-              {% elif details[0].status == 'inprogress' %}
+              {% elif component.lts_releases['14.04 ESM'][0].status == 'inprogress' %}
               <td aria-label="14.04 ESM"><i class="p-icon--help">In progress</i></td>
-              {% elif details[0].status == 'certified' %}
+              {% elif component.lts_releases['14.04 ESM'][0].status == 'certified' %}
               <td aria-label="14.04 ESM"><i class="p-icon--success">Supported</i></td>
               {% endif %}
             {% else %}
              <td aria-label="14.04 ESM"></td>
             {% endif %}
-            {% if lts_release == '16.04 LTS' %}
-              {% if details[0].third_party_driver == True %}
+            {% if '16.04 LTS' in component.lts_releases %}
+              {% if component.lts_releases['16.04 LTS'][0].third_party_driver %}
               <td aria-label="16.04 LTS">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
@@ -192,16 +191,16 @@
                   ) | safe
                 }}
               </td>
-              {% elif details[0].status == 'inprogress' %}
+              {% elif component.lts_releases['16.04 LTS'][0].status == 'inprogress' %}
               <td aria-label="16.04 ESM"><i class="p-icon--help">Untested</i></td>
-              {% elif details[0].status == 'certified'%}
+              {% elif component.lts_releases['16.04 LTS'][0].status == 'certified'%}
               <td aria-label="16.04 LTS"><i class="p-icon--success">Supported</i></td>
               {% endif %}
             {% else %}
              <td aria-label="16.04 LTS"></td>
             {% endif %}
-            {% if lts_release == '18.04 LTS' %}
-              {% if details[0].third_party_driver == True %}
+            {% if '18.04 LTS' in component.lts_releases %}
+              {% if component.lts_releases['18.04 LTS'][0].third_party_driver %}
               <td aria-label="18.04 LTS">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
@@ -214,16 +213,16 @@
                   ) | safe
                 }}
               </td>
-              {% elif details[0].status == 'inprogress' %}
+              {% elif component.lts_releases['18.04 LTS'][0].status == 'inprogress' %}
               <td aria-label="18.04 ESM"><i class="p-icon--help">In progress</i></td>
-              {% elif details[0].status == 'certified'%}
+              {% elif component.lts_releases['18.04 LTS'][0].status == 'certified'%}
               <td aria-label="18.04 LTS"><i class="p-icon--success">Supported</i></td>
               {% endif %}
             {% else %}
              <td aria-label="18.04 LTS"></td>
             {% endif %}
-            {% if lts_release == '20.04 LTS' %}
-              {% if details[0].third_party_driver == True %}
+            {% if '20.04 LTS' in component.lts_releases %}
+              {% if component.lts_releases['20.04 LTS'][0].third_party_driver %}
               <td aria-label="20.04 LTS">
                 {{ image (
                   url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
@@ -236,15 +235,14 @@
                   ) | safe
                 }}
               </td>
-              {% elif details[0].status == 'inprogress' %}
+              {% elif component.lts_releases['20.04 LTS'][0].status == 'inprogress' %}
               <td aria-label="20.04 ESM"><i class="p-icon--help">In progress</i></td>
-              {% elif details[0].status == 'certified' %}
+              {% elif component.lts_releases['20.04 LTS'][0].status == 'certified' %}
               <td aria-label="20.04 LTS"><i class="p-icon--success">Supported</i></td>
               {% endif %}
             {% else %}
              <td aria-label="20.04 LTS"></td>
             {% endif %}
-          {% endfor %}
           <td aria-label="Comments" >{{ component.note }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Done

Fix components table releases

## QA

- Check https://ubuntu-com-10133.demos.haus/certified/202102-28728 components table contains 20.04 checkmark for nVidia Quadro P400

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9923

## Screenshots

### Before
<img width="1440" alt="Screenshot 2021-08-04 at 17 57 26" src="https://user-images.githubusercontent.com/14939793/128222779-269c7b5b-7a46-4eff-a344-382d2f3987ef.png">


### After
<img width="1440" alt="Screenshot 2021-08-04 at 17 56 42" src="https://user-images.githubusercontent.com/14939793/128222695-cf9de3d8-cb6e-4bd1-b70e-4b0839723dee.png">
