### PR TITLE
Reduce redundant API calls on /advantage/subscribe page

### DIFF
--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -158,7 +158,7 @@ const PurchaseModal = () => {
         setStep(2);
         queryClient.setQueryData(
           "userInfo",
-          getUserInfoFromVariables(variables, data)
+          getUserInfoFromVariables(data, variables)
         );
         queryClient.invalidateQueries("preview");
 

--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -158,7 +158,7 @@ const PurchaseModal = () => {
         setStep(2);
         queryClient.setQueryData(
           "userInfo",
-          getUserInfoFromVariables(data, variables)
+          getUserInfoFromVariables(variables, data)
         );
         queryClient.invalidateQueries("preview");
 

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -30,10 +30,10 @@ import usePostCustomerInfoForPurchasePreview from "../APICalls/usePostCustomerIn
 function PaymentMethodForm({ setCardValid }) {
   const { product, quantity } = useProduct();
   const { data: preview } = usePreview();
+  const queryClient = useQueryClient();
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
   const [cardFieldError, setCardFieldError] = useState(null);
-  const mutation = usePostCustomerInfoForPurchasePreview();
-  const queryClient = useQueryClient();
+  const customerInfoForPreviewMutation = usePostCustomerInfoForPurchasePreview();
 
   const { errors, touched, values, setTouched, setErrors } = useFormikContext();
 
@@ -91,7 +91,7 @@ function PaymentMethodForm({ setCardValid }) {
   }, [values.buyingFor]);
 
   const updateCustomerInfoForPurchasePreview = (formValues) => {
-    mutation.mutate(formValues, {
+    customerInfoForPreviewMutation.mutate(formValues, {
       onError: (error) => {
         if (error.message === "tax_id_invalid") {
           setErrors({
@@ -118,7 +118,12 @@ function PaymentMethodForm({ setCardValid }) {
   }, [values.country]);
 
   useEffect(() => {
-    if (window.accountId) {
+    const userInfo = queryClient.getQueryData("userInfo");
+    const shouldUpdatePreview =
+      userInfo?.customerInfo?.taxID.value !== values?.VATNumber ||
+      userInfo?.customerInfo?.address?.country !== values?.country;
+
+    if (window.accountId && shouldUpdatePreview) {
       updateCustomerInfoForPurchasePreviewDebounced(values);
     }
   }, [values.country, values.VATNumber]);

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -31,10 +31,10 @@ import { getUserInfoFromVariables } from "../utils/utils";
 function PaymentMethodForm({ setCardValid }) {
   const { product, quantity } = useProduct();
   const { data: preview } = usePreview();
-  const queryClient = useQueryClient();
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
   const [cardFieldError, setCardFieldError] = useState(null);
   const customerInfoForPreviewMutation = usePostCustomerInfoForPurchasePreview();
+  const queryClient = useQueryClient();
 
   const { errors, touched, values, setTouched, setErrors } = useFormikContext();
 
@@ -104,7 +104,7 @@ function PaymentMethodForm({ setCardValid }) {
       onSuccess: () => {
         queryClient.setQueryData(
           "userInfo",
-          getUserInfoFromVariables(variables)
+          getUserInfoFromVariables(undefined, variables)
         );
         queryClient.invalidateQueries("preview");
       },

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -26,6 +26,7 @@ import { Field, Form, useFormikContext } from "formik";
 import { useQueryClient } from "react-query";
 
 import usePostCustomerInfoForPurchasePreview from "../APICalls/usePostCustomerInfoForPurchasePreview";
+import { getUserInfoFromVariables } from "../utils/utils";
 
 function PaymentMethodForm({ setCardValid }) {
   const { product, quantity } = useProduct();
@@ -101,6 +102,10 @@ function PaymentMethodForm({ setCardValid }) {
         }
       },
       onSuccess: () => {
+        queryClient.setQueryData(
+          "userInfo",
+          getUserInfoFromVariables(variables)
+        );
         queryClient.invalidateQueries("preview");
       },
     });

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -37,7 +37,7 @@ interface FormValues {
   VATNumber?: string;
 }
 
-function getUserInfoFromVariables(data: Data, variables: FormValues): UserInfo {
+function getUserInfoFromVariables(variables: FormValues, data: Data): UserInfo {
   return {
     customerInfo: {
       email: variables.email,
@@ -51,10 +51,10 @@ function getUserInfoFromVariables(data: Data, variables: FormValues): UserInfo {
           variables.country === "US" ? variables.usState : variables.caProvince,
       },
       defaultPaymentMethod: {
-        brand: data.paymentMethod.brand,
-        last4: data.paymentMethod.last4,
-        expMonth: data.paymentMethod.exp_month,
-        expYear: data.paymentMethod.exp_year,
+        brand: data?.paymentMethod?.brand,
+        last4: data?.paymentMethod?.last4,
+        expMonth: data?.paymentMethod?.exp_month,
+        expYear: data?.paymentMethod?.exp_year,
       },
       taxID: { value: variables.VATNumber },
     },

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -37,7 +37,7 @@ interface FormValues {
   VATNumber?: string;
 }
 
-function getUserInfoFromVariables(variables: FormValues, data: Data): UserInfo {
+function getUserInfoFromVariables(data: Data, variables: FormValues): UserInfo {
   return {
     customerInfo: {
       email: variables.email,


### PR DESCRIPTION
## Done

- Reduce redundant API calls on /advantage/subscribe page
  - I have never used react-query before so if there's a better way of doing this please let me know!

## QA

- go to https://ubuntu-com-10242.demos.haus/advantage/subscribe?test_backend=true
- proceed to the 2nd step in the purchase modal
- go back by pressing "Change..."
- verify that no call to `customer-info-anon` has been made
- change the VAT number or country
- verify that there's been a call to `customer-info-anon` and price has been updated to reflect the changes

