### PR TITLE
Fix price preview recalculation 

### DIFF
--- a/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoForPurchasePreview.jsx
+++ b/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoForPurchasePreview.jsx
@@ -1,7 +1,7 @@
 import { useMutation } from "react-query";
 import { postCustomerInfoForPurchasePreview } from "../../../contracts-api";
 
-const usePostCustomerInfoAnon = () => {
+const usePostCustomerInfoForPurchasePreview = () => {
   const mutation = useMutation(async (formData) => {
     const {
       name,
@@ -22,28 +22,24 @@ const usePostCustomerInfoAnon = () => {
       state: country === "US" ? usState : caProvince,
     };
 
-    if (VATNumber) {
-      const res = await postCustomerInfoForPurchasePreview(
-        window.accountId,
-        name,
-        addressObject,
-        {
-          type: "eu_vat",
-          value: VATNumber,
-        }
-      );
-
-      if (res.errors) {
-        throw new Error(JSON.parse(res.errors).code);
+    const res = await postCustomerInfoForPurchasePreview(
+      window.accountId,
+      name,
+      addressObject,
+      {
+        type: "eu_vat",
+        value: VATNumber,
       }
+    );
 
-      return res;
+    if (res.errors) {
+      throw new Error(JSON.parse(res.errors).code);
     }
 
-    throw new Error("VAT is missing");
+    return res;
   });
 
   return mutation;
 };
 
-export default usePostCustomerInfoAnon;
+export default usePostCustomerInfoForPurchasePreview;

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -115,7 +115,9 @@ function PaymentMethodForm({ setCardValid }) {
   }, [values.country]);
 
   useEffect(() => {
-    checkVATDebounced(values);
+    if (vatCountries.includes(values.country) && values.VATNumber) {
+      checkVATDebounced(values);
+    }
   }, [values.country, values.VATNumber]);
 
   return (

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -25,14 +25,14 @@ import { getErrorMessage } from "../../../error-handler";
 import { Field, Form, useFormikContext } from "formik";
 import { useQueryClient } from "react-query";
 
-import usePostCustomerInfoAnon from "../APICalls/usePostCustomerInfoAnon";
+import usePostCustomerInfoForPurchasePreview from "../APICalls/usePostCustomerInfoForPurchasePreview";
 
 function PaymentMethodForm({ setCardValid }) {
   const { product, quantity } = useProduct();
   const { data: preview } = usePreview();
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
   const [cardFieldError, setCardFieldError] = useState(null);
-  const mutation = usePostCustomerInfoAnon();
+  const mutation = usePostCustomerInfoForPurchasePreview();
   const queryClient = useQueryClient();
 
   const { errors, touched, values, setTouched, setErrors } = useFormikContext();
@@ -92,9 +92,6 @@ function PaymentMethodForm({ setCardValid }) {
 
   const checkVAT = (formValues) => {
     mutation.mutate(formValues, {
-      onSuccess: () => {
-        queryClient.invalidateQueries("preview");
-      },
       onError: (error) => {
         if (error.message === "tax_id_invalid") {
           setErrors({
@@ -102,6 +99,9 @@ function PaymentMethodForm({ setCardValid }) {
               "That VAT number is invalid. Check the number and try again.",
           });
         }
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries("preview");
       },
     });
   };
@@ -115,9 +115,7 @@ function PaymentMethodForm({ setCardValid }) {
   }, [values.country]);
 
   useEffect(() => {
-    if (vatCountries.includes(values.country) && values.VATNumber) {
-      checkVATDebounced(values);
-    }
+    checkVATDebounced(values);
   }, [values.country, values.VATNumber]);
 
   return (


### PR DESCRIPTION
## Background
- the VAT error occurs because the [checkVAT function](https://github.com/canonical-web-and-design/ubuntu.com/blob/master/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx#L93-L119) that's calling the API is being called even when VAT is undefined (e.g. hasn't been entered by the user yet). 
![image](https://user-images.githubusercontent.com/7452681/130470077-daf7798f-3e58-4425-b3af-7dad297f8020.png)

## Done
  - invoke the checkVAT function only if a VAT country is selected and VAT is defined


## QA

- go to https://ubuntu-com-10215.demos.haus/advantage/subscribe?test_backend=true
- make sure you're logged in
- select "buy" and fill out the form
  - select United Kingdom as a country
  - enter incorrect VAT (any random string will do)
- you should see an error `Error: That VAT number is invalid. Check the number and try again.`
- enter a valid VAT (e.g. GB 123 1234 12 123)
- error should disappear
- there should be no `VAT is missing` errors in the console


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/176

