### PR TITLE
Display free token details from the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
     "minimatch": "3.0.4"
   },
   "jest": {
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setupTests.js"
     ],

--- a/static/js/src/advantage/api/enum.ts
+++ b/static/js/src/advantage/api/enum.ts
@@ -1,0 +1,19 @@
+export enum SupportLevel {
+  NONE = "n/a",
+  ESSENTIAL = "essential",
+  STANDARD = "standard",
+  ADVANCED = "advanced",
+}
+
+export enum EntitlementType {
+  BLENDER = "blender",
+  CC_EAL = "cc-eal",
+  CIS = "cis",
+  ESM_APPS = "esm-apps",
+  ESM_INFRA = "esm-infra",
+  FIPS_UPDATES = "fips-updates",
+  FIPS = "fips",
+  LIVEPATCH_ONPREM = "livepatch-onprem",
+  LIVEPATCH = "livepatch",
+  SUPPORT = "support",
+}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -1,13 +1,24 @@
 import { Card, Col, List, Row } from "@canonical/react-components";
 import React from "react";
+import { format, parseJSON } from "date-fns";
 
 type Props = {
   created: string;
-  expires: string;
+  expires?: string | null;
   features: string[];
   machines: number;
   label: string;
   title: string;
+};
+
+const DATE_FORMAT = "dd.MM.yyyy";
+
+const formatDate = (date: string) => {
+  try {
+    return format(parseJSON(date), DATE_FORMAT);
+  } catch (error) {
+    return date;
+  }
 };
 
 const ListCard = ({
@@ -32,11 +43,11 @@ const ListCard = ({
       </Col>
       <Col size={4}>
         <p className="u-text--muted u-no-margin--bottom">Created</p>
-        {created}
+        {formatDate(created)}
       </Col>
       <Col size={4}>
         <p className="u-text--muted u-no-margin--bottom">Expires</p>
-        {expires}
+        {expires ? formatDate(expires) : "Never"}
       </Col>
     </Row>
     <List

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,5 +1,6 @@
 import type { PersonalAccount } from "advantage/api/types";
 import { usePersonalAccount } from "advantage/react/hooks";
+import { selectFreeContract } from "advantage/react/hooks/usePersonalAccount";
 import { getFeaturesDisplay } from "advantage/react/utils";
 import React from "react";
 
@@ -7,18 +8,11 @@ import ListCard from "./ListCard";
 import ListGroup from "./ListGroup";
 
 /**
- * Find the contract that matches the free token.
- */
-const getFreeContract = (personalAccount?: PersonalAccount) =>
-  personalAccount?.contracts.find(
-    ({ token }) => token === personalAccount.free_token
-  ) || null;
-
-/**
  * Get the data to display in the card for the free token.
  */
-const getFreeContractData = (personalAccount?: PersonalAccount) => {
-  const freeContract = getFreeContract(personalAccount);
+const getFreeContractData = (
+  freeContract?: PersonalAccount["contracts"][0] | null
+) => {
   if (!freeContract) {
     return null;
   }
@@ -34,9 +28,10 @@ const getFreeContractData = (personalAccount?: PersonalAccount) => {
 };
 
 const SubscriptionList = () => {
-  const { personalAccount } = usePersonalAccount();
-  const freeContract = getFreeContractData(personalAccount);
-
+  const { data: freeContractData } = usePersonalAccount({
+    select: selectFreeContract,
+  });
+  const freeContract = getFreeContractData(freeContractData);
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,33 +1,71 @@
+import type { PersonalAccount } from "advantage/api/types";
+import { usePersonalAccount } from "advantage/react/hooks";
+import { getFeaturesDisplay } from "advantage/react/utils";
 import React from "react";
 
 import ListCard from "./ListCard";
 import ListGroup from "./ListGroup";
 
-const SubscriptionList = () => (
-  <div className="p-subscriptions__list">
-    <div className="p-subscriptions__list-scroll">
-      <ListGroup title="Ubuntu Advantage">
-        <ListCard
-          created="12.02.2021"
-          expires="23.04.2022"
-          features={["ESM Infra", "livepatch", "24/5 support"]}
-          machines={10}
-          label="Annual"
-          title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-        />
-      </ListGroup>
-      <ListGroup title="free personal token">
-        <ListCard
-          created="12.02.2021"
-          expires="Never"
-          features={["ESM Infra", "livepatch"]}
-          machines={3}
-          label="Free"
-          title="Free Personal Token"
-        />
-      </ListGroup>
+/**
+ * Find the contract that matches the free token.
+ */
+const getFreeContract = (personalAccount?: PersonalAccount) =>
+  personalAccount?.contracts.find(
+    ({ token }) => token === personalAccount.free_token
+  ) || null;
+
+/**
+ * Get the data to display in the card for the free token.
+ */
+const getFreeContractData = (personalAccount?: PersonalAccount) => {
+  const freeContract = getFreeContract(personalAccount);
+  if (!freeContract) {
+    return null;
+  }
+  const { contractInfo } = freeContract;
+  const machines =
+    contractInfo.items?.find(({ metric }) => metric === "units")?.value || 0;
+  return {
+    created: contractInfo.createdAt,
+    expires: null,
+    features: getFeaturesDisplay(contractInfo),
+    machines,
+  };
+};
+
+const SubscriptionList = () => {
+  const { personalAccount } = usePersonalAccount();
+  const freeContract = getFreeContractData(personalAccount);
+
+  return (
+    <div className="p-subscriptions__list">
+      <div className="p-subscriptions__list-scroll">
+        <ListGroup title="Ubuntu Advantage">
+          <ListCard
+            created="2021-07-09T07:14:56Z"
+            expires="2021-07-09T07:14:56Z"
+            features={["ESM Infra", "livepatch", "24/5 support"]}
+            machines={10}
+            label="Annual"
+            title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+          />
+        </ListGroup>
+        {freeContract ? (
+          <ListGroup title="Free personal token">
+            <ListCard
+              created={freeContract.created}
+              data-test="free-token"
+              expires={freeContract.expires}
+              features={freeContract.features.included}
+              machines={freeContract.machines}
+              label="Free"
+              title="Free Personal Token"
+            />
+          </ListGroup>
+        ) : null}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default SubscriptionList;

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useLoadWindowData } from "./useLoadWindowData";
 export { usePendingPurchaseId } from "./usePendingPurchaseId";
+export { usePersonalAccount } from "./usePersonalAccount";
 export { useURLs } from "./useURLs";

--- a/static/js/src/advantage/react/hooks/usePersonalAccount.test.tsx
+++ b/static/js/src/advantage/react/hooks/usePersonalAccount.test.tsx
@@ -1,0 +1,30 @@
+import React, { PropsWithChildren } from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { usePersonalAccount } from "./usePersonalAccount";
+import { personalAccountFactory } from "advantage/tests/factories/api";
+
+describe("usePersonalAccount", () => {
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    wrapper = Wrapper;
+  });
+
+  it("can return the pending purchase id from the store", async () => {
+    const personalAccount = personalAccountFactory.build();
+    queryClient.setQueryData("personalAccount", personalAccount);
+    const { result, waitForNextUpdate } = renderHook(
+      () => usePersonalAccount(),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.personalAccount).toBe(personalAccount);
+  });
+});

--- a/static/js/src/advantage/react/hooks/usePersonalAccount.ts
+++ b/static/js/src/advantage/react/hooks/usePersonalAccount.ts
@@ -1,0 +1,9 @@
+import type { PersonalAccount } from "advantage/api/types";
+import { useQuery } from "react-query";
+
+export const usePersonalAccount = () => {
+  const { data: personalAccount } = useQuery<PersonalAccount>(
+    "personalAccount"
+  );
+  return { personalAccount };
+};

--- a/static/js/src/advantage/react/hooks/usePersonalAccount.ts
+++ b/static/js/src/advantage/react/hooks/usePersonalAccount.ts
@@ -1,9 +1,17 @@
 import type { PersonalAccount } from "advantage/api/types";
-import { useQuery } from "react-query";
+import { useQuery, UseQueryOptions } from "react-query";
 
-export const usePersonalAccount = () => {
-  const { data: personalAccount } = useQuery<PersonalAccount>(
-    "personalAccount"
-  );
-  return { personalAccount };
+/**
+ * Find the contract that matches the free token.
+ */
+export const selectFreeContract = (personalAccount: PersonalAccount) =>
+  personalAccount?.contracts.find(
+    ({ token }) => token === personalAccount.free_token
+  ) || null;
+
+export const usePersonalAccount = <D = PersonalAccount>(
+  options?: UseQueryOptions<PersonalAccount, unknown, D>
+) => {
+  const query = useQuery("personalAccount", options);
+  return query;
 };

--- a/static/js/src/advantage/react/utils/dedupeArray.test.ts
+++ b/static/js/src/advantage/react/utils/dedupeArray.test.ts
@@ -1,0 +1,9 @@
+import { dedupeArray } from "./dedupeArray";
+
+describe("dedupeArray", () => {
+  it("dedupes items in an array", () => {
+    expect(
+      dedupeArray(["one", "two", "one", null, true, "three"])
+    ).toStrictEqual(["one", "two", null, true, "three"]);
+  });
+});

--- a/static/js/src/advantage/react/utils/dedupeArray.ts
+++ b/static/js/src/advantage/react/utils/dedupeArray.ts
@@ -1,0 +1,7 @@
+export const dedupeArray = <I>(items: I[]): I[] =>
+  items.reduce<I[]>((collection, item) => {
+    if (!collection.includes(item)) {
+      collection.push(item);
+    }
+    return collection;
+  }, []);

--- a/static/js/src/advantage/react/utils/getFeaturesDisplay.test.ts
+++ b/static/js/src/advantage/react/utils/getFeaturesDisplay.test.ts
@@ -1,0 +1,105 @@
+import { EntitlementType, SupportLevel } from "advantage/api/enum";
+import {
+  affordancesSupportFactory,
+  contractInfoFactory,
+  entitlementFactory,
+  entitlementSupportFactory,
+} from "advantage/tests/factories/contracts";
+import { getFeaturesDisplay } from "./getFeaturesDisplay";
+
+describe("getFeaturesDisplay", () => {
+  it("generates display labels for features", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [
+        entitlementFactory.build({ type: EntitlementType.LIVEPATCH }),
+        entitlementSupportFactory.build({
+          affordances: affordancesSupportFactory.build({
+            supportLevel: SupportLevel.ADVANCED,
+          }),
+        }),
+      ],
+    });
+    expect(getFeaturesDisplay(contractInfo)).toStrictEqual({
+      excluded: ["Blender", "ESM Apps", "ESM Infra"],
+      included: ["Livepatch", "24/7 Support"],
+    });
+  });
+
+  it("dedupes livepatch labels", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [
+        entitlementFactory.build({ type: EntitlementType.LIVEPATCH }),
+        entitlementFactory.build({ type: EntitlementType.LIVEPATCH_ONPREM }),
+      ],
+    });
+    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([
+      "Livepatch",
+    ]);
+  });
+
+  it("ignores some labels", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [
+        entitlementFactory.build({ type: EntitlementType.CC_EAL }),
+        entitlementFactory.build({ type: EntitlementType.CIS }),
+        entitlementFactory.build({ type: EntitlementType.FIPS_UPDATES }),
+        entitlementFactory.build({ type: EntitlementType.FIPS }),
+      ],
+    });
+    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([]);
+  });
+
+  it("handles advanced support label", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [
+        entitlementSupportFactory.build({
+          affordances: affordancesSupportFactory.build({
+            supportLevel: SupportLevel.ADVANCED,
+          }),
+        }),
+      ],
+    });
+    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([
+      "24/7 Support",
+    ]);
+  });
+
+  it("handles standard support label", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [
+        entitlementSupportFactory.build({
+          affordances: affordancesSupportFactory.build({
+            supportLevel: SupportLevel.STANDARD,
+          }),
+        }),
+      ],
+    });
+    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([
+      "24/5 Support",
+    ]);
+  });
+
+  it("handles excluded support labels", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [],
+    });
+    expect(getFeaturesDisplay(contractInfo).excluded.includes("Support")).toBe(
+      true
+    );
+  });
+
+  it("does not show excluded support label if a support affordance exists", () => {
+    const contractInfo = contractInfoFactory.build({
+      resourceEntitlements: [
+        entitlementSupportFactory.build({
+          affordances: affordancesSupportFactory.build({
+            supportLevel: SupportLevel.STANDARD,
+          }),
+        }),
+      ],
+    });
+    expect(getFeaturesDisplay(contractInfo).excluded.includes("Support")).toBe(
+      false
+    );
+  });
+});

--- a/static/js/src/advantage/react/utils/getFeaturesDisplay.ts
+++ b/static/js/src/advantage/react/utils/getFeaturesDisplay.ts
@@ -1,0 +1,126 @@
+import type { ContractInfo } from "advantage/api/contracts-types";
+import { EntitlementType, SupportLevel } from "advantage/api/enum";
+import { dedupeArray } from "./dedupeArray";
+import { removeFalsy } from "./removeFalsy";
+
+enum EntitlementLabelType {
+  SUPPORT_STANDARD = "support-5",
+  SUPPORT_ADVANCED = "support-7",
+}
+
+type EntitlementBaseType = Exclude<
+  EntitlementType,
+  EntitlementType.SUPPORT | EntitlementType.LIVEPATCH_ONPREM
+>;
+
+type LabelType = EntitlementLabelType | EntitlementBaseType;
+
+const baseLabels: Record<EntitlementBaseType, string | null> = {
+  [EntitlementType.BLENDER]: "Blender",
+  [EntitlementType.CC_EAL]: null,
+  [EntitlementType.CIS]: null,
+  [EntitlementType.ESM_APPS]: "ESM Apps",
+  [EntitlementType.ESM_INFRA]: "ESM Infra",
+  [EntitlementType.FIPS_UPDATES]: null,
+  [EntitlementType.FIPS]: null,
+  [EntitlementType.LIVEPATCH]: "Livepatch",
+};
+
+const includeLabels: Record<LabelType, string | null> = {
+  ...baseLabels,
+  [EntitlementLabelType.SUPPORT_STANDARD]: "24/5 Support",
+  [EntitlementLabelType.SUPPORT_ADVANCED]: "24/7 Support",
+};
+
+const excludeLabels: Record<LabelType, string | null> = {
+  ...baseLabels,
+  [EntitlementLabelType.SUPPORT_STANDARD]: "Support",
+  [EntitlementLabelType.SUPPORT_ADVANCED]: "Support",
+};
+
+/**
+ * Map the entitlements to the display label.
+ */
+const generateLabels = (entitlements: LabelType[], included: boolean) => {
+  const labels = included ? includeLabels : excludeLabels;
+  // Remove any labels that have been mapped to `null` i.e. should not be displayed.
+  return removeFalsy(
+    // Remove any duplicate labels.
+    dedupeArray(
+      entitlements.map((feature) =>
+        labels.hasOwnProperty(feature)
+          ? labels[feature]
+          : // Ignore any features there is no label for.
+            null
+      )
+    )
+  );
+};
+
+export const getFeaturesDisplay = (contractInfo: ContractInfo) => {
+  const included: LabelType[] = [];
+  contractInfo.resourceEntitlements.forEach((entitlement) => {
+    let entitlementType: string | null = null;
+    if (
+      entitlement.type === "support" &&
+      "supportLevel" in entitlement.affordances
+    ) {
+      // Map any support features to their appropriate level.
+      switch (entitlement.affordances.supportLevel) {
+        case SupportLevel.STANDARD:
+          entitlementType = EntitlementLabelType.SUPPORT_STANDARD;
+          break;
+        case SupportLevel.ADVANCED:
+          entitlementType = EntitlementLabelType.SUPPORT_ADVANCED;
+          break;
+        // Don't display anything for none and essential levels.
+        case SupportLevel.NONE:
+        case SupportLevel.ESSENTIAL:
+        default:
+          entitlementType = null;
+          break;
+      }
+    } else {
+      switch (entitlement.type) {
+        // Map livepatch-onprem to livepatch as they will both get displayed as
+        // the same thing.
+        case EntitlementType.LIVEPATCH_ONPREM:
+          entitlementType = EntitlementType.LIVEPATCH;
+          break;
+        default:
+          entitlementType = entitlement.type;
+          break;
+      }
+    }
+    if (entitlementType) {
+      included.push(entitlementType as LabelType);
+    }
+  });
+  // Find all the features that have not been included to display in the
+  // excluded list.
+  const excluded = Object.keys(excludeLabels).reduce<LabelType[]>(
+    (features, feature) => {
+      if (
+        feature === EntitlementLabelType.SUPPORT_STANDARD ||
+        feature === EntitlementLabelType.SUPPORT_ADVANCED
+      ) {
+        // If either support level has been added to the included list then do
+        // not add anything other support levels to the excluded list.
+        if (
+          !included.includes(EntitlementLabelType.SUPPORT_STANDARD) &&
+          !included.includes(EntitlementLabelType.SUPPORT_ADVANCED)
+        ) {
+          features.push(feature as LabelType);
+        }
+      } else if (!included.includes(feature as LabelType)) {
+        features.push(feature as LabelType);
+      }
+      return features;
+    },
+    []
+  );
+  return {
+    excluded: generateLabels(excluded, false),
+    included: generateLabels(included, true),
+  };
+};

--- a/static/js/src/advantage/react/utils/index.ts
+++ b/static/js/src/advantage/react/utils/index.ts
@@ -1,0 +1,3 @@
+export { dedupeArray } from "./dedupeArray";
+export { getFeaturesDisplay } from "./getFeaturesDisplay";
+export { removeFalsy } from "./removeFalsy";

--- a/static/js/src/advantage/react/utils/removeFalsy.test.ts
+++ b/static/js/src/advantage/react/utils/removeFalsy.test.ts
@@ -1,0 +1,9 @@
+import { removeFalsy } from "./removeFalsy";
+
+describe("removeFalsy", () => {
+  it("removes falsy items in an array", () => {
+    expect(
+      removeFalsy(["one", 2, false, null, true, "", undefined, 0])
+    ).toStrictEqual(["one", 2, true]);
+  });
+});

--- a/static/js/src/advantage/react/utils/removeFalsy.ts
+++ b/static/js/src/advantage/react/utils/removeFalsy.ts
@@ -1,0 +1,6 @@
+type Falsy = false | 0 | "" | null | undefined;
+
+export const removeFalsy = <I>(items: I[]): Exclude<I, Falsy>[] =>
+  items.filter<Exclude<I, Falsy>>(
+    (item: I): item is Exclude<I, Falsy> => !!item
+  );

--- a/static/js/src/advantage/tests/factories/contracts.ts
+++ b/static/js/src/advantage/tests/factories/contracts.ts
@@ -3,18 +3,21 @@ import {
   AccountContractInfo,
   AccountInfo,
   AffordancesAptRepository,
+  AffordancesSupport,
   AllowanceInfo,
   BillingInfo,
   ContractInfo,
   ContractItem,
   DirectivesAptRepository,
   EntitlementAptRepository,
+  EntitlementSupport,
   ExternalIDs,
   Obligations,
   Price,
   Renewal,
   RenewalItem,
 } from "advantage/api/contracts-types";
+import { EntitlementType, SupportLevel } from "advantage/api/enum";
 
 export const externalIDsFactory = Factory.define<ExternalIDs>(
   ({ sequence }) => ({
@@ -88,6 +91,21 @@ export const entitlementAptRepositoryFactory = Factory.define<EntitlementAptRepo
         obligations: obligationsFactory.build(),
       },
     },
+  })
+);
+
+export const affordancesSupportFactory = Factory.define<AffordancesSupport>(
+  () => ({
+    supportLevel: SupportLevel.STANDARD,
+  })
+);
+
+export const entitlementSupportFactory = Factory.define<EntitlementSupport>(
+  () => ({
+    affordances: affordancesSupportFactory.build(),
+    entitled: true,
+    obligations: obligationsFactory.build(),
+    type: EntitlementType.SUPPORT,
   })
 );
 


### PR DESCRIPTION
## Done

- Display free token details from the API.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10172.demos.haus/advantage?test_backend=true).
- You should see a free personal token card and it should show the correct data from the API ([design here](https://app.zeplin.io/project/60ec5fb4e07cc90fbbf2b318/screen/60eeee7dbe6908aeed7151c8)).


## Issue / Card

Fixes: canonical-web-and-design/commercial-squad#103.

## Screenshots

<img width="418" alt="Screen Shot 2021-08-11 at 3 35 03 pm" src="https://user-images.githubusercontent.com/361637/128975360-b038fd2a-4c30-4b0a-a319-76f1a2f079c2.png">

