### PR TITLE
Tidy up redundant css

### DIFF
--- a/static/sass/_pattern_tco-calculator.scss
+++ b/static/sass/_pattern_tco-calculator.scss
@@ -1,0 +1,12 @@
+@mixin ubuntu-p-tco-calculator {
+  .tco-tooltip {
+    margin-bottom: 0.5rem;
+    margin-left: 0.5rem;
+  }
+
+  .tco-input {
+    @media (min-width: $breakpoint-medium) {
+      max-width: 10rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -79,6 +79,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_takeovers";
 @import "pattern_table-of-contents";
 @import "pattern_table";
+@import "pattern_tco-calculator";
 @import "pattern_ubuntu_intro";
 @import "takeovers/financial-services";
 @import "utility_animations";
@@ -131,6 +132,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include ubuntu-p-tables;
 @include ubuntu-p-takeunders;
 @include ubuntu-p-takeovers;
+@include ubuntu-p-tco-calculator;
 @include ubuntu-p-engage-banner;
 @include ubuntu-p-ubuntu-intro;
 @include ubuntu-p-tabs;
@@ -286,20 +288,6 @@ h5.u-align--center,
 h6.u-align--center,
 p.u-align--center {
   max-width: none;
-}
-
-/// XXX Caleb: abbr hotfix - to be fixed in Vanilla
-// https://github.com/vanilla-framework/vanilla-framework/issues/1962
-abbr[title] {
-  border-bottom: 0.1em dotted;
-  cursor: help;
-  text-decoration: none;
-}
-
-// XXX Ant: is-bordered hotfix - to be removed when the following is resolved:
-// https://github.com/vanilla-framework/vanilla-framework/issues/2045
-[class^="p-strip"].is-bordered {
-  margin-bottom: 0;
 }
 
 // Override for wordpress use of <figure>
@@ -773,19 +761,6 @@ summary {
   padding: 0.25rem 0.85rem;
 }
 
-// Keep font weight 300 for copyable code snippets
-// Bug https://github.com/canonical-web-and-design/vanilla-framework/issues/3564
-
-.p-code-copyable__input {
-  font-weight: 300;
-}
-
-// XXX: Align accordion icons top instead of center
-// Bug: https://github.com/canonical-web-and-design/vanilla-framework/issues/2926
-.p-accordion__tab {
-  background-position: top $spv-inner--medium left $sph-inner;
-}
-
 td.p-accordion {
   padding-top: 0;
 }
@@ -793,26 +768,6 @@ td.p-accordion {
 // Local override for custom table
 .p-accordion.is-compact .p-accordion__panel {
   padding-left: $sph-inner--small;
-}
-
-// XXX: 14.05.2020 remove when this is fixed: https://github.com/canonical-web-and-design/vanilla-framework/issues/3066
-h4.p-stepped-list__title + .p-stepped-list__content {
-  @media (min-width: $breakpoint-large) {
-    margin-left: 0;
-  }
-}
-
-// XXX: Muted text patterm - will be added to Vanilla
-// Bug: https://github.com/canonical-web-and-design/vanilla-framework/issues/3063
-.p-muted-text {
-  color: $color-mid-dark;
-}
-
-// XXX: 14.05.2020 remove when this is fixed https://github.com/canonical-web-and-design/vanilla-framework/issues/3066
-@media (min-width: $breakpoint-large) {
-  h4.p-stepped-list__title + .p-stepped-list__content {
-    margin-left: 0;
-  }
 }
 
 .is-bordered--top {
@@ -1065,16 +1020,4 @@ body {
 
 html {
   scroll-behavior: smooth;
-}
-
-//tco calculatior
-.tco-tooltip {
-  margin-bottom: 0.5rem;
-  margin-left: 0.5rem;
-}
-
-.tco-input {
-  @media (min-width: $breakpoint-medium) {
-    max-width: 10rem;
-  }
 }

--- a/templates/advantage/table/_manage-monthly.html
+++ b/templates/advantage/table/_manage-monthly.html
@@ -45,7 +45,7 @@
     {% if not mobile %}
       <hr />
     {% endif %}
-    <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
+    <p class="u-text--muted" style="margin-bottom: .5rem">Machines</p>
     <div class="panel-input-wrapper">
       <input 
         id="resize-input--{{contract["contractInfo"]["id"]}}--monthly" 

--- a/templates/advantage/table/_manage-yearly.html
+++ b/templates/advantage/table/_manage-yearly.html
@@ -49,7 +49,7 @@
         <span class="p-notification__status">You can add machines to your annual subscription, but not remove machines until the end of your agreed term.</span><a href="/contact-us">Contact us</a> for further information or to amend your subscription.
       </p>
     </div>
-    <p class="p-muted-text" style="margin-bottom: .5rem">Machines</p>
+    <p class="u-text--muted" style="margin-bottom: .5rem">Machines</p>
     <div class="panel-input-wrapper">
       <input 
         id="resize-input--{{contract["contractInfo"]["id"]}}--yearly" 

--- a/templates/certified/component-details.html
+++ b/templates/certified/component-details.html
@@ -44,39 +44,39 @@
       <table class="p-table--component-details" aria-label="Component details table">
         <tbody>
           <tr>
-            <th class="p-muted-text">Vendor</th>
+            <th class="u-text--muted">Vendor</th>
             <td>{{ component.vendor_name }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Model name</th>
+            <th class="u-text--muted">Model name</th>
             <td>{{ component.model }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Identifier</th>
+            <th class="u-text--muted">Identifier</th>
             <td>{{ component.identifier }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Subsystem Identifier</th>
+            <th class="u-text--muted">Subsystem Identifier</th>
             <td>{{ component.subsystem_identifier}}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Hardware Vendor make</th>
+            <th class="u-text--muted">Hardware Vendor make</th>
             <td>{{ component.hardware_vendor_make }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Vendor make</th>
+            <th class="u-text--muted">Vendor make</th>
             <td>{{ component.vendor_make }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Part number</th>
+            <th class="u-text--muted">Part number</th>
             <td>{{ component.part_number }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Device category</th>
+            <th class="u-text--muted">Device category</th>
             <td>{{ component.category }}</td>
           </tr>
           <tr>
-            <th class="p-muted-text">Note</th>
+            <th class="u-text--muted">Note</th>
             <td>{{ component.note }}</td>
           </tr>
         </tbody>

--- a/templates/certified/hardware-details.html
+++ b/templates/certified/hardware-details.html
@@ -68,7 +68,7 @@
           {% for category, devices in hardware_details.items() %}
             {% if category != "Other" %}
             <tr>
-              <th class="p-muted-text">
+              <th class="u-text--muted">
                 {{ category }}
               </th>
               <td>

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -58,7 +58,7 @@
       <h2 class="p-card__title p-heading--3">Ubuntu certified desktops</h2>
       <p class="p-card__content u-sv2">Many of the world's biggest PC manufacturers certify their desktops for Ubuntu, ensuring it always runs as smoothly as its millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education and enterprise, and in homes around the world.</p>
       <hr />
-      <p class="p-muted-text u-no-margin--bottom">Vendor</p>
+      <p class="u-text--muted u-no-margin--bottom">Vendor</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
         {% for desktop_vendor in desktop_vendors %}
         <li class="p-inline-list__item">
@@ -66,7 +66,7 @@
         </li>
         {% endfor %}
       </ul>
-      <p class="p-muted-text u-no-margin--bottom">Certified for Ubuntu</p>
+      <p class="u-text--muted u-no-margin--bottom">Certified for Ubuntu</p>
       <ul class="p-inline-list--midline">
         {% for desktop_release in desktop_releases %}
         <li class="p-inline-list__item">
@@ -89,7 +89,7 @@
       <h2 class="p-card__title p-heading--3">Ubuntu certified laptops</h2>
       <p class="p-card__content u-sv2">Just like desktops, manufacturers choose to certify their laptops for Ubuntu, ensuring it works just like you would expect.</p>
       <hr />
-      <p class="p-muted-text u-no-margin--bottom">Vendor</p>
+      <p class="u-text--muted u-no-margin--bottom">Vendor</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
         {% for laptop_vendor in laptop_vendors %}
         <li class="p-inline-list__item">
@@ -97,7 +97,7 @@
         </li>
         {% endfor %}
       </ul>
-      <p class="p-muted-text u-no-margin--bottom">Certified for Ubuntu</p>
+      <p class="u-text--muted u-no-margin--bottom">Certified for Ubuntu</p>
       <ul class="p-inline-list--midline">
         {% for laptop_release in laptop_releases %}
         <li class="p-inline-list__item">
@@ -123,7 +123,7 @@
       <p class="p-card__content u-sv2">Using Ubuntu Server speeds up the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
       <p>Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
       <hr />
-      <p class="p-muted-text u-no-margin--bottom">Certified for Ubuntu</p>
+      <p class="u-text--muted u-no-margin--bottom">Certified for Ubuntu</p>
       <ul class="p-inline-list--midline">
         {% for server_release, total in server_releases.items() %}
         <li class="p-inline-list__item">
@@ -147,7 +147,7 @@
       <p class="p-card__content u-sv2">A number of IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure and optimised Ubuntu, either pre-loaded or as build your own option.</p>
       <p>Canonical's certification program offers you the peace of mind that all your Internet of Things devices will remain secure and regularly updated.</p>
       <hr />
-      <p class="p-muted-text u-no-margin--bottom">Vendor</p>
+      <p class="u-text--muted u-no-margin--bottom">Vendor</p>
       <ul class="p-inline-list--midline">
         {% for iot_vendor in iot_vendors %}
         <li class="p-inline-list__item">
@@ -173,7 +173,7 @@
       <p class="p-card__content u-sv2">Low-power small-footprint System on a Chip (SoC) hardware are re-defining the future of sustainable data centers. Ubuntu Core delivers bullet-proof security, reliable updates and access to a rich ecosystem on 32 and 64-bit ARM and X86 platforms, perfect to power the Internet of Things.</p>
       <p>Canonical's certification program offers server manufacturers a selection of SoCs officially supported and maintained in Ubuntu to choose from for their products from servers to IoT.</p>
       <hr />
-      <p class="p-muted-text u-no-margin--bottom">Vendor</p>
+      <p class="u-text--muted u-no-margin--bottom">Vendor</p>
       <ul class="p-inline-list--midline">
         {% for soc_vendor in soc_vendors %}
         <li class="p-inline-list__item">

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -116,7 +116,7 @@
                 <tbody>
                 {% for hardware_subtitle, values in release_details["components"].items() %}
                   <tr>
-                    <th colspan="2" class="p-muted-text">{{ hardware_subtitle }}</th>
+                    <th colspan="2" class="u-text--muted">{{ hardware_subtitle }}</th>
                     <td colspan="8">{% for value in values %} 
                       <p style="margin-bottom: 0.5rem;">{{ value.name }} {{ value.bus }}({{ value.identifier }})</p>
                       {% endfor %}


### PR DESCRIPTION
## Done

- Extract tco calculator styles into their own file
- Remove `p-text-muted` class as this is now in vanilla as `u-text--muted` - and replace all uses of `p-text--muted`
Remove custom styles for: 
- `abbr[title]` as fixed [here](https://github.com/vanilla-framework/vanilla-framework/issues/1962)
- `[class^="p-strip"].is-bordered` as fixed [here](https://github.com/vanilla-framework/vanilla-framework/issues/2045)
- `p-code-copyable__input` as fixed [here](https://github.com/canonical-web-and-design/vanilla-framework/issues/3564)
- `p-accordion__tab` as fixed [here](https://github.com/canonical-web-and-design/vanilla-framework/issues/2926)
- `h4.p-stepped-list__title + .p-stepped-list__content` as fixed [here](https://github.com/canonical-web-and-design/vanilla-framework/issues/3066)
- Checked nothing broke when the custom styles were removed. 

## QA

- View page at: /certified/component/675 -  Check text is still muted in table 
- View homepage at:  - Check cursor is a `?` not a pointer here: 
<img width="469" alt="Screenshot 2021-08-11 at 15 06 34" src="https://user-images.githubusercontent.com/58959073/129043913-19147dfc-00ee-424d-b6f9-ebefd407aa0e.png">

- View page at: /appliance/adguard/vm - Check spacing of instructions list against live
- Check pages with a bordered section the border is visible
- View page at: /certified/202005-27921 - Check the accordion `+` icon is aligned correctly
- View page at: internet-of-things/edgex and check code snippet has correct font weight against live. 


## Issue / Card

Fixes [#4309](https://github.com/canonical-web-and-design/web-squad/issues/4309)

