### PR TITLE
Display the subscription details in a modal on small screens.

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,23 +1,36 @@
 import { Card } from "@canonical/react-components";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import SubscriptionDetails from "../SubscriptionDetails";
 import SubscriptionList from "../SubscriptionList";
 import { SelectedToken } from "./types";
 
 const Content = () => {
-  // TODO: toggle the details modal visibility when the details are made to be
-  // responsive:
-  // https://github.com/canonical-web-and-design/commercial-squad/issues/111
-  const [modalActive] = useState(false);
+  const [modalActive, setModalActive] = useState(false);
   const [selectedToken, setSelectedToken] = useState<SelectedToken>(null);
+  const onSetActive = useCallback(
+    (token: SelectedToken) => {
+      // Only set the token if it has changed to another token. The selected
+      // token is always needed for large screens.
+      if (token) {
+        setSelectedToken(token);
+      }
+      setModalActive(!!token);
+    },
+    [setSelectedToken]
+  );
   return (
     <Card className="u-no-margin--bottom u-no-padding p-subscriptions__card">
       <SubscriptionList
         selectedToken={selectedToken}
-        setSelectedToken={setSelectedToken}
+        onSetActive={onSetActive}
       />
-      <SubscriptionDetails modalActive={modalActive} />
+      <SubscriptionDetails
+        modalActive={modalActive}
+        onCloseModal={() => {
+          onSetActive(null);
+        }}
+      />
     </Card>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,5 +1,5 @@
 import { Card } from "@canonical/react-components";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import SubscriptionDetails from "../SubscriptionDetails";
 import SubscriptionList from "../SubscriptionList";
@@ -19,6 +19,18 @@ const Content = () => {
     },
     [setSelectedToken]
   );
+
+  // Select a token on the first load.
+  useEffect(() => {
+    if (!selectedToken) {
+      // TODO: this should select the "most recently-started" or free token by default:
+      // https://github.com/canonical-web-and-design/commercial-squad/issues/101
+      // This only sets the selected token and does not set the modal to active
+      // to prevent the modal appearing on first load on mobile.
+      setSelectedToken("ua-sub-123");
+    }
+  }, [selectedToken, setSelectedToken]);
+
   return (
     <Card className="u-no-margin--bottom u-no-padding p-subscriptions__card">
       <SubscriptionList

--- a/static/js/src/advantage/react/components/Subscriptions/Content/types.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/types.ts
@@ -1,5 +1,3 @@
 import type { ContractToken } from "advantage/api/types";
 
 export type SelectedToken = ContractToken | null;
-
-export type SetSelectedToken = (token: ContractToken | null) => void;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -17,9 +17,9 @@ type Feature = {
 
 const generateFeatures = (features: Feature[]) =>
   features.map(({ size = 3, title, value }) => (
-    <Col key={title} size={size}>
+    <Col key={title} medium={2} size={size} small={2}>
       <p className="u-text--muted u-no-margin--bottom">{title}</p>
-      {value}
+      <p className="u-no-margin--bottom u-sv1">{value}</p>
     </Col>
   ));
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -5,20 +5,20 @@ import SubscriptionDetails from "./SubscriptionDetails";
 
 describe("SubscriptionDetails", () => {
   it("initially shows the content", () => {
-    const wrapper = shallow(<SubscriptionDetails />);
+    const wrapper = shallow(<SubscriptionDetails onCloseModal={jest.fn()} />);
     expect(wrapper.find("DetailsContent").exists()).toBe(true);
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
   });
 
   it("can show the edit form", () => {
-    const wrapper = shallow(<SubscriptionDetails />);
+    const wrapper = shallow(<SubscriptionDetails onCloseModal={jest.fn()} />);
     wrapper.find("[data-test='edit-button']").simulate("click");
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
     expect(wrapper.find("DetailsContent").exists()).toBe(false);
   });
 
   it("disables the buttons when showing the edit form", () => {
-    const wrapper = shallow(<SubscriptionDetails />);
+    const wrapper = shallow(<SubscriptionDetails onCloseModal={jest.fn()} />);
     expect(wrapper.find("[data-test='edit-button']").prop("disabled")).toBe(
       false
     );
@@ -32,5 +32,14 @@ describe("SubscriptionDetails", () => {
     expect(wrapper.find("[data-test='cancel-button']").prop("disabled")).toBe(
       true
     );
+  });
+
+  it("can close the modal", () => {
+    const onCloseModal = jest.fn();
+    const wrapper = shallow(
+      <SubscriptionDetails onCloseModal={onCloseModal} />
+    );
+    wrapper.find(".p-modal__close").simulate("click");
+    expect(onCloseModal).toHaveBeenCalled();
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -7,43 +7,49 @@ import SubscriptionEdit from "../SubscriptionEdit";
 
 type Props = {
   modalActive?: boolean;
+  onCloseModal: () => void;
 };
 
-const SubscriptionDetails = ({ modalActive }: Props) => {
+const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
   const [editing, setEditing] = useState(false);
   return (
     <div
-      className={classNames("p-subscriptions__details", {
+      className={classNames("p-modal p-subscriptions__details", {
         "is-active": modalActive,
       })}
     >
-      <h4>UA Infra Essential (Virtual)</h4>
-      <div className="u-sv4">
-        <Button
-          appearance="positive"
-          className="u-no-margin--bottom"
-          data-test="cancel-button"
-          disabled={editing}
-          element="a"
-          href="https://support.canonical.com/"
-        >
-          Support portal
-        </Button>
-        <Button
-          appearance="neutral"
-          className="u-no-margin--bottom"
-          data-test="edit-button"
-          disabled={editing}
-          onClick={() => setEditing(true)}
-        >
-          Edit subscription&hellip;
-        </Button>
-      </div>
-      {editing ? (
-        <SubscriptionEdit onClose={() => setEditing(false)} />
-      ) : (
-        <DetailsContent />
-      )}
+      <section className="p-modal__dialog">
+        <header className="p-modal__header">
+          <h2 className="p-modal__title">UA Infra Essential (Virtual)</h2>
+          <button className="p-modal__close" onClick={() => onCloseModal()}>
+            Close
+          </button>
+        </header>
+        <div className="u-sv2">
+          <Button
+            appearance="positive"
+            data-test="cancel-button"
+            disabled={editing}
+            element="a"
+            href="https://support.canonical.com/"
+          >
+            Support portal
+          </Button>
+          <Button
+            appearance="neutral"
+            data-test="edit-button"
+            disabled={editing}
+            onClick={() => setEditing(true)}
+          >
+            Edit subscription&hellip;
+          </Button>
+        </div>
+        {editing ? (
+          <SubscriptionEdit onClose={() => setEditing(false)} />
+        ) : (
+          <DetailsContent />
+        )}
+      </section>
     </div>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -48,15 +48,15 @@ const ListCard = ({
       </span>
     </div>
     <Row>
-      <Col size={3} small={1}>
+      <Col medium={3} size={3} small={1}>
         <p className="u-text--muted u-no-margin--bottom">Machines</p>
         {machines}
       </Col>
-      <Col size={4} small={1}>
+      <Col medium={3} size={4} small={1}>
         <p className="u-text--muted u-no-margin--bottom">Created</p>
         {formatDate(created)}
       </Col>
-      <Col size={4} small={1}>
+      <Col medium={3} size={4} small={1}>
         <p className="u-text--muted u-no-margin--bottom">Expires</p>
         {expires ? formatDate(expires) : "Never"}
       </Col>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -36,7 +36,7 @@ describe("SubscriptionList", () => {
     queryClient.setQueryData("personalAccount", personalAccount);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionList setSelectedToken={jest.fn()} />
+        <SubscriptionList onSetActive={jest.fn()} />
       </QueryClientProvider>
     );
     const token = wrapper.find("[data-test='free-token']");
@@ -60,10 +60,7 @@ describe("SubscriptionList", () => {
     queryClient.setQueryData("personalAccount", personalAccount);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionList
-          selectedToken="free-token"
-          setSelectedToken={jest.fn()}
-        />
+        <SubscriptionList selectedToken="free-token" onSetActive={jest.fn()} />
       </QueryClientProvider>
     );
     expect(wrapper.find("[data-test='free-token']").prop("isSelected")).toBe(

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -2,15 +2,15 @@ import type { PersonalAccount } from "advantage/api/types";
 import { usePersonalAccount } from "advantage/react/hooks";
 import { selectFreeContract } from "advantage/react/hooks/usePersonalAccount";
 import { getFeaturesDisplay } from "advantage/react/utils";
-import React from "react";
-import { SelectedToken, SetSelectedToken } from "../Content/types";
+import React, { useEffect } from "react";
+import { SelectedToken } from "../Content/types";
 
 import ListCard from "./ListCard";
 import ListGroup from "./ListGroup";
 
 type Props = {
   selectedToken?: SelectedToken;
-  setSelectedToken: SetSelectedToken;
+  onSetActive: (token: SelectedToken) => void;
 };
 
 /**
@@ -33,11 +33,19 @@ const getFreeContractData = (
   };
 };
 
-const SubscriptionList = ({ selectedToken, setSelectedToken }: Props) => {
+const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
   const { data: freeContractData } = usePersonalAccount({
     select: selectFreeContract,
   });
   const freeContract = getFreeContractData(freeContractData);
+  // Select a token on the first load.
+  useEffect(() => {
+    if (!selectedToken) {
+      // TODO: this should select the "most recently-started" or free token by default:
+      // https://github.com/canonical-web-and-design/commercial-squad/issues/101
+      onSetActive("ua-sub-123");
+    }
+  }, [selectedToken, onSetActive]);
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">
@@ -46,11 +54,11 @@ const SubscriptionList = ({ selectedToken, setSelectedToken }: Props) => {
             created="2021-07-09T07:14:56Z"
             expires="2021-07-09T07:14:56Z"
             features={["ESM Infra", "livepatch", "24/5 support"]}
-            isSelected={!selectedToken}
+            isSelected={selectedToken === "ua-sub-123"}
             label="Annual"
             machines={10}
             onClick={() => {
-              setSelectedToken(null);
+              onSetActive("ua-sub-123");
             }}
             title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
           />
@@ -62,12 +70,12 @@ const SubscriptionList = ({ selectedToken, setSelectedToken }: Props) => {
               data-test="free-token"
               expires={freeContract.expires}
               features={freeContract.features.included}
-              isSelected={freeContractData?.token === selectedToken}
+              isSelected={selectedToken === freeContractData?.token}
               label="Free"
               machines={freeContract.machines}
               onClick={() => {
                 if (freeContractData?.token) {
-                  setSelectedToken(freeContractData.token);
+                  onSetActive(freeContractData.token);
                 }
               }}
               title="Free Personal Token"

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -2,7 +2,7 @@ import type { PersonalAccount } from "advantage/api/types";
 import { usePersonalAccount } from "advantage/react/hooks";
 import { selectFreeContract } from "advantage/react/hooks/usePersonalAccount";
 import { getFeaturesDisplay } from "advantage/react/utils";
-import React, { useEffect } from "react";
+import React from "react";
 import { SelectedToken } from "../Content/types";
 
 import ListCard from "./ListCard";
@@ -38,14 +38,6 @@ const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
     select: selectFreeContract,
   });
   const freeContract = getFreeContractData(freeContractData);
-  // Select a token on the first load.
-  useEffect(() => {
-    if (!selectedToken) {
-      // TODO: this should select the "most recently-started" or free token by default:
-      // https://github.com/canonical-web-and-design/commercial-squad/issues/101
-      onSetActive("ua-sub-123");
-    }
-  }, [selectedToken, onSetActive]);
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -84,10 +84,47 @@
     padding: $card-padding;
 
     @media only screen and (max-width: $breakpoint-small) {
+      // On small screens the details are hidden when not active.
       display: none;
 
+      // Show the modal when the details are active.
       &.is-active {
         display: flex;
+      }
+    }
+
+    // Remove modal classes on large screens.
+    @media only screen and (min-width: $breakpoint-small) {
+      &,
+      &.is-active {
+        background: unset;
+        display: block;
+        height: unset;
+        padding: 0;
+        position: relative;
+        width: unset;
+
+        .p-modal__dialog {
+          box-shadow: unset;
+          max-height: unset;
+          max-width: unset;
+          overflow: unset;
+          position: unset;
+        }
+
+        .p-modal__header {
+          margin-bottom: 0;
+
+          &::after {
+            // Remove the bottom border from the title.
+            display: none;
+          }
+        }
+
+        // Don't display the modal close button on large screens.
+        .p-modal__close {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
## Done

- Display the subscription details in a modal on small screens.
- Make it possible to open and close the modal.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10212.demos.haus/advantage?test_backend=true).
- On a large screen the list of subscriptions and the subscription details should appear side by side.
- Resize your screen down to mobile size.
- The subscription details should now appear in a modal.
- Close the modal and you should be able to see the list of subscriptions.
- You should now be able to open and close subscriptions.
- With the modal close resize your window to the large size.
- You should see both the list and details again.


## Issue / Card

Fixes: canonical-web-and-design/commercial-squad#111.

## Screenshots

<img width="452" alt="Screen Shot 2021-08-23 at 12 12 36 pm" src="https://user-images.githubusercontent.com/361637/130380748-99c90f62-7e6a-4fea-9bb4-307a1471bed3.png">

