### PR TITLE
Add trial label to sticky footer on the product selector

### DIFF
--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -170,6 +170,9 @@ function renderSummary(state) {
     // if the selection matches a product we populate the 'cart' section and show it
     const image = summarySection.querySelector("#summary-plan-image");
     const title = summarySection.querySelector("#summary-plan-name");
+    const freeTrialLabel = summarySection.querySelector(
+      "#summary-free-trial-label"
+    );
     const costElement = summarySection.querySelector(".js-summary-cost");
     const quantityElement = summarySection.querySelector(
       "#summary-plan-quantity"
@@ -180,6 +183,11 @@ function renderSummary(state) {
     quantityElement.innerHTML = `${quantity}x`;
     image.setAttribute("src", imgUrl[type]);
     title.innerHTML = state.product.name;
+    if (state.product.canBeTrialled) {
+      freeTrialLabel.classList.remove("u-hide");
+    } else {
+      freeTrialLabel.classList.add("u-hide");
+    }
     costElement.innerHTML = `${formatter.format((price / 100) * quantity)} / ${
       billing === "monthly" ? "month" : "year"
     }`;

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -12,10 +12,21 @@
       display: flex;
       flex-wrap: wrap;
 
+      > .p-label {
+        align-self: center;
+        margin-top: 0.5rem;
+        margin-left: 0.5rem;
+      }
+
       @media (min-width: $breakpoint-x-small) {
         flex-wrap: nowrap;
         > div {
           margin-left: 2.5rem;
+        }
+        > .p-label {
+          align-self: flex-start;
+          margin-top: calc(0.4rem - 1px);
+          margin-left: 1rem;
         }
       }
 

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -12,8 +12,9 @@
       display: flex;
       flex-wrap: wrap;
 
-      > .p-label {
-        align-self: center;
+      .p-shop-cart__label {
+        display: flex;
+        align-items: center;
         margin-top: 0.5rem;
         margin-left: 0.5rem;
       }
@@ -23,8 +24,10 @@
         > div {
           margin-left: 2.5rem;
         }
-        > .p-label {
-          align-self: flex-start;
+
+        .p-shop-cart__label {
+          display: flex;
+          align-items: flex-start;
           margin-top: calc(0.4rem - 1px);
           margin-left: 1rem;
         }

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -90,6 +90,7 @@
             <strong>Switch to annual billing and save over 15%</strong>
           </p>
         </div>
+        <div id="summary-free-trial-label" class="p-label">1 month free trial</div>
       </div>
       <div class="col-4 p-shop-cart__buy">
         <span>

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -90,7 +90,9 @@
             <strong>Switch to annual billing and save over 15%</strong>
           </p>
         </div>
-        <div id="summary-free-trial-label" class="p-label">1 month free trial</div>
+        <div id="summary-free-trial-label" class="p-shop-cart__label">
+          <div class="p-label">1 month free trial</div>
+        </div>
       </div>
       <div class="col-4 p-shop-cart__buy">
         <span>


### PR DESCRIPTION
## Done

- added free trial label for eligible products

## QA

:warning: *The free trial backend is not yet implemented in the target branch so, it will never show* :warning: 

- Go on https://ubuntu-com-10250.demos.haus/advantage/subscribe?test_backend=true logged out
- Select any annual product
- you should see a grey tag on the bottom summary telling you you're eligible for 1month free trial

## Issue / Card

Fixes #canonical-web-and-design/commercial-squad/issues/166

## Screenshots

![2021-08-30_12-13](https://user-images.githubusercontent.com/11927929/131324105-b3460000-7d7b-4ed1-9351-3245caa52490.png)

