### PR TITLE
Backend new advantage add parsers

### DIFF
--- a/tests/advantage/fixtures/account.json
+++ b/tests/advantage/fixtures/account.json
@@ -1,0 +1,19 @@
+{
+  "createdAt": "2011-01-01T10:00:00Z",
+  "externalAccountIDs": [
+    {
+      "IDs": [
+        "randomAccountID"
+      ],
+      "origin": "Salesforce"
+    },
+    {
+      "IDs": [
+        "randomAccountID2"
+      ],
+      "origin": "Stripe"
+    }
+  ],
+  "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+  "name": "Account Name"
+}

--- a/tests/advantage/fixtures/accounts.json
+++ b/tests/advantage/fixtures/accounts.json
@@ -1,0 +1,26 @@
+[
+  {
+    "createdAt": "2010-01-01T10:00:00Z",
+    "id": "a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+    "name": "Free"
+  },
+  {
+    "createdAt": "2011-01-01T10:00:00Z",
+    "externalAccountIDs": [
+      {
+        "IDs": [
+          "randomAccountID"
+        ],
+        "origin": "Salesforce"
+      },
+      {
+        "IDs": [
+          "randomAccountID2"
+        ],
+        "origin": "Stripe"
+      }
+    ],
+    "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+    "name": "Account Name"
+  }
+]

--- a/tests/advantage/fixtures/contract-items.json
+++ b/tests/advantage/fixtures/contract-items.json
@@ -1,0 +1,94 @@
+[
+    {
+        "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "created": "2014-01-01T10:00:00Z",
+        "effectiveFrom": "2014-01-01T10:00:00Z",
+        "effectiveTo": "2015-01-01T00:00:00Z",
+        "externalIDs": [
+            {"IDs": ["randomExternalID1"], "origin": "Salesforce"}
+        ],
+        "id": 1,
+        "lastModified": "2014-01-01T10:00:00Z",
+        "metric": "units",
+        "reason": "contract_created",
+        "value": 5
+    },
+    {
+        "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "created": "2014-02-01T10:00:00Z",
+        "effectiveFrom": "2014-02-01T10:00:00Z",
+        "effectiveTo": "2015-02-01T00:00:00Z",
+        "externalIDs": null,
+        "id": 2,
+        "lastModified": "2014-02-01T10:00:00Z",
+        "metric": "",
+        "reason": "extend_contract_by_renewal",
+        "value": 0
+    },
+    {
+        "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "created": "2014-02-01T10:00:00Z",
+        "effectiveFrom": "2014-03-01T10:00:00Z",
+        "effectiveTo": "2015-03-01T00:00:00Z",
+        "externalIDs": [
+            {
+                "IDs": [
+                    "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                    "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2"
+                ],
+                "origin": "Shop"
+            }
+        ],
+        "id": 3,
+        "lastModified": "2014-03-01T10:00:00Z",
+        "metric": "units",
+        "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "purchaseID": "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "reason": "purchase_made",
+        "value": 1
+    },
+    {
+        "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "created": "2014-03-01T10:00:00Z",
+        "effectiveFrom": "2014-04-01T10:00:00Z",
+        "effectiveTo": "2015-04-01T00:00:00Z",
+        "externalIDs": [
+            {
+                "IDs": [
+                    "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                    "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2"
+                ],
+                "origin": "Shop"
+            }
+        ],
+        "id": 4,
+        "lastModified": "2014-04-01T10:00:00Z",
+        "metric": "units",
+        "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "purchaseID": "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "reason": "purchase_made",
+        "value": -2
+    },
+    {
+        "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "created": "2014-06-01T10:00:00Z",
+        "effectiveFrom": "2014-06-01T10:00:00Z",
+        "effectiveTo": "2015-07-01T00:00:00Z",
+        "externalIDs": [
+            {
+                "IDs": [
+                    "tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                    "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP23"
+                ],
+                "origin": "Shop"
+            }
+        ],
+        "id": 5,
+        "lastModified": "2014-06-01T10:00:00Z",
+        "metric": "units",
+        "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP23",
+        "reason": "trial_started",
+        "trialID": "tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+        "value": 1
+    }
+]

--- a/tests/advantage/fixtures/contract.json
+++ b/tests/advantage/fixtures/contract.json
@@ -1,0 +1,101 @@
+{
+    "accountInfo": {
+        "createdAt": "2017-01-01T10:00:00Z",
+        "externalAccountIDs": [
+            {"IDs": ["randomExternalID"], "origin": "Salesforce"},
+            {"IDs": ["randomExternalID2"], "origin": "Stripe"}
+        ],
+        "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+        "name": "Account Name"
+    },
+    "contractInfo": {
+        "allowances": [{"metric": "units", "value": 2}],
+        "createdAt": "2017-01-02T10:00:00Z",
+        "createdBy": "canonical.Handler",
+        "effectiveFrom": "2017-01-02T10:00:00Z",
+        "effectiveTo": "2018-01-02T10:00:00Z",
+        "externalAssetIDs": {
+            "IDs": ["randomExternalID3"],
+            "origin": "Salesforce"
+        },
+        "id": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+        "items": [
+            {
+                "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                "created": "2017-01-02T10:00:00Z",
+                "effectiveFrom": "2017-01-02T10:00:00Z",
+                "effectiveTo": "2018-01-02T10:00:00Z",
+                "externalIDs": [
+                    {
+                        "IDs": [
+                            "tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                            "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP"
+                        ],
+                        "origin": "Shop"
+                    }
+                ],
+                "id": 10,
+                "lastModified": "2017-01-02T10:00:00Z",
+                "metric": "units",
+                "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                "reason": "trial_started",
+                "trialID": "tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                "value": 1
+            },
+            {
+                "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                "created": "2017-02-02T10:00:00Z",
+                "effectiveFrom": "2017-02-02T10:00:00Z",
+                "effectiveTo": "2018-02-02T10:00:00Z",
+                "externalIDs": [
+                    {"IDs": ["randomExternalID12"], "origin": "Salesforce"},
+                    {
+                        "IDs": [
+                            "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                            "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP"
+                        ],
+                        "origin": "Shop"
+                    }
+                ],
+                "id": 11,
+                "lastModified": "2017-02-02T10:00:00Z",
+                "metric": "units",
+                "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                "purchaseID": "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                "reason": "purchase_made",
+                "value": 1
+            }
+        ],
+        "name": "Product Name",
+        "products": ["product-id"],
+        "resourceEntitlements": [
+            {
+                "type": "entitlement-type-2",
+                "entitled": true,
+                "affordances": {
+                    "architectures": ["abc123b"],
+                    "series": ["focal"]
+                },
+                "directives": {
+                    "aptKey": "123123123",
+                    "aptURL": "https://url",
+                    "suites": ["focal"]
+                },
+                "obligations": {"enableByDefault": false},
+                "series": {"focal": {"directives": {"suites": ["focal"]}}}
+            },
+            {
+                "type": "support",
+                "entitled": true,
+                "affordances": {"supportLevel": "advanced"},
+                "directives": {
+                    "aptKey": "123123123",
+                    "aptURL": "https://url",
+                    "suites": ["focal"]
+                },
+                "obligations": {"enableByDefault": false},
+                "series": {"focal": {"directives": {"suites": ["focal"]}}}
+            }
+        ]
+    }
+}

--- a/tests/advantage/fixtures/contracts.json
+++ b/tests/advantage/fixtures/contracts.json
@@ -1,0 +1,68 @@
+[
+    {
+        "accountInfo": {
+            "createdAt": "2017-01-01T10:00:00Z",
+            "externalAccountIDs": [
+                {"IDs": ["randomExternalID"], "origin": "Salesforce"},
+                {"IDs": ["randomExternalID2"], "origin": "Stripe"}
+            ],
+            "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            "name": "Account Name"
+        },
+        "contractInfo": {
+            "allowances": [{"metric": "units", "value": 2}],
+            "createdAt": "2017-01-02T10:00:00Z",
+            "createdBy": "canonical.Handler",
+            "effectiveFrom": "2017-01-02T10:00:00Z",
+            "effectiveTo": "2018-01-02T10:00:00Z",
+            "externalAssetIDs": {
+                "IDs": ["randomExternalID3"],
+                "origin": "Salesforce"
+            },
+            "id": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            "items": [
+                {
+                    "contractID": "cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    "created": "2017-01-02T10:00:00Z",
+                    "effectiveFrom": "2017-01-02T10:00:00Z",
+                    "effectiveTo": "2018-01-02T10:00:00Z",
+                    "externalIDs": [
+                        {
+                            "IDs": [
+                                "tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                                "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP"
+                            ],
+                            "origin": "Shop"
+                        }
+                    ],
+                    "id": 10,
+                    "lastModified": "2017-01-02T10:00:00Z",
+                    "metric": "units",
+                    "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    "reason": "trial_started",
+                    "trialID": "tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    "value": 1
+                }
+            ],
+            "name": "Product Name 2",
+            "products": ["product-id-2"],
+            "resourceEntitlements": [
+                {
+                    "type": "entitlement-type",
+                    "entitled": true,
+                    "affordances": {
+                        "architectures": ["abc123b"],
+                        "series": ["focal"]
+                    },
+                    "directives": {
+                        "aptKey": "123123123",
+                        "aptURL": "https://url",
+                        "suites": ["focal"]
+                    },
+                    "obligations": {"enableByDefault": true},
+                    "series": {"focal": {"directives": {"suites": ["focal"]}}}
+                }
+            ]
+        }
+    }
+]

--- a/tests/advantage/fixtures/entitlements.json
+++ b/tests/advantage/fixtures/entitlements.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "entitlement-type",
+    "entitled": true,
+    "affordances": {"architectures": ["abc123a"], "series": ["bionic"]},
+    "directives": {
+      "aptKey": "123123123",
+      "aptURL": "https://url",
+      "suites": ["bionic"]
+    },
+    "obligations": {"enableByDefault": true},
+    "series": {"bionic": {"directives": {"suites": ["bionic"]}}}
+  },
+  {
+    "type": "entitlement-type-2",
+    "entitled": true,
+    "affordances": {"architectures": ["abc123b"], "series": ["focal"]},
+    "directives": {
+      "aptKey": "123123123",
+      "aptURL": "https://url",
+      "suites": ["focal"]
+    },
+    "obligations": {"enableByDefault": false},
+    "series": {"focal": {"directives": {"suites": ["focal"]}}}
+  },
+  {
+    "type": "support",
+    "entitled": true,
+    "affordances": {"supportLevel": "advanced"},
+    "directives": {
+      "aptKey": "123123123",
+      "aptURL": "https://url",
+      "suites": ["focal"]
+    },
+    "obligations": {"enableByDefault": false},
+    "series": {"focal": {"directives": {"suites": ["focal"]}}}
+  }
+]

--- a/tests/advantage/fixtures/product-listing.json
+++ b/tests/advantage/fixtures/product-listing.json
@@ -1,0 +1,23 @@
+{
+  "allowanceMetric": "units",
+  "bundleQuantity": 1,
+  "createdAt": "2013-01-01T10:00:00Z",
+  "externalIDs": [{"IDs": ["randomExternalID"], "origin": "Salesforce"}],
+  "externalMarketplaceIDs": {
+      "IDs": ["randomExternalID2"],
+      "origin": "Salesforce"
+  },
+  "externalPricingID": {
+      "IDs": ["randomExternalID3"],
+      "origin": "Stripe"
+  },
+  "id": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+  "lastModifiedAt": "2014-01-01T10:00:00Z",
+  "marketplace": "canonical-ua",
+  "name": "product-id",
+  "period": null,
+  "price": {"currency": "USD", "value": 1000},
+  "productID": "product-id",
+  "status": "active",
+  "trialDays": 20
+}

--- a/tests/advantage/fixtures/product-listings.json
+++ b/tests/advantage/fixtures/product-listings.json
@@ -1,0 +1,23 @@
+[
+  {
+    "allowanceMetric": "units",
+    "bundleQuantity": 1,
+    "createdAt": "2013-01-01T10:00:00Z",
+    "externalIDs": [{"IDs": ["randomExternalID"], "origin": "Salesforce"}],
+    "externalMarketplaceIDs": {
+        "IDs": ["randomExternalID2"],
+        "origin": "Salesforce"
+    },
+    "externalPricingID": {
+        "IDs": ["randomExternalID3"],
+        "origin": "Stripe"
+    },
+    "id": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+    "lastModifiedAt": "2014-01-01T10:00:00Z",
+    "marketplace": "canonical-ua",
+    "name": "product-id-2",
+    "price": {"currency": "USD", "value": 1000},
+    "productID": "product-id-2",
+    "status": "active"
+  }
+]

--- a/tests/advantage/fixtures/product.json
+++ b/tests/advantage/fixtures/product.json
@@ -1,0 +1,51 @@
+{
+  "externalBillingIDs": [
+    {
+      "IDs": [
+        "externalID1"
+      ],
+      "origin": "Stripe"
+    }
+  ],
+  "externalMarketplaceIDs": {
+    "IDs": [
+      "externalID2"
+    ],
+    "origin": "Salesforce"
+  },
+  "id": "product-id",
+  "name": "Product Name",
+  "resourceEntitlements": [
+    {
+      "type": "entitlement-type",
+      "entitled": true,
+      "affordances": {
+        "architectures": [
+          "abc123"
+        ],
+        "series": [
+          "bionic"
+        ]
+      },
+      "directives": {
+        "aptKey": "123123123",
+        "aptURL": "https://url",
+        "suites": [
+          "bionic"
+        ]
+      },
+      "obligations": {
+        "enableByDefault": true
+      },
+      "series": {
+        "bionic": {
+          "directives": {
+            "suites": [
+              "bionic"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/advantage/fixtures/products.json
+++ b/tests/advantage/fixtures/products.json
@@ -1,0 +1,54 @@
+[
+  {
+    "externalBillingIDs": [{"IDs": ["externalID1"], "origin": "Stripe"}],
+    "externalMarketplaceIDs": {
+      "IDs": ["externalID2"],
+      "origin": "Salesforce"
+    },
+    "id": "product-id-2",
+    "name": "Product Name 2",
+    "resourceEntitlements": [
+      {
+        "type": "entitlement-type",
+        "entitled": true,
+        "affordances": {
+          "architectures": ["abc123"],
+          "series": ["bionic"]
+        },
+        "directives": {
+          "aptKey": "123123123",
+          "aptURL": "https://url",
+          "suites": ["bionic"]
+        },
+        "obligations": {"enableByDefault": true},
+        "series": {"bionic": {"directives": {"suites": ["bionic"]}}}
+      }
+    ]
+  },
+  {
+    "externalBillingIDs": [{"IDs": ["externalID1"], "origin": "Stripe"}],
+    "externalMarketplaceIDs": {
+      "IDs": ["externalID2"],
+      "origin": "Salesforce"
+    },
+    "id": "product-id",
+    "name": "Product Name",
+    "resourceEntitlements": [
+      {
+        "type": "entitlement-type",
+        "entitled": true,
+        "affordances": {
+          "architectures": ["abc123"],
+          "series": ["bionic"]
+        },
+        "directives": {
+          "aptKey": "123123123",
+          "aptURL": "https://url",
+          "suites": ["bionic"]
+        },
+        "obligations": {"enableByDefault": true},
+          "series": {"bionic": {"directives": {"suites": ["bionic"]}}}
+        }
+    ]
+  }
+]

--- a/tests/advantage/fixtures/subscription-items.json
+++ b/tests/advantage/fixtures/subscription-items.json
@@ -1,0 +1,80 @@
+[
+  {
+    "productListing": {
+      "allowanceMetric": "units",
+      "bundleQuantity": 1,
+      "createdAt": "2012-01-01T10:00:00Z",
+      "externalIDs": [
+        {
+          "IDs": [
+            "randomExternalID"
+          ],
+          "origin": "Salesforce"
+        }
+      ],
+      "externalMarketplaceIDs": {
+        "IDs": [
+          "randomExternalID2"
+        ],
+        "origin": "Salesforce"
+      },
+      "externalPricingID": {
+        "IDs": [
+          "randomExternalID3"
+        ],
+        "origin": "Stripe"
+      },
+      "id": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+      "lastModifiedAt": "2013-01-01T10:00:00Z",
+      "marketplace": "canonical-ua",
+      "name": "awesome-product-slug",
+      "period": "monthly",
+      "price": {
+        "currency": "USD",
+        "value": 1000
+      },
+      "productID": "awesome-product-slug",
+      "status": "active"
+    },
+    "value": 4
+  },
+  {
+    "productListing": {
+      "allowanceMetric": "units",
+      "bundleQuantity": 1,
+      "createdAt": "2013-01-01T10:00:00Z",
+      "externalIDs": [
+        {
+          "IDs": [
+            "randomExternalID"
+          ],
+          "origin": "Salesforce"
+        }
+      ],
+      "externalMarketplaceIDs": {
+        "IDs": [
+          "randomExternalID2"
+        ],
+        "origin": "Salesforce"
+      },
+      "externalPricingID": {
+        "IDs": [
+          "randomExternalID3"
+        ],
+        "origin": "Stripe"
+      },
+      "id": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+      "lastModifiedAt": "2014-01-01T10:00:00Z",
+      "marketplace": "canonical-ua",
+      "name": "awesome-product-slug-2",
+      "period": "monthly",
+      "price": {
+        "currency": "USD",
+        "value": 1000
+      },
+      "productID": "awesome-product-slug-2",
+      "status": "active"
+    },
+    "value": 2
+  }
+]

--- a/tests/advantage/fixtures/subscription.json
+++ b/tests/advantage/fixtures/subscription.json
@@ -1,0 +1,58 @@
+{
+  "lastPurchaseID": "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+  "purchasedProductListings": [
+    {
+      "productListing": {
+        "allowanceMetric": "units",
+        "bundleQuantity": 1,
+        "createdAt": "2012-01-01T10:00:00Z",
+        "externalIDs": [
+          {
+            "IDs": [
+              "randomExternalID"
+            ],
+            "origin": "Salesforce"
+          }
+        ],
+        "externalMarketplaceIDs": {
+          "IDs": [
+            "randomExternalID2"
+          ],
+          "origin": "Salesforce"
+        },
+        "externalPricingID": {
+          "IDs": [
+            "randomExternalID3"
+          ],
+          "origin": "Stripe"
+        },
+        "id": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+        "lastModifiedAt": "2013-01-01T10:00:00Z",
+        "marketplace": "canonical-ua",
+        "name": "awesome-product-slug",
+        "period": "yearly",
+        "price": {
+          "currency": "USD",
+          "value": 50000
+        },
+        "productID": "awesome-product-slug",
+        "status": "active"
+      },
+      "value": 3
+    }
+  ],
+  "subscription": {
+    "accountID": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+    "endOfCycle": "2016-01-01T10:00:00Z",
+    "externalID": {
+      "IDs": [
+        "randomExternalID4"
+      ],
+      "origin": "Stripe"
+    },
+    "id": "sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+    "marketplace": "canonical-ua",
+    "period": "yearly",
+    "status": "active"
+  }
+}

--- a/tests/advantage/fixtures/subscriptions.json
+++ b/tests/advantage/fixtures/subscriptions.json
@@ -1,0 +1,60 @@
+[
+  {
+    "lastPurchaseID": "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+    "purchasedProductListings": [
+      {
+        "productListing": {
+          "allowanceMetric": "units",
+          "bundleQuantity": 1,
+          "createdAt": "2012-01-01T10:00:00Z",
+          "externalIDs": [
+            {
+              "IDs": [
+                "randomExternalID"
+              ],
+              "origin": "Salesforce"
+            }
+          ],
+          "externalMarketplaceIDs": {
+            "IDs": [
+              "randomExternalID2"
+            ],
+            "origin": "Salesforce"
+          },
+          "externalPricingID": {
+            "IDs": [
+              "randomExternalID3"
+            ],
+            "origin": "Stripe"
+          },
+          "id": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+          "lastModifiedAt": "2013-01-01T10:00:00Z",
+          "marketplace": "canonical-ua",
+          "name": "awesome-product-slug",
+          "period": "monthly",
+          "price": {
+            "currency": "USD",
+            "value": 50000
+          },
+          "productID": "awesome-product-slug",
+          "status": "active"
+        },
+        "value": 3
+      }
+    ],
+    "subscription": {
+      "accountID": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+      "endOfCycle": "2016-01-01T10:00:00Z",
+      "externalID": {
+        "IDs": [
+          "randomExternalID4"
+        ],
+        "origin": "Stripe"
+      },
+      "id": "sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+      "marketplace": "canonical-ua",
+      "period": "monthly",
+      "status": "active"
+    }
+  }
+]

--- a/tests/advantage/helpers.py
+++ b/tests/advantage/helpers.py
@@ -1,0 +1,51 @@
+import json
+import pathlib
+from requests.exceptions import HTTPError
+
+from webapp.advantage.api import UAContractsAPI
+
+
+class Response:
+    def __init__(
+        self,
+        status_code: int,
+        content: dict,
+    ):
+        self.status_code = status_code
+        self._content = content
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise (HTTPError(response=self))
+
+    def json(self):
+        return self._content
+
+
+class Session:
+    def __init__(self, response: Response):
+        self._response = response
+        self.request_kwargs = None
+
+    def request(self, **kwargs):
+        self.request_kwargs = kwargs
+
+        return self._response
+
+
+def make_client(session: Session, **kwargs):
+    return UAContractsAPI(
+        session,
+        "secret-token",
+        api_url="https://1.2.3.4",
+        **kwargs,
+    )
+
+
+def get_fixture(file: str) -> dict:
+    current_path = pathlib.Path(__file__).parent.absolute()
+    with open(f"{current_path}/./fixtures/{file}.json") as json_data:
+        file_data = json_data.read()
+        json_data.close()
+
+    return json.loads(file_data)

--- a/tests/advantage/helpers.py
+++ b/tests/advantage/helpers.py
@@ -2,7 +2,7 @@ import json
 import pathlib
 from requests.exceptions import HTTPError
 
-from webapp.advantage.api import UAContractsAPI
+from webapp.advantage.ua_contracts.api import UAContractsAPI
 
 
 class Response:

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -9,82 +9,33 @@ from webapp.advantage.ua_contracts.api import (
     UAContractsAPIErrorView,
 )
 from webapp.advantage.models import Listing
-from webapp.advantage.ua_contracts.primitives import Account, Contract
-
-
-class TestAPIErrorResponses(unittest.TestCase):
-    def test_errors(self):
-        api_error_tests = [
-            {
-                "endpoint": "get_accounts",
-                "cases": [
-                    (401, False, UAContractsAPIAuthError),
-                    (401, True, UAContractsAPIAuthErrorView),
-                    (500, False, UAContractsAPIError),
-                    (500, True, UAContractsAPIErrorView),
-                ],
-            },
-            {
-                "endpoint": "get_account_contracts",
-                "cases": [
-                    (401, False, UAContractsAPIAuthError),
-                    (401, True, UAContractsAPIAuthErrorView),
-                    (500, False, UAContractsAPIError),
-                    (500, True, UAContractsAPIErrorView),
-                ],
-            },
-            {
-                "endpoint": "get_product_listings",
-                "cases": [
-                    (401, False, UAContractsAPIError),
-                    (401, True, UAContractsAPIErrorView),
-                    (500, False, UAContractsAPIError),
-                    (500, True, UAContractsAPIErrorView),
-                ],
-            },
-            {
-                "endpoint": "get_account_subscriptions",
-                "cases": [
-                    (401, False, UAContractsAPIAuthError),
-                    (401, True, UAContractsAPIAuthErrorView),
-                    (500, False, UAContractsAPIError),
-                    (500, True, UAContractsAPIErrorView),
-                ],
-            },
-        ]
-
-        for api_test in api_error_tests:
-            self.try_endpoint(
-                api_endpoint=api_test["endpoint"],
-                test_cases=api_test["cases"],
-            )
-
-    def try_endpoint(self, api_endpoint: str, test_cases: List):
-        for code, is_for_view, expected_error in test_cases:
-            with self.subTest(code=code, is_for_view=is_for_view):
-                response_content = {"code": "expected error"}
-                response = Response(status_code=code, content=response_content)
-                session = Session(response=response)
-                client = make_client(session, is_for_view=is_for_view)
-
-                with self.assertRaises(expected_error) as error:
-                    if api_endpoint == "get_accounts":
-                        client.get_accounts()
-                    if api_endpoint == "get_account_contracts":
-                        client.get_account_contracts(account_id="aABbCcdD")
-                    if api_endpoint == "get_product_listings":
-                        client.get_product_listings(marketplace="canonical-ua")
-                    if api_endpoint == "get_product_listings":
-                        client.get_account_subscriptions(
-                            account_id="aABbCcdD", marketplace="canonical-ua"
-                        )
-
-                self.assertEqual(
-                    error.exception.response.json(), response_content
-                )
+from webapp.advantage.ua_contracts.primitives import (
+    Account,
+    Contract,
+    Subscription,
+)
 
 
 class TestGetAccounts(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (401, False, UAContractsAPIAuthError),
+            (401, True, UAContractsAPIAuthErrorView),
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            response_content = {"code": "expected error"}
+            response = Response(status_code=code, content=response_content)
+            session = Session(response=response)
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error) as error:
+                client.get_accounts()
+
+            self.assertEqual(error.exception.response.json(), response_content)
+
     def test_success(self):
         json_accounts = get_fixture("accounts")
         session = Session(
@@ -159,6 +110,25 @@ class TestGetAccounts(unittest.TestCase):
 
 
 class TestGetAccountContracts(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (401, False, UAContractsAPIAuthError),
+            (401, True, UAContractsAPIAuthErrorView),
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            response_content = {"code": "expected error"}
+            response = Response(status_code=code, content=response_content)
+            session = Session(response=response)
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error) as error:
+                client.get_account_contracts(account_id="aABbCcdD")
+
+            self.assertEqual(error.exception.response.json(), response_content)
+
     def test_success(self):
         json_contracts = get_fixture("contracts")
         session = Session(
@@ -210,6 +180,25 @@ class TestGetAccountContracts(unittest.TestCase):
 
 
 class TestGetProductListings(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (401, False, UAContractsAPIError),
+            (401, True, UAContractsAPIErrorView),
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            response_content = {"code": "expected error"}
+            response = Response(status_code=code, content=response_content)
+            session = Session(response=response)
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error) as error:
+                client.get_product_listings(marketplace="canonical-ua")
+
+            self.assertEqual(error.exception.response.json(), response_content)
+
     def test_success(self):
         json_listings = {
             "productListings": get_fixture("product-listings"),
@@ -269,5 +258,121 @@ class TestGetProductListings(unittest.TestCase):
         self.assertIsInstance(response, Dict)
         for listing in response.values():
             self.assertIsInstance(listing, Listing)
+
+        self.assertEqual(session.request_kwargs, expected_args)
+
+
+class TestGetAccountSubscriptions(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (401, False, UAContractsAPIAuthError),
+            (401, True, UAContractsAPIAuthErrorView),
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            response_content = {"code": "expected error"}
+            response = Response(status_code=code, content=response_content)
+            session = Session(response=response)
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error) as error:
+                client.get_account_subscriptions(
+                    account_id="aABbCcdD", marketplace="canonical-ua"
+                )
+
+            self.assertEqual(error.exception.response.json(), response_content)
+
+    def test_success(self):
+        json_subscriptions = get_fixture("subscriptions")
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={"subscriptions": json_subscriptions},
+            )
+        )
+        client = make_client(session)
+
+        response = client.get_account_subscriptions(
+            account_id="aABbCcdD", marketplace="canonical-ua"
+        )
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": (
+                "https://1.2.3.4/v1/accounts/aABbCcdD"
+                "/marketplace/canonical-ua/subscriptions"
+            ),
+        }
+
+        self.assertEqual(response, json_subscriptions)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_account_subscriptions_filters(self):
+        json_subscriptions = get_fixture("subscriptions")
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={"subscriptions": json_subscriptions},
+            )
+        )
+        client = make_client(session)
+
+        response = client.get_account_subscriptions(
+            account_id="aABbCcdD",
+            marketplace="canonical-ua",
+            filters={"status": "active", "period": "monthly"},
+        )
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": (
+                "https://1.2.3.4/v1/accounts/aABbCcdD"
+                "/marketplace/canonical-ua/subscriptions"
+                "?status=active&period=monthly"
+            ),
+        }
+
+        self.assertEqual(response, json_subscriptions)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_convert_response_returns_list_of_subscriptions(self):
+        json_subscriptions = get_fixture("subscriptions")
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={"subscriptions": json_subscriptions},
+            )
+        )
+        client = make_client(session, convert_response=True)
+
+        response = client.get_account_subscriptions(
+            account_id="aABbCcdD",
+            marketplace="canonical-ua",
+            filters={"status": "active", "period": "monthly"},
+        )
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": (
+                "https://1.2.3.4/v1/accounts/aABbCcdD"
+                "/marketplace/canonical-ua/subscriptions"
+                "?status=active&period=monthly"
+            ),
+        }
+
+        self.assertIsInstance(response, List)
+        for item in response:
+            self.assertIsInstance(item, Subscription)
 
         self.assertEqual(session.request_kwargs, expected_args)

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -1,0 +1,260 @@
+import unittest
+from typing import List, Dict
+
+from tests.advantage.helpers import Session, Response, make_client, get_fixture
+from webapp.advantage.api import (
+    UAContractsAPIAuthError,
+    UAContractsAPIAuthErrorView,
+    UAContractsAPIError,
+    UAContractsAPIErrorView,
+)
+from webapp.advantage.models import Listing
+from webapp.advantage.primitives import Account, Contract
+
+
+class TestAPIErrorResponses(unittest.TestCase):
+    def test_errors(self):
+        api_error_tests = [
+            {
+                "endpoint": "get_accounts",
+                "cases": [
+                    (401, False, UAContractsAPIAuthError),
+                    (401, True, UAContractsAPIAuthErrorView),
+                    (500, False, UAContractsAPIError),
+                    (500, True, UAContractsAPIErrorView),
+                ],
+            },
+            {
+                "endpoint": "get_account_contracts",
+                "cases": [
+                    (401, False, UAContractsAPIAuthError),
+                    (401, True, UAContractsAPIAuthErrorView),
+                    (500, False, UAContractsAPIError),
+                    (500, True, UAContractsAPIErrorView),
+                ],
+            },
+            {
+                "endpoint": "get_product_listings",
+                "cases": [
+                    (401, False, UAContractsAPIError),
+                    (401, True, UAContractsAPIErrorView),
+                    (500, False, UAContractsAPIError),
+                    (500, True, UAContractsAPIErrorView),
+                ],
+            },
+        ]
+
+        for api_test in api_error_tests:
+            self.try_endpoint(
+                api_endpoint=api_test["endpoint"],
+                test_cases=api_test["cases"],
+            )
+
+    def try_endpoint(self, api_endpoint: str, test_cases: List):
+        for code, is_for_view, expected_error in test_cases:
+            with self.subTest(code=code, is_for_view=is_for_view):
+                response_content = {"code": "expected error"}
+                response = Response(status_code=code, content=response_content)
+                session = Session(response=response)
+                client = make_client(session, is_for_view=is_for_view)
+
+                with self.assertRaises(expected_error) as error:
+                    if api_endpoint == "get_accounts":
+                        client.get_accounts()
+                    if api_endpoint == "get_account_contracts":
+                        client.get_account_contracts(account_id="aABbCcdD")
+                    if api_endpoint == "get_product_listings":
+                        client.get_product_listings(marketplace="canonical-ua")
+
+                self.assertEqual(
+                    error.exception.response.json(), response_content
+                )
+
+
+class TestGetAccounts(unittest.TestCase):
+    def test_success(self):
+        json_accounts = get_fixture("accounts")
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={"accounts": json_accounts},
+            )
+        )
+        client = make_client(session)
+
+        response = client.get_accounts()
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/accounts",
+        }
+
+        self.assertEqual(response, json_accounts)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_view_as_adds_email(self):
+        json_accounts = get_fixture("accounts")
+        session = Session(
+            Response(
+                status_code=200,
+                content={"accounts": json_accounts},
+            )
+        )
+        client = make_client(session)
+
+        response = client.get_accounts(email="email@address.abc")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": {"email": "email@address.abc"},
+            "url": "https://1.2.3.4/v1/accounts",
+        }
+
+        self.assertEqual(response, json_accounts)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_convert_response_returns_list_of_accounts(self):
+        json_accounts = get_fixture("accounts")
+        session = Session(
+            Response(
+                status_code=200,
+                content={"accounts": json_accounts},
+            )
+        )
+        client = make_client(session, convert_response=True)
+
+        response = client.get_accounts()
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/accounts",
+        }
+
+        self.assertIsInstance(response, List)
+        for item in response:
+            self.assertIsInstance(item, Account)
+
+        self.assertEqual(session.request_kwargs, expected_args)
+
+
+class TestGetAccountContracts(unittest.TestCase):
+    def test_success(self):
+        json_contracts = get_fixture("contracts")
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={"contracts": json_contracts},
+            )
+        )
+        client = make_client(session)
+
+        response = client.get_account_contracts("aAbBcCdD")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/accounts/aAbBcCdD/contracts",
+        }
+
+        self.assertEqual(response, json_contracts)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_convert_response_returns_list_of_contracts(self):
+        json_contracts = get_fixture("contracts")
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={"contracts": json_contracts},
+            )
+        )
+        client = make_client(session, convert_response=True)
+
+        response = client.get_account_contracts("aAbBcCdD")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/accounts/aAbBcCdD/contracts",
+        }
+
+        self.assertIsInstance(response, List)
+        for item in response:
+            self.assertIsInstance(item, Contract)
+
+        self.assertEqual(session.request_kwargs, expected_args)
+
+
+class TestGetProductListings(unittest.TestCase):
+    def test_success(self):
+        json_listings = {
+            "productListings": get_fixture("product-listings"),
+            "products": get_fixture("products"),
+        }
+
+        session = Session(
+            response=Response(status_code=200, content=json_listings)
+        )
+
+        client = make_client(session)
+
+        response = client.get_product_listings(marketplace="canonical-ua")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": (
+                "https://1.2.3.4"
+                "/v1/marketplace/canonical-ua/product-listings"
+            ),
+        }
+
+        self.assertEqual(response, json_listings)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_convert_response_returns_list_of_contracts(self):
+        json_listings = {
+            "productListings": get_fixture("product-listings"),
+            "products": get_fixture("products"),
+        }
+
+        session = Session(
+            response=Response(
+                status_code=200,
+                content=json_listings,
+            )
+        )
+
+        client = make_client(session, convert_response=True)
+
+        response = client.get_product_listings(marketplace="canonical-ua")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": (
+                "https://1.2.3.4"
+                "/v1/marketplace/canonical-ua/product-listings"
+            ),
+        }
+
+        self.assertIsInstance(response, Dict)
+        for listing in response.values():
+            self.assertIsInstance(listing, Listing)
+
+        self.assertEqual(session.request_kwargs, expected_args)

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -2,14 +2,14 @@ import unittest
 from typing import List, Dict
 
 from tests.advantage.helpers import Session, Response, make_client, get_fixture
-from webapp.advantage.api import (
+from webapp.advantage.ua_contracts.api import (
     UAContractsAPIAuthError,
     UAContractsAPIAuthErrorView,
     UAContractsAPIError,
     UAContractsAPIErrorView,
 )
 from webapp.advantage.models import Listing
-from webapp.advantage.primitives import Account, Contract
+from webapp.advantage.ua_contracts.primitives import Account, Contract
 
 
 class TestAPIErrorResponses(unittest.TestCase):
@@ -42,6 +42,15 @@ class TestAPIErrorResponses(unittest.TestCase):
                     (500, True, UAContractsAPIErrorView),
                 ],
             },
+            {
+                "endpoint": "get_account_subscriptions",
+                "cases": [
+                    (401, False, UAContractsAPIAuthError),
+                    (401, True, UAContractsAPIAuthErrorView),
+                    (500, False, UAContractsAPIError),
+                    (500, True, UAContractsAPIErrorView),
+                ],
+            },
         ]
 
         for api_test in api_error_tests:
@@ -65,6 +74,10 @@ class TestAPIErrorResponses(unittest.TestCase):
                         client.get_account_contracts(account_id="aABbCcdD")
                     if api_endpoint == "get_product_listings":
                         client.get_product_listings(marketplace="canonical-ua")
+                    if api_endpoint == "get_product_listings":
+                        client.get_account_subscriptions(
+                            account_id="aABbCcdD", marketplace="canonical-ua"
+                        )
 
                 self.assertEqual(
                     error.exception.response.json(), response_content

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -1,0 +1,389 @@
+import unittest
+from typing import List, Dict
+
+from tests.advantage.helpers import get_fixture
+from webapp.advantage.helpers import to_dict
+from webapp.advantage.models import Listing
+from webapp.advantage.parsers import (
+    parse_account,
+    parse_accounts,
+    parse_subscription_items,
+    parse_subscription,
+    parse_subscriptions,
+    parse_product,
+    parse_product_listings,
+    parse_product_listing,
+    parse_entitlements,
+    parse_contract_items,
+    parse_contract,
+    parse_contracts,
+)
+from webapp.advantage.primitives import (
+    Account,
+    Subscription,
+    SubscriptionItem,
+    Product,
+    Entitlement,
+    ContractItem,
+    Contract,
+)
+
+
+class TestParsers(unittest.TestCase):
+    def test_parse_account(self):
+        raw_account = get_fixture("account")
+        parsed_account = parse_account(raw_account=raw_account)
+
+        expectation = Account(
+            id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            name="Account Name",
+        )
+
+        self.assertIsInstance(parsed_account, Account)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_account))
+
+    def test_parse_accounts(self):
+        raw_accounts = get_fixture("accounts")
+        parsed_accounts = parse_accounts(raw_accounts=raw_accounts)
+
+        expectation = [
+            Account(
+                id="a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                name="Free",
+            ),
+            Account(
+                id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                name="Account Name",
+            ),
+        ]
+
+        self.assertIsInstance(parsed_accounts, List)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_accounts))
+
+    def test_parse_subscription_items(self):
+        raw_subscription_items = get_fixture("subscription-items")
+        parsed_subscription_items = parse_subscription_items(
+            subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            raw_items=raw_subscription_items,
+        )
+
+        expectation = [
+            SubscriptionItem(
+                subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                value=4,
+            ),
+            SubscriptionItem(
+                subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                value=2,
+            ),
+        ]
+
+        self.assertIsInstance(parsed_subscription_items, List)
+        self.assertEqual(
+            to_dict(expectation), to_dict(parsed_subscription_items)
+        )
+
+    def test_parse_subscription(self):
+        raw_subscription = get_fixture("subscription")
+
+        parsed_subscription = parse_subscription(
+            raw_subscription=raw_subscription
+        )
+
+        expectation = Subscription(
+            id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            account_id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            marketplace="canonical-ua",
+            period="yearly",
+            status="active",
+            last_purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            items=[
+                SubscriptionItem(
+                    subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    value=3,
+                ),
+            ],
+        )
+
+        self.assertIsInstance(parsed_subscription, Subscription)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_subscription))
+
+    def test_parse_subscriptions(self):
+        raw_subscriptions = get_fixture("subscriptions")
+
+        parsed_subscriptions = parse_subscriptions(
+            raw_subscriptions=raw_subscriptions
+        )
+
+        expectation = [
+            Subscription(
+                id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                account_id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                marketplace="canonical-ua",
+                period="monthly",
+                status="active",
+                last_purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                items=[
+                    SubscriptionItem(
+                        subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                        product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                        value=3,
+                    ),
+                ],
+            )
+        ]
+
+        self.assertIsInstance(parsed_subscriptions, List)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_subscriptions))
+
+    def test_parse_product(self):
+        raw_product = get_fixture("product")
+        parsed_product = parse_product(raw_product=raw_product)
+
+        expectation = Product(
+            id="product-id",
+            name="Product Name",
+        )
+
+        self.assertIsInstance(parsed_product, Product)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_product))
+
+    def test_parse_listing(self):
+        raw_products = get_fixture("products")
+        raw_product_listing = get_fixture("product-listing")
+
+        parsed_listing = parse_product_listing(
+            raw_product_listing=raw_product_listing,
+            raw_products=raw_products,
+        )
+
+        expectation = Listing(
+            id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+            name="product-id",
+            marketplace="canonical-ua",
+            product=Product(
+                id="product-id",
+                name="Product Name",
+            ),
+            price=1000,
+            currency="USD",
+            status="active",
+            trial_days=20,
+            period=None,
+        )
+
+        self.assertIsInstance(expectation, Listing)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_listing))
+
+    def test_parse_listings(self):
+        raw_products = get_fixture("products")
+        raw_product_listings = get_fixture("product-listings")
+
+        parsed_listings = parse_product_listings(
+            raw_product_listings=raw_product_listings,
+            raw_products=raw_products,
+        )
+
+        expectation = {
+            "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2": Listing(
+                id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                name="product-id-2",
+                marketplace="canonical-ua",
+                product=Product(
+                    id="product-id-2",
+                    name="Product Name 2",
+                ),
+                price=1000,
+                currency="USD",
+                status="active",
+                trial_days=None,
+                period=None,
+            )
+        }
+
+        self.assertIsInstance(expectation, Dict)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_listings))
+
+    def test_parse_entitlements(self):
+        raw_entitlements = get_fixture("entitlements")
+        parsed_entitlements = parse_entitlements(
+            raw_entitlements=raw_entitlements
+        )
+
+        expectation = [
+            Entitlement(
+                type="entitlement-type",
+                support_level=None,
+                enabled_by_default=True,
+            ),
+            Entitlement(
+                type="entitlement-type-2",
+                support_level=None,
+                enabled_by_default=False,
+            ),
+            Entitlement(
+                type="support",
+                support_level="advanced",
+                enabled_by_default=False,
+            ),
+        ]
+
+        self.assertIsInstance(parsed_entitlements, List)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_entitlements))
+
+    def test_parse_contract_items(self):
+        raw_contract_items = get_fixture("contract-items")
+
+        parsed_contract_items = parse_contract_items(
+            raw_items=raw_contract_items
+        )
+
+        expectation = [
+            ContractItem(
+                contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                created_at="2014-01-01T10:00:00Z",
+                start_date="2014-01-01T10:00:00Z",
+                end_date="2015-01-01T00:00:00Z",
+                reason="contract_created",
+                value=5,
+                product_listing_id=None,
+                purchase_id=None,
+                trial_id=None,
+            ),
+            ContractItem(
+                contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                created_at="2014-02-01T10:00:00Z",
+                start_date="2014-02-01T10:00:00Z",
+                end_date="2015-02-01T00:00:00Z",
+                reason="extend_contract_by_renewal",
+                value=0,
+                product_listing_id=None,
+                purchase_id=None,
+                trial_id=None,
+            ),
+            ContractItem(
+                contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                created_at="2014-02-01T10:00:00Z",
+                start_date="2014-03-01T10:00:00Z",
+                end_date="2015-03-01T00:00:00Z",
+                reason="purchase_made",
+                value=1,
+                product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                trial_id=None,
+            ),
+            ContractItem(
+                contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                created_at="2014-03-01T10:00:00Z",
+                start_date="2014-04-01T10:00:00Z",
+                end_date="2015-04-01T00:00:00Z",
+                reason="purchase_made",
+                value=-2,
+                product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                trial_id=None,
+            ),
+            ContractItem(
+                contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                created_at="2014-06-01T10:00:00Z",
+                start_date="2014-06-01T10:00:00Z",
+                end_date="2015-07-01T00:00:00Z",
+                reason="trial_started",
+                value=1,
+                product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP23",
+                purchase_id=None,
+                trial_id="tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+            ),
+        ]
+
+        self.assertIsInstance(expectation, List)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_contract_items))
+
+    def test_parse_contract(self):
+        raw_contract = get_fixture("contract")
+        parsed_contract = parse_contract(raw_contract=raw_contract)
+
+        expectation = Contract(
+            id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            account_id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            name="Product Name",
+            product_id="product-id",
+            entitlements=[
+                Entitlement(
+                    type="entitlement-type-2",
+                    support_level=None,
+                    enabled_by_default=False,
+                ),
+                Entitlement(
+                    type="support",
+                    support_level="advanced",
+                    enabled_by_default=False,
+                ),
+            ],
+            items=[
+                ContractItem(
+                    contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    created_at="2017-01-02T10:00:00Z",
+                    start_date="2017-01-02T10:00:00Z",
+                    end_date="2018-01-02T10:00:00Z",
+                    reason="trial_started",
+                    value=1,
+                    product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    purchase_id=None,
+                    trial_id="tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                ),
+                ContractItem(
+                    contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    created_at="2017-02-02T10:00:00Z",
+                    start_date="2017-02-02T10:00:00Z",
+                    end_date="2018-02-02T10:00:00Z",
+                    reason="purchase_made",
+                    value=1,
+                    product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    trial_id=None,
+                ),
+            ],
+        )
+
+        self.assertIsInstance(parsed_contract, Contract)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_contract))
+
+    def test_parse_contracts(self):
+        raw_contracts = get_fixture("contracts")
+        parsed_contracts = parse_contracts(raw_contracts=raw_contracts)
+
+        expectation = [
+            Contract(
+                id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                account_id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                name="Product Name 2",
+                product_id="product-id-2",
+                entitlements=[
+                    Entitlement(
+                        type="entitlement-type",
+                        support_level=None,
+                        enabled_by_default=True,
+                    ),
+                ],
+                items=[
+                    ContractItem(
+                        contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                        created_at="2017-01-02T10:00:00Z",
+                        start_date="2017-01-02T10:00:00Z",
+                        end_date="2018-01-02T10:00:00Z",
+                        reason="trial_started",
+                        value=1,
+                        product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                        purchase_id=None,
+                        trial_id="tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                    ),
+                ],
+            )
+        ]
+
+        self.assertIsInstance(parsed_contracts, List)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_contracts))

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -2,9 +2,9 @@ import unittest
 from typing import List, Dict
 
 from tests.advantage.helpers import get_fixture
-from webapp.advantage.helpers import to_dict
-from webapp.advantage.models import Listing
-from webapp.advantage.parsers import (
+from webapp.advantage.ua_contracts.helpers import to_dict
+from webapp.advantage.models import Listing, Entitlement
+from webapp.advantage.ua_contracts.parsers import (
     parse_account,
     parse_accounts,
     parse_subscription_items,
@@ -18,12 +18,11 @@ from webapp.advantage.parsers import (
     parse_contract,
     parse_contracts,
 )
-from webapp.advantage.primitives import (
+from webapp.advantage.ua_contracts.primitives import (
     Account,
     Subscription,
     SubscriptionItem,
     Product,
-    Entitlement,
     ContractItem,
     Contract,
 )
@@ -164,10 +163,7 @@ class TestParsers(unittest.TestCase):
             id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
             name="product-id",
             marketplace="canonical-ua",
-            product=Product(
-                id="product-id",
-                name="Product Name",
-            ),
+            product_name="Product Name",
             price=1000,
             currency="USD",
             status="active",
@@ -192,10 +188,7 @@ class TestParsers(unittest.TestCase):
                 id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
                 name="product-id-2",
                 marketplace="canonical-ua",
-                product=Product(
-                    id="product-id-2",
-                    name="Product Name 2",
-                ),
+                product_name="Product Name 2",
                 price=1000,
                 currency="USD",
                 status="active",

--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -5,8 +5,8 @@ class Entitlement:
     def __init__(
         self,
         type: str,
-        support_level: str,
         enabled_by_default: bool,
+        support_level: str = None,
     ):
         self.type = type
         self.support_level = support_level

--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -23,7 +23,7 @@ class Listing:
         price: int,
         currency: str,
         status: str,
-        trial_days: int,
+        trial_days: int = None,
         period: str = None,
     ):
         self.id = id

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -30,65 +30,55 @@ class UAContractsAPI:
         self.is_for_view = is_for_view
         self.convert_response = convert_response
 
-    def _request(self, method, path, json=None, params=None):
-        headers = {
-            "Authorization": (
-                f"{self.token_type} " f"{self.authentication_token}"
-            )
-        }
+    def _request(self, method, path, json=None, params=None, error_rules=None):
+        authorization = f"{self.token_type} {self.authentication_token}"
 
         response = self.session.request(
             method=method,
             url=f"{self.api_url}/{path}",
             json=json,
-            headers=headers,
+            headers={"Authorization": authorization},
             params=params,
         )
-        response.raise_for_status()
+
+        if error_rules:
+            try:
+                response.raise_for_status()
+            except HTTPError as error:
+                self.handle_error(error, error_rules)
+        else:
+            response.raise_for_status()
 
         return response
 
-    def get_accounts(self, email=""):
-        params = {"email": email} if email else None
-        try:
-            response = self._request(
-                method="get", path="v1/accounts", params=params
-            )
-        except HTTPError as error:
-            if error.response.status_code == 401:
-                if self.is_for_view:
-                    raise UAContractsAPIAuthErrorView(error)
-                raise UAContractsAPIAuthError(error)
+    def get_accounts(self, email: str = None):
+        response = self._request(
+            method="get",
+            path="v1/accounts",
+            params={"email": email} if email else None,
+            error_rules=["default", "auth"],
+        )
 
-            if self.is_for_view:
-                raise UAContractsAPIErrorView(error)
-            raise UAContractsAPIError(error)
+        accounts = response.json().get("accounts", [])
 
-        if not self.convert_response:
-            return response.json().get("accounts", [])
+        if self.convert_response:
+            return parse_accounts(accounts)
 
-        return parse_accounts(response.json().get("accounts", []))
+        return accounts
 
     def get_account_contracts(self, account_id: str):
-        try:
-            response = self._request(
-                method="get", path=f"v1/accounts/{account_id}/contracts"
-            )
-        except HTTPError as error:
-            if error.response.status_code == 401:
-                if self.is_for_view:
-                    raise UAContractsAPIAuthErrorView(error)
-                raise UAContractsAPIAuthError(error)
+        response = self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/contracts",
+            error_rules=["default", "auth"],
+        )
 
-            if self.is_for_view:
-                raise UAContractsAPIErrorView(error)
+        contracts = response.json().get("contracts", [])
 
-            raise UAContractsAPIError(error)
+        if self.convert_response:
+            return parse_contracts(contracts)
 
-        if not self.convert_response:
-            return response.json().get("contracts", [])
-
-        return parse_contracts(response.json().get("contracts", []))
+        return contracts
 
     def get_contract_token(self, contract_id: str):
         try:
@@ -109,20 +99,6 @@ class UAContractsAPI:
             raise UAContractsAPIError(error)
 
         return response.json().get("contractToken")
-
-    def get_contract_machines(self, contract_id: str):
-        try:
-            response = self._request(
-                method="get",
-                path=f"v1/contracts/{contract_id}/context/machines",
-            )
-        except HTTPError as error:
-            if error.response.status_code == 401:
-                raise UAContractsAPIAuthError(error)
-
-            raise UAContractsAPIError(error)
-
-        return response.json()
 
     def get_customer_info(self, account_id):
         try:
@@ -244,24 +220,19 @@ class UAContractsAPI:
         return {}
 
     def get_product_listings(self, marketplace: str):
-        try:
-            response = self._request(
-                method="get",
-                path=f"v1/marketplace/{marketplace}/product-listings",
-            )
-        except HTTPError as error:
-            if self.is_for_view:
-                raise UAContractsAPIErrorView(error)
-            else:
-                raise UAContractsAPIError(error)
-
-        if not self.convert_response:
-            return response.json()
-
-        return parse_product_listings(
-            response.json().get("productListings", []),
-            response.json().get("products", []),
+        response = self._request(
+            method="get",
+            path=f"v1/marketplace/{marketplace}/product-listings",
+            error_rules=["default"]
         )
+
+        if self.convert_response:
+            return parse_product_listings(
+                response.json().get("productListings", []),
+                response.json().get("products", []),
+            )
+
+        return response.json()
 
     def get_account_subscriptions(
         self, account_id: str, marketplace: str, filters=None
@@ -477,6 +448,19 @@ class UAContractsAPI:
             raise UAContractsAPIError(error)
 
         return response.json() if response.status_code != 200 else None
+
+    def handle_error(self, error, error_rules=[]):
+        status_code = error.response.status_code
+
+        if "auth" in error_rules and status_code == 401:
+            if self.is_for_view:
+                raise UAContractsAPIAuthErrorView(error)
+            raise UAContractsAPIAuthError(error)
+
+        if "default" in error_rules:
+            if self.is_for_view:
+                raise UAContractsAPIErrorView(error)
+            raise UAContractsAPIError(error)
 
 
 class UnauthorizedError(Exception):

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -1,5 +1,12 @@
 from requests.exceptions import HTTPError
 
+from webapp.advantage.ua_contracts.parsers import (
+    parse_contracts,
+    parse_subscriptions,
+    parse_product_listings,
+    parse_accounts,
+)
+
 
 class UAContractsAPI:
     def __init__(
@@ -9,6 +16,7 @@ class UAContractsAPI:
         token_type="Macaroon",
         api_url="https://contracts.canonical.com",
         is_for_view=False,
+        convert_response=False,
     ):
         """
         Expects a Talisker session in most circumstances,
@@ -20,6 +28,7 @@ class UAContractsAPI:
         self.token_type = token_type
         self.api_url = api_url.rstrip("/")
         self.is_for_view = is_for_view
+        self.convert_response = convert_response
 
     def _request(self, method, path, json=None, params=None):
         headers = {
@@ -55,7 +64,10 @@ class UAContractsAPI:
                 raise UAContractsAPIErrorView(error)
             raise UAContractsAPIError(error)
 
-        return response.json().get("accounts", [])
+        if not self.convert_response:
+            return response.json().get("accounts", [])
+
+        return parse_accounts(response.json().get("accounts", []))
 
     def get_account_contracts(self, account_id: str):
         try:
@@ -73,7 +85,10 @@ class UAContractsAPI:
 
             raise UAContractsAPIError(error)
 
-        return response.json().get("contracts", [])
+        if not self.convert_response:
+            return response.json().get("contracts", [])
+
+        return parse_contracts(response.json().get("contracts", []))
 
     def get_contract_token(self, contract_id: str):
         try:
@@ -228,7 +243,7 @@ class UAContractsAPI:
 
         return {}
 
-    def get_product_listings(self, marketplace: str) -> dict:
+    def get_product_listings(self, marketplace: str):
         try:
             response = self._request(
                 method="get",
@@ -240,11 +255,17 @@ class UAContractsAPI:
             else:
                 raise UAContractsAPIError(error)
 
-        return response.json()
+        if not self.convert_response:
+            return response.json()
+
+        return parse_product_listings(
+            response.json().get("productListings", []),
+            response.json().get("products", []),
+        )
 
     def get_account_subscriptions(
         self, account_id: str, marketplace: str, filters=None
-    ) -> dict:
+    ):
         if filters:
             filters = "&".join(
                 "{}={}".format(key, value) for key, value in filters.items()
@@ -271,7 +292,10 @@ class UAContractsAPI:
 
             raise UAContractsAPIError(error)
 
-        return response.json().get("subscriptions", [])
+        if not self.convert_response:
+            return response.json().get("subscriptions", [])
+
+        return parse_subscriptions(response.json().get("subscriptions", []))
 
     def get_account_purchases(self, account_id: str, filters=None) -> dict:
         if filters:

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -223,7 +223,7 @@ class UAContractsAPI:
         response = self._request(
             method="get",
             path=f"v1/marketplace/{marketplace}/product-listings",
-            error_rules=["default"]
+            error_rules=["default"],
         )
 
         if self.convert_response:
@@ -237,36 +237,29 @@ class UAContractsAPI:
     def get_account_subscriptions(
         self, account_id: str, marketplace: str, filters=None
     ):
+        url_filters = ""
         if filters:
             filters = "&".join(
                 "{}={}".format(key, value) for key, value in filters.items()
             )
+            url_filters = f"?{filters}"
 
-        try:
-            response = self._request(
-                method="get",
-                path=(
-                    f"v1/accounts/{account_id}"
-                    f"/marketplace/{marketplace}"
-                    f"/subscriptions?{filters}"
-                ),
-            )
-        except HTTPError as error:
-            if error.response.status_code == 401:
-                if self.is_for_view:
-                    raise UAContractsAPIAuthErrorView(error)
-                else:
-                    raise UAContractsAPIAuthError(error)
+        response = self._request(
+            method="get",
+            path=(
+                f"v1/accounts/{account_id}"
+                f"/marketplace/{marketplace}"
+                f"/subscriptions{url_filters}"
+            ),
+            error_rules=["default", "auth"],
+        )
 
-            if self.is_for_view:
-                raise UAContractsAPIErrorView(error)
+        subscriptions = response.json().get("subscriptions", [])
 
-            raise UAContractsAPIError(error)
+        if self.convert_response:
+            return parse_subscriptions(raw_subscriptions=subscriptions)
 
-        if not self.convert_response:
-            return response.json().get("subscriptions", [])
-
-        return parse_subscriptions(response.json().get("subscriptions", []))
+        return subscriptions
 
     def get_account_purchases(self, account_id: str, filters=None) -> dict:
         if filters:
@@ -449,7 +442,10 @@ class UAContractsAPI:
 
         return response.json() if response.status_code != 200 else None
 
-    def handle_error(self, error, error_rules=[]):
+    def handle_error(self, error, error_rules=None):
+        if not error_rules:
+            return
+
         status_code = error.response.status_code
 
         if "auth" in error_rules and status_code == 401:

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -1,7 +1,6 @@
 from typing import List, Dict
 
 from webapp.advantage.ua_contracts.primitives import (
-    Entitlement,
     Contract,
     ContractItem,
     Subscription,
@@ -9,7 +8,7 @@ from webapp.advantage.ua_contracts.primitives import (
     Product,
     Account,
 )
-from webapp.advantage.models import Listing
+from webapp.advantage.models import Listing, Entitlement
 
 
 def parse_product(raw_product: dict) -> Product:
@@ -32,7 +31,7 @@ def parse_product_listing(
         id=raw_product_listing.get("id"),
         name=raw_product_listing.get("name"),
         marketplace=raw_product_listing.get("marketplace"),
-        product=product,
+        product_name=product.name,
         price=raw_product_listing.get("price").get("value"),
         currency=raw_product_listing.get("price").get("currency"),
         status=raw_product_listing.get("status"),

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -19,21 +19,13 @@ def parse_product(raw_product: dict) -> Product:
     )
 
 
-def parse_products(raw_products: dict) -> List[Product]:
-    return [parse_product(product) for product in raw_products]
-
-
 def parse_product_listing(
     raw_product_listing: dict, raw_products: dict
 ) -> Listing:
     product = None
     for raw_product in raw_products:
-        if raw_product["id"] == raw_product_listing.get("productID"):
-            product = Product(
-                id=raw_product["id"],
-                name=raw_product.get("name"),
-            )
-
+        if raw_product.get("id") == raw_product_listing.get("productID"):
+            product = parse_product(raw_product)
             break
 
     return Listing(
@@ -50,14 +42,14 @@ def parse_product_listing(
 
 
 def parse_product_listings(
-    raw_product_listing: dict,
+    raw_product_listings: dict,
     raw_products: dict,
 ) -> Dict[str, Listing]:
     return {
         product_listing.get("id"): parse_product_listing(
             product_listing, raw_products
         )
-        for product_listing in raw_product_listing
+        for product_listing in raw_product_listings
     }
 
 
@@ -80,7 +72,7 @@ def parse_entitlements(raw_entitlements: dict) -> List[Entitlement]:
 
         support_level = None
         if affordances:
-            support_level = affordances.get("support_level")
+            support_level = affordances.get("supportLevel")
 
         entitlement = Entitlement(
             type=raw_entitlement.get("type"),
@@ -105,7 +97,7 @@ def parse_contract_items(raw_items: dict) -> List[ContractItem]:
             value=raw_item.get("value"),
             product_listing_id=raw_item.get("productListingID"),
             purchase_id=raw_item.get("purchaseID"),
-            trial_id=raw_item.get("trial_id"),
+            trial_id=raw_item.get("trialID"),
         )
 
         items.append(item)

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -1,7 +1,174 @@
-from typing import List
+from typing import List, Dict
 
-from webapp.advantage.ua_contracts.primitives import Contract
+from webapp.advantage.ua_contracts.primitives import (
+    Entitlement,
+    Contract,
+    ContractItem,
+    Subscription,
+    SubscriptionItem,
+    Product,
+    Account,
+)
+from webapp.advantage.models import Listing
+
+
+def parse_product(raw_product: dict) -> Product:
+    return Product(
+        id=raw_product.get("id"),
+        name=raw_product.get("name"),
+    )
+
+
+def parse_products(raw_products: dict) -> List[Product]:
+    return [parse_product(product) for product in raw_products]
+
+
+def parse_product_listing(
+    raw_product_listing: dict, raw_products: dict
+) -> Listing:
+    product = None
+    for raw_product in raw_products:
+        if raw_product["id"] == raw_product_listing.get("productID"):
+            product = Product(
+                id=raw_product["id"],
+                name=raw_product.get("name"),
+            )
+
+            break
+
+    return Listing(
+        id=raw_product_listing.get("id"),
+        name=raw_product_listing.get("name"),
+        marketplace=raw_product_listing.get("marketplace"),
+        product=product,
+        price=raw_product_listing.get("price").get("value"),
+        currency=raw_product_listing.get("price").get("currency"),
+        status=raw_product_listing.get("status"),
+        trial_days=raw_product_listing.get("trialDays"),
+        period=raw_product_listing.get("period"),
+    )
+
+
+def parse_product_listings(
+    raw_product_listing: dict,
+    raw_products: dict,
+) -> Dict[str, Listing]:
+    return {
+        product_listing.get("id"): parse_product_listing(
+            product_listing, raw_products
+        )
+        for product_listing in raw_product_listing
+    }
+
+
+def parse_account(raw_account: dict) -> Account:
+    return Account(
+        id=raw_account.get("id"),
+        name=raw_account.get("name"),
+    )
+
+
+def parse_accounts(raw_accounts: dict) -> List[Account]:
+    return [parse_account(raw_account) for raw_account in raw_accounts]
+
+
+def parse_entitlements(raw_entitlements: dict) -> List[Entitlement]:
+    entitlements = []
+    for raw_entitlement in raw_entitlements:
+        affordances = raw_entitlement.get("affordances")
+        obligations = raw_entitlement.get("obligations")
+
+        support_level = None
+        if affordances:
+            support_level = affordances.get("support_level")
+
+        entitlement = Entitlement(
+            type=raw_entitlement.get("type"),
+            support_level=support_level,
+            enabled_by_default=obligations.get("enableByDefault"),
+        )
+
+        entitlements.append(entitlement)
+
+    return entitlements
+
+
+def parse_contract_items(raw_items: dict) -> List[ContractItem]:
+    items = []
+    for raw_item in raw_items:
+        item = ContractItem(
+            contract_id=raw_item.get("contractID"),
+            created_at=raw_item.get("created"),
+            start_date=raw_item.get("effectiveFrom"),
+            end_date=raw_item.get("effectiveTo"),
+            reason=raw_item.get("reason"),
+            value=raw_item.get("value"),
+            product_listing_id=raw_item.get("productListingID"),
+            purchase_id=raw_item.get("purchaseID"),
+            trial_id=raw_item.get("trial_id"),
+        )
+
+        items.append(item)
+
+    return items
+
+
+def parse_contract(raw_contract: dict) -> Contract:
+    account_info = raw_contract.get("accountInfo")
+    contract_info = raw_contract.get("contractInfo")
+    raw_entitlements = contract_info.get("resourceEntitlements")
+    entitlements = parse_entitlements(raw_entitlements)
+    raw_items = contract_info.get("items")
+    items = parse_contract_items(raw_items)
+
+    return Contract(
+        id=contract_info.get("id"),
+        account_id=account_info.get("id"),
+        name=contract_info.get("name"),
+        product_id=contract_info.get("products")[0],
+        entitlements=entitlements,
+        items=items,
+    )
 
 
 def parse_contracts(raw_contracts: dict) -> List[Contract]:
-    pass
+    return [parse_contract(raw_contract) for raw_contract in raw_contracts]
+
+
+def parse_subscription_items(
+    subscription_id: str,
+    raw_items: dict,
+) -> List[SubscriptionItem]:
+    subscription_items = []
+    for raw_item in raw_items:
+        subscription_item = SubscriptionItem(
+            subscription_id=subscription_id,
+            product_listing_id=raw_item.get("productListing").get("id"),
+            value=raw_item.get("value"),
+        )
+
+        subscription_items.append(subscription_item)
+
+    return subscription_items
+
+
+def parse_subscription(raw_subscription: dict) -> Subscription:
+    subscription_id = raw_subscription.get("subscription").get("id")
+    raw_items = raw_subscription.get("purchasedProductListings")
+
+    return Subscription(
+        id=subscription_id,
+        account_id=raw_subscription.get("subscription").get("accountID"),
+        marketplace=raw_subscription.get("subscription").get("marketplace"),
+        period=raw_subscription.get("subscription").get("period"),
+        status=raw_subscription.get("subscription").get("status"),
+        last_purchase_id=raw_subscription.get("lastPurchaseID"),
+        items=parse_subscription_items(subscription_id, raw_items),
+    )
+
+
+def parse_subscriptions(raw_subscriptions: dict) -> List[Subscription]:
+    return [
+        parse_subscription(raw_subscription)
+        for raw_subscription in raw_subscriptions
+    ]

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -1,6 +1,16 @@
 from typing import List
 
-from webapp.advantage.models import Entitlement
+
+class Entitlement:
+    def __init__(
+        self,
+        type: str,
+        enabled_by_default: bool,
+        support_level: str = None,
+    ):
+        self.type = type
+        self.support_level = support_level
+        self.enabled_by_default = enabled_by_default
 
 
 class Product:
@@ -22,9 +32,9 @@ class ContractItem:
         end_date: str,
         reason: str,
         value: int,
-        product_listing_id: str,
-        purchase_id: str,
-        trial_id: str,
+        product_listing_id: str = None,
+        purchase_id: str = None,
+        trial_id: str = None,
     ):
         self.contract_id = contract_id
         self.created_at = created_at

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -1,16 +1,6 @@
 from typing import List
 
-
-class Entitlement:
-    def __init__(
-        self,
-        type: str,
-        enabled_by_default: bool,
-        support_level: str = None,
-    ):
-        self.type = type
-        self.support_level = support_level
-        self.enabled_by_default = enabled_by_default
+from webapp.advantage.models import Entitlement
 
 
 class Product:


### PR DESCRIPTION
## Done

Adding the parser functions to convert the API json responses to Objects and List of Objects. This conversion will happen only if the flag `convert_responses` is set to `true` when instantiating the `UAContractAPI` class.

Adding tests for each parser as well as adding tests for the changed api functions whose responses get parsed. Creating fixture files as a mock for each json response.

We have the following parsers:
- **parse_account**: Parses a single account json and converts it to an `Account` instance 
- **parse_accounts**: Parses an array of accounts json and converts it to a `List` of `Account` instances
- **parse_subscription_items** - Parses an array of purchased product listings of a subscription and returns a `List` of `SubscriptionItem` instances
- **parse_subscription** - Parses a single subscription json and converts it to a `Subscription` instance
- **parse_subscriptions** - Parses an array of subscriptions json and converts it to a `List` of `Subscription` instances
- **parse_product** - Parses a single product json and converts it to a `Product` instance
- **parse_product_listings** - Parses an array of product listings json and converts it to a `List` of `Listing` instances
- **parse_product_listing** - Parses a single product listing json and converts it to a `Listing` instance,
- **parse_entitlements** - Parses an array of entitlements json and converts it to a `List` of `Entitlement` instances
- **parse_contract_items** - Parses an array of contract items json and converts it to a `List` of `ContractItem` instances
- **parse_contract** - Parses a contract json and converts it to a `Contract` instance
- **parse_contracts**- Parses an array of contracts json and converts it to a `List` of `Contract` instances

## QA

- Are the test passing?


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/183
