### PR TITLE
Add trial information to header of product selecto

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -25,6 +25,7 @@
       {% else %}
         <h1>Add machines to your subscription</h1>
       {% endif %}
+        <h2 class="p-heading--3">Evaluate Ubuntu Advantage with your first month free on all subscriptions</h2>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Added a subtitle to let users know about free trials
- Copy coming from this doc https://miro.com/app/board/o9J_lSky0cQ=/

## QA

- go to https://ubuntu-com-10249.demos.haus/advantage/subscribe
- check that there is a subtitle letting you know about a first month free

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/165

## Screenshots

Logged in
![2021-08-30_11-47](https://user-images.githubusercontent.com/11927929/131320978-ae4f9d1d-0822-4391-afff-17367644b04a.png)

logged out
![2021-08-30_11-48](https://user-images.githubusercontent.com/11927929/131321060-d96d7338-a118-4319-be4f-18e30cbfb43d.png)

