### PR TITLE
Updated copy title and contact link for CUBE /faq

### DIFF
--- a/templates/cube/faq.html
+++ b/templates/cube/faq.html
@@ -9,7 +9,7 @@
 <div class="p-strip">
   <div class="row">
     <div class="col-12">
-      <h1>CUBE FAQ</h1>
+      <h1>CUBE Frequently asked questions</h1>
       <hr class="p-separator">
     </div>
   <div>
@@ -60,7 +60,7 @@
       <h3 id="authentic-badges">How will people know my badges are authentic?</h3>
       <p>Each badge contains unique metadata that is recorded when the badge is issued. This metadata proves that the badge comes from Canonical, and that this particular badge was awarded to one and only one individual.</p>
       <h2>What if my question is not answered here?</h2>
-      <p>If your question is not solved by any of these FAQ items, please open a ticket in the <a class="p-link--external" href="https://support.canonical.com/cube">Support Portal</a> describing your issue.</p>
+      <p>If your question is not solved by any of these FAQ items, please open a ticket in the <a class="p-link--external" href="http://portal.support.canonical.com/cube">Support Portal</a> describing your issue.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updated copy title and contact link for CUBE /faq per:
https://docs.google.com/document/d/1tDByDnXmf6QnpvtzxrX3JsgNYuBZbv1Bx7o6mGnbzSg/edit#heading=h.g1eby6bz6419

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/faq
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4388

## Screenshots

[If relevant, please include a screenshot.]
