### PR TITLE
Limit number of filters by category

### DIFF
--- a/templates/certified/desktops.html
+++ b/templates/certified/desktops.html
@@ -85,10 +85,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if vendor_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
                     <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
@@ -110,10 +112,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if release_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
                     <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
               </ul>
             </aside>

--- a/templates/certified/devices.html
+++ b/templates/certified/devices.html
@@ -85,10 +85,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if vendor_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
                     <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
@@ -110,10 +112,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if release_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
                     <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
               </ul>
             </aside>

--- a/templates/certified/laptops.html
+++ b/templates/certified/laptops.html
@@ -85,10 +85,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if vendor_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
                     <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
@@ -110,10 +112,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if release_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
                     <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
               </ul>
             </aside>

--- a/templates/certified/servers.html
+++ b/templates/certified/servers.html
@@ -85,10 +85,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if vendor_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
                     <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
@@ -110,10 +112,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if release_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
                     <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
               </ul>
             </aside>

--- a/templates/certified/socs.html
+++ b/templates/certified/socs.html
@@ -77,7 +77,7 @@
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
+                  <section class="p-accordion__panel {% if vendor_filters | length > 5 %}is-collapsed{% endif %} is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
                     {% for vendor_filter in vendor_filters %}
                     <label class="p-checkbox">
                       <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
@@ -85,10 +85,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if vendor_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
                     <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
@@ -110,10 +112,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if release_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
                     <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
               </ul>
             </aside>

--- a/webapp/certified/api.py
+++ b/webapp/certified/api.py
@@ -38,6 +38,7 @@ class CertificationAPI:
         laptops__gte=None,
         smart_core__gte=None,
         soc__gte=None,
+        servers__gte=None,
         make__iexact=None,
     ):
         return self._get(
@@ -49,6 +50,7 @@ class CertificationAPI:
                 "laptops__gte": laptops__gte,
                 "smart_core__gte": smart_core__gte,
                 "soc__gte": soc__gte,
+                "servers__gte": servers__gte,
                 "make__iexact": make__iexact,
             },
         ).json()
@@ -145,15 +147,25 @@ class CertificationAPI:
         ).json()
 
     def certified_releases(
-        self, limit=None, offset=None, smart_core__gte=None, soc__gte=None
+        self,
+        limit=None,
+        offset=None,
+        desktops__gte=None,
+        laptops__gte=None,
+        smart_core__gte=None,
+        soc__gte=None,
+        servers__gte=None,
     ):
         return self._get(
             "certifiedreleases",
             params={
                 "limit": limit,
                 "offset": offset,
+                "desktops__gte": desktops__gte,
+                "laptops__gte": laptops__gte,
                 "smart_core__gte": smart_core__gte,
                 "soc__gte": soc__gte,
+                "servers__gte": servers__gte,
             },
         ).json()
 

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -395,12 +395,46 @@ def create_category_views(category, template_path):
     Helper function to create multiple /certified/<page> category views
 
     Keyword arguments:
-    category -- must be categories accepted by API (Desktop, Laptop, SoC, \
+    category -- must be categories accepted by API (Desktop, Laptop, \
     Server, Ubuntu Core, Server SoC)
     template_path -- full template path (e.g. certified/search-results.html)
     """
-    certified_releases = api.certified_releases(limit="0")["objects"]
-    certified_makes = api.certified_makes(limit="0")["objects"]
+    if category == "Desktop":
+        certified_releases = api.certified_releases(
+            limit="0", desktops__gte=1
+        )["objects"]
+        certified_makes = api.certified_makes(limit="0", desktops__gte=1)[
+            "objects"
+        ]
+    elif category == "Laptop":
+        certified_releases = api.certified_releases(limit="0", laptops__gte=1)[
+            "objects"
+        ]
+        certified_makes = api.certified_makes(limit="0", laptops__gte=1)[
+            "objects"
+        ]
+    elif category == "Server SoC":
+        certified_releases = api.certified_releases(limit="0", soc__gte=1)[
+            "objects"
+        ]
+        certified_makes = api.certified_makes(limit="0", soc__gte=1)["objects"]
+    elif category == "Ubuntu Core":
+        certified_releases = api.certified_releases(
+            limit="0", smart_core__gte=1
+        )["objects"]
+        certified_makes = api.certified_makes(limit="0", smart_core__gte=1)[
+            "objects"
+        ]
+    elif category == "Server":
+        certified_releases = api.certified_releases(limit="0", servers__gte=1)[
+            "objects"
+        ]
+        certified_makes = api.certified_makes(limit="0", servers__gte=1)[
+            "objects"
+        ]
+    else:
+        certified_releases = api.certified_releases(limit="0")["objects"]
+        certified_makes = api.certified_makes(limit="0")["objects"]
 
     # Search results filters
     all_releases = []


### PR DESCRIPTION
## Done

Show vendors and filters only for that specific category #4317

## QA

- Check https://ubuntu-com-10171.demos.haus/certified/desktops and check only shows filters that apply to that category (that have results)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4317

