### PR TITLE
Add cron job to check Ubuntu download mirrors

### DIFF
--- a/.github/workflows/mirrors.yaml
+++ b/.github/workflows/mirrors.yaml
@@ -1,0 +1,18 @@
+name: Ubuntu mirrors on live
+
+on:
+  schedule:
+    - cron: "20 7 * * *"
+
+jobs:
+  check-mirrors:
+    if: github.repository == 'canonical-web-and-design/ubuntu.com'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if /mirrors.json returns list of links
+        run: curl https://ubuntu.com/mirrors.json | jq .[].link -e
+
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web--design


### PR DESCRIPTION
## Done

- Added the cron job to check in `/mirrors.json` returns a list of links

## QA

This is a cron job in GH action, so not sure how to QA it.

The job was tested running on staging here:
https://github.com/canonical-web-and-design/ubuntu.com/runs/3321716261?check_suite_focus=true

## Issue / Card

Part of #8583
