### PR TITLE
updated copy and images on /public-cloud page

### DIFF
--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -44,12 +44,12 @@
       <p><a class="p-link--external" href="https://jujucharms.com/">Learn more about Juju</a></p>
     </div>
     <div class="col-6 p-divider__block">
-      <h2 class="p-heading--three">The best management and&nbsp;support</h2>
+      <h2 class="p-heading--three">Trusted Container (OCI) Images</h2>
       <div class="u-hide--small u-align--center u-sv1">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/434e177d-cloud-landscape-chart.jpg",
-            alt="Landscape managing 913 machines screenshot",
+            url="https://assets.ubuntu.com/v1/fcb97fce-canonical-on-amazon-ecr.png",
+            alt="Canonical on Amazon screenshot",
             height="208",
             width="371",
             hi_def=True,
@@ -57,8 +57,8 @@
           ) | safe
         }}
       </div>
-      <p>The Ubuntu Advantage support service has flexible Ubuntu Virtual Guest options, designed for virtualised enterprise workloads on Ubuntu-certified public clouds. Thanks to Landscape, efficient management of all your Ubuntu instances is only a few clicks away. And with the Canonical Livepatch Service, you can apply critical kernel patches without rebooting.</p>
-      <p><a href="/support">Find out all about support&nbsp;&rsaquo;</a></p>
+      <p>The provenance of base and application images is critical for security. While tooling like Docker makes retrieving and running images trivial, ensuring a trusted software supply chain is required. A simple way to get started is by using our hardened repositories. We maintain a set of stable & secure (LTS) tracks for application, runtime, and base container images. Get the best of the Ubuntu developer experience and commercial commitments for enterprise containers.</p>
+      <p><a href="/support">Explore Canonical's LTS Docker Images Portfolio&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -66,14 +66,14 @@
 <section class="p-strip--light is-bordered">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-5">
-      <h2>Developers' favourite</h2>
-      <p>Ubuntu is the most popular Linux distribution for development and deployment. If your developers already use Ubuntu, moving to the cloud is even easier. </p>
-      <p><a href="/desktop/developers">Learn more about Ubuntu for developers&nbsp;&rsaquo;</a></p>
+      <h2>Managed Applications</h2>
+      <p>Accelerate innovation across clouds with fully managed Apache Kafka, Kubeflow, ElasticSearch and more. We build and operate the solution for you, backed by a full SLA. With Canonical’s managed open source application services there’s no lock in and you can take over control whenever you want.</p>
+      <p><a href="/desktop/developers">Learn more about Canonical Managed Apps&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-7 u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/b3061ad7-laptop-dev.png",
+          url="https://assets.ubuntu.com/v1/8961ce5a-managed-apps-kafka-osm-mysql-kubeflow-influxdb-mariadb-cassandra-postgresql-grafana.png",
           alt="",
           height="298",
           width="500",

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -58,7 +58,7 @@
         }}
       </div>
       <p>The provenance of base and application images is critical for security. While tooling like Docker makes retrieving and running images trivial, ensuring a trusted software supply chain is required. A simple way to get started is by using our hardened repositories. We maintain a set of stable & secure (LTS) tracks for application, runtime, and base container images. Get the best of the Ubuntu developer experience and commercial commitments for enterprise containers.</p>
-      <p><a href="/support">Explore Canonical's LTS Docker Images Portfolio&nbsp;&rsaquo;</a></p>
+      <p><a href="/security/docker-images">Explore Canonical's LTS Docker Images Portfolio&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/public-cloud/index.html
+++ b/templates/public-cloud/index.html
@@ -67,7 +67,7 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-5">
       <h2>Managed Applications</h2>
-      <p>Accelerate innovation across clouds with fully managed Apache Kafka, Kubeflow, ElasticSearch and more. We build and operate the solution for you, backed by a full SLA. With Canonical’s managed open source application services there’s no lock in and you can take over control whenever you want.</p>
+      <p>Accelerate innovation across clouds with fully managed Apache Kafka, Kubeflow, ElasticSearch and more. We build and operate the solution for you, backed by a full SLA. With Canonical's managed open source application services there's no lock in and you can take over control whenever you want.</p>
       <p><a href="/desktop/developers">Learn more about Canonical Managed Apps&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-7 u-hide--small u-align--center">


### PR DESCRIPTION
## Done

Updated copy and replaced needed images on /public-cloud-page per : 
https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit#

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/public-cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4389

## Screenshots

[If relevant, please include a screenshot.]
<img width="816" alt="Screenshot 2021-08-30 at 14 52 16" src="https://user-images.githubusercontent.com/17607612/131342700-594dc402-9f94-4a2c-a934-2d7967a99bf7.png">

