### PR TITLE
Add link to /managed from /observability

### DIFF
--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -353,7 +353,7 @@
     <h2>Managed monitoring tools, anywhere</h2>
     <p class="p-heading--four">You focus on your apps, we run the tools for you</p>
     <p>Great monitoring tools enable you to greatly improve your applications, but are hard and time-consuming to run reliably and at scale. Let us run the best open source monitoring tools for you, so you can leverage them to continuously improve your own applications.</p>
-    <p class="u-sv3"><a href="/managed/contact-us" class="p-button--positive">Request a free deployment assessment</a></p>
+    <p class="u-sv3"><a href="/managed/contact-us" class="p-button--positive">Request a free deployment assessment</a> <a href="/managed">More about Managed Apps</a></p>
   </div>
   <div class="row u-equal-height">
     <div class="col-4">


### PR DESCRIPTION
## Done

- Add link to /managed that was super obvious but I did not realized it was needed until after page went live :-)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
