### PR TITLE
Certified category copy

### DIFF
--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 function clearFilters() {
-  location.assign(`/certified?q=`);
+  let objUrl = new URL(window.location);
+  objUrl.search = "";
+  window.location.assign(objUrl);
   return false;
 }
 

--- a/templates/certified/base_certification.html
+++ b/templates/certified/base_certification.html
@@ -1,7 +1,0 @@
-{% extends "templates/base.html" %}
-
-{% block meta_copydoc %}https://docs.google.com/document/d/1pSkPo5fvgrLb-Tjiq_he9MAvPLFX79xiz-H9s2mSXgI/edit{% endblock meta_copydoc %}
-
-{% block outer_content %}
-  {% block content %}{% endblock %}
-{% endblock %}

--- a/templates/certified/component-details.html
+++ b/templates/certified/component-details.html
@@ -1,10 +1,10 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Ubuntu certified component: {{ component.vendor_name }} {{ component.model }}{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 
-{% block content %}
+{% block outer_content %}
 <section class="p-strip--suru-topped">
   <div class="row u-sv3">
     <div class="col-12">
@@ -95,4 +95,4 @@
   </div>
 </section>
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/desktops.html
+++ b/templates/certified/desktops.html
@@ -1,195 +1,48 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Certified desktops{% endblock %}
+{% block meta_description %}Ubuntu certifies thousands of desktops to guarantee they work well with Ubuntu.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1OWoADcvZ-KQX-BzsCS--pvs9_pY3E-Lb8Ba6a-T-AZ8/edit{% endblock %}
 
-{% block meta_description %}Desktops that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block outer_content %}
 
-{% block content %}
-
-<form class="js-search-results">
-  <section class="p-strip--suru-topped">
-    <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified desktops</h1>
+<section class="p-strip--suru-topped is-bordered">
+  <div class="u-fixed-width">
+    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+  </div>
+  <br />
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu certified desktops</h1>
+      <p>Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu.</p>
     </div>
-    <div class="u-fixed-width">
-      <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
-      </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/21efb2ec-desktop.svg",
+        alt="",
+        width="126",
+        height="82",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
-    <div class="row">
-      <div class="col-3">
-        <h2 class="p-heading--4">Filter</h2>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">
-          {% if total_results %}
-          {% if total_results and total_results > 1 %}
-          {{ offset + 1 }}
-          &ndash;
-          {% if offset + limit > total_results %}
-          {{ total_results }}
-          {% else %}
-          {{ offset + limit }}
-          {% endif %}
-          of
-          {% endif %}
-          {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-          {% endif %}
-        </h2>
-      </div>
-      <div class="col-5 u-align--right">
-        {% if total_results > 0 %}
-        <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-          <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
-          {% if total_results > 20 %}
-          <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
-          {% endif %}
-          {% if total_results > 40 %}
-          <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
-          {% endif %}
-          <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
-        </select>
-        {% endif %}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle filters
-            </a>
-          </div>
-          <div>
-            <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
-              <ul class="p-accordion__list">
-                <li class="p-accordion__group--certified" id="vendor-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
-                      <div class="p-round-chip u-hide">
-                        <span class="p-chip__value" id="vendor-count">1</span>
-                      </div>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
-                    {% for vendor_filter in vendor_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if vendor_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                    <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-                <li class="p-accordion__group--certified" id="version-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
-                        <div class="p-round-chip u-hide">
-                          <span class="p-chip__value" id="release-count">1</span>
-                        </div>
-                        <br> release
-                      </span>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
-                    {% for release_filter in release_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if release_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                    <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-              </ul>
-            </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-          </div>
-        </nav>
-      </div>
-      {% if total_results > 0 %}
-      <div class="col-9">
-        <table class="p-certification-results">
-          <thead>
-            <tr>
-              <th><span class="p-certification-header">Vendor</span></th>
-              <th><span class="p-certification-header">Model</span></th>
-              <th><span class="p-certification-header">Category</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for result in results %}
-            <tr>
-              <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
-              <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-              <td>{{ result.category }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        <div class="row">
-          <div class="col-5">
-            {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-            {% include "security/cve/_pagination.html" %}
-            {% endwith %}
-          </div>
-          <div class="col-4 u-align--right">
-            {% if total_results > 0 %}
-            <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-              <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
-              {% if total_results > 20 %}
-              <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% endif %}
-              {% if total_results > 40 %}
-              <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
-              {% endif %}
-              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
-            </select>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      {% else %}
-      <div class="col-9">
-        <h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
-        <p>You can do this by:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">
-            <p>Adding alternative words or phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Using individual words instead of phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Trying a different spelling</p>
-          </li>
-        </ul>
-      </div>
-      {% endif %}
-    </div>
-  </section>
-</form>
+  </div>
+</section>
 
-<script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
+{% with
+  title="All certified desktops",
+  query=query,
+  placeholder="Search in certified desktops",
+  total_results=total_results,
+  total_pages=total_pages,
+  offset=offset,
+  limit=limit,
+  vendor_filters=vendor_filters,
+  release_filters=release_filters,
+  results=results
+%}
+  {% include "certified/shared/category-search-results.html" %}
+{% endwith %}
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/devices.html
+++ b/templates/certified/devices.html
@@ -1,196 +1,48 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Certified devices{% endblock %}
+{% block meta_description %}Devices that have been certified for use with Ubuntu.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1HdOYjjt175MPJz86abLx5XGPaERccQuK8HlyUnVEEIQ/edit{% endblock %}
 
-{% block meta_description %}Devices that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block outer_content %}
 
-{% block content %}
-
-<form class="js-search-results">
-  <section class="p-strip--suru-topped">
-    <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified devices</h1>
+<section class="p-strip--suru-topped is-bordered">
+  <div class="u-fixed-width">
+    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+  </div>
+  <br />
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu certified devices</h1>
+      <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. Ubuntu Core delivers bullet-proof security, reliable updates and access to a rich ecosystem on 32 and 64-bit ARM and X86 platforms.      </p>
     </div>
-    <div class="u-fixed-width">
-      <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
-      </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
+        alt="",
+        width="126",
+        height="150",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
-    <div class="row">
-      <div class="col-3">
-        <h2 class="p-heading--4">Filter</h2>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">
-          {% if total_results %}
-          {% if total_results and total_results > 1 %}
-          {{ offset + 1 }}
-          &ndash;
-          {% if offset + limit > total_results %}
-          {{ total_results }}
-          {% else %}
-          {{ offset + limit }}
-          {% endif %}
-          of
-          {% endif %}
-          {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-          {% endif %}
-        </h2>
-      </div>
-      <div class="col-5 u-align--right">
-        {% if total_results > 0 %}
-        <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-          <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
-          {% if total_results > 20 %}
-          <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
-          {% endif %}
-          {% if total_results > 40 %}
-          <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
-          {% endif %}
-          <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
-        </select>
-        {% endif %}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle filters
-            </a>
-          </div>
-          <div>
-            <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
-              <ul class="p-accordion__list">
-                <li class="p-accordion__group--certified" id="vendor-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
-                      <div class="p-round-chip u-hide">
-                        <span class="p-chip__value" id="vendor-count">1</span>
-                      </div>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
-                    {% for vendor_filter in vendor_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if vendor_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                    <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-                <li class="p-accordion__group--certified" id="version-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
-                        <div class="p-round-chip u-hide">
-                          <span class="p-chip__value" id="release-count">1</span>
-                        </div>
-                        <br> release
-                      </span>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
-                    {% for release_filter in release_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if release_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                    <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-              </ul>
-            </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-          </div>
-        </nav>
-      </div>
-      {% if total_results > 0 %}
-      <div class="col-9">
-        <table class="p-certification-results">
-          <thead>
-            <tr>
-              <th><span class="p-certification-header">Vendor</span></th>
-              <th><span class="p-certification-header">Model</span></th>
-              <th><span class="p-certification-header">Category</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for result in results %}
-            <tr>
-              <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
-              <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-              <td>{{ result.category }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        <div class="row">
-          <div class="col-5">
-            {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-            {% include "security/cve/_pagination.html" %}
-            {% endwith %}
-          </div>
-          <div class="col-4 u-align--right">
-            {% if total_results > 0 %}
-            <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
+  </div>
+</section>
 
-            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-              <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
-              {% if total_results > 20 %}
-              <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% endif %}
-              {% if total_results > 40 %}
-              <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
-              {% endif %}
-              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
-            </select>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      {% else %}
-      <div class="col-9">
-        <h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
-        <p>You can do this by:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">
-            <p>Adding alternative words or phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Using individual words instead of phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Trying a different spelling</p>
-          </li>
-        </ul>
-      </div>
-      {% endif %}
-    </div>
-  </section>
-</form>
+{% with
+  title="All certified devices",
+  query=query,
+  placeholder="Search in certified devices",
+  total_results=total_results,
+  total_pages=total_pages,
+  offset=offset,
+  limit=limit,
+  vendor_filters=vendor_filters,
+  release_filters=release_filters,
+  results=results
+%}
+  {% include "certified/shared/category-search-results.html" %}
+{% endwith %}
 
-<script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
-
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/devices.html
+++ b/templates/certified/devices.html
@@ -155,6 +155,7 @@
           <div class="col-4 u-align--right">
             {% if total_results > 0 %}
             <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
+
             <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}

--- a/templates/certified/hardware-details.html
+++ b/templates/certified/hardware-details.html
@@ -1,10 +1,10 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %} {{ vendor }} {{ model }} certified with Ubuntu {{ release }}{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 
-{% block content %}
+{% block outer_content %}
 
 <section class="p-strip--suru-topped">
   <div class="row u-sv3">
@@ -89,4 +89,4 @@
   </div>
 </section>
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -1,10 +1,9 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Certified hardware{% endblock %}
-
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 
-{% block content %}
+{% block outer_content %}
 
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
@@ -45,7 +44,7 @@
 
 <section class="p-strip">
   <div class="row u-equal-height">
-<div class="col-6 p-card">
+    <div class="col-6 p-card">
       {{ image (
         url="https://assets.ubuntu.com/v1/21efb2ec-desktop.svg",
         alt="",
@@ -211,7 +210,7 @@
   <div class="row u-vertically-center">
     <div class="col-7">
       <h2>Become Ubuntu certified!</h2>
-      <p>Work with us to test that your hardware works fine with Ubuntu and join the OEM market leaders in the list of Ubuntu Certified hardware.</p>
+      <p>Work with us to test that your hardware works fine with Ubuntu and join the OEM market leaders in the list of Ubuntu certified hardware.</p>
       <a href="https://canonical.com/partners/become-a-partner">Learn more&nbsp;&rsaquo;</a>
     </div>
     <div class="col-5 u-align--center">
@@ -228,4 +227,4 @@
   </div>
 </section>
 
-{% endblock content%}
+{% endblock %}

--- a/templates/certified/laptops.html
+++ b/templates/certified/laptops.html
@@ -1,195 +1,48 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Certified laptops{% endblock %}
-
 {% block meta_description %}Laptops that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/19pONXVlPLIMVdl9Sy5grJchc-tIQzVnwCen_gC32GQE/edit{% endblock %}
 
-{% block content %}
+{% block outer_content %}
 
-<form class="js-search-results">
-  <section class="p-strip--suru-topped">
-    <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified Laptops</h1>
+<section class="p-strip--suru-topped is-bordered">
+  <div class="u-fixed-width">
+    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+  </div>
+  <br />
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu certified laptops</h1>
+      <p>Many of the world’s biggest PC manufacturers certify their laptops for Ubuntu.</p>
     </div>
-    <div class="u-fixed-width">
-      <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
-      </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
+        alt="",
+        width="126",
+        height="82",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
-    <div class="row">
-      <div class="col-3">
-        <h2 class="p-heading--4">Filter</h2>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">
-          {% if total_results %}
-          {% if total_results and total_results > 1 %}
-          {{ offset + 1 }}
-          &ndash;
-          {% if offset + limit > total_results %}
-          {{ total_results }}
-          {% else %}
-          {{ offset + limit }}
-          {% endif %}
-          of
-          {% endif %}
-          {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-          {% endif %}
-        </h2>
-      </div>
-      <div class="col-5 u-align--right">
-        {% if total_results > 0 %}
-        <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-          <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
-          {% if total_results > 20 %}
-          <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
-          {% endif %}
-          {% if total_results > 40 %}
-          <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
-          {% endif %}
-          <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
-        </select>
-        {% endif %}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle filters
-            </a>
-          </div>
-          <div>
-            <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
-              <ul class="p-accordion__list">
-                <li class="p-accordion__group--certified" id="vendor-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
-                      <div class="p-round-chip u-hide">
-                        <span class="p-chip__value" id="vendor-count">1</span>
-                      </div>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
-                    {% for vendor_filter in vendor_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if vendor_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                    <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-                <li class="p-accordion__group--certified" id="version-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
-                        <div class="p-round-chip u-hide">
-                          <span class="p-chip__value" id="release-count">1</span>
-                        </div>
-                        <br> release
-                      </span>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
-                    {% for release_filter in release_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if release_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                    <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-              </ul>
-            </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-          </div>
-        </nav>
-      </div>
-      {% if total_results > 0 %}
-      <div class="col-9">
-        <table class="p-certification-results">
-          <thead>
-            <tr>
-              <th><span class="p-certification-header">Vendor</span></th>
-              <th><span class="p-certification-header">Model</span></th>
-              <th><span class="p-certification-header">Category</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for result in results %}
-            <tr>
-              <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
-              <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-              <td>{{ result.category }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        <div class="row">
-          <div class="col-5">
-            {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-            {% include "security/cve/_pagination.html" %}
-            {% endwith %}
-          </div>
-          <div class="col-4 u-align--right">
-            {% if total_results > 0 %}
-            <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-              <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
-              {% if total_results > 20 %}
-              <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% endif %}
-              {% if total_results > 40 %}
-              <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
-              {% endif %}
-              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
-            </select>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      {% else %}
-      <div class="col-9">
-        <h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
-        <p>You can do this by:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">
-            <p>Adding alternative words or phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Using individual words instead of phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Trying a different spelling</p>
-          </li>
-        </ul>
-      </div>
-      {% endif %}
-    </div>
-  </section>
-</form>
+  </div>
+</section>
 
-<script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
+{% with
+  title="All certified laptops",
+  query=query,
+  placeholder="Search in certified laptops",
+  total_results=total_results,
+  total_pages=total_pages,
+  offset=offset,
+  limit=limit,
+  vendor_filters=vendor_filters,
+  release_filters=release_filters,
+  results=results
+%}
+  {% include "certified/shared/category-search-results.html" %}
+{% endwith %}
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -1,10 +1,10 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %} {{ vendor }} {{ model }} certified with Ubuntu{% endblock %}
 
 {% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
 
-{% block content %}
+{% block outer_content %}
 
 <section class="p-strip--suru-topped u-no-margin--bottom">
   <div class="row u-sv3">
@@ -267,4 +267,4 @@
   </div>
 </section>
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/servers.html
+++ b/templates/certified/servers.html
@@ -1,195 +1,49 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Certified servers{% endblock %}
-
 {% block meta_description %}Servers that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1TN2UKhUSB6-kXbLyDM4al2ufB4cgx-W6BsIUOBLP8vU/edit{% endblock meta_copydoc %}
 
-{% block content %}
+{% block outer_content %}
 
-<form class="js-search-results">
-  <section class="p-strip--suru-topped">
-    <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified servers</h1>
+<section class="p-strip--suru-topped is-bordered">
+  <div class="u-fixed-width">
+    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+  </div>
+  <br />
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu certified servers</h1>
+      <p>Using Ubuntu Server speeds up the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
+      <p>Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
     </div>
-    <div class="u-fixed-width">
-      <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
-      </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
+        alt="",
+        width="136",
+        height="153",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
-    <div class="row">
-      <div class="col-3">
-        <h2 class="p-heading--4">Filter</h2>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">
-          {% if total_results %}
-          {% if total_results and total_results > 1 %}
-          {{ offset + 1 }}
-          &ndash;
-          {% if offset + limit > total_results %}
-          {{ total_results }}
-          {% else %}
-          {{ offset + limit }}
-          {% endif %}
-          of
-          {% endif %}
-          {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-          {% endif %}
-        </h2>
-      </div>
-      <div class="col-5 u-align--right">
-        {% if total_results > 0 %}
-        <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-          <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
-          {% if total_results > 20 %}
-          <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
-          {% endif %}
-          {% if total_results > 40 %}
-          <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
-          {% endif %}
-          <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
-        </select>
-        {% endif %}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle filters
-            </a>
-          </div>
-          <div>
-            <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
-              <ul class="p-accordion__list">
-                <li class="p-accordion__group--certified" id="vendor-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
-                      <div class="p-round-chip u-hide">
-                        <span class="p-chip__value" id="vendor-count">1</span>
-                      </div>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
-                    {% for vendor_filter in vendor_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if vendor_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                    <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-                <li class="p-accordion__group--certified" id="version-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
-                        <div class="p-round-chip u-hide">
-                          <span class="p-chip__value" id="release-count">1</span>
-                        </div>
-                        <br> release
-                      </span>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
-                    {% for release_filter in release_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if release_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                    <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-              </ul>
-            </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-          </div>
-        </nav>
-      </div>
-      {% if total_results > 0 %}
-      <div class="col-9">
-        <table class="p-certification-results">
-          <thead>
-            <tr>
-              <th><span class="p-certification-header">Vendor</span></th>
-              <th><span class="p-certification-header">Model</span></th>
-              <th><span class="p-certification-header">Category</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for result in results %}
-            <tr>
-              <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
-              <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-              <td>{{ result.category }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        <div class="row">
-          <div class="col-5">
-            {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-            {% include "security/cve/_pagination.html" %}
-            {% endwith %}
-          </div>
-          <div class="col-4 u-align--right">
-            {% if total_results > 0 %}
-            <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-              <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
-              {% if total_results > 20 %}
-              <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% endif %}
-              {% if total_results > 40 %}
-              <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
-              {% endif %}
-              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
-            </select>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      {% else %}
-      <div class="col-9">
-        <h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
-        <p>You can do this by:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">
-            <p>Adding alternative words or phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Using individual words instead of phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Trying a different spelling</p>
-          </li>
-        </ul>
-      </div>
-      {% endif %}
-    </div>
-  </section>
-</form>
+  </div>
+</section>
 
-<script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
+{% with
+  title="All certified servers",
+  query=query,
+  placeholder="Search in certified servers",
+  total_results=total_results,
+  total_pages=total_pages,
+  offset=offset,
+  limit=limit,
+  vendor_filters=vendor_filters,
+  release_filters=release_filters,
+  results=results
+%}
+  {% include "certified/shared/category-search-results.html" %}
+{% endwith %}
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -1,19 +1,11 @@
-{% extends "templates/base.html" %}
-
-{% block title %}Certified hardware{% endblock %}
-
-{% block meta_description %}Hardware that have been certified for use with Ubuntu.{% endblock meta_description %}
-
-{% block outer_content %}
-
 <form class="js-search-results">
-  <section class="p-strip--suru-topped">
+  <section class="p-strip">
     <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified hardware</h1>
+      <h2>{{ title }}</h2>
     </div>
     <div class="u-fixed-width">
       <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
+        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="{{ placeholder or '' }}">
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
       </div>
     </div>
@@ -67,25 +59,6 @@
           <div>
             <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
               <ul class="p-accordion__list">
-                <li class="p-accordion__group--certified">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab1" aria-controls="tab1-section" aria-expanded="true">
-                      <span class="p-certification-header">Category</span>
-                      <div class="p-round-chip u-hide">
-                        <span class="p-chip__value" id="category-count"></span>
-                      </div>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
-                    {% for category_filter in category_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input js-enable-apply-filters" id="category-filter" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ category_filter }}">{{ category_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                </li>
                 <li class="p-accordion__group--certified" id="vendor-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
@@ -96,7 +69,7 @@
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
+                  <section class="p-accordion__panel {% if vendor_filters | length > 5 %}is-collapsed{% endif %} is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
                     {% for vendor_filter in vendor_filters %}
                     <label class="p-checkbox">
                       <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
@@ -104,10 +77,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if vendor_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
                     <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
@@ -121,7 +96,7 @@
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
+                  <section class="p-accordion__panel {% if vendor_filters | length > 5 %}is-collapsed{% endif %} is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
                     {% for release_filter in release_filters %}
                     <label class="p-checkbox">
                       <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
@@ -129,10 +104,12 @@
                     </label>
                     {% endfor %}
                   </section>
+                  {% if release_filters | length > 5 %}
                   <span class="js-toggle-links">
                     <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
                     <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
                   </span>
+                  {% endif %}
                 </li>
               </ul>
             </aside>
@@ -174,10 +151,11 @@
               <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
               {% if total_results > 20 %}
               <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% elif total_results > 40 %}
+              {% endif %}
+              {% if total_results > 40 %}
               <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
               {% endif %}
-              <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
+              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
             </select>
             {% endif %}
           </div>
@@ -185,16 +163,18 @@
       </div>
       {% else %}
       <div class="col-9">
-        <h3 class="p-heading--4">No results - why not try widening your search?</h3>
+        <h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
         <p>You can do this by:</p>
         <ul class="p-list">
-          <li class="p-list__item is-ticked u-sv1">
-            Adding alternative words or phrases
+          <li class="p-list__item is-ticked">
+            <p>Adding alternative words or phrases</p>
           </li>
-          <li class="p-list__item is-ticked  u-sv1">
-            Using individual words instead of phrases
+          <li class="p-list__item is-ticked">
+            <p>Using individual words instead of phrases</p>
           </li>
-          <li class="p-list__item is-ticked">Trying a different spelling</li>
+          <li class="p-list__item is-ticked">
+            <p>Trying a different spelling</p>
+          </li>
         </ul>
       </div>
       {% endif %}
@@ -203,5 +183,3 @@
 </form>
 
 <script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
-
-{% endblock %}

--- a/templates/certified/socs.html
+++ b/templates/certified/socs.html
@@ -1,195 +1,48 @@
-{% extends "certified/base_certification.html" %}
+{% extends "templates/base.html" %}
 
 {% block title %}Certified SoCs{% endblock %}
+{% block meta_description %}SoCs that have been certified for use with Ubuntu.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1mcI6V6hem4PmG1YxQONjJq-U_I6LGaz_6kkpZOnGVU8/edit{% endblock %}
 
-{% block meta_description %}SoCs that have been certified for use with Ubuntu.{% endblock meta_description %}
+{% block outer_content %}
 
-{% block content %}
-
-<form class="js-search-results">
-  <section class="p-strip--suru-topped">
-    <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified SoCs</h1>
+<section class="p-strip--suru-topped is-bordered">
+  <div class="u-fixed-width">
+    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+  </div>
+  <br />
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu certified SoCs</h1>
+      <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
     </div>
-    <div class="u-fixed-width">
-      <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search hardware">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
-      </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
+        alt="",
+        width="136",
+        height="153",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
-    <div class="row">
-      <div class="col-3">
-        <h2 class="p-heading--4">Filter</h2>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">
-          {% if total_results %}
-          {% if total_results and total_results > 1 %}
-          {{ offset + 1 }}
-          &ndash;
-          {% if offset + limit > total_results %}
-          {{ total_results }}
-          {% else %}
-          {{ offset + limit }}
-          {% endif %}
-          of
-          {% endif %}
-          {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-          {% endif %}
-        </h2>
-      </div>
-      <div class="col-5 u-align--right">
-        {% if total_results > 0 %}
-        <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-        <select id="page-size-top" class="p-results-per-page" name="limit" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-          <option value="20"{% if limit == 20 %}selected{% endif %}>20</option>
-          {% if total_results > 20 %}
-          <option value="40"{% if limit == 40 %}selected{% endif %}>40</option>
-          {% endif %}
-          {% if total_results > 40 %}
-          <option value="60"{% if limit == 60 %}selected{% endif %}>60</option>
-          {% endif %}
-          <option value="{{ total_results }}" {% if limit == total_results %}selected{% endif %}>All</option>
-        </select>
-        {% endif %}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle filters
-            </a>
-          </div>
-          <div>
-            <aside class="p-accordion js-filter-count" data-multiple-expanded="true">
-              <ul class="p-accordion__list">
-                <li class="p-accordion__group--certified" id="vendor-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
-                      <div class="p-round-chip u-hide">
-                        <span class="p-chip__value" id="vendor-count">1</span>
-                      </div>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel {% if vendor_filters | length > 5 %}is-collapsed{% endif %} is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
-                    {% for vendor_filter in vendor_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" id="vendor-filter" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if vendor_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-vendors is-dense"><a>Show all vendors ({{ vendor_filters|length - 5}})</a></p>
-                    <p class="p-reveal-vendors is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-                <li class="p-accordion__group--certified" id="version-section">
-                  <div role="heading" aria-level="2">
-                    <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
-                        <div class="p-round-chip u-hide">
-                          <span class="p-chip__value" id="release-count">1</span>
-                        </div>
-                        <br> release
-                      </span>
-                    </button>
-                  </div>
-                  <hr class="u-no-margin--bottom">
-                  <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
-                    {% for release_filter in release_filters %}
-                    <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" id="release-filter" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
-                    </label>
-                    {% endfor %}
-                  </section>
-                  {% if release_filters | length > 5 %}
-                  <span class="js-toggle-links">
-                    <p class="p-reveal-versions is-dense"><a> Show all versions ({{release_filters|length - 5}})</a></p>
-                    <p class="p-reveal-versions is-dense u-hide"><a>Show fewer</a></p>
-                  </span>
-                  {% endif %}
-                </li>
-              </ul>
-            </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-          </div>
-        </nav>
-      </div>
-      {% if total_results > 0 %}
-      <div class="col-9">
-        <table class="p-certification-results">
-          <thead>
-            <tr>
-              <th><span class="p-certification-header">Vendor</span></th>
-              <th><span class="p-certification-header">Model</span></th>
-              <th><span class="p-certification-header">Category</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for result in results %}
-            <tr>
-              <td><a href="/certified?vendor={{ result.make }}">{{ result.make }}</a></td>
-              <td><a href="/certified/{{ result.canonical_id }}">{{ result.make }} {{ result.model }}</a></td>
-              <td>{{ result.category }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        <div class="row">
-          <div class="col-5">
-            {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left"%}
-            {% include "security/cve/_pagination.html" %}
-            {% endwith %}
-          </div>
-          <div class="col-4 u-align--right">
-            {% if total_results > 0 %}
-            <p style="display: inline-block; padding-right: 0.5rem;">Results per page</p>
-            <select id="page-size-bottom" class="p-results-per-page" aria-label="Results per page" style="max-width: 5.3rem; min-width: 5.3rem;" data-limit="{{ limit }}">
-              <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
-              {% if total_results > 20 %}
-              <option value="40" {% if limit == 40 %}selected{% endif %}>40</option>
-              {% endif %}
-              {% if total_results > 40 %}
-              <option value="60" {% if limit == 60 %}selected{% endif %}>60</option>
-              {% endif %}
-              <option value="{{ total_results }}"  {% if limit == total_results %}selected{% endif %}>All</option>
-            </select>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      {% else %}
-      <div class="col-9">
-        <h3 class="p-heading--4">Sorry we found no results matching your criteria. Please try and wide your search.</h3>
-        <p>You can do this by:</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">
-            <p>Adding alternative words or phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Using individual words instead of phrases</p>
-          </li>
-          <li class="p-list__item is-ticked">
-            <p>Trying a different spelling</p>
-          </li>
-        </ul>
-      </div>
-      {% endif %}
-    </div>
-  </section>
-</form>
+  </div>
+</section>
 
-<script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
+{% with
+  title="All certified SoCs",
+  query=query,
+  placeholder="Search in certified SoCs",
+  total_results=total_results,
+  total_pages=total_pages,
+  offset=offset,
+  limit=limit,
+  vendor_filters=vendor_filters,
+  release_filters=release_filters,
+  results=results
+%}
+  {% include "certified/shared/category-search-results.html" %}
+{% endwith %}
 
-{% endblock content %}
+{% endblock %}


### PR DESCRIPTION
## Done

- Copy updates and setup for certified/<category> views
- Refactor category view templates into one single template
- Removed `base_certification` include template, as this doesn't provide any value (only a few linesand we need also direct access to `meta_copydoc` in `base.html`)

## QA

- Navigate to https://ubuntu-com-10207.demos.haus
- In the top navigation try each link (Desktops, Laptops, Devices etc...)
- Make sure the following work as on https://ubuntu.com/certified:
  - Filters, select multiple filters and apply them
  - Clear filters
  - Click to show or hide filters when applicable
  - Results per page work as expected and they do not duplicate the `limit` query
  - Pagination works as expected
- Check copy docs are correctly linked and the content matches. To see this, inspect in developer tools and look for the meta tag `copy_doc` if you don't have the copy doc Chrome plugin installed.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4290
