### PR TITLE
build /cpu-compatibility page

### DIFF
--- a/templates/cpu-compatibility/base_cpu-compatibility.html
+++ b/templates/cpu-compatibility/base_cpu-compatibility.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/cpu-compatibility/base_cpu-compatibility.html
+++ b/templates/cpu-compatibility/base_cpu-compatibility.html
@@ -1,6 +1,6 @@
 {% extends "templates/base.html" %}
 
-{% block meta_copydoc %}{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1T7BXK7-IjN9Rq_5C4PYTVGkuv5mxhIX7OeFTsY6pTKs/edit#{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}{% endblock %}

--- a/templates/cpu-compatibility/index.html
+++ b/templates/cpu-compatibility/index.html
@@ -1,0 +1,250 @@
+{% extends "cpu-compatibility/base_cpu-compatibility.html" %}
+
+{% block title %}CPU compatibility matrix for Ubuntu{% endblock %}
+
+{% block meta_description %}The Compatibility matrix for CPU hardware (Intel and AMD) for Ubuntu and OpenStack releases.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/16E0xMuCIrGRwGa1G0poDEil9zd_5UAWTpxFRiA8j-KU/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-7">
+        <h1>CPU compatibility matrix for Ubuntu</h1>
+        <p>The CPU compatibility matrix for Ubuntu and related products. The matrix shows which Ubuntu LTS version introduces an initial support for a given processor or chipset. Canonical recommends running the latest LTS release to take advantage of the full capabilities of a CPU.</p>
+    </div>
+  
+    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg",
+        alt="products hero ubuntu",
+        width=160,
+        height="160",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+
+  <div class="u-fixed-width" style="margin-top: 2rem;">
+    <table aria-label="Table of CPU compatibility matrix for Ubuntu">
+      <thead>
+        <tr>
+          <th>VENDOR</th>
+          <th>CPU FAMILY</th>
+          <th>CODE NAME</th>
+          <th class="u-align--right">INITIAL SUPPORT IN UBUNTU LTS</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="3">AMD</td>
+          <td>EPYC 7xx3</td>
+          <td>Milan (Zen 3)</td>
+          <td class="u-align--right">18.04.5</td>
+        </tr>
+        <tr style="border: none">
+          <td>EPYC 7xx2</td>
+          <td>Milan (Zen 2)</td>
+          <td class="u-align--right">16.04.5</td>
+        </tr>
+        <tr style="border: none">
+          <td>EPYC 7xx1</td>
+          <td>Milan (Zen 1)</td>
+          <td class="u-align--right">16.04.5</td>
+        </tr>
+        <tr>
+          <td rowspan="3">Intel</td>
+          <td>Xeon</td>
+          <td>Sapphire Rapids</td>
+          <td class="u-align--right">20.04.2</td>
+        </tr>
+        <tr style="border: none">
+          <td>Xeon</td>
+          <td>Ice Lake (SP)</td>
+          <td class="u-align--right">18.04</td>
+        </tr>
+        <tr style="border: none">
+          <td>Xeon</td>
+          <td>Cooper Lake</td>
+          <td class="u-align--right">18.04</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Supported OpenStack versions</h2>
+      <p>
+        OpenStack release cadence follows Ubuntu release cadence. This means that a new version of OpenStack is released twice a year: in April and in October. Those are shipped with new versions of Ubuntu, however, since Canonical recommends using Ubuntu LTS in production environments, new versions of OpenStack are also available on Ubuntu LTS version through the <a class="p-link--external" href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a>.
+      </p>
+      <p>The OpenStack support lifecycle on Ubuntu can be represented this way:</p>
+    </div>
+  </div>
+
+<div class="row">
+  <div class="col-10" style="overflow: auto;">
+    <div class="u-hide--small" id="openstack-eol"></div>
+    <table class="u-hide--medium u-hide--large">
+      <thead>
+        <tr>
+          <th>Release</th>
+          <th>Tech preview</th>
+          <th>Released</th>
+          <th>End of life</th>
+          <th>Extended customer support</th>
+          <th>Extended Security Maintenance (ESM)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>OpenStack Y LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2022</td>
+          <td>Apr 2027</td>
+          <td>&nbsp;</td>
+          <td>Apr 2032</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 22.04 LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2022</td>
+          <td>Apr 2027</td>
+          <td>&nbsp;</td>
+          <td>Apr 2032</td>
+        </tr>
+        <tr>
+          <td>OpenStack Y</td>
+          <td>&nbsp;</td>
+          <td>Apr 2022</td>
+          <td>Apr 2025</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Xena</td>
+          <td>&nbsp;</td>
+          <td>Oct 2021</td>
+          <td>Apr 2023</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack W</td>
+          <td>&nbsp;</td>
+          <td>Apr 2021</td>
+          <td>Oct 2022</td>
+          <td>Apr 2024</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Victoria</td>
+          <td>&nbsp;</td>
+          <td>Oct 2020</td>
+          <td>Apr 2022</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Ussuri LTS</td>
+          <td>Apr 2020</td>
+          <td>May 2020</td>
+          <td>Apr 2025</td>
+          <td>&nbsp;</td>
+          <td>Apr 2030</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 20.04 LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2020</td>
+          <td>Apr 2025</td>
+          <td>&nbsp;</td>
+          <td>Apr 2030</td>
+        </tr>
+        <tr>
+          <td>OpenStack Ussuri</td>
+          <td>Apr 2020</td>
+          <td>May 2020</td>
+          <td>Apr 2023</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Train</td>
+          <td>&nbsp;</td>
+          <td>Aug 2019</td>
+          <td>Feb 2021</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Stein</td>
+          <td>&nbsp;</td>
+          <td>Apr 2019</td>
+          <td>Oct 2020</td>
+          <td>Apr 2022</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Rocky</td>
+          <td>&nbsp;</td>
+          <td>Aug 2018</td>
+          <td>Feb 2020</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Queens LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2018</td>
+          <td>Apr 2023</td>
+          <td>&nbsp;</td>
+          <td>Apr 2028</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 18.04 LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2018</td>
+          <td>Apr 2023</td>
+          <td>&nbsp;</td>
+          <td>Apr 2028</td>
+        </tr>
+        <tr>
+          <td>OpenStack Queens</td>
+          <td>&nbsp;</td>
+          <td>Feb 2018</td>
+          <td>Apr 2021</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Mitaka LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2016</td>
+          <td>Apr 2021</td>
+          <td>&nbsp;</td>
+          <td>Apr 2024</td>
+        </tr>
+        <tr>
+          <td>Ubuntu 16.04 LTS</td>
+          <td>&nbsp;</td>
+          <td>Apr 2016</td>
+          <td>Apr 2021</td>
+          <td>&nbsp;</td>
+          <td>Apr 2024</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</section>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.5.0/d3.min.js" defer></script>
+<script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Created `/cpu-compatibility` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cpu-compatibility
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check page against [copy doc](https://docs.google.com/document/d/16E0xMuCIrGRwGa1G0poDEil9zd_5UAWTpxFRiA8j-KU/edit).
- Check against [design](https://app.zeplin.io/project/611fb1a83c7c1d56eaae1239)


## Issue / Card

Fixes [#4368](https://github.com/canonical-web-and-design/web-squad/issues/4368)

## Screenshots

<img width="1600" alt="CPU compatibility matrix for Ubuntu | Ubuntu (2021-08-23 14-46-44)" src="https://user-images.githubusercontent.com/57550290/130459406-c7335ba4-b4d7-4c75-b158-82f8517829f9.png">
