### PR TITLE
Filter out CUBE contracts

### DIFF
--- a/webapp/advantage/api.py
+++ b/webapp/advantage/api.py
@@ -60,7 +60,11 @@ class UAContractsAPI:
     def get_account_contracts(self, account_id: str):
         try:
             response = self._request(
-                method="get", path=f"v1/accounts/{account_id}/contracts"
+                method="get",
+                path=(
+                    f"v1/accounts/{account_id}/contracts"
+                    f"?productTags=ua&productTags=classic&productTags=pro"
+                ),
             )
         except HTTPError as error:
             if error.response.status_code == 401:


### PR DESCRIPTION
## Done

- Filter out CUBE contracts form /advantage

## QA

- Login to https://ubuntu.com production
- Go to /advantage you will see the Canonical Staff account with lots of CUBE contracts
- Switch to the demo site: https://ubuntu-com-10214.demos.haus
- Go to /advantage you will not see the Canonical Staff account with any CUBE contracts


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/182
