### PR TITLE
use certified category pages instead of search

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -104,7 +104,7 @@
         </li>
         {% endfor %}
       </ul>
-      <p><a href="/certified?category=Laptop" class="p-button--positive">See all</a></p>
+      <p><a href="/certified/laptops" class="p-button--positive">See all</a></p>
     </div>
   </div>
   <div class="row u-equal-height">
@@ -130,7 +130,7 @@
         </li>
         {% endfor %}
       </ul>
-      <p><a href="/certified?category=Server" class="p-button--positive">See all</a></p>
+      <p><a href="/certified/servers" class="p-button--positive">See all</a></p>
     </div>
     <div class="col-6 p-card">
       {{ image (
@@ -154,7 +154,7 @@
         </li>
         {% endfor %}
       </ul>
-      <p><a href="/certified?category=Device" class="p-button--positive">See all</a></p>
+      <p><a href="/certified/devices" class="p-button--positive">See all</a></p>
     </div>
   </div>
   <div class="row">
@@ -180,7 +180,7 @@
         </li>
         {% endfor %}
       </ul>
-      <p><a href="/certified?category=SoC" class="p-button--positive">See all</a></p>
+      <p><a href="/certified/socs" class="p-button--positive">See all</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
'See all' for each category should go to the category's landing page rather than a generic category search.

## QA

- Visit https://ubuntu-com-10241.demos.haus/certified
- Click on each 'See all' for each category and verify that it goes to each category's landing page rather than performing a search.
