### PR TITLE
Fix invoices page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -949,7 +949,7 @@ body {
 }
 
 .p-strip-account-page {
-  height: 600px;
+  min-height: 600px;
 
   @media (max-width: $breakpoint-small) {
     height: auto;

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -36,7 +36,7 @@
           <tbody>
             {% for invoice in invoices %}
               <tr>
-                <td aria-label="Service">{{ invoice.service }} ({{ invoice.period }})</td>
+                <td aria-label="Service">{{ invoice.service }}{% if invoice.period %} ({{ invoice.period }}){% endif %}</td>
                 <td aria-label="Date">{{ invoice.date }}</td>
                 <td class="u-align--right" aria-label="Total" style="padding-right: 15%">
                   {% if invoice.total %}

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -822,13 +822,15 @@ def invoices_view(**kwargs):
                 currency = invoice.get("currency")
                 total = f"{cost} {currency}"
 
-            listing_id = raw_payment["purchaseItems"][0]["productListingID"]
             period = None
-            for product_listing in product_listings:
-                if product_listing["id"] == listing_id:
-                    period = product_listing["period"]
+            listing_id = raw_payment["purchaseItems"][0]["productListingID"]
+            if payment_marketplace != "canonical-cube":
+                for product_listing in product_listings:
+                    if product_listing["id"] == listing_id:
+                        period = product_listing["period"]
 
-                    break
+                        break
+                period = "Monthly" if period == "monthly" else "Annual"
 
             download_link = ""
             if raw_payment.get("invoice"):
@@ -838,7 +840,7 @@ def invoices_view(**kwargs):
                 {
                     "created_at": created_at,
                     "service": SERVICES[payment_marketplace]["name"],
-                    "period": "Monthly" if period == "monthly" else "Annual",
+                    "period": period,
                     "date": parse(created_at).strftime("%d %B, %Y"),
                     "total": total,
                     "download_file_name": "Download",

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -816,9 +816,10 @@ def invoices_view(**kwargs):
             created_at = raw_payment["createdAt"]
 
             total = None
-            if raw_payment.get("invoice"):
-                cost = raw_payment["invoice"]["total"] / 100
-                currency = raw_payment["invoice"]["currency"]
+            invoice = raw_payment.get("invoice")
+            if invoice and invoice.get("total"):
+                cost = invoice.get("total") / 100
+                currency = invoice.get("currency")
                 total = f"{cost} {currency}"
 
             listing_id = raw_payment["purchaseItems"][0]["productListingID"]


### PR DESCRIPTION
## Done
- Change 1:
Some invoices do not come with a total cost field. This change makes it so that we handle those situations more graceful. If total is missing we just display `-`.
- Change 2:
The table is overriding the footer. Replacing `height` with `min-height`.
- Change 3:
Canonical CUBE invoices should not show show `(annual)` in the service column.

## QA

- Be someone with access to the Canonical Staff account
- Go to https://ubuntu-com-10206.demos.haus
- Login
- Go to https://ubuntu-com-10206.demos.haus/account/invoices
- Change 1: The page should work
- Change 2: The table should not overlap the footer
- Change 3: Canonical CUBE should not show `(Annual)`