### PR TITLE
Add a subscription edit form

### DIFF
--- a/static/js/src/advantage/react/components/FormikField/FormikField.test.tsx
+++ b/static/js/src/advantage/react/components/FormikField/FormikField.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Textarea } from "@canonical/react-components";
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import FormikField from "./FormikField";
+
+describe("FormikField", () => {
+  it("can render", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikField
+          name="username"
+          help="Required."
+          id="username"
+          label="Username"
+          required={true}
+          type="text"
+        />
+      </Formik>
+    );
+    const input = wrapper.find("Input");
+    expect(input.exists()).toBe(true);
+    expect(input.prop("name")).toBe("username");
+    expect(input.prop("type")).toBe("text");
+  });
+
+  it("can set a different component", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikField component={Textarea} name="username" />
+      </Formik>
+    );
+    expect(wrapper.find("Textarea").exists()).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/components/FormikField/FormikField.tsx
+++ b/static/js/src/advantage/react/components/FormikField/FormikField.tsx
@@ -1,0 +1,37 @@
+import type {
+  ComponentProps,
+  ComponentType,
+  ElementType,
+  HTMLProps,
+} from "react";
+import React, { useRef } from "react";
+
+import { Input } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+import { useField } from "formik";
+
+export type Props<C extends ElementType | ComponentType = typeof Input> = {
+  component?: C;
+  name: string;
+  value?: HTMLProps<HTMLElement>["value"];
+} & ComponentProps<C>;
+
+const FormikField = <C extends ElementType | ComponentType = typeof Input>({
+  component: Component = Input,
+  name,
+  value,
+  ...props
+}: Props<C>): JSX.Element => {
+  const id = useRef(nanoid());
+  const [field, meta] = useField({ name, type: props.type, value });
+  return (
+    <Component
+      error={meta.touched ? meta.error : null}
+      id={id.current}
+      {...field}
+      {...props}
+    />
+  );
+};
+
+export default FormikField;

--- a/static/js/src/advantage/react/components/FormikField/index.ts
+++ b/static/js/src/advantage/react/components/FormikField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FormikField";

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -4,8 +4,33 @@ import { shallow } from "enzyme";
 import SubscriptionDetails from "./SubscriptionDetails";
 
 describe("SubscriptionDetails", () => {
-  it("renders", () => {
+  it("initially shows the content", () => {
     const wrapper = shallow(<SubscriptionDetails />);
-    expect(wrapper.find(".p-subscriptions__details").exists()).toBe(true);
+    expect(wrapper.find("DetailsContent").exists()).toBe(true);
+    expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
+  });
+
+  it("can show the edit form", () => {
+    const wrapper = shallow(<SubscriptionDetails />);
+    wrapper.find("[data-test='edit-button']").simulate("click");
+    expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
+    expect(wrapper.find("DetailsContent").exists()).toBe(false);
+  });
+
+  it("disables the buttons when showing the edit form", () => {
+    const wrapper = shallow(<SubscriptionDetails />);
+    expect(wrapper.find("[data-test='edit-button']").prop("disabled")).toBe(
+      false
+    );
+    expect(wrapper.find("[data-test='cancel-button']").prop("disabled")).toBe(
+      false
+    );
+    wrapper.find("[data-test='edit-button']").simulate("click");
+    expect(wrapper.find("[data-test='edit-button']").prop("disabled")).toBe(
+      true
+    );
+    expect(wrapper.find("[data-test='cancel-button']").prop("disabled")).toBe(
+      true
+    );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,9 +1,11 @@
 import { Button } from "@canonical/react-components";
-import React from "react";
+import React, { useState } from "react";
 
 import DetailsContent from "./DetailsContent";
+import SubscriptionEdit from "../SubscriptionEdit";
 
 const SubscriptionDetails = () => {
+  const [editing, setEditing] = useState(false);
   return (
     <div className="p-subscriptions__details">
       <h4>UA Infra Essential (Virtual)</h4>
@@ -11,16 +13,28 @@ const SubscriptionDetails = () => {
         <Button
           appearance="positive"
           className="u-no-margin--bottom"
+          data-test="cancel-button"
+          disabled={editing}
           element="a"
           href="https://support.canonical.com/"
         >
           Support portal
         </Button>
-        <Button appearance="neutral" className="u-no-margin--bottom">
+        <Button
+          appearance="neutral"
+          className="u-no-margin--bottom"
+          data-test="edit-button"
+          disabled={editing}
+          onClick={() => setEditing(true)}
+        >
           Edit subscription&hellip;
         </Button>
       </div>
-      <DetailsContent />
+      {editing ? (
+        <SubscriptionEdit onClose={() => setEditing(false)} />
+      ) : (
+        <DetailsContent />
+      )}
     </div>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
@@ -1,21 +1,23 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import SubscriptionEdit from "./SubscriptionEdit";
 
 describe("SubscriptionEdit", () => {
   it("initially hides the cancel modal", () => {
-    const wrapper = shallow(<SubscriptionEdit />);
+    const wrapper = shallow(<SubscriptionEdit onClose={jest.fn()} />);
     expect(wrapper.find("SubscriptionCancel").exists()).toBe(false);
   });
 
-  it("initially hides the cancel modal", async () => {
-    const wrapper = shallow(<SubscriptionEdit />);
+  it("can show the cancel modal", async () => {
+    const wrapper = mount(<SubscriptionEdit onClose={jest.fn()} />);
     // The portal currently requires a fake event, this should be able to be
     // removed when this issue is resolved:
     // https://github.com/alex-cory/react-useportal/issues/36
     const fakeEvent = { currentTarget: true };
-    wrapper.find("[data-test='cancel-button']").simulate("click", fakeEvent);
+    wrapper
+      .find("Button[data-test='cancel-button']")
+      .simulate("click", fakeEvent);
     expect(wrapper.find("SubscriptionCancel").exists()).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -1,21 +1,76 @@
-import { Button } from "@canonical/react-components";
+import { ActionButton, Button } from "@canonical/react-components";
 import React from "react";
 import usePortal from "react-useportal";
+import { Formik } from "formik";
 
 import SubscriptionCancel from "../SubscriptionCancel";
+import FormikField from "../../FormikField";
 
-const SubscriptionEdit = () => {
+type Props = {
+  onClose: () => void;
+};
+
+const SubscriptionEdit = ({ onClose }: Props) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   return (
     <>
-      <Button appearance="link" data-test="cancel-button" onClick={openPortal}>
-        You can cancel this subscription online or contact us.
-      </Button>
-      {isOpen && (
-        <Portal>
-          <SubscriptionCancel onClose={closePortal} />
-        </Portal>
-      )}
+      <Formik
+        initialValues={{
+          // TODO: use the initial value from the edited subscription.
+          size: 0,
+        }}
+        onSubmit={() => {
+          // TODO: Implement updating the subscription:
+          // https://github.com/canonical-web-and-design/commercial-squad/issues/113
+        }}
+      >
+        {({ handleSubmit }) => (
+          <>
+            <div className="u-sv3">
+              <hr />
+            </div>
+            <form className="u-sv2" onSubmit={handleSubmit}>
+              <h5>Resize subscription</h5>
+              <div className="u-sv3">
+                <FormikField
+                  className="p-subscription__resize"
+                  help={
+                    <>
+                      You can resize your subscriptions to as many machines as
+                      needed.
+                      <br />
+                      Your next billing period will reflect the changes
+                      accordingly.
+                    </>
+                  }
+                  label="Number of machines"
+                  name="size"
+                  type="number"
+                />
+              </div>
+              <div className="u-align--right">
+                <Button appearance="base" onClick={onClose}>
+                  Cancel
+                </Button>
+                <ActionButton appearance="positive">Resize</ActionButton>
+              </div>
+            </form>
+            <hr />
+            <Button
+              appearance="link"
+              data-test="cancel-button"
+              onClick={openPortal}
+            >
+              You can cancel this subscription online or contact us.
+            </Button>
+            {isOpen && (
+              <Portal>
+                <SubscriptionCancel onClose={closePortal} />
+              </Portal>
+            )}
+          </>
+        )}
+      </Formik>
     </>
   );
 };

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -90,4 +90,10 @@
     // Push the modal actions to the bottom of the modal.
     grid-template-rows: auto 1fr auto;
   }
+
+  .p-subscription__resize {
+    // Manually set the size of the resize input.
+    min-width: unset;
+    width: 6rem;
+  }
 }


### PR DESCRIPTION
## Done

- Add a subscription edit form.
- Copy over the FormikField component from maas-ui.

## QA

- Visit /advantage?test_backend=true.
- Click "Edit subscription..."
- You should see a form to resize the subscription.


## Issue / Card

Fixes canonical-web-and-design/commercial-squad#112.

## Screenshots

<img width="665" alt="Screen Shot 2021-08-09 at 3 57 41 pm" src="https://user-images.githubusercontent.com/361637/128665166-17c3f1cd-2664-40ff-b27b-2f1683e12eed.png">

