### PR TITLE
Fix linkchecker issues

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1044,8 +1044,8 @@
           </a>
         </li>
         <li class="p-inline-list__item">
-          <a class="p-link--external" href="https://maas.io/#get-in-touch">
-            Contact us&nbsp;&rsaquo;
+          <a class="p-link--external" href="https://maas.io/contact-us">
+            Contact us
           </a>
         </li>
       </ul>

--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -650,7 +650,7 @@
       <h2>Optimise your open source observability</h2>
       <p>Your monitoring tools and monitoring dashboards, run by Canonical, wherever your applications are.</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/observability/contact">
+        <a class="p-button--positive js-invoke-modal" href="/observability/contact-us">
           Get in touch
         </a>
       </p>


### PR DESCRIPTION
## Done
- Update MAAS contact-us link on the homepage
- Update the observability contact us link
- _Drive by:_ removed the chevron from the external link on the homepage

## QA
- You could just check the code to be honest. 
- Check it fixes the issues reported: https://github.com/canonical-web-and-design/ubuntu.com/runs/3298132611?check_suite_focus=true