### PR TITLE
Certified design fixes

### DIFF
--- a/static/sass/_pattern_certification-results.scss
+++ b/static/sass/_pattern_certification-results.scss
@@ -40,13 +40,6 @@
     }
   }
 
-  .p-certification-header {
-    font-size: 0.863rem;
-    font-weight: 400;
-    line-height: 1rem;
-    text-transform: uppercase;
-  }
-
   .p-results-per-page {
     max-width: 5.3rem;
     min-width: 5.3rem;

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -89,7 +89,7 @@
                 <li class="p-accordion__group--certified" id="vendor-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
+                      Vendor
                       <div class="p-round-chip u-hide">
                         <span class="p-chip__value" id="vendor-count">1</span>
                       </div>
@@ -112,12 +112,10 @@
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
+                      Certified Ubuntu release
                         <div class="p-round-chip u-hide">
                           <span class="p-chip__value" id="release-count">1</span>
                         </div>
-                        <br> release
-                      </span>
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
@@ -136,8 +134,8 @@
                 </li>
               </ul>
             </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
             <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
+            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
           </div>
         </nav>
       </div>

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -70,7 +70,7 @@
                 <li class="p-accordion__group--certified">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab1" aria-controls="tab1-section" aria-expanded="true">
-                      <span class="p-certification-header">Category</span>
+                      <span>Category</span>
                       <div class="p-round-chip u-hide">
                         <span class="p-chip__value" id="category-count"></span>
                       </div>
@@ -112,10 +112,11 @@
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      Certified Ubuntu release
+                      Certified Ubuntu
                         <div class="p-round-chip u-hide">
                           <span class="p-chip__value" id="release-count">1</span>
                         </div>
+                        release
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
@@ -133,9 +134,12 @@
                   </span>
                 </li>
               </ul>
+              <hr style="margin-bottom: 1rem;">
             </aside>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
+            <div class="u-align--right">
+              <button class="p-button--neutral p-update-results u-no-margin--right" onclick="return clearFilters()">Clear</button>
+              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
+            </div>
           </div>
         </nav>
       </div>
@@ -144,9 +148,9 @@
         <table class="p-certification-results">
           <thead>
             <tr>
-              <th><span class="p-certification-header">Vendor</span></th>
-              <th><span class="p-certification-header">Model</span></th>
-              <th><span class="p-certification-header">Category</span></th>
+              <th>Vendor</th>
+              <th>Model</th>
+              <th>Category</th>
             </tr>
           </thead>
           <tbody>

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -62,7 +62,7 @@
                 <li class="p-accordion__group--certified" id="vendor-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab2" aria-controls="tab2-section" aria-expanded="true">
-                      <span class="p-certification-header">Vendor</span>
+                      Vendor
                       <div class="p-round-chip u-hide">
                         <span class="p-chip__value" id="vendor-count">1</span>
                       </div>
@@ -87,12 +87,10 @@
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      <span class="p-certification-header">Certified Ubuntu
+                      Certified ubuntu release
                         <div class="p-round-chip u-hide">
                           <span class="p-chip__value" id="release-count">1</span>
                         </div>
-                        <br> release
-                      </span>
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
@@ -113,8 +111,8 @@
                 </li>
               </ul>
             </aside>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply filters</button>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear filters</button>
+            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear</button>
+            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
           </div>
         </nav>
       </div>

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -87,10 +87,11 @@
                 <li class="p-accordion__group--certified" id="version-section">
                   <div role="heading" aria-level="2">
                     <button type="button" class="p-accordion__tab u-no-padding--right" id="tab3" aria-controls="tab3-section" aria-expanded="true">
-                      Certified ubuntu release
+                      Certified ubuntu
                         <div class="p-round-chip u-hide">
                           <span class="p-chip__value" id="release-count">1</span>
                         </div>
+                        release
                     </button>
                   </div>
                   <hr class="u-no-margin--bottom">
@@ -110,9 +111,12 @@
                   {% endif %}
                 </li>
               </ul>
+              <hr style="margin-bottom: 1rem;">
             </aside>
-            <button class="p-button--neutral p-update-results" onclick="return clearFilters()">Clear</button>
-            <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
+            <div class="u-align--right">
+              <button class="p-button--neutral p-update-results u-no-margin--right" onclick="return clearFilters()">Clear</button>
+              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
+            </div>
           </div>
         </nav>
       </div>


### PR DESCRIPTION
## Done

Search results and category search results filters have applied the following changes:
- Adapted filter titles to what is in the Accordion pattern originally (or Navigation).
- "Apply" and "Clear" filter buttons positioning

Not done:
- The section titles have a hover state when closed but not when open - this is a Vanilla discussion as there is discrepancy among designers, so [issue](https://github.com/canonical-web-and-design/vanilla-framework/issues/3950) was created.
- Remove left padding from filter buttons - I believe there is a `u-no-padding-right` already.

## QA

- check https://ubuntu-com-10224.demos.haus/certified/desktops (or any other item on the top navigation, the code comes from the same file)
- See that the accordion titles fit the [Vanilla accordion pattern](https://vanillaframework.io/docs/patterns/accordion) 
- Check that Apply and Clear filter buttons are aligned
- **Design should also review** the new strips for /desktops, /laptops, /devices ... (navigation on top) against [design](https://app.zeplin.io/project/60c1ca887b99f18a380e57e9/screen/60f169f46ff9dc0dccf77cc0)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4315
