### PR TITLE
Add last-payment-ids endpoint

### DIFF
--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -501,7 +501,7 @@ class TestHelpers(unittest.TestCase):
 
         expectation = {
             "monthly": "pABC1",
-            "yearly": None,
+            "yearly": "",
         }
 
         self.assertEqual(last_purchase_ids, expectation)

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -20,6 +20,7 @@ from webapp.advantage.ua_contracts.helpers import (
     is_user_subscription_cancelled,
     get_date_statuses,
     get_user_subscription_statuses,
+    extract_last_purchase_ids,
 )
 
 
@@ -476,3 +477,31 @@ class TestHelpers(unittest.TestCase):
                     )
 
                     self.assertEqual(statuses, scenario["expectations"])
+
+    def test_get_last_purchase_ids(self):
+        subscriptions = [
+            make_subscription(period="monthly", last_purchase_id="pABC1"),
+            make_subscription(period="yearly", last_purchase_id="pABC2"),
+        ]
+
+        last_purchase_ids = extract_last_purchase_ids(subscriptions)
+
+        expectation = {
+            "monthly": "pABC1",
+            "yearly": "pABC2",
+        }
+
+        self.assertEqual(last_purchase_ids, expectation)
+
+        subscriptions = [
+            make_subscription(period="monthly", last_purchase_id="pABC1"),
+        ]
+
+        last_purchase_ids = extract_last_purchase_ids(subscriptions)
+
+        expectation = {
+            "monthly": "pABC1",
+            "yearly": None,
+        }
+
+        self.assertEqual(last_purchase_ids, expectation)

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -478,7 +478,7 @@ class TestHelpers(unittest.TestCase):
 
                     self.assertEqual(statuses, scenario["expectations"])
 
-    def test_get_last_purchase_ids(self):
+    def test_extract_last_purchase_ids(self):
         subscriptions = [
             make_subscription(period="monthly", last_purchase_id="pABC1"),
             make_subscription(period="yearly", last_purchase_id="pABC2"),

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -174,6 +174,19 @@ def is_user_subscription_cancelled(
     return is_cancelled
 
 
+def extract_last_purchase_ids(subscriptions: List[Subscription]) -> Dict:
+    last_purchase_ids = {
+        "monthly": None,
+        "yearly": None,
+    }
+
+    for subscription in subscriptions:
+        period = subscription.period
+        last_purchase_ids[period] = subscription.last_purchase_id
+
+    return last_purchase_ids
+
+
 def to_dict(structure, class_key=None):
     """Converts structure to dictionary
 

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -176,8 +176,8 @@ def is_user_subscription_cancelled(
 
 def extract_last_purchase_ids(subscriptions: List[Subscription]) -> Dict:
     last_purchase_ids = {
-        "monthly": None,
-        "yearly": None,
+        "monthly": "",
+        "yearly": "",
     }
 
     for subscription in subscriptions:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -95,6 +95,7 @@ from webapp.advantage.views import (
     invoices_view,
     download_invoice,
     get_user_subscriptions,
+    get_last_purchase_ids,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -298,6 +299,10 @@ app.add_url_rule("/marketo/submit", view_func=marketo_submit, methods=["POST"])
 app.add_url_rule("/advantage", view_func=advantage_view)
 app.add_url_rule(
     "/advantage/user-subscriptions", view_func=get_user_subscriptions
+)
+app.add_url_rule(
+    "/advantage/last-purchase-ids/<account_id>",
+    view_func=get_last_purchase_ids,
 )
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)


### PR DESCRIPTION
## Done

- Add /advantage/last-purchase-ids endpoint

## QA

- Be logged in
- Go to: https://ubuntu-com-10257.demos.haus/advantage/last-purchase-ids/<account_id>?test_backend=true
- You will see your last purchases ids

### How to find out your `account_id`?
1) Find your token:
Go to:  https://ubuntu-com-10257.demos.haus/account.json
2) Make CURL request:
`curl -H "Authorization: Macaroon <token>" https://contracts.staging.canonical.com/v1/accounts`
Make sure you do not choose your free token account_id (it's usually the first one)

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/185
