### PR TITLE
Engage language filter

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -14,10 +14,36 @@
 {% endblock %}
 
 {% block content %}
-
-<section class="p-strip u-no-padding--bottom">
+<section class="p-strip--suru-blog-header is-dark">
   <div class="row">
-    <h1>Ubuntu case studies, whitepapers and webinars</h1>
+    <div class="col-6">
+      <h1>Engage pages</h1>
+      <p>Ubuntu case studies, whitepapers and webinars.</p>
+      <a class="p-button--positive p-link--external" href="https://discourse.ubuntu.com/t/engage-pages-and-takeovers/17229">Add new engage pages</a>
+      <a class="p-button--neutral p-link--external" href="https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185">How to add engage pages</a>
+    </div>
+  </div>
+</section>
+
+
+<section class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-4">
+      <div class="p-form__group">
+        <form action="/">
+          <label for="language-selector">Select language:</label>
+          <select name="language-selector" id="language-selector" class="u-no-margin--bottom">
+            <option value="all">All languages</option>
+            <option value="de">Deutsch</option>
+            <option value="en">English</option>
+            <option value="es">Espa&nacute;ol</option>
+            <option value="fr">Fran&ccedil;ais</option>
+            <option value="it">Italiano</option>
+            <option value="pt">Portugu&ecirc;s</option>
+          </select>
+        </form>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -38,4 +64,34 @@
   </div>
 
 </section>
+<script>
+(function() {
+  const languageSelector = document.getElementById("language-selector");
+  const urlObj = new URL(window.location);
+
+  function handleFilter(key, el, url) {
+    if (!el) {
+      return;
+    }
+
+    if (url.searchParams.has(key)) {
+      el.value = url.searchParams.get(key);
+    }
+
+    el.addEventListener("change", function(e) {
+      const value = e.target.value;
+
+      if (url.searchParams.has(key)) {
+        url.searchParams.delete(key);
+      }
+      if (value !== "all") {
+        url.searchParams.append(key, value);
+      }
+      
+      window.location = url;
+    });
+  }
+  handleFilter("language", languageSelector, urlObj);
+})()
+</script>
 {% endblock content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -575,8 +575,7 @@ def build_tutorials_index(session, tutorials_docs):
 def build_engage_index(engage_docs):
     def engage_index():
         page = flask.request.args.get("page", default=1, type=int)
-        topic = flask.request.args.get("topic", default=None, type=str)
-        sort = flask.request.args.get("sort", default=None, type=str)
+        language = flask.request.args.get("language", default=None, type=str)
         preview = flask.request.args.get("preview")
         posts_per_page = 15
         engage_docs.parser.parse()
@@ -589,6 +588,15 @@ def build_engage_index(engage_docs):
                 if "active" in item and item["active"] == "true"
             ]
 
+        if language:
+            new_metadata = []
+            for item in metadata:
+                if "language" in item:
+                    if item["language"] == language:
+                        new_metadata.append(item)
+                    elif language == "en" and item["language"] == "":
+                        new_metadata.append(item)
+            metadata = new_metadata
         total_pages = math.ceil(len(metadata) / posts_per_page)
 
         return flask.render_template(
@@ -596,8 +604,7 @@ def build_engage_index(engage_docs):
             forum_url=engage_docs.parser.api.base_url,
             metadata=metadata,
             page=page,
-            topic=topic,
-            sort=sort,
+            language=language,
             preview=preview,
             posts_per_page=posts_per_page,
             total_pages=total_pages,


### PR DESCRIPTION
## Done

Add language filter

## QA

Note: preferably test this on local to use a different [discourse API key](https://pastebin.canonical.com/p/wNW3cF6YPs/) to avoid getting the Connection error (I believe this is due to rate limits per minute).

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
- Filter by each of the languages given, and check that only engage pages in the chosen language appear.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/3682

## Screenshots

[If relevant, please include a screenshot.]
