### PR TITLE
Encode email address when calling Open edX API

### DIFF
--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -1,3 +1,4 @@
+from urllib.parse import quote
 from requests import Session
 
 
@@ -121,8 +122,9 @@ class EdxAPI:
         ).json()
 
     def get_user(self, email: str):
+        safe_email = quote(email)
         response = self.make_request(
-            "GET", f"/api/user/v1/accounts?email={email}"
+            "GET", f"/api/user/v1/accounts?email={safe_email}"
         )
 
         if not response.ok:


### PR DESCRIPTION
## Done

- Call [`urllib.parse.quote()`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote) on an email address before using it to look up the associated account

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10131
