### PR TITLE
Update the subscription list for small screens

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -48,15 +48,15 @@ const ListCard = ({
       </span>
     </div>
     <Row>
-      <Col size={3}>
+      <Col size={3} small={1}>
         <p className="u-text--muted u-no-margin--bottom">Machines</p>
         {machines}
       </Col>
-      <Col size={4}>
+      <Col size={4} small={1}>
         <p className="u-text--muted u-no-margin--bottom">Created</p>
         {formatDate(created)}
       </Col>
-      <Col size={4}>
+      <Col size={4} small={1}>
         <p className="u-text--muted u-no-margin--bottom">Expires</p>
         {expires ? formatDate(expires) : "Never"}
       </Col>

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -17,35 +17,38 @@
     }
   }
 
-  .p-subscriptions__list-card {
-    // Include the active stripe on the left, but make it transparent. This is
-    // so the background colour can be animated when it becomes active.
-    @include vf-highlight-bar(transparent, left, true);
+  // Only apply the active card styles for non-mobile screens.
+  @media only screen and (min-width: $breakpoint-small) {
+    .p-subscriptions__list-card {
+      // Include the active stripe on the left, but make it transparent. This is
+      // so the background colour can be animated when it becomes active.
+      @include vf-highlight-bar(transparent, left, true);
 
-    &::before {
-      // Set up the animation on the active stripe.
-      @include vf-animation(background-color, snap, in);
-    }
+      &::before {
+        // Set up the animation on the active stripe.
+        @include vf-animation(background-color, snap, in);
+      }
 
-    // Only show the pointer on inactive cards.
-    &:not(.is-active) {
-      cursor: pointer;
-    }
-  }
+      // Only show the pointer on inactive cards.
+      &:not(.is-active) {
+        cursor: pointer;
+      }
 
-  .p-subscriptions__list-card.is-active {
-    // Update the active stripe to use the brand colour.
-    @include vf-highlight-bar($color-brand, left, true);
+      &.is-active {
+        // Update the active stripe to use the brand colour.
+        @include vf-highlight-bar($color-brand, left, true);
 
-    background-color: $color-light;
-    // Show the overflow so that the stripe can cover the border.
-    overflow: visible;
+        background-color: $color-light;
+        // Show the overflow so that the stripe can cover the border.
+        overflow: visible;
 
-    &::before {
-      // Make the stripe match the border radius of the card.
-      border-radius: $border-radius 0 0 $border-radius;
-      // Move the stripe over the outer border of the card.
-      left: -1px;
+        &::before {
+          // Make the stripe match the border radius of the card.
+          border-radius: $border-radius 0 0 $border-radius;
+          // Move the stripe over the outer border of the card.
+          left: -1px;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Update the subscription list column sizes for small screens.
- Remove the highlight from the card on small screens.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10211.demos.haus/advantage?test_backend=true)
- Resize your window down to mobile size.
- Check that the cards appear like the [design](https://app.zeplin.io/project/60ec5fb4e07cc90fbbf2b318/screen/60f6fa108d36bb10a7f201a0)


## Issue / Card

Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/105.

## Screenshots

<img width="380" alt="Screen Shot 2021-08-20 at 1 01 09 pm" src="https://user-images.githubusercontent.com/361637/130172857-9248ad81-e91b-4f73-aa3e-c1e74642d36a.png">

