### PR TITLE
Display a pending purchase notification

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
@@ -1,11 +1,33 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
+import { QueryClient, QueryClientProvider } from "react-query";
 
 import Notifications from "./Notifications";
 
 describe("Notifications", () => {
-  it("renders", () => {
-    const wrapper = shallow(<Notifications />);
-    expect(wrapper.find("Notification").exists()).toBe(true);
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  it("displays a pending purchase notification", () => {
+    queryClient.setQueryData("pendingPurchaseId", "abc123");
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='pendingPurchase']").exists()).toBe(true);
+  });
+
+  it("does not diplay a pending purchase notification when there is no id", () => {
+    queryClient.setQueryData("pendingPurchaseId", null);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='pendingPurchase']").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -3,13 +3,12 @@ import {
   NotificationSeverity,
 } from "@canonical/react-components";
 import React from "react";
-import { useQuery } from "react-query";
 
-import { useURLs } from "../../../hooks";
+import { usePendingPurchaseId, useURLs } from "../../../hooks";
 
 const Notifications = () => {
   const urls = useURLs();
-  const { data: pendingPurchaseId } = useQuery("pendingPurchaseId");
+  const { pendingPurchaseId } = usePendingPurchaseId();
   const notifications = [
     {
       children:

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -3,24 +3,14 @@ import {
   NotificationSeverity,
 } from "@canonical/react-components";
 import React from "react";
+import { useQuery } from "react-query";
 
 import { useURLs } from "../../../hooks";
 
 const Notifications = () => {
   const urls = useURLs();
+  const { data: pendingPurchaseId } = useQuery("pendingPurchaseId");
   const notifications = [
-    {
-      children: (
-        <>
-          You need to{" "}
-          <a href={urls.account.paymentMethods}>update your payment methods</a>{" "}
-          to ensure there is no interruption to your Ubuntu Advantage
-          subscriptions
-        </>
-      ),
-      title: "Payment method:",
-      severity: NotificationSeverity.CAUTION,
-    },
     {
       children:
         'Select a subscripton, then "Renew subscription..." to renew it.',
@@ -31,6 +21,19 @@ const Notifications = () => {
 
   return (
     <>
+      {pendingPurchaseId ? (
+        <Notification
+          data-test="pendingPurchase"
+          inline
+          title="Payment method:"
+          severity="caution"
+        >
+          You need to{" "}
+          <a href={urls.account.paymentMethods}>update your payment methods</a>{" "}
+          to ensure there is no interruption to your Ubuntu Advantage
+          subscriptions
+        </Notification>
+      ) : null}
       {notifications.map((props, i) => (
         <Notification inline {...props} key={`notification-${i}`} />
       ))}

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useLoadWindowData } from "./useLoadWindowData";
+export { usePendingPurchaseId } from "./usePendingPurchaseId";
 export { useURLs } from "./useURLs";

--- a/static/js/src/advantage/react/hooks/usePendingPurchaseId.test.tsx
+++ b/static/js/src/advantage/react/hooks/usePendingPurchaseId.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { usePendingPurchaseId } from "./usePendingPurchaseId";
+
+describe("usePendingPurchaseId", () => {
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  });
+
+  it("can return the pending purchase id from the store", async () => {
+    queryClient.setQueryData("pendingPurchaseId", "abc123");
+    const { result, waitForNextUpdate } = renderHook(
+      () => usePendingPurchaseId(),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.pendingPurchaseId).toBe("abc123");
+  });
+});

--- a/static/js/src/advantage/react/hooks/usePendingPurchaseId.test.tsx
+++ b/static/js/src/advantage/react/hooks/usePendingPurchaseId.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { PropsWithChildren } from "react";
 import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -10,9 +10,10 @@ describe("usePendingPurchaseId", () => {
 
   beforeEach(() => {
     queryClient = new QueryClient();
-    wrapper = ({ children }) => (
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
+    wrapper = Wrapper;
   });
 
   it("can return the pending purchase id from the store", async () => {

--- a/static/js/src/advantage/react/hooks/usePendingPurchaseId.ts
+++ b/static/js/src/advantage/react/hooks/usePendingPurchaseId.ts
@@ -1,0 +1,9 @@
+import type { PendingPurchaseId } from "advantage/api/types";
+import { useQuery } from "react-query";
+
+export const usePendingPurchaseId = () => {
+  const { data: pendingPurchaseId } = useQuery<PendingPurchaseId>(
+    "pendingPurchaseId"
+  );
+  return { pendingPurchaseId };
+};

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -32,16 +32,6 @@
     </div>
   </section>
 
-  {% if pending_purchase_id %}
-  <div class="row">
-    <div class="p-notification--caution">
-      <p class="p-notification__response" role="status">
-        <span class="p-notification__status">Payment method:</span>You need to <a href="/account/payment-methods{% if get_test_backend %}?test_backend=true{% endif %}">update your payment methods</a> to ensure there is no interruption to your Ubuntu Advantage subscriptions
-      </p>
-    </div>
-  </div>
-  {% endif %}
-
   <div id="react-root">
     <section class="p-strip u-no-padding--top">
       <div class="row">


### PR DESCRIPTION
## Done

- Update the pending purchase notification to only appear when the id is set.

## QA

- Visit https://ubuntu.com/account/payment-methods?test_backend=true
- Change your card number to `4000000000000341`.
- Visit https://ubuntu.com/advantage?test_backend=true
- Open the edit form for a subscription and change the number of machines and click save.
- Run this branch and visit /advantage?test_backend=true
- You should see a payment method notification.
- Visit https://ubuntu.com/account/payment-methods?test_backend=true
- Change your card number to `4242424242424242`.
- The page will reload and a notification will appear. Click "Retry payment".
- In this branch go to /advantage?test_backend=true
- You should not see a payment method notification.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/121.