### PR TITLE
Add tax id condition

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -551,9 +551,11 @@ def post_anonymised_customer_info(**kwargs):
     address = kwargs.get("address")
     tax_id = kwargs.get("tax_id")
 
-    tax_id["value"] = tax_id["value"].replace(" ", "")
-    if tax_id["value"] == "":
-        tax_id["delete"] = True
+    if tax_id:
+        tax_id["value"] = tax_id["value"].replace(" ", "")
+
+        if tax_id["value"] == "":
+            tax_id["delete"] = True
 
     advantage = UAContractsAPI(
         session, token, token_type=token_type, api_url=api_url
@@ -640,9 +642,11 @@ def post_customer_info(**kwargs):
     name = kwargs.get("name")
     tax_id = kwargs.get("tax_id")
 
-    tax_id["value"] = tax_id["value"].replace(" ", "")
-    if tax_id["value"] == "":
-        tax_id["delete"] = True
+    if tax_id:
+        tax_id["value"] = tax_id["value"].replace(" ", "")
+
+        if tax_id["value"] == "":
+            tax_id["delete"] = True
 
     advantage = UAContractsAPI(
         session, token, token_type=token_type, api_url=api_url


### PR DESCRIPTION
## Done

- Add tax ID condition. When implementing the recent `tax_id` validation, it was not taken into account that sometimes the `tax_id` parameter can be `null`. 
- The wizard always provides `tax_id` even if the value is `""`
- However the renewal modal, does not. Which makes it fail at the moment.
 
# QA
- have a renewable renewal (ask Albert for help if needed)
- go to on https://ubuntu.com/advantage?test_backend=true
- press the renewal button
- insert your customer details in the modal
- press continue
- you will get a 500 in the console from `POST get-costomer-info`
- try on http://ubuntu-com-10155.demos.haus/advantage?test_backend=true
- you will get a 200 in the console `POST get-costomer-info`

# Issue

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/137