### PR TITLE
Add conversion api cookies to facebook on /legal/data-privacy

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -194,15 +194,37 @@
           </tr>
           <tr>
             <td>Facebook</td>
-            <td><code>fr</code>, <code>datr</code>, <code>reg_ext_ref</code>, <code>reg_fb_gate</code>, <code>reg_fb_ref</code>, <code>sb</code>, <code>wb</code></td>
             <td>
-              <p>The Facebook pixel allows us to see how many people take action on our ads and which ad led to a conversion.</p>
-              <p><a class="p-link--external" href="https://www.facebook.com/about/privacy/">Facebook's privacy policy</a></p>
+              <p class="p-muted-heading">
+                Pixel cookies
+              </p>
+              <p>
+                <code>fr</code>, <code>datr</code>, <code>reg_ext_ref</code>, <code>reg_fb_gate</code>, <code>reg_fb_ref</code>, <code>sb</code>, <code>wb</code>
+              </p>
+              <p class="p-muted-heading">
+                Conversion API cookies
+              </p>
+              <p>
+                <code>client_user_agent</code>, <code>action_source</code>, <code>event_source_url</code>
+              </p>
+            </td>
+            <td>
+              <p>
+                The Facebook pixel allows us to see how many people take action on our ads and which ad led to a conversion.
+              </p>
+              <p>
+                Website events are shared with the Facebook Conversions API. This contributes to improving quality of events used for ad delivery
+              </p>
+              <p>
+                <a class="p-link--external" href="https://www.facebook.com/about/privacy/">Facebook's privacy policy</a>
+              </p>
             </td>
           </tr>
           <tr>
             <td>LinkedIn</td>
-            <td><code>bcookie</code>, <code>lidc</code>, <code>BizoID</code>, <code>UserMatchHistory</code>, <code>lang</code>, <code>bscookie</code></td>
+            <td>
+              <code>bcookie</code>, <code>lidc</code>, <code>BizoID</code>, <code>UserMatchHistory</code>, <code>lang</code>, <code>bscookie</code>
+            </td>
             <td>
               <p>LinkedIn tracking allows us to see how many people take action on our ads and which ad led to a conversion.</p>
               <p><a class="p-link--external" href="https://www.linkedin.com/legal/privacy-policy">LinkedIn's privacy policy</a></p>


### PR DESCRIPTION
## Done

- Added facebook's data conversion cookies ot the data-privacy page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/data-privacy
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit#) and resolve comments

## Screenshots

![image](https://user-images.githubusercontent.com/441217/129359266-cf5eab11-6e85-466d-87d4-e97ff1cf7f41.png)
