### PR TITLE
Fix results per page

### DIFF
--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 function clearFilters() {
   location.assign(`/certified?q=`);
   return false;
@@ -73,14 +75,19 @@ function enableApplyFilters() {
 // function to ensure only the option which has been changed is appended to the URL
 function updateResultsPerPage() {
   const searchResults = document.querySelector(".js-search-results");
-  let resultsDropdowns = document.querySelectorAll(".p-results-per-page");
-  resultsDropdowns.forEach((resultsDropdown) => {
-    const options = resultsDropdown.querySelectorAll("option");
-    options.forEach((option) => {
-      if (option.selected) {
-        searchResults.submit();
-      }
-    });
+  const pageSizeTop = document.getElementById("page-size-top");
+  const pageSizeBottom = document.getElementById("page-size-bottom");
+
+  pageSizeTop.addEventListener("change", (e) => {
+    // Needs to be set because the other dropdown is a dummy
+    searchResults.submit();
+  });
+
+  pageSizeBottom.addEventListener("change", (e) => {
+    // Avoids submitting 2 redundant fields
+    let pageSizeTopChange = new Event("change");
+    pageSizeTop.value = e.target.value;
+    pageSizeTop.dispatchEvent(pageSizeTopChange);
   });
 }
 
@@ -133,3 +140,4 @@ enableApplyFilters();
 toggleVersionsList();
 toggleVendorsList();
 toggleShowAllLinks();
+updateResultsPerPage();

--- a/templates/certified/desktops.html
+++ b/templates/certified/desktops.html
@@ -41,7 +41,7 @@
       <div class="col-5 u-align--right">
         {% if total_results > 0 %}
         <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
           <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
           {% if total_results > 20 %}
           <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
@@ -155,7 +155,7 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
@@ -163,7 +163,7 @@
               {% if total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" name="all">All</option>
+              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>

--- a/templates/certified/devices.html
+++ b/templates/certified/devices.html
@@ -41,7 +41,7 @@
       <div class="col-5 u-align--right">
         {% if total_results > 0 %}
         <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
           <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
           {% if total_results > 20 %}
           <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
@@ -155,7 +155,7 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
@@ -163,7 +163,7 @@
               {% if total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" name="all">All</option>
+              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>

--- a/templates/certified/laptops.html
+++ b/templates/certified/laptops.html
@@ -41,7 +41,7 @@
       <div class="col-5 u-align--right">
         {% if total_results > 0 %}
         <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
           <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
           {% if total_results > 20 %}
           <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
@@ -155,7 +155,7 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
@@ -163,7 +163,7 @@
               {% if total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" name="all">All</option>
+              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -41,7 +41,7 @@
       <div class="col-5 u-align--right">
         {% if total_results > 0 %}
         <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
           <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
           {% if total_results > 20 %}
           <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
@@ -170,15 +170,14 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% endif %}
-              {% if total_results > 40 %}
+              {% elif total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" name="all">All</option>
+              <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>

--- a/templates/certified/servers.html
+++ b/templates/certified/servers.html
@@ -41,7 +41,7 @@
       <div class="col-5 u-align--right">
         {% if total_results > 0 %}
         <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
           <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
           {% if total_results > 20 %}
           <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
@@ -155,7 +155,7 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
@@ -163,7 +163,7 @@
               {% if total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" name="all">All</option>
+              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>

--- a/templates/certified/socs.html
+++ b/templates/certified/socs.html
@@ -41,7 +41,7 @@
       <div class="col-5 u-align--right">
         {% if total_results > 0 %}
         <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange="updateResultsPerPage()" data-limit="{{ limit }}">
+        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
           <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
           {% if total_results > 20 %}
           <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
@@ -155,7 +155,7 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" onchange=updateResultsPerPage() data-limit="{{ limit }}">
+            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
@@ -163,7 +163,7 @@
               {% if total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" name="all">All</option>
+              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>


### PR DESCRIPTION
## Done

Fix limit appending twice.
Refactored loops and unnecessary conditions.

## QA

- Check /certified/desktops or any search results page, and try the different page sizes (20, 40, all...) and make sure the URL does not append the `limit` query twice.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4316
