### PR TITLE
Copy update on /kubernetes

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -665,7 +665,7 @@
         <div class="p-heading-icon__header">
           {{
             image(
-            url="https://assets.ubuntu.com/v1/816ae23b-Webinar+-+white.svg",
+            url="https://assets.ubuntu.com/v1/271921af-Datasheet+-+white.svg",
             alt="",
             width="32",
             height="28",
@@ -673,10 +673,10 @@
             loading="lazy",
             ) | safe
           }}
-          <p class="p-heading-icon__title p-muted-heading" style="color: #fff;">Webinar</p>
+          <p class="p-heading-icon__title p-muted-heading" style="color: #fff;">CASE STUDY</p>
         </div>
       </div>
-      <a class="p-link--external p-link--inverted" href="https://www.brighttalk.com/webcast/6793/421884">Kubernetes from cloud to edge</a>
+      <a class="p-link--inverted" href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain’s OTT media market with Charmed Kubernetes</a>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--small">


### PR DESCRIPTION
## Done

- Updated image and text in the `Kubernetes resources` section
- Updated `WEBINAR` to `CASE STUDY`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Please check page against [copy doc](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit) and resolve comments


## Issue / Card

Fixes [#4346](https://github.com/canonical-web-and-design/web-squad/issues/4346)

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/129530916-67fe968c-57eb-4596-b2ce-0b80dad56883.png)
