### PR TITLE
Fail the build when esbuild has an error

### DIFF
--- a/build.js
+++ b/build.js
@@ -21,7 +21,7 @@ let entries = {
   openstackChart: "./static/js/src/openstack-chart.js",
   uaSubscribe: "./static/js/src/advantage/subscribe/react/app.jsx",
   "cloud-price-slider": "./static/js/src/cloud-price-slider.js",
-  "certified-search-results": "./static/js/src/certified-search-results.js",
+  "certified-search-results": "./static/js/src/certified-search-results.js"
 };
 
 for (const [key, value] of Object.entries(entries)) {
@@ -38,11 +38,15 @@ for (const [key, value] of Object.entries(entries)) {
         // 'production' in all other cases.
         process && process.env && process.env.NODE_ENV === "development"
           ? '"development"'
-          : '"production"',
-    },
+          : '"production"'
+    }
   };
 
-  esbuild.build(options).then((result) => {
-    console.log("Built " + key + ".js");
-  });
+  esbuild
+    .build(options)
+    .then((result) => {
+      console.log("Built " + key + ".js");
+    })
+    // Fail the build if there are errors.
+    .catch(() => process.exit(1));
 }


### PR DESCRIPTION
## Done

- Fail the build when esbuild has an error.

## QA

- Check that the demo service has successfully built the branch.
- If you wish you could also test that this fails locally by adding `import nothing from "nothing";` to a js file and running `dotrun build-js` and you should see a failure.