### PR TITLE
Only display the edit or cancel modal.

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { shallow } from "enzyme";
 
 import SubscriptionDetails from "./SubscriptionDetails";
+import SubscriptionEdit from "../SubscriptionEdit";
 
 describe("SubscriptionDetails", () => {
   it("initially shows the content", () => {
@@ -41,5 +42,17 @@ describe("SubscriptionDetails", () => {
     );
     wrapper.find(".p-modal__close").simulate("click");
     expect(onCloseModal).toHaveBeenCalled();
+  });
+
+  it("does not set the modal to active when the cancel modal is visible", () => {
+    const onCloseModal = jest.fn();
+    const wrapper = shallow(
+      <SubscriptionDetails modalActive={true} onCloseModal={onCloseModal} />
+    );
+    // Open the edit modal:
+    wrapper.find("[data-test='edit-button']").simulate("click");
+    expect(wrapper.hasClass("is-active")).toBe(true);
+    wrapper.find(SubscriptionEdit).invoke("setShowingCancel")(true);
+    expect(wrapper.hasClass("is-active")).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -12,10 +12,13 @@ type Props = {
 
 const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
   const [editing, setEditing] = useState(false);
+  const [showingCancel, setShowingCancel] = useState(false);
   return (
     <div
       className={classNames("p-modal p-subscriptions__details", {
-        "is-active": modalActive,
+        // Don't show the modal as active when the cancel modal is visible so
+        // that we don't have two modals on top of each other.
+        "is-active": modalActive && !showingCancel,
       })}
     >
       <section className="p-modal__dialog">
@@ -45,7 +48,10 @@ const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
           </Button>
         </div>
         {editing ? (
-          <SubscriptionEdit onClose={() => setEditing(false)} />
+          <SubscriptionEdit
+            setShowingCancel={setShowingCancel}
+            onClose={() => setEditing(false)}
+          />
         ) : (
           <DetailsContent />
         )}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
@@ -5,12 +5,20 @@ import SubscriptionEdit from "./SubscriptionEdit";
 
 describe("SubscriptionEdit", () => {
   it("initially hides the cancel modal", () => {
-    const wrapper = shallow(<SubscriptionEdit onClose={jest.fn()} />);
+    const wrapper = shallow(
+      <SubscriptionEdit onClose={jest.fn()} setShowingCancel={jest.fn()} />
+    );
     expect(wrapper.find("SubscriptionCancel").exists()).toBe(false);
   });
 
   it("can show the cancel modal", async () => {
-    const wrapper = mount(<SubscriptionEdit onClose={jest.fn()} />);
+    const setShowingCancel = jest.fn();
+    const wrapper = mount(
+      <SubscriptionEdit
+        onClose={jest.fn()}
+        setShowingCancel={setShowingCancel}
+      />
+    );
     // The portal currently requires a fake event, this should be able to be
     // removed when this issue is resolved:
     // https://github.com/alex-cory/react-useportal/issues/36
@@ -19,5 +27,6 @@ describe("SubscriptionEdit", () => {
       .find("Button[data-test='cancel-button']")
       .simulate("click", fakeEvent);
     expect(wrapper.find("SubscriptionCancel").exists()).toBe(true);
+    expect(setShowingCancel).toHaveBeenCalledWith(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -1,5 +1,5 @@
 import { ActionButton, Button } from "@canonical/react-components";
-import React from "react";
+import React, { useCallback } from "react";
 import usePortal from "react-useportal";
 import { Formik } from "formik";
 
@@ -7,11 +7,29 @@ import SubscriptionCancel from "../SubscriptionCancel";
 import FormikField from "../../FormikField";
 
 type Props = {
+  setShowingCancel: (showingCancel: boolean) => void;
   onClose: () => void;
 };
 
-const SubscriptionEdit = ({ onClose }: Props) => {
+const SubscriptionEdit = ({ setShowingCancel, onClose }: Props) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
+  const showPortal = useCallback(
+    (show: boolean) => {
+      // Programatically opening portals currently has an unresolved issue so we
+      // need to provide a fake event:
+      // https://github.com/alex-cory/react-useportal/issues/36
+      const NULL_EVENT = { currentTarget: { contains: () => false } };
+      if (show) {
+        openPortal(NULL_EVENT);
+      } else {
+        closePortal(NULL_EVENT);
+      }
+      setShowingCancel(show);
+    },
+    [setShowingCancel]
+  );
+
   return (
     <>
       <Formik
@@ -59,13 +77,13 @@ const SubscriptionEdit = ({ onClose }: Props) => {
             <Button
               appearance="link"
               data-test="cancel-button"
-              onClick={openPortal}
+              onClick={() => showPortal(true)}
             >
               You can cancel this subscription online or contact us.
             </Button>
             {isOpen && (
               <Portal>
-                <SubscriptionCancel onClose={closePortal} />
+                <SubscriptionCancel onClose={() => showPortal(false)} />
               </Portal>
             )}
           </>


### PR DESCRIPTION
## Done

- Don't display the cancel and edit modals on top of each other.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10247.demos.haus/advantage?test_backend=true).
- Resize down to mobile.
- Click on a subscription.
- Click the 'Edit subscription...' button.
- Click the 'You can cancel this subscription online or contact us.' link.
- There shouldn't be stacked portals (you can kind of see this by the transparency of the page overlay not getting darker).


## Issue / Card

Fixes #207.
