### PR TITLE
Add inclusive-naming workflow

### DIFF
--- a/.github/workflows/inclusive-naming.yml
+++ b/.github/workflows/inclusive-naming.yml
@@ -1,0 +1,10 @@
+name: Check Inclusive Language
+on: [issues, pull_request]
+jobs:
+  check-language:
+    runs-on: ubuntu-latest
+    steps:
+    - name: check-language
+      uses: petesfrench/inclusive-language-github-action@master
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Done

- Adds inclusive-naming.yml to github workflows. To check that no non-inclusive language is being used, such as 'whitelist'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the inclusive langauge action is working and flagging any non-inclusive language. Functionality of the action can be found in more detail [here](https://github.com/bencgreenberg/inclusive-language-github-action)

