### PR TITLE
Adapt the resize form for the mobile view.

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -25,7 +25,7 @@ const generateFeatures = (features: Feature[]) =>
 
 const DetailsContent = () => {
   return (
-    <>
+    <div>
       <Row className="u-sv4">
         {generateFeatures([
           {
@@ -68,7 +68,7 @@ const DetailsContent = () => {
         className="u-sv4 u-no-margin--bottom"
       />
       <DetailsTabs />
-    </>
+    </div>
   );
 };
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -22,13 +22,13 @@ const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
       })}
     >
       <section className="p-modal__dialog">
-        <header className="p-modal__header">
-          <h2 className="p-modal__title">UA Infra Essential (Virtual)</h2>
-          <button className="p-modal__close" onClick={() => onCloseModal()}>
-            Close
-          </button>
-        </header>
         <div className="u-sv2">
+          <header className="p-modal__header">
+            <h2 className="p-modal__title">UA Infra Essential (Virtual)</h2>
+            <button className="p-modal__close" onClick={() => onCloseModal()}>
+              Close
+            </button>
+          </header>
           <Button
             appearance="positive"
             data-test="cancel-button"

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -43,52 +43,65 @@ const SubscriptionEdit = ({ setShowingCancel, onClose }: Props) => {
         }}
       >
         {({ handleSubmit }) => (
-          <>
-            <div className="u-sv3">
-              <hr />
-            </div>
-            <form className="u-sv2" onSubmit={handleSubmit}>
+          <form className="p-subscription__edit" onSubmit={handleSubmit}>
+            <div className="u-sv2">
+              <div className="u-sv3 u-hide--small">
+                <hr />
+              </div>
               <h5>Resize subscription</h5>
-              <div className="u-sv3">
-                <FormikField
-                  className="p-subscription__resize"
-                  help={
-                    <>
-                      You can resize your subscriptions to as many machines as
-                      needed.
-                      <br />
-                      Your next billing period will reflect the changes
-                      accordingly.
-                    </>
-                  }
-                  label="Number of machines"
-                  name="size"
-                  type="number"
-                />
-              </div>
-              <div className="u-align--right">
-                <Button appearance="base" onClick={onClose} type="button">
-                  Cancel
-                </Button>
-                <ActionButton appearance="positive">Resize</ActionButton>
-              </div>
-            </form>
-            <hr />
-            <Button
-              appearance="link"
-              data-test="cancel-button"
-              onClick={() => showPortal(true)}
-            >
-              You can cancel this subscription online or contact us.
-            </Button>
-            {isOpen && (
-              <Portal>
-                <SubscriptionCancel onClose={() => showPortal(false)} />
-              </Portal>
-            )}
-          </>
+              <FormikField
+                className="p-subscription__resize"
+                help={
+                  <>
+                    You can resize your subscriptions to as many machines as
+                    needed.
+                    <br />
+                    Your next billing period will reflect the changes
+                    accordingly.
+                  </>
+                }
+                label="Number of machines"
+                name="size"
+                type="number"
+                wrapperClassName="u-sv3"
+              />
+            </div>
+            <div className="p-subscription__resize-actions u-align--right u-sv3">
+              <Button
+                appearance="base"
+                className="p-subscription__resize-action"
+                onClick={onClose}
+                type="button"
+              >
+                Cancel
+              </Button>
+              <ActionButton
+                appearance="positive"
+                className="p-subscription__resize-action"
+              >
+                Resize
+              </ActionButton>
+            </div>
+            <div>
+              <hr />
+              <Button
+                appearance="link"
+                className="u-align-text--left"
+                data-test="cancel-button"
+                onClick={() => showPortal(true)}
+                type="button"
+              >
+                You can cancel this subscription online or contact us.
+              </Button>
+            </div>
+          </form>
         )}
       </Formik>
+      {isOpen && (
+        <Portal>
+          <SubscriptionCancel onClose={() => showPortal(false)} />
+        </Portal>
+      )}
     </>
   );
 };

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -90,6 +90,47 @@
       // Show the modal when the details are active.
       &.is-active {
         display: flex;
+
+        .p-modal__dialog {
+          display: grid;
+          // Make the modal content take up the full height.
+          grid-template-rows: auto 1fr;
+        }
+
+        .p-subscription__edit {
+          display: grid;
+          grid-template-areas:
+            "header"
+            "content"
+            "footer";
+          // Push the modal actions to the bottom of the modal.
+          grid-template-rows: auto auto 1fr;
+
+          .p-subscription__resize-actions {
+            // Move the actions down to the bottom of the container.
+            align-self: end;
+            border-top: 1px solid $colors--light-theme--border-default;
+            column-gap: $sp-medium;
+            display: grid;
+            // Move the actions down to the footer area.
+            grid-area: footer;
+            // Make the buttons side-by-side instead of stacked.
+            grid-template-columns: 1fr 1fr;
+            padding-top: $sp-medium;
+
+            &::after {
+              // Remove the extra space that was needed when the buttons were in
+              // the content area.
+              display: none;
+            }
+          }
+
+          .p-subscription__resize-action {
+            // Remove the button margin from the buttons that was needed when
+            // they were in the content area.
+            margin-bottom: 0;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Done

- Adapt the resize form for the mobile view.
- Update the details HTML structure to support the mobile resize form.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10248.demos.haus/advantage?test_backend=true)
- Resize your browser down to mobile size.
- Click on a subscription.
- Click on the 'Edit subscription...' button.
- Check that the modal appears like [the design](https://app.zeplin.io/project/60ec5fb4e07cc90fbbf2b318/screen/60f82e36b24ad91391e16c44).


## Issue / Card

Fixes canonical-web-and-design/commercial-squad#147.

## Screenshots

<img width="400" alt="Screen Shot 2021-08-30 at 12 53 16 pm" src="https://user-images.githubusercontent.com/361637/131278523-8056b7ed-2f31-4b95-95e4-4cbc4f2e5997.png">

