### PR TITLE
Add footer_item_small to make adding footer lists more explicit

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -181,7 +181,7 @@
     padding: 0;
 
     &.second-level-nav-small {
-      @media only screen and (max-width: $breakpoint-small) {
+      @media only screen and (max-width: $breakpoint-medium) {
         margin-left: -0.7rem;
 
         li {

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -7,7 +7,7 @@
     {% for child in section.children %}
       {% if child.title != 'Overview' %}
       {% if not child.hidden %}
-        <li class="p-footer-list--margin"><a href="{{ child.path }}">{{ child.title }}</a></li>
+        <li><a href="{{ child.path }}">{{ child.title }}</a></li>
       {% endif %}
       {% endif %}
     {% endfor %}

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -1,7 +1,3 @@
-{% if section.children|length < 3 %}
-<li class="p-footer-list--margin p-footer-list-single-child">
-  <a class="p-link--soft" href="{{ section.path }}">{{ section.title }}</a>
-{% else %}
 <li class="p-footer__item">
   <h2 class="p-footer__title">
     <a class="p-link--soft" href="{{ section.path }}">{{ section.title }}</a>
@@ -16,5 +12,4 @@
       {% endif %}
     {% endfor %}
   </ul>
-  {% endif %}
 </li>

--- a/templates/templates/_footer_item_small.html
+++ b/templates/templates/_footer_item_small.html
@@ -1,4 +1,4 @@
 
-<li class="p-footer-list--margin p-footer-list-single-child">
+<li class="p-footer-list-single-child">
   <a class="p-link--soft" href="{{ section.path }}">{{ section.title }}</a>
 </li>

--- a/templates/templates/_footer_item_small.html
+++ b/templates/templates/_footer_item_small.html
@@ -1,0 +1,4 @@
+
+<li class="p-footer-list--margin p-footer-list-single-child">
+  <a class="p-link--soft" href="{{ section.path }}">{{ section.title }}</a>
+</li>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -90,22 +90,22 @@
           <li>
             <ul class="second-level-nav second-level-nav-small">
               {% with section=nav_sections.publiccloud %}
-              {% include 'templates/_footer_item.html' %}
+              {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
               {% with section=nav_sections.cloud %}
-              {% include 'templates/_footer_item.html' %}
+              {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
               {% with section=nav_sections.containers %}
-              {% include 'templates/_footer_item.html' %}
+              {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
               {% with section=nav_sections.tutorials %}
-              {% include 'templates/_footer_item.html' %}
+              {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
               {% with section=nav_sections.ubuntu1604 %}
-              {% include 'templates/_footer_item.html' %}
+              {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
               {% with section=nav_sections.observability %}
-              {% include 'templates/_footer_item.html' %}
+              {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
             </ul>
           </li>

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -81,10 +81,10 @@
               <span>Sectors</span>
             </h2>
             <ul class="second-level-nav">
-              <li class="p-footer-list--margin"><a href="/industrial">Industrial</a></li>
-              <li class="p-footer-list--margin"><a href="/gov">Government</a></li>
-              <li class="p-footer-list--margin"><a href="/telco">Telco</a></li>
-              <li class="p-footer-list--margin"><a href="/financial-services">Finance</a></li>
+              <li><a href="/industrial">Industrial</a></li>
+              <li><a href="/gov">Government</a></li>
+              <li><a href="/telco">Telco</a></li>
+              <li><a href="/financial-services">Finance</a></li>
             </ul>
           </li>
           <li>


### PR DESCRIPTION
## Done

- Broke the old `_footer_item.html` into two partials, one for navigation sections with sub-pages and one with no sub-pages.  It used to be based on the number of subpages; however, that doesn't work in cases where there are hidden pages like contact-us and thank-you perfectly.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Look at the footer and see that all the sections that should be expanded are and those that are not are not

## Demo

https://ubuntu-com-10167.demos.haus/

FYI @mmanciop 