### PR TITLE
Fix guest user vat calculation

### DIFF
--- a/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoForPurchasePreview.jsx
+++ b/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoForPurchasePreview.jsx
@@ -34,6 +34,8 @@ const usePostCustomerInfoForPurchasePreview = () => {
 
     if (res.errors) {
       throw new Error(JSON.parse(res.errors).code);
+    } else if (res.error) {
+      throw new Error(res.error);
     }
 
     return res;

--- a/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoForPurchasePreview.jsx
+++ b/static/js/src/advantage/subscribe/react/APICalls/usePostCustomerInfoForPurchasePreview.jsx
@@ -22,23 +22,31 @@ const usePostCustomerInfoForPurchasePreview = () => {
       state: country === "US" ? usState : caProvince,
     };
 
-    const res = await postCustomerInfoForPurchasePreview(
-      window.accountId,
-      name,
-      addressObject,
-      {
-        type: "eu_vat",
-        value: VATNumber,
+    if (window.accountId) {
+      const res = await postCustomerInfoForPurchasePreview(
+        window.accountId,
+        name,
+        addressObject,
+        {
+          type: "eu_vat",
+          value: VATNumber,
+        }
+      );
+
+      if (res.errors) {
+        let error = "";
+        try {
+          error = JSON.parse(res.errors).code;
+        } catch (e) {
+          error = res.errors;
+        }
+        throw new Error(error);
       }
-    );
 
-    if (res.errors) {
-      throw new Error(JSON.parse(res.errors).code);
-    } else if (res.error) {
-      throw new Error(res.error);
+      return res;
+    } else {
+      throw new Error("missing accountId");
     }
-
-    return res;
   });
 
   return mutation;

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -90,7 +90,7 @@ function PaymentMethodForm({ setCardValid }) {
     }
   }, [values.buyingFor]);
 
-  const checkVAT = (formValues) => {
+  const updateCustomerInfoForPurchasePreview = (formValues) => {
     mutation.mutate(formValues, {
       onError: (error) => {
         if (error.message === "tax_id_invalid") {
@@ -100,12 +100,15 @@ function PaymentMethodForm({ setCardValid }) {
           });
         }
       },
-      onSettled: () => {
+      onSuccess: () => {
         queryClient.invalidateQueries("preview");
       },
     });
   };
-  const checkVATDebounced = useMemo(() => debounce(checkVAT, 250), []);
+  const updateCustomerInfoForPurchasePreviewDebounced = useMemo(
+    () => debounce(updateCustomerInfoForPurchasePreview, 250),
+    []
+  );
 
   useEffect(() => {
     if (!vatCountries.includes(values.country)) {
@@ -115,7 +118,9 @@ function PaymentMethodForm({ setCardValid }) {
   }, [values.country]);
 
   useEffect(() => {
-    checkVATDebounced(values);
+    if (window.accountId) {
+      updateCustomerInfoForPurchasePreviewDebounced(values);
+    }
   }, [values.country, values.VATNumber]);
 
   return (


### PR DESCRIPTION
## Done
- ensure user has an account before updating the account

## Background
- currently the app is making a request to update the account for guest users (when `accountId` is undefined)
  - this causes `customer-info-anon`endpoint to throw an `unauthorised` error

## QA

- log out
- Go to https://ubuntu-com-10220.demos.haus/advantage/subscribe?test_backend=true
- make a selection and press "Buy now"
- verify `customer-info-anon` isn't being called before you press "Continue"
- Verify `customer-info` and `preview` are called after you press "Continue" and correct price is displayed


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/172
