### PR TITLE
Add renewal settings component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
     "minimatch": "3.0.4"
   },
   "jest": {
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setupTests.js"
     ],

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -49,7 +49,7 @@ const SubscriptionEdit = ({ onClose }: Props) => {
                 />
               </div>
               <div className="u-align--right">
-                <Button appearance="base" onClick={onClose}>
+                <Button appearance="base" onClick={onClose} type="button">
                   Cancel
                 </Button>
                 <ActionButton appearance="positive">Resize</ActionButton>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
@@ -1,27 +1,35 @@
-import { ContextualMenu } from "@canonical/react-components";
-import React from "react";
+import React, { useRef, useState } from "react";
 import type { ReactNode } from "react";
+
+import RenewalSettings from "../RenewalSettings";
 
 type Props = {
   children: ReactNode;
   title: string;
 };
 
-const ListGroup = ({ children, title }: Props): JSX.Element => (
-  <div className="p-subscriptions__list-group">
-    <div className="p-subscriptions__list-group-title">
-      <span className="p-text--x-small-capitalised u-align-text--small-to-default u-no-margin--bottom">
-        {title}
-      </span>
-      <ContextualMenu
-        hasToggleIcon
-        links={[]}
-        toggleClassName="is-dense u-no-margin--bottom"
-        toggleLabel="Renewal settings"
-      />
+const ListGroup = ({ children, title }: Props): JSX.Element => {
+  const positionNode = useRef<HTMLDivElement | null>(null);
+  const [, setRefReady] = useState(false);
+  return (
+    <div className="p-subscriptions__list-group">
+      <div
+        className="p-subscriptions__list-group-title"
+        ref={(element) => {
+          positionNode.current = element;
+          // Fire state change so that the menu rerenders now that the ref
+          // exists in the DOM.
+          setRefReady(true);
+        }}
+      >
+        <span className="p-text--x-small-capitalised u-align-text--small-to-default u-no-margin--bottom">
+          {title}
+        </span>
+        <RenewalSettings positionNodeRef={positionNode} />
+      </div>
+      {children}
     </div>
-    {children}
-  </div>
-);
+  );
+};
 
 export default ListGroup;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import RenewalSettings from "./RenewalSettings";
+
+describe("RenewalSettings", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <RenewalSettings positionNodeRef={{ current: null }} />
+    );
+    expect(wrapper.find("ContextualMenu").exists()).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.tsx
@@ -1,0 +1,51 @@
+import { ContextualMenu } from "@canonical/react-components";
+import React, { RefObject, useState } from "react";
+import { Formik } from "formik";
+
+import RenewalSettingsFields from "./RenewalSettingsFields";
+
+type Props = {
+  positionNodeRef: RefObject<HTMLDivElement>;
+};
+
+const RenewalSettings = ({ positionNodeRef }: Props): JSX.Element => {
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
+  return (
+    <ContextualMenu
+      constrainPanelWidth
+      dropdownClassName="p-subscription__renewal-dropdown"
+      hasToggleIcon
+      onToggleMenu={(isOpen) => setMenuOpen(isOpen)}
+      position="left"
+      positionNode={positionNodeRef.current}
+      toggleClassName="is-dense u-no-margin--bottom"
+      toggleLabel="Renewal settings"
+      visible={menuOpen}
+    >
+      <p className="u-no-padding--top u-no-margin--bottom u-sv1">
+        <strong>
+          2 monthly subscriptions are affected by auto-renew settings.
+        </strong>
+      </p>
+      <hr />
+      <p className="u-no-margin--bottom u-sv1">
+        Your next recurring payment of <strong>$30.00</strong> will be taken on{" "}
+        <strong>17 July 2021</strong>.
+      </p>
+      <Formik
+        initialValues={{
+          // TODO: use the initial value from the subscription.
+          should_auto_renew: false,
+        }}
+        onSubmit={() => {
+          // TODO: Implement updating the renewal settings:
+          // https://github.com/canonical-web-and-design/commercial-squad/issues/99
+        }}
+      >
+        <RenewalSettingsFields setMenuOpen={setMenuOpen} />
+      </Formik>
+    </ContextualMenu>
+  );
+};
+
+export default RenewalSettings;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import RenewalSettingsFields from "./RenewalSettingsFields";
+
+describe("RenewalSettingsFields", () => {
+  it("closes the form when the cancel button is clicked", () => {
+    const setMenuOpen = jest.fn();
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <RenewalSettingsFields setMenuOpen={setMenuOpen} />
+      </Formik>
+    );
+    wrapper.find("Button[data-test='cancel-button']").simulate("click");
+    expect(setMenuOpen).toHaveBeenCalled();
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.tsx
@@ -1,0 +1,39 @@
+import { ActionButton, Button } from "@canonical/react-components";
+import React from "react";
+import { useFormikContext } from "formik";
+import FormikField from "advantage/react/components/FormikField";
+
+type Props = {
+  setMenuOpen: (menuOpen: boolean) => void;
+};
+
+const RenewalSettingsFields = ({ setMenuOpen }: Props): JSX.Element => {
+  const { handleSubmit } = useFormikContext();
+  return (
+    <form onSubmit={handleSubmit}>
+      <FormikField
+        label="Auto-renewal"
+        labelClassName="u-no-margin--bottom"
+        name="should_auto_renew"
+        type="checkbox"
+        wrapperClassName="u-sv4"
+      />
+      <div className="u-align--right">
+        <Button
+          appearance="neutral"
+          className="u-no-margin--bottom"
+          data-test="cancel-button"
+          onClick={() => setMenuOpen(false)}
+          type="button"
+        >
+          Cancel changes
+        </Button>
+        <ActionButton appearance="positive" className="u-no-margin--bottom">
+          Save changes
+        </ActionButton>
+      </div>
+    </form>
+  );
+};
+
+export default RenewalSettingsFields;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RenewalSettingsFields";

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RenewalSettings";

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -60,7 +60,7 @@
     // Space the context menu to the right of the container.
     justify-content: space-between;
     // Provide space before the first card.
-    padding-bottom: $spv-inner--large;
+    margin-bottom: $spv-inner--large;
   }
 
   .p-subscriptions__list-card-title {
@@ -95,5 +95,10 @@
     // Manually set the size of the resize input.
     min-width: unset;
     width: 6rem;
+  }
+
+  .p-subscription__renewal-dropdown {
+    // The dropdown does not have any padding by default.
+    padding: $card-padding;
   }
 }


### PR DESCRIPTION
## Done

- Add renewal settings component.

## QA

- Visit /advantage?test_backend=true.
- Click one of the 'Renewal settings' contextual menus.
- You should see the form.
- Clicking cancel should close the form.


## Issue / Card

Fixes: canonical-web-and-design/commercial-squad#97.

## Screenshots

<img width="454" alt="Screen Shot 2021-08-10 at 3 55 44 pm" src="https://user-images.githubusercontent.com/361637/128817333-1aee5c3a-0d7d-4a75-930e-05bf653ecc11.png">
