### PR TITLE
Display free token data from the new API

### DIFF
--- a/static/js/src/advantage/api/enum.ts
+++ b/static/js/src/advantage/api/enum.ts
@@ -1,19 +1,27 @@
 export enum SupportLevel {
-  NONE = "n/a",
-  ESSENTIAL = "essential",
-  STANDARD = "standard",
-  ADVANCED = "advanced",
+  None = "n/a",
+  Essential = "essential",
+  Standard = "standard",
+  Advanced = "advanced",
 }
 
 export enum EntitlementType {
-  BLENDER = "blender",
-  CC_EAL = "cc-eal",
-  CIS = "cis",
-  ESM_APPS = "esm-apps",
-  ESM_INFRA = "esm-infra",
-  FIPS_UPDATES = "fips-updates",
-  FIPS = "fips",
-  LIVEPATCH_ONPREM = "livepatch-onprem",
-  LIVEPATCH = "livepatch",
-  SUPPORT = "support",
+  Blender = "blender",
+  CcEal = "cc-eal",
+  Cis = "cis",
+  EsmApps = "esm-apps",
+  EsmInfra = "esm-infra",
+  FipsUpdates = "fips-updates",
+  Fips = "fips",
+  LivepatchOnprem = "livepatch-onprem",
+  Livepatch = "livepatch",
+  Support = "support",
+}
+
+export enum UserSubscriptionType {
+  Free = "free",
+  Yearly = "yearly",
+  Monthly = "monthly",
+  Trial = "trial",
+  Legacy = "legacy",
 }

--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -3,6 +3,7 @@ import {
   AccountInfo,
   GetContractTokenResponse,
 } from "./contracts-types";
+import { EntitlementType, SupportLevel, UserSubscriptionType } from "./enum";
 
 export type ContractToken = GetContractTokenResponse["contractToken"];
 
@@ -21,8 +22,8 @@ export type UsingTestBackend = boolean;
 
 export type UserSubscriptionEntitlement = {
   enabled_by_default: boolean;
-  support_level: "essential" | "advanced" | "standard" | null;
-  type: string;
+  support_level: SupportLevel | null;
+  type: EntitlementType | string;
 };
 
 export type UserSubscriptionStatuses = {
@@ -36,14 +37,6 @@ export type UserSubscriptionStatuses = {
   is_trialled: boolean;
   is_upsizeable: boolean;
 };
-
-export enum UserSubscriptionType {
-  Free = "free",
-  Yearly = "yearly",
-  Monthly = "monthly",
-  Trial = "trial",
-  Legacy = "legacy",
-}
 
 export type UserSubscription = {
   account_id: string;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -7,10 +7,9 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import classNames from "classnames";
-import { UserSubscriptionType } from "advantage/api/types";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import { selectFreeSubscription } from "advantage/react/hooks/useUserSubscriptions";
-import { formatDate } from "advantage/react/utils";
+import { formatDate, isFreeSubscription } from "advantage/react/utils";
 import React, { ReactNode } from "react";
 
 import DetailsTabs from "../DetailsTabs";
@@ -37,10 +36,12 @@ const generateFeatures = (features: Feature[]) =>
 
 const DetailsContent = () => {
   const { data: subscription, isLoading } = useUserSubscriptions({
-    // TODO: Get the selected subscription once the subscription token is available.
+    // TODO: Get the selected subscription once the subscription token is
+    // available.
+    // https://github.com/canonical-web-and-design/commercial-squad/issues/210
     select: selectFreeSubscription,
   });
-  const isFreeSubscription = subscription?.type === UserSubscriptionType.Free;
+  const isFree = isFreeSubscription(subscription);
   if (isLoading || !subscription) {
     return <Spinner />;
   }
@@ -54,16 +55,16 @@ const DetailsContent = () => {
           },
           {
             title: "Expires",
-            value: isFreeSubscription ? "Never" : null,
+            value: isFree ? "Never" : null,
           },
           {
             size: 2,
             title: "Billing",
-            value: isFreeSubscription ? "None" : null,
+            value: isFree ? "None" : null,
           },
           {
             title: "Cost",
-            value: isFreeSubscription ? "Free" : null,
+            value: isFree ? "Free" : null,
           },
           {
             title: "Machine type",

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -5,8 +5,8 @@ import classNames from "classnames";
 import DetailsContent from "./DetailsContent";
 import SubscriptionEdit from "../SubscriptionEdit";
 import { useUserSubscriptions } from "advantage/react/hooks";
-import { UserSubscriptionType } from "advantage/api/types";
 import { selectFreeSubscription } from "advantage/react/hooks/useUserSubscriptions";
+import { isFreeSubscription } from "advantage/react/utils";
 
 type Props = {
   modalActive?: boolean;
@@ -17,10 +17,12 @@ const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
   const [editing, setEditing] = useState(false);
   const [showingCancel, setShowingCancel] = useState(false);
   const { data: subscription, isLoading } = useUserSubscriptions({
-    // TODO: Get the selected subscription once the subscription token is available.
+    // TODO: Get the selected subscription once the subscription token is
+    // available.
+    // https://github.com/canonical-web-and-design/commercial-squad/issues/210
     select: selectFreeSubscription,
   });
-  const isFreeSubscription = subscription?.type === UserSubscriptionType.Free;
+  const isFree = isFreeSubscription(subscription);
   if (isLoading || !subscription) {
     return <Spinner />;
   }
@@ -36,15 +38,13 @@ const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
         <div className="u-sv2">
           <header className="p-modal__header">
             <h2 className="p-modal__title">
-              {isFreeSubscription
-                ? "Free Personal Token"
-                : subscription.product_name}
+              {isFree ? "Free Personal Token" : subscription.product_name}
             </h2>
             <button className="p-modal__close" onClick={() => onCloseModal()}>
               Close
             </button>
           </header>
-          {isFreeSubscription ? null : (
+          {isFree ? null : (
             <>
               <Button
                 appearance="positive"

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.test.tsx
@@ -1,34 +1,58 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import ListCard from "./ListCard";
+import { UserSubscription } from "advantage/api/types";
+import {
+  freeSubscriptionFactory,
+  userSubscriptionEntitlementFactory,
+} from "advantage/tests/factories/api";
+import { EntitlementType, SupportLevel } from "advantage/api/enum";
 
 describe("ListCard", () => {
-  it("renders", () => {
-    const wrapper = shallow(
-      <ListCard
-        created="12.02.2021"
-        expires="23.04.2022"
-        features={["ESM Infra", "livepatch", "24/5 support"]}
-        machines={10}
-        label="Annual"
-        onClick={jest.fn()}
-        title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-      />
+  let freeSubscription: UserSubscription;
+
+  beforeEach(async () => {
+    freeSubscription = freeSubscriptionFactory.build();
+  });
+
+  it("can render a free subscription", () => {
+    freeSubscription = freeSubscriptionFactory.build({
+      entitlements: [
+        userSubscriptionEntitlementFactory.build({
+          type: EntitlementType.Livepatch,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          support_level: SupportLevel.Advanced,
+          type: EntitlementType.Support,
+        }),
+      ],
+      number_of_machines: 2,
+      start_date: "2021-07-09T07:14:56Z",
+    });
+    const wrapper = mount(
+      <ListCard subscription={freeSubscription} onClick={jest.fn()} />
     );
-    expect(wrapper.find("Card").exists()).toBe(true);
+    expect(wrapper.find("[data-test='card-title']").text()).toBe(
+      "Free Personal Token"
+    );
+    expect(wrapper.find("[data-test='card-type']").text()).toBe("free");
+    expect(wrapper.find("[data-test='card-machines']").text()).toBe("2");
+    expect(wrapper.find("[data-test='card-start-date']").text()).toBe(
+      "09.07.2021"
+    );
+    expect(wrapper.find("[data-test='card-end-date']").text()).toBe("Never");
+    expect(wrapper.find("List[data-test='card-entitlements']").text()).toBe(
+      "Livepatch24/7 Support"
+    );
   });
 
   it("can be marked as selected", () => {
     const wrapper = shallow(
       <ListCard
-        created="12.02.2021"
-        features={["ESM Infra", "livepatch", "24/5 support"]}
+        subscription={freeSubscription}
         isSelected={true}
-        machines={10}
-        label="Annual"
         onClick={jest.fn()}
-        title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
       />
     );
     expect(wrapper.find("Card").hasClass("is-active")).toBe(true);
@@ -38,13 +62,9 @@ describe("ListCard", () => {
     const onClick = jest.fn();
     const wrapper = shallow(
       <ListCard
-        created="12.02.2021"
-        features={["ESM Infra", "livepatch", "24/5 support"]}
+        subscription={freeSubscription}
         isSelected={true}
-        machines={10}
-        label="Annual"
         onClick={onClick}
-        title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
       />
     );
     wrapper.find("Card").simulate("click");

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -1,72 +1,77 @@
 import { Card, Col, List, Row } from "@canonical/react-components";
 import React from "react";
-import { format, parseJSON } from "date-fns";
 import classNames from "classnames";
-import { makeInteractiveProps } from "advantage/react/utils";
+import {
+  formatDate,
+  getFeaturesDisplay,
+  isFreeSubscription,
+  makeInteractiveProps,
+} from "advantage/react/utils";
+import { UserSubscription } from "advantage/api/types";
 
 type Props = {
-  created: string;
-  expires?: string | null;
-  features: string[];
   isSelected?: boolean;
-  label: string;
-  machines: number;
   onClick: () => void;
-  title: string;
-};
-
-const DATE_FORMAT = "dd.MM.yyyy";
-
-const formatDate = (date: string) => {
-  try {
-    return format(parseJSON(date), DATE_FORMAT);
-  } catch (error) {
-    return date;
-  }
+  subscription: UserSubscription;
 };
 
 const ListCard = ({
-  created,
-  expires,
-  features,
   isSelected,
-  machines,
-  label,
   onClick,
-  title,
-}: Props): JSX.Element => (
-  <Card
-    className={classNames("p-subscriptions__list-card", {
-      "is-active": isSelected,
-    })}
-    {...makeInteractiveProps(onClick)}
-  >
-    <div className="p-subscriptions__list-card-title">
-      <h5 className="u-no-padding--top u-no-margin--bottom">{title}</h5>
-      <span className="p-text--x-small-capitalised u-text--muted p-subscriptions__list-card-period">
-        {label}
-      </span>
-    </div>
-    <Row>
-      <Col medium={3} size={3} small={1}>
-        <p className="u-text--muted u-no-margin--bottom">Machines</p>
-        {machines}
-      </Col>
-      <Col medium={3} size={4} small={1}>
-        <p className="u-text--muted u-no-margin--bottom">Created</p>
-        {formatDate(created)}
-      </Col>
-      <Col medium={3} size={4} small={1}>
-        <p className="u-text--muted u-no-margin--bottom">Expires</p>
-        {expires ? formatDate(expires) : "Never"}
-      </Col>
-    </Row>
-    <List
-      className="p-subscriptions__list-card-features p-text--x-small-capitalised u-text--muted u-no-margin--bottom"
-      inline
-      items={features}
-    />
-  </Card>
-);
+  subscription,
+}: Props): JSX.Element => {
+  const isFree = isFreeSubscription(subscription);
+  return (
+    <Card
+      className={classNames("p-subscriptions__list-card", {
+        "is-active": isSelected,
+      })}
+      {...makeInteractiveProps(onClick)}
+    >
+      <div className="p-subscriptions__list-card-title">
+        <h5
+          className="u-no-padding--top u-no-margin--bottom"
+          data-test="card-title"
+        >
+          {isFree ? "Free Personal Token" : subscription.product_name}
+        </h5>
+        <span
+          className="p-text--x-small-capitalised u-text--muted p-subscriptions__list-card-period"
+          data-test="card-type"
+        >
+          {subscription.type}
+        </span>
+      </div>
+      <Row>
+        <Col medium={3} size={3} small={1}>
+          <p className="u-text--muted u-no-margin--bottom">Machines</p>
+          <span data-test="card-machines">
+            {subscription.number_of_machines}
+          </span>
+        </Col>
+        <Col medium={3} size={4} small={1}>
+          <p className="u-text--muted u-no-margin--bottom">Created</p>
+          <span data-test="card-start-date">
+            {formatDate(subscription.start_date)}
+          </span>
+        </Col>
+        <Col medium={3} size={4} small={1}>
+          <p className="u-text--muted u-no-margin--bottom">Expires</p>
+          <span data-test="card-end-date">
+            {subscription.end_date
+              ? formatDate(subscription.end_date)
+              : "Never"}
+          </span>
+        </Col>
+      </Row>
+      <List
+        className="p-subscriptions__list-card-features p-text--x-small-capitalised u-text--muted u-no-margin--bottom"
+        data-test="card-entitlements"
+        inline
+        items={getFeaturesDisplay(subscription.entitlements).included}
+      />
+    </Card>
+  );
+};
 
 export default ListCard;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -3,37 +3,20 @@ import { mount } from "enzyme";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 import SubscriptionList from "./SubscriptionList";
-import {
-  contractWithTokenFactory,
-  personalAccountFactory,
-} from "advantage/tests/factories/api";
-import {
-  contractInfoFactory,
-  contractItemFactory,
-  entitlementSupportFactory,
-} from "advantage/tests/factories/contracts";
+import { freeSubscriptionFactory } from "advantage/tests/factories/api";
+import { UserSubscription } from "advantage/api/types";
 
 describe("SubscriptionList", () => {
+  let queryClient: QueryClient;
+  let freeSubscription: UserSubscription;
+
+  beforeEach(async () => {
+    queryClient = new QueryClient();
+    freeSubscription = freeSubscriptionFactory.build();
+    queryClient.setQueryData("userSubscriptions", [freeSubscription]);
+  });
+
   it("displays a free token", () => {
-    const personalAccount = personalAccountFactory.build({
-      contracts: [
-        contractWithTokenFactory.build({
-          contractInfo: contractInfoFactory.build({
-            items: [
-              contractItemFactory.build({
-                metric: "units",
-                value: 2,
-              }),
-            ],
-            resourceEntitlements: [entitlementSupportFactory.build()],
-          }),
-          token: "free-token",
-        }),
-      ],
-      free_token: "free-token",
-    });
-    const queryClient = new QueryClient();
-    queryClient.setQueryData("personalAccount", personalAccount);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <SubscriptionList onSetActive={jest.fn()} />
@@ -41,23 +24,10 @@ describe("SubscriptionList", () => {
     );
     const token = wrapper.find("[data-test='free-token']");
     expect(token.exists()).toBe(true);
-    expect(token.prop("created")).toBe(personalAccount.createdAt);
-    expect(token.prop("expires")).toBe(null);
-    expect(token.prop("features")).toStrictEqual(["24/5 Support"]);
-    expect(token.prop("machines")).toBe(2);
+    expect(token.prop("subscription")).toStrictEqual(freeSubscription);
   });
 
   it("can display the free token as selected", () => {
-    const personalAccount = personalAccountFactory.build({
-      contracts: [
-        contractWithTokenFactory.build({
-          token: "free-token",
-        }),
-      ],
-      free_token: "free-token",
-    });
-    const queryClient = new QueryClient();
-    queryClient.setQueryData("personalAccount", personalAccount);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <SubscriptionList selectedToken="free-token" onSetActive={jest.fn()} />

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,7 +1,6 @@
-import type { PersonalAccount } from "advantage/api/types";
-import { usePersonalAccount } from "advantage/react/hooks";
-import { selectFreeContract } from "advantage/react/hooks/usePersonalAccount";
-import { getFeaturesDisplay } from "advantage/react/utils";
+import { Spinner } from "@canonical/react-components";
+import { useUserSubscriptions } from "advantage/react/hooks";
+import { selectFreeSubscription } from "advantage/react/hooks/useUserSubscriptions";
 import React from "react";
 import { SelectedToken } from "../Content/types";
 
@@ -13,64 +12,43 @@ type Props = {
   onSetActive: (token: SelectedToken) => void;
 };
 
-/**
- * Get the data to display in the card for the free token.
- */
-const getFreeContractData = (
-  freeContract?: PersonalAccount["contracts"][0] | null
-) => {
-  if (!freeContract) {
-    return null;
-  }
-  const { contractInfo } = freeContract;
-  const machines =
-    contractInfo.items?.find(({ metric }) => metric === "units")?.value || 0;
-  return {
-    created: contractInfo.createdAt,
-    expires: null,
-    features: getFeaturesDisplay(contractInfo),
-    machines,
-  };
-};
-
 const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
-  const { data: freeContractData } = usePersonalAccount({
-    select: selectFreeContract,
+  const {
+    data: freeSubscription,
+    isLoading: isLoadingFree,
+  } = useUserSubscriptions({
+    select: selectFreeSubscription,
   });
-  const freeContract = getFreeContractData(freeContractData);
+  if (isLoadingFree || !freeSubscription) {
+    return <Spinner />;
+  }
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">
         <ListGroup title="Ubuntu Advantage">
           <ListCard
-            created="2021-07-09T07:14:56Z"
-            expires="2021-07-09T07:14:56Z"
-            features={["ESM Infra", "livepatch", "24/5 support"]}
             isSelected={selectedToken === "ua-sub-123"}
-            label="Annual"
-            machines={10}
             onClick={() => {
               onSetActive("ua-sub-123");
             }}
-            title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+            subscription={freeSubscription}
           />
         </ListGroup>
-        {freeContract ? (
+        {freeSubscription ? (
           <ListGroup title="Free personal token">
             <ListCard
-              created={freeContract.created}
               data-test="free-token"
-              expires={freeContract.expires}
-              features={freeContract.features.included}
-              isSelected={selectedToken === freeContractData?.token}
-              label="Free"
-              machines={freeContract.machines}
+              isSelected={
+                // TODO: update this to use the sub token when it is available.
+                // https://github.com/canonical-web-and-design/commercial-squad/issues/210
+                selectedToken === "free-token"
+              }
               onClick={() => {
-                if (freeContractData?.token) {
-                  onSetActive(freeContractData.token);
-                }
+                // TODO: update this to use the sub token when it is available.
+                // https://github.com/canonical-web-and-design/commercial-squad/issues/210
+                onSetActive("free-token");
               }}
-              title="Free Personal Token"
+              subscription={freeSubscription}
             />
           </ListGroup>
         ) : null}

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -1,5 +1,6 @@
 import { getUserSubscriptions } from "advantage/api/contracts";
-import { UserSubscription, UserSubscriptionType } from "advantage/api/types";
+import { UserSubscriptionType } from "advantage/api/enum";
+import { UserSubscription } from "advantage/api/types";
 import { useQuery, UseQueryOptions } from "react-query";
 
 /**

--- a/static/js/src/advantage/react/utils/formatDate.ts
+++ b/static/js/src/advantage/react/utils/formatDate.ts
@@ -2,7 +2,7 @@ import { format, parseJSON } from "date-fns";
 
 const DATE_FORMAT = "dd.MM.yyyy";
 
-export const formatDate = (date: string | Date, dateFormat = DATE_FORMAT) => {
+export const formatDate = (date: Date, dateFormat = DATE_FORMAT) => {
   try {
     return format(parseJSON(date), dateFormat);
   } catch (error) {

--- a/static/js/src/advantage/react/utils/getFeaturesDisplay.test.ts
+++ b/static/js/src/advantage/react/utils/getFeaturesDisplay.test.ts
@@ -1,105 +1,96 @@
 import { EntitlementType, SupportLevel } from "advantage/api/enum";
-import {
-  affordancesSupportFactory,
-  contractInfoFactory,
-  entitlementFactory,
-  entitlementSupportFactory,
-} from "advantage/tests/factories/contracts";
+import { userSubscriptionEntitlementFactory } from "advantage/tests/factories/api";
 import { getFeaturesDisplay } from "./getFeaturesDisplay";
 
 describe("getFeaturesDisplay", () => {
   it("generates display labels for features", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [
-        entitlementFactory.build({ type: EntitlementType.LIVEPATCH }),
-        entitlementSupportFactory.build({
-          affordances: affordancesSupportFactory.build({
-            supportLevel: SupportLevel.ADVANCED,
-          }),
-        }),
-      ],
-    });
-    expect(getFeaturesDisplay(contractInfo)).toStrictEqual({
+    const entitlements = [
+      userSubscriptionEntitlementFactory.build({
+        type: EntitlementType.Livepatch,
+      }),
+      userSubscriptionEntitlementFactory.build({
+        support_level: SupportLevel.Advanced,
+        type: EntitlementType.Support,
+      }),
+      userSubscriptionEntitlementFactory.build({
+        enabled_by_default: false,
+        type: EntitlementType.Blender,
+      }),
+      userSubscriptionEntitlementFactory.build({
+        enabled_by_default: false,
+        type: EntitlementType.EsmApps,
+      }),
+      userSubscriptionEntitlementFactory.build({
+        enabled_by_default: false,
+        type: EntitlementType.EsmInfra,
+      }),
+    ];
+    expect(getFeaturesDisplay(entitlements)).toStrictEqual({
       excluded: ["Blender", "ESM Apps", "ESM Infra"],
       included: ["Livepatch", "24/7 Support"],
     });
   });
 
   it("dedupes livepatch labels", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [
-        entitlementFactory.build({ type: EntitlementType.LIVEPATCH }),
-        entitlementFactory.build({ type: EntitlementType.LIVEPATCH_ONPREM }),
-      ],
-    });
-    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([
+    const entitlements = [
+      userSubscriptionEntitlementFactory.build({
+        type: EntitlementType.Livepatch,
+      }),
+      userSubscriptionEntitlementFactory.build({
+        type: EntitlementType.LivepatchOnprem,
+      }),
+    ];
+    expect(getFeaturesDisplay(entitlements).included).toStrictEqual([
       "Livepatch",
     ]);
   });
 
   it("ignores some labels", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [
-        entitlementFactory.build({ type: EntitlementType.CC_EAL }),
-        entitlementFactory.build({ type: EntitlementType.CIS }),
-        entitlementFactory.build({ type: EntitlementType.FIPS_UPDATES }),
-        entitlementFactory.build({ type: EntitlementType.FIPS }),
-      ],
-    });
-    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([]);
+    const entitlements = [
+      userSubscriptionEntitlementFactory.build({ type: EntitlementType.CcEal }),
+      userSubscriptionEntitlementFactory.build({ type: EntitlementType.Cis }),
+      userSubscriptionEntitlementFactory.build({
+        type: EntitlementType.FipsUpdates,
+      }),
+      userSubscriptionEntitlementFactory.build({ type: EntitlementType.Fips }),
+    ];
+    expect(getFeaturesDisplay(entitlements).included).toStrictEqual([]);
   });
 
   it("handles advanced support label", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [
-        entitlementSupportFactory.build({
-          affordances: affordancesSupportFactory.build({
-            supportLevel: SupportLevel.ADVANCED,
-          }),
-        }),
-      ],
-    });
-    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([
+    const entitlements = [
+      userSubscriptionEntitlementFactory.build({
+        support_level: SupportLevel.Advanced,
+        type: EntitlementType.Support,
+      }),
+    ];
+    expect(getFeaturesDisplay(entitlements).included).toStrictEqual([
       "24/7 Support",
     ]);
   });
 
   it("handles standard support label", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [
-        entitlementSupportFactory.build({
-          affordances: affordancesSupportFactory.build({
-            supportLevel: SupportLevel.STANDARD,
-          }),
-        }),
-      ],
-    });
-    expect(getFeaturesDisplay(contractInfo).included).toStrictEqual([
+    const entitlements = [
+      userSubscriptionEntitlementFactory.build({
+        support_level: SupportLevel.Standard,
+        type: EntitlementType.Support,
+      }),
+    ];
+    expect(getFeaturesDisplay(entitlements).included).toStrictEqual([
       "24/5 Support",
     ]);
   });
 
   it("handles excluded support labels", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [],
-    });
-    expect(getFeaturesDisplay(contractInfo).excluded.includes("Support")).toBe(
-      true
-    );
-  });
-
-  it("does not show excluded support label if a support affordance exists", () => {
-    const contractInfo = contractInfoFactory.build({
-      resourceEntitlements: [
-        entitlementSupportFactory.build({
-          affordances: affordancesSupportFactory.build({
-            supportLevel: SupportLevel.STANDARD,
-          }),
-        }),
-      ],
-    });
-    expect(getFeaturesDisplay(contractInfo).excluded.includes("Support")).toBe(
-      false
-    );
+    const entitlements = [
+      userSubscriptionEntitlementFactory.build({
+        support_level: SupportLevel.Standard,
+        type: EntitlementType.Support,
+        enabled_by_default: false,
+      }),
+    ];
+    expect(
+      getFeaturesDisplay(entitlements).excluded.includes("24/5 Support")
+    ).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/utils/getFeaturesDisplay.ts
+++ b/static/js/src/advantage/react/utils/getFeaturesDisplay.ts
@@ -1,126 +1,52 @@
-import type { ContractInfo } from "advantage/api/contracts-types";
 import { EntitlementType, SupportLevel } from "advantage/api/enum";
-import { dedupeArray } from "./dedupeArray";
-import { removeFalsy } from "./removeFalsy";
+import { UserSubscriptionEntitlement } from "advantage/api/types";
 
-enum EntitlementLabelType {
-  SUPPORT_STANDARD = "support-5",
-  SUPPORT_ADVANCED = "support-7",
-}
-
-type EntitlementBaseType = Exclude<
-  EntitlementType,
-  EntitlementType.SUPPORT | EntitlementType.LIVEPATCH_ONPREM
->;
-
-type LabelType = EntitlementLabelType | EntitlementBaseType;
-
-const baseLabels: Record<EntitlementBaseType, string | null> = {
-  [EntitlementType.BLENDER]: "Blender",
-  [EntitlementType.CC_EAL]: null,
-  [EntitlementType.CIS]: null,
-  [EntitlementType.ESM_APPS]: "ESM Apps",
-  [EntitlementType.ESM_INFRA]: "ESM Infra",
-  [EntitlementType.FIPS_UPDATES]: null,
-  [EntitlementType.FIPS]: null,
-  [EntitlementType.LIVEPATCH]: "Livepatch",
+const labels: Record<string, string | null> = {
+  [EntitlementType.Blender]: "Blender",
+  [EntitlementType.CcEal]: null,
+  [EntitlementType.Cis]: null,
+  [EntitlementType.EsmApps]: "ESM Apps",
+  [EntitlementType.EsmInfra]: "ESM Infra",
+  [EntitlementType.FipsUpdates]: null,
+  [EntitlementType.Fips]: null,
+  [EntitlementType.Livepatch]: "Livepatch",
+  [EntitlementType.LivepatchOnprem]: "Livepatch",
 };
 
-const includeLabels: Record<LabelType, string | null> = {
-  ...baseLabels,
-  [EntitlementLabelType.SUPPORT_STANDARD]: "24/5 Support",
-  [EntitlementLabelType.SUPPORT_ADVANCED]: "24/7 Support",
-};
-
-const excludeLabels: Record<LabelType, string | null> = {
-  ...baseLabels,
-  [EntitlementLabelType.SUPPORT_STANDARD]: "Support",
-  [EntitlementLabelType.SUPPORT_ADVANCED]: "Support",
-};
-
-/**
- * Map the entitlements to the display label.
- */
-const generateLabels = (entitlements: LabelType[], included: boolean) => {
-  const labels = included ? includeLabels : excludeLabels;
-  // Remove any labels that have been mapped to `null` i.e. should not be displayed.
-  return removeFalsy(
-    // Remove any duplicate labels.
-    dedupeArray(
-      entitlements.map((feature) =>
-        labels.hasOwnProperty(feature)
-          ? labels[feature]
-          : // Ignore any features there is no label for.
-            null
-      )
-    )
-  );
-};
-
-export const getFeaturesDisplay = (contractInfo: ContractInfo) => {
-  const included: LabelType[] = [];
-  contractInfo.resourceEntitlements.forEach((entitlement) => {
-    let entitlementType: string | null = null;
+export const getFeaturesDisplay = (
+  entitlements: UserSubscriptionEntitlement[]
+) => {
+  const included: string[] = [];
+  const excluded: string[] = [];
+  entitlements.forEach((entitlement) => {
+    let label: string | null = null;
     if (
-      entitlement.type === "support" &&
-      "supportLevel" in entitlement.affordances
+      entitlement.type === EntitlementType.Support &&
+      entitlement.support_level
     ) {
-      // Map any support features to their appropriate level.
-      switch (entitlement.affordances.supportLevel) {
-        case SupportLevel.STANDARD:
-          entitlementType = EntitlementLabelType.SUPPORT_STANDARD;
+      // Map any support features to their appropriate level. Nothing needs to
+      // be displayed for "none" and "essential" levels.
+      switch (entitlement.support_level) {
+        case SupportLevel.Standard:
+          label = "24/5 Support";
           break;
-        case SupportLevel.ADVANCED:
-          entitlementType = EntitlementLabelType.SUPPORT_ADVANCED;
-          break;
-        // Don't display anything for none and essential levels.
-        case SupportLevel.NONE:
-        case SupportLevel.ESSENTIAL:
-        default:
-          entitlementType = null;
+        case SupportLevel.Advanced:
+          label = "24/7 Support";
           break;
       }
-    } else {
-      switch (entitlement.type) {
-        // Map livepatch-onprem to livepatch as they will both get displayed as
-        // the same thing.
-        case EntitlementType.LIVEPATCH_ONPREM:
-          entitlementType = EntitlementType.LIVEPATCH;
-          break;
-        default:
-          entitlementType = entitlement.type;
-          break;
-      }
+    } else if (entitlement.type in labels) {
+      label = labels[entitlement.type];
     }
-    if (entitlementType) {
-      included.push(entitlementType as LabelType);
+    if (label && !included.includes(label) && !excluded.includes(label)) {
+      if (entitlement.enabled_by_default) {
+        included.push(label);
+      } else {
+        excluded.push(label);
+      }
     }
   });
-  // Find all the features that have not been included to display in the
-  // excluded list.
-  const excluded = Object.keys(excludeLabels).reduce<LabelType[]>(
-    (features, feature) => {
-      if (
-        feature === EntitlementLabelType.SUPPORT_STANDARD ||
-        feature === EntitlementLabelType.SUPPORT_ADVANCED
-      ) {
-        // If either support level has been added to the included list then do
-        // not add anything other support levels to the excluded list.
-        if (
-          !included.includes(EntitlementLabelType.SUPPORT_STANDARD) &&
-          !included.includes(EntitlementLabelType.SUPPORT_ADVANCED)
-        ) {
-          features.push(feature as LabelType);
-        }
-      } else if (!included.includes(feature as LabelType)) {
-        features.push(feature as LabelType);
-      }
-      return features;
-    },
-    []
-  );
   return {
-    excluded: generateLabels(excluded, false),
-    included: generateLabels(included, true),
+    excluded,
+    included,
   };
 };

--- a/static/js/src/advantage/react/utils/index.ts
+++ b/static/js/src/advantage/react/utils/index.ts
@@ -1,5 +1,6 @@
 export { dedupeArray } from "./dedupeArray";
 export { formatDate } from "./formatDate";
 export { getFeaturesDisplay } from "./getFeaturesDisplay";
+export { isFreeSubscription } from "./isFreeSubscription";
 export { makeInteractiveProps } from "./makeInteractiveProps";
 export { removeFalsy } from "./removeFalsy";

--- a/static/js/src/advantage/react/utils/isFreeSubscription.test.ts
+++ b/static/js/src/advantage/react/utils/isFreeSubscription.test.ts
@@ -1,0 +1,21 @@
+import { UserSubscriptionType } from "advantage/api/enum";
+import { userSubscriptionFactory } from "advantage/tests/factories/api";
+import { isFreeSubscription } from "./isFreeSubscription";
+
+describe("isFreeSubscription", () => {
+  it("can identify free subscriptions", () => {
+    expect(
+      isFreeSubscription(
+        userSubscriptionFactory.build({ type: UserSubscriptionType.Free })
+      )
+    ).toBe(true);
+  });
+
+  it("can identify non-free subscriptions", () => {
+    expect(
+      isFreeSubscription(
+        userSubscriptionFactory.build({ type: UserSubscriptionType.Trial })
+      )
+    ).toBe(false);
+  });
+});

--- a/static/js/src/advantage/react/utils/isFreeSubscription.ts
+++ b/static/js/src/advantage/react/utils/isFreeSubscription.ts
@@ -1,0 +1,5 @@
+import { UserSubscriptionType } from "advantage/api/enum";
+import { UserSubscription } from "advantage/api/types";
+
+export const isFreeSubscription = (subscription?: UserSubscription | null) =>
+  !!subscription && subscription?.type === UserSubscriptionType.Free;

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -3,15 +3,24 @@ import {
   ContractWithToken,
   PersonalAccount,
   UserSubscription,
+  UserSubscriptionEntitlement,
   UserSubscriptionStatuses,
-  UserSubscriptionType,
 } from "advantage/api/types";
 import { accountContractInfoFactory, accountInfoFactory } from "./contracts";
+import { EntitlementType, UserSubscriptionType } from "advantage/api/enum";
 
 export const contractWithTokenFactory = Factory.define<ContractWithToken>(
   () => ({
     ...accountContractInfoFactory.build(),
     token: "B13sf54ZfJt51AMwynubzPyaGE9ZA2",
+  })
+);
+
+export const userSubscriptionEntitlementFactory = Factory.define<UserSubscriptionEntitlement>(
+  () => ({
+    enabled_by_default: true,
+    support_level: null,
+    type: EntitlementType.EsmApps,
   })
 );
 


### PR DESCRIPTION
## Done

- Update the free token card to display data from the new user subscriptions API.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10255.demos.haus/advantage?test_backend=true).
- Check that the 'Free Personal Token' card is displayed in the list (both cards will show the free data for now). The data shown in the card should be exactly the same, but it is coming from the new API.


## Issue / Card

Fixes canonical-web-and-design/commercial-squad#209


