### PR TITLE
Scroll to the subscription content if it is off the screen

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -32,7 +32,7 @@ const Content = () => {
       // https://github.com/canonical-web-and-design/commercial-squad/issues/101
       // This only sets the selected token and does not set the modal to active
       // to prevent the modal appearing on first load on mobile.
-      setSelectedToken("ua-sub-123");
+      setSelectedToken("ua-sub-0");
     }
   }, [selectedToken, setSelectedToken]);
 

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@canonical/react-components";
+import { useScrollIntoView } from "advantage/react/hooks/useScrollIntoView";
 import React, { useCallback, useEffect, useState } from "react";
 
 import SubscriptionDetails from "../SubscriptionDetails";
@@ -8,12 +9,16 @@ import { SelectedToken } from "./types";
 const Content = () => {
   const [modalActive, setModalActive] = useState(false);
   const [selectedToken, setSelectedToken] = useState<SelectedToken>(null);
+  const [scrollTargetRef, scrollIntoView] = useScrollIntoView<HTMLDivElement>(
+    20
+  );
   const onSetActive = useCallback(
     (token: SelectedToken) => {
       // Only set the token if it has changed to another token. The selected
       // token is always needed for large screens.
       if (token) {
         setSelectedToken(token);
+        scrollIntoView();
       }
       setModalActive(!!token);
     },
@@ -42,6 +47,7 @@ const Content = () => {
         onCloseModal={() => {
           onSetActive(null);
         }}
+        ref={scrollTargetRef}
       />
     </Card>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,5 +1,5 @@
 import { Button, Spinner } from "@canonical/react-components";
-import React, { useState } from "react";
+import React, { forwardRef, useState } from "react";
 import classNames from "classnames";
 
 import DetailsContent from "./DetailsContent";
@@ -13,71 +13,76 @@ type Props = {
   onCloseModal: () => void;
 };
 
-const SubscriptionDetails = ({ modalActive, onCloseModal }: Props) => {
-  const [editing, setEditing] = useState(false);
-  const [showingCancel, setShowingCancel] = useState(false);
-  const { data: subscription, isLoading } = useUserSubscriptions({
-    // TODO: Get the selected subscription once the subscription token is available.
-    select: selectFreeSubscription,
-  });
-  const isFreeSubscription = subscription?.type === UserSubscriptionType.Free;
-  if (isLoading || !subscription) {
-    return <Spinner />;
-  }
-  return (
-    <div
-      className={classNames("p-modal p-subscriptions__details", {
-        // Don't show the modal as active when the cancel modal is visible so
-        // that we don't have two modals on top of each other.
-        "is-active": modalActive && !showingCancel,
-      })}
-    >
-      <section className="p-modal__dialog">
-        <div className="u-sv2">
-          <header className="p-modal__header">
-            <h2 className="p-modal__title">
-              {isFreeSubscription
-                ? "Free Personal Token"
-                : subscription.product_name}
-            </h2>
-            <button className="p-modal__close" onClick={() => onCloseModal()}>
-              Close
-            </button>
-          </header>
-          {isFreeSubscription ? null : (
-            <>
-              <Button
-                appearance="positive"
-                className="u-no-margin--bottom"
-                data-test="support-button"
-                disabled={editing}
-                element="a"
-                href="https://support.canonical.com/"
-              >
-                Support portal
-              </Button>
-              <Button
-                appearance="neutral"
-                data-test="edit-button"
-                disabled={editing}
-                onClick={() => setEditing(true)}
-              >
-                Edit subscription&hellip;
-              </Button>
-            </>
+const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
+  ({ modalActive, onCloseModal }: Props, ref) => {
+    const [editing, setEditing] = useState(false);
+    const [showingCancel, setShowingCancel] = useState(false);
+    const { data: subscription, isLoading } = useUserSubscriptions({
+      // TODO: Get the selected subscription once the subscription token is available.
+      select: selectFreeSubscription,
+    });
+    const isFreeSubscription = subscription?.type === UserSubscriptionType.Free;
+    if (isLoading || !subscription) {
+      return <Spinner />;
+    }
+    return (
+      <div
+        className={classNames("p-modal p-subscriptions__details", {
+          // Don't show the modal as active when the cancel modal is visible so
+          // that we don't have two modals on top of each other.
+          "is-active": modalActive && !showingCancel,
+        })}
+        ref={ref}
+      >
+        <section className="p-modal__dialog">
+          <div className="u-sv2">
+            <header className="p-modal__header">
+              <h2 className="p-modal__title">
+                {isFreeSubscription
+                  ? "Free Personal Token"
+                  : subscription.product_name}
+              </h2>
+              <button className="p-modal__close" onClick={() => onCloseModal()}>
+                Close
+              </button>
+            </header>
+            {isFreeSubscription ? null : (
+              <>
+                <Button
+                  appearance="positive"
+                  className="u-no-margin--bottom"
+                  data-test="support-button"
+                  disabled={editing}
+                  element="a"
+                  href="https://support.canonical.com/"
+                >
+                  Support portal
+                </Button>
+                <Button
+                  appearance="neutral"
+                  data-test="edit-button"
+                  disabled={editing}
+                  onClick={() => setEditing(true)}
+                >
+                  Edit subscription&hellip;
+                </Button>
+              </>
+            )}
+          </div>
+          {editing ? (
+            <SubscriptionEdit
+              setShowingCancel={setShowingCancel}
+              onClose={() => setEditing(false)}
+            />
+          ) : (
+            <DetailsContent />
           )}
-        </div>
-        {editing ? (
-          <SubscriptionEdit
-            setShowingCancel={setShowingCancel}
-            onClose={() => setEditing(false)}
-          />
-        ) : (
-          <DetailsContent />
-        )}
-      </section>
-    </div>
-  );
-};
+        </section>
+      </div>
+    );
+  }
+);
+
+SubscriptionDetails.displayName = "SubscriptionDetails";
 
 export default SubscriptionDetails;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -38,23 +38,25 @@ const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
     select: selectFreeContract,
   });
   const freeContract = getFreeContractData(freeContractData);
+  const uaSubscriptions = [...Array(20)].map((_, i) => (
+    <ListCard
+      created="2021-07-09T07:14:56Z"
+      expires="2021-07-09T07:14:56Z"
+      features={["ESM Infra", "livepatch", "24/5 support"]}
+      isSelected={selectedToken === `ua-sub-${i}`}
+      key={i}
+      label="Annual"
+      machines={10}
+      onClick={() => {
+        onSetActive(`ua-sub-${i}`);
+      }}
+      title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    />
+  ));
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">
-        <ListGroup title="Ubuntu Advantage">
-          <ListCard
-            created="2021-07-09T07:14:56Z"
-            expires="2021-07-09T07:14:56Z"
-            features={["ESM Infra", "livepatch", "24/5 support"]}
-            isSelected={selectedToken === "ua-sub-123"}
-            label="Annual"
-            machines={10}
-            onClick={() => {
-              onSetActive("ua-sub-123");
-            }}
-            title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-          />
-        </ListGroup>
+        <ListGroup title="Ubuntu Advantage">{uaSubscriptions}</ListGroup>
         {freeContract ? (
           <ListGroup title="Free personal token">
             <ListCard

--- a/static/js/src/advantage/react/hooks/useScrollIntoView.test.tsx
+++ b/static/js/src/advantage/react/hooks/useScrollIntoView.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { mount } from "enzyme";
+import React from "react";
+
+import { useScrollIntoView } from "./useScrollIntoView";
+
+describe("useScrollIntoView", () => {
+  let html: HTMLHtmlElement | null;
+  let scrollToSpy: jest.Mock;
+
+  beforeEach(() => {
+    global.innerHeight = 500;
+    html = document.querySelector("html");
+    scrollToSpy = jest.fn();
+    global.scrollTo = scrollToSpy;
+  });
+
+  afterEach(() => {
+    if (html) {
+      html.scrollTop = 0;
+    }
+  });
+
+  it("does not scroll if the target is on screen", () => {
+    if (html) {
+      html.scrollTop = 10;
+    }
+    const { result } = renderHook(() => useScrollIntoView<HTMLDivElement>());
+    const [targetRef, scrollIntoView] = result.current;
+    mount(<div ref={targetRef}></div>);
+    if (targetRef.current) {
+      targetRef.current.getBoundingClientRect = () => ({ y: 10 } as DOMRect);
+    }
+    scrollIntoView();
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+
+  it("scrolls if the target is off the top of the screen", () => {
+    if (html) {
+      html.scrollTop = 100;
+    }
+    const { result } = renderHook(() => useScrollIntoView<HTMLDivElement>());
+    const [targetRef, scrollIntoView] = result.current;
+    mount(<div ref={targetRef}></div>);
+    if (targetRef.current) {
+      targetRef.current.getBoundingClientRect = () => ({ y: -10 } as DOMRect);
+    }
+    scrollIntoView();
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 90,
+      left: 0,
+      behavior: "smooth",
+    });
+  });
+});

--- a/static/js/src/advantage/react/hooks/useScrollIntoView.ts
+++ b/static/js/src/advantage/react/hooks/useScrollIntoView.ts
@@ -1,0 +1,28 @@
+import { RefObject, useCallback, useRef } from "react";
+
+/**
+ * Scroll an element into view if the top is not visible.
+ * @param buffer Additional space to leave above the target.
+ */
+export const useScrollIntoView = <T extends HTMLElement>(
+  buffer = 0
+): [RefObject<T>, () => void] => {
+  const htmlRef = useRef<HTMLElement>(document.querySelector("html"));
+  const targetRef = useRef<T | null>(null);
+  const scrollIntoView = useCallback(() => {
+    if (targetRef?.current && htmlRef?.current) {
+      const { y: targetTop } = targetRef.current.getBoundingClientRect();
+      const windowTop = htmlRef.current.scrollTop;
+      // Whether the top of the target is above the top of the screen.
+      const topOffTop = targetTop < 0;
+      if (topOffTop) {
+        window.scrollTo({
+          top: windowTop - buffer + targetTop,
+          left: 0,
+          behavior: "smooth",
+        });
+      }
+    }
+  }, []);
+  return [targetRef, scrollIntoView];
+};

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -23,6 +23,9 @@
       // Include the active stripe on the left, but make it transparent. This is
       // so the background colour can be animated when it becomes active.
       @include vf-highlight-bar(transparent, left, true);
+      // Show the overflow so that the stripe can cover the border and doesn't
+      // cause scrollbars to appear.
+      overflow: visible;
 
       &::before {
         // Set up the animation on the active stripe.
@@ -39,8 +42,6 @@
         @include vf-highlight-bar($color-brand, left, true);
 
         background-color: $color-light;
-        // Show the overflow so that the stripe can cover the border.
-        overflow: visible;
 
         &::before {
           // Make the stripe match the border radius of the card.


### PR DESCRIPTION
## Done

- Scroll to the subscription content if it is off the screen.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10256.demos.haus/advantage?test_backend=true).
- Scroll down until all the subscription details is visible on the screen.
- Click on a subscription and the window shouldn't scroll.
- Click on the top subscription.
- Scroll down until just the free personal token card on the left is visible.
- Click on the free personal token card.
- You should get scrolled up until the top of the details is visible.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/93.

## Screenshots

![scroll](https://user-images.githubusercontent.com/361637/131447040-27036701-4b0d-48b3-b954-b5bd53ad3fd1.gif)

