### PR TITLE
Fix vat number prefill on payment form

### DIFF
--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -41,7 +41,7 @@ const getUserInfoFromVariables = (data, variables) => {
         expMonth: data.paymentMethod.exp_month,
         expYear: data.paymentMethod.exp_year,
       },
-      taxID: { value: variables.VATNumber.value },
+      taxID: { value: variables.VATNumber },
     },
     accountInfo: {
       name: variables.organisationName,

--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -21,33 +21,7 @@ import { getErrorMessage } from "../../error-handler";
 import usePreview from "./APICalls/usePreview";
 import { checkoutEvent, purchaseEvent } from "../../ecom-events";
 import { getSessionData } from "../../../utils/getSessionData";
-
-const getUserInfoFromVariables = (data, variables) => {
-  return {
-    customerInfo: {
-      email: variables.email,
-      name: variables.name,
-      address: {
-        line1: variables.address,
-        postal_code: variables.postalCode,
-        country: variables.country,
-        city: variables.city,
-        state:
-          variables.country === "US" ? variables.usState : variables.caProvince,
-      },
-      defaultPaymentMethod: {
-        brand: data.paymentMethod.brand,
-        last4: data.paymentMethod.last4,
-        expMonth: data.paymentMethod.exp_month,
-        expYear: data.paymentMethod.exp_year,
-      },
-      taxID: { value: variables.VATNumber },
-    },
-    accountInfo: {
-      name: variables.organisationName,
-    },
-  };
-};
+import { getUserInfoFromVariables, getInitialFormValues } from "./utils/utils";
 
 const PurchaseModal = () => {
   const [error, setError] = useState(null);
@@ -74,22 +48,7 @@ const PurchaseModal = () => {
   const paymentMethodMutation = registerPaymentMethod();
   const purchaseMutation = usePurchase();
 
-  const initialValues = {
-    email: userInfo?.customerInfo?.email ?? "",
-    name: userInfo?.customerInfo?.name ?? "",
-    buyingFor:
-      !window.accountId || userInfo?.accountInfo?.name
-        ? "organisation"
-        : "myself",
-    organisationName: userInfo?.accountInfo?.name ?? "",
-    address: userInfo?.customerInfo?.address?.line1 ?? "",
-    postalCode: userInfo?.customerInfo?.address?.postal_code ?? "",
-    country: userInfo?.customerInfo?.address?.country ?? "",
-    city: userInfo?.customerInfo?.address?.city ?? "",
-    usState: userInfo?.customerInfo?.address?.state ?? "",
-    caProvince: userInfo?.customerInfo?.address?.state ?? "",
-    VATNumber: userInfo?.customerInfo?.taxID?.value ?? "",
-  };
+  const initialValues = getInitialFormValues(userInfo, window.accountId);
 
   useEffect(() => {
     if (userInfo?.customerInfo?.defaultPaymentMethod) {

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -1,0 +1,87 @@
+import { PaymentMethod, PaymentMethodCreateParams } from "@stripe/stripe-js";
+
+interface DefaultPaymentMethod {
+  brand: PaymentMethod.Card["brand"];
+  last4: PaymentMethod.Card["last4"];
+  expMonth: PaymentMethod.Card["exp_month"];
+  expYear: PaymentMethod.Card["exp_year"];
+}
+
+interface CustomerInfo extends PaymentMethodCreateParams.BillingDetails {
+  defaultPaymentMethod: DefaultPaymentMethod;
+  taxID: { value?: string };
+}
+
+interface UserInfo {
+  customerInfo: CustomerInfo;
+  accountInfo: {
+    name?: string;
+  };
+}
+
+interface Data {
+  paymentMethod: PaymentMethod.Card;
+}
+
+interface FormValues {
+  email?: string;
+  name?: string;
+  buyingFor?: "organisation" | "myself";
+  organisationName?: string;
+  address?: string;
+  postalCode?: string;
+  country?: string;
+  city?: string;
+  usState?: string;
+  caProvince?: string;
+  VATNumber?: string;
+}
+
+function getUserInfoFromVariables(data: Data, variables: FormValues): UserInfo {
+  return {
+    customerInfo: {
+      email: variables.email,
+      name: variables.name,
+      address: {
+        line1: variables.address,
+        postal_code: variables.postalCode,
+        country: variables.country,
+        city: variables.city,
+        state:
+          variables.country === "US" ? variables.usState : variables.caProvince,
+      },
+      defaultPaymentMethod: {
+        brand: data.paymentMethod.brand,
+        last4: data.paymentMethod.last4,
+        expMonth: data.paymentMethod.exp_month,
+        expYear: data.paymentMethod.exp_year,
+      },
+      taxID: { value: variables.VATNumber },
+    },
+    accountInfo: {
+      name: variables.organisationName,
+    },
+  };
+}
+
+function getInitialFormValues(
+  userInfo: UserInfo,
+  accountId?: string
+): FormValues {
+  return {
+    email: userInfo?.customerInfo?.email ?? "",
+    name: userInfo?.customerInfo?.name ?? "",
+    buyingFor:
+      !accountId || userInfo?.accountInfo?.name ? "organisation" : "myself",
+    organisationName: userInfo?.accountInfo?.name ?? "",
+    address: userInfo?.customerInfo?.address?.line1 ?? "",
+    postalCode: userInfo?.customerInfo?.address?.postal_code ?? "",
+    country: userInfo?.customerInfo?.address?.country ?? "",
+    city: userInfo?.customerInfo?.address?.city ?? "",
+    usState: userInfo?.customerInfo?.address?.state ?? "",
+    caProvince: userInfo?.customerInfo?.address?.state ?? "",
+    VATNumber: userInfo?.customerInfo?.taxID?.value ?? "",
+  };
+}
+
+export { getUserInfoFromVariables, getInitialFormValues };


### PR DESCRIPTION
## Done

- Fixed vat number prefill on payment form
  - replaced `variables.VATNumber.value` with `variables.VATNumber` 
  - added type annotations that will prevent similar issue
![image](https://user-images.githubusercontent.com/7452681/130802320-8b0cdc26-378e-40b3-9b52-d0b58e61cc2b.png)

### Note
It's best to review commit-by-commit.
This commit contains the acutal bugfix: https://github.com/canonical-web-and-design/ubuntu.com/commit/c39cb04695ec3a595c888feef65e940d5c1da8c2

## QA

**Logged in user:**
- make sure you're logged in and have entered a VAT number before
- go to /advantage/subscribe?test_backend=true
- click "Buy now"
- click "Change..."
- VAT number should be prefilled with a value that you used previously on this account

**Logged out (guest) user:**
- go to /advantage/subscribe?test_backend=true
- click "Buy now"
- fill out the form (including VAT number)
- click "Continue"
- click "Change..."
- VAT number should still be prefilled

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/173

## Screenshots

### After (logged in user flow)

https://user-images.githubusercontent.com/7452681/130802064-c0f1b608-2801-44ba-b79c-4039e3998a67.mp4


