### PR TITLE
Marketo API token refresh

### DIFF
--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -30,13 +30,20 @@ class MarketoAPI:
             self._authenticate()
 
         params = urlencode(url_args)
-        url = f"{self.base_url}{url}?access_token={self.token}&{params}"
-        response = self.session.request(method=method, url=url, json=json)
+        response = self.session.request(
+            method=method,
+            url=f"{self.base_url}{url}?access_token={self.token}&{params}",
+            json=json,
+        )
 
         errors = response.json().get("errors")
         if errors and errors[0]["code"] in ["601", "602"]:
             self._authenticate()
-            response = self.session.request(method=method, url=url, json=json)
+            response = self.session.request(
+                method=method,
+                url=f"{self.base_url}{url}?access_token={self.token}&{params}",
+                json=json,
+            )
 
         return response
 


### PR DESCRIPTION
## Done

We were not swaping the token after authentication when retrying a request
and that would result in another failed request.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]