### PR TITLE
Add observability to navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1445,10 +1445,6 @@ observability:
   children:
     - title: Overview
       path: /observability
-
-  children:
-    - title: Overview
-      path: /observability
     - title: Contact us
       path: /observability/contact-us
       hidden: True

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1438,6 +1438,10 @@ legal:
           path: /legal/terms-and-policies/thank-you
           hidden: True
 
+observability:
+  title: Observability
+  path: /observability
+
 security:
   title: Security
   path: /security

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1441,7 +1441,13 @@ legal:
 observability:
   title: Observability
   path: /observability
-
+observability:
+  title: Observability
+  path: /observability
+  
+  children:
+    - title: Overview
+      path: /observability
 security:
   title: Security
   path: /security

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1446,6 +1446,16 @@ observability:
     - title: Overview
       path: /observability
 
+  children:
+    - title: Overview
+      path: /observability
+    - title: Contact us
+      path: /observability/contact-us
+      hidden: True
+    - title: Thank you
+      path: /observability/thank-you
+      hidden: True
+
 security:
   title: Security
   path: /security

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1441,13 +1441,11 @@ legal:
 observability:
   title: Observability
   path: /observability
-observability:
-  title: Observability
-  path: /observability
   
   children:
     - title: Overview
       path: /observability
+
 security:
   title: Security
   path: /security

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -104,6 +104,9 @@
               {% with section=nav_sections.ubuntu1604 %}
               {% include 'templates/_footer_item.html' %}
               {% endwith %}
+              {% with section=nav_sections.observability %}
+              {% include 'templates/_footer_item.html' %}
+              {% endwith %}
             </ul>
           </li>
         </ul>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -115,6 +115,7 @@
             <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/managed">Managed Apps</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>
+            <li class="p-list__item"><a href="/observability">Observability</a></li>
             <li class="p-list__item"><a href="/security">Security</a></li>
             <li class="p-list__item"><a href="/certified">Hardware certification</a></li>
             <li class="p-list__item"><a href="/aws">Get Ubuntu Pro on AWS</a></li>


### PR DESCRIPTION
## Done

- Adding `/observability` to the enterprise navigation

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ and https://ubuntu-com-10162.demos.haus/observability
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]
