### PR TITLE
Create /cube/faq page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1441,7 +1441,7 @@ legal:
 observability:
   title: Observability
   path: /observability
-  
+
   children:
     - title: Overview
       path: /observability
@@ -1615,6 +1615,9 @@ cube:
     - title: Study
       path: /cube/study
       persist: True
+
+    - title: FAQ
+      path: /cube/faq
 
     - title: Contact us
       path: /cube/contact-us

--- a/templates/cube/faq.html
+++ b/templates/cube/faq.html
@@ -1,0 +1,68 @@
+{% extends "cube/base_cube.html" %}
+
+{% block title %}CUBE FAQ{% endblock %}
+{% block meta_description %}The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. It consists of 15 microcertifications.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1tDByDnXmf6QnpvtzxrX3JsgNYuBZbv1Bx7o6mGnbzSg/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h1>CUBE FAQ</h1>
+      <hr class="p-separator">
+    </div>
+  <div>
+  <div class="row">
+    <div class="col-8">
+      <h2>CUBE</h2>
+      <h3 id="what-is-cube">What is CUBE?</h3>
+      <p>CUBE (short for <strong>C</strong>ertified <strong>Ub</strong>untu <strong>E</strong>ngineer) is Canonical’s professional certification program for the Ubuntu ecosystem.</p>
+      <p>CUBE candidates must demonstrate their skills in 15 key subject areas (called “microcerts”) by passing a focused exam for each one. Each completed microcert awards a corresponding microbadge, and collecting all 15 microbadges confers CUBE certification.</p>
+      <h3 id="what-is-microcerts">What are microcerts?</h3>
+      <p>A microcert is an examination module covering a key Ubuntu skill or subject area. Completing a microcert successfully awards that module’s microbadge.</p>
+      <p>Although microbadges are parts of the journey to CUBE, each one is an accomplishment in its own right. Accordingly, each earned microbadge can be shared on your online profiles in recognition of the achievement.</p>
+      <h3 id="training-program">Is CUBE a training program?</h3>
+      <p>No. CUBE is a certification and credentialing program. It is designed to identify and certify professional Ubuntu skills that candidates already possess.</p>
+      <h2>Enrollment</h2>
+      <h3 id="how-to-enroll">How do I enroll in CUBE?</h3>
+      <p>You can enroll in CUBE using an Ubuntu One account. If you do not already have an Ubuntu One account, you can create one at <a class="p-link--external" href="https://login.ubuntu.com/">https://login.ubuntu.com</a>.</p>
+      <h2>Exams</h2>
+      <h3 id="exams-format">What is the format of the exams?</h3>
+      <p>CUBE exams are administered as interactive labs. You will be provided with a virtual Ubuntu terminal that runs in your web browser, and will be given three separate problems to solve using the terminal. You are able to cycle among the questions, and may approach them in any order you wish.</p>
+      <p>You will have a certain amount of time to complete all of the questions. However, the amount of time you allocate to each question is up to you.</p>
+      <h3 id="exam-result">When will I know the results of my exam?</h3>
+      <p>You will know the results of your exam not long after submitting it. Please allow up to 2 business days for your results to be processed. The results will be visible under your profile on the <a href="/cube/microcerts">Microcertifications</a> page.</p>
+      <h3 id="pass-exam">What happens if I pass my exam?</h3>
+      <p>If you pass your exam, you will be awarded the corresponding microcert, and you will be granted a microbadge that you can share online. The microbadge and the links to share it will appear under the appropriate module on the <a href="/cube/microcerts">Microcertifications</a> page.</p>
+      <h3 id="fail-exam">What happens if I fail my exam?</h3>
+      <p>If you fail the exam, a message will appear under the corresponding module on the <a href="/cube/microcerts">Microcertifications</a> page. You will not be awarded the microcert for that exam.</p>
+      <p>You can purchase another enrollment in order to take the exam again.</p>
+      <h2>Preparatory Materials</h2>
+      <h3 id="differences">What is the difference between the Study Labs and Study Materials?</h3>
+      <p>The <a href="/cube/study">CUBE Study Materials</a> are available free of charge, and offer a brief overview of some of the topics covered in the CUBE exams.</p>
+      <p>The CUBE Study Labs are available for a small fee. They provide access to virtual Ubuntu terminals and related exercises that simulate the experience of taking an exam.</p>
+      <h3 id="preparatory-materials">Will the preparatory materials train me in using Ubuntu?</h3>
+      <p>No. The Study Materials and Study Labs are meant to refresh your existing knowledge. They are not designed to turn an inexperienced Ubuntu user into a professional.</p>
+      <h3 id="preparatory-materials-coverage">Do the preparatory materials cover everything in the exams?</h3>
+      <p>No. The exams explore a wide range of topics related to their particular subject areas. The preparatory materials cover many of these topics, but not all of them.</p>
+      <p>To see what kinds of topics each microcert covers, consult the “Topics” column on the <a href="/cube/microcerts">Microcertifications</a> page.</p>
+      <h2>Badges</h2>
+      <h3 id="what-are-badges">What are badges?</h3>
+      <p>Badges are digital artifacts awarded for completing certain CUBE milestones. They include the microbadges earned for completing individual microcerts, and the CUBE badge granted upon attaining CUBE designation.</p>
+      <h3 id="with-badges">What can I do with my badges?</h3>
+      <p>You can showcase your badges virtually anywhere that digital content can be shared. For example, you can post them on your personal website, embed them in your online résumé, or share them on your professional and social media profiles.</p>
+      <h3 id="share-badges">How do I share my badges?</h3>
+      <p>You can share your badges on LinkedIn and Twitter directly from the CUBE site. On the <a href="/cube/microcerts">Microcertifications</a> page, find the badge you wish to share, and click the <strong>Share</strong> menu on the right of the screen. Then, select your preferred platform for sharing the badge.</p>
+      <p>To share your badge on a different platform, open the <strong>Share</strong> menu, and select “Copy to clipboard”. In the popup, copy the URL provided. Then, follow your target platform’s procedures for sharing content.</p>
+      <h3 id="badges-format">What format are the CUBE badges?</h3>
+      <p>All CUBE badges adhere to the <a class="p-link--external" href="https://openbadges.org/about">Open Badge Standard</a>. For more information about Open Badge specifications, refer to <a class="p-link--external" href="https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/index.html">Open Badges v2.0</a>.</p>
+      <h3 id="authentic-badges">How will people know my badges are authentic?</h3>
+      <p>Each badge contains unique metadata that is recorded when the badge is issued. This metadata proves that the badge comes from Canonical, and that this particular badge was awarded to one and only one individual.</p>
+      <h2>What if my question is not answered here?</h2>
+      <p>If your question is not solved by any of these FAQ items, please open a ticket in the <a class="p-link--external" href="https://support.canonical.com/cube">Support Portal</a> describing your issue.</p>
+    </div>
+  </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Create /cube/faq page
- Add `FAQ` in the navigation menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/faq
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check page against [copy doc](https://docs.google.com/document/d/1tDByDnXmf6QnpvtzxrX3JsgNYuBZbv1Bx7o6mGnbzSg/edit#heading=h.g1eby6bz6419)

## Issue / Card

Fixes [4354](https://github.com/canonical-web-and-design/web-squad/issues/4354)

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/129715159-1aab1892-217a-411f-884f-6e95128933aa.png)
