### PR TITLE
Add Xilinx to /embedded

### DIFF
--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -654,8 +654,8 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">Raspberry Pi</li>
         <li class="p-list__item is-ticked">Intel NUC</li>
+        <li class="p-list__item is-ticked">Xilinx Evaluation Kits and SOMs</li>
         <li class="p-list__item is-ticked">Qualcomm Dragonboard</li>
-        <li class="p-list__item is-ticked">i.MX6 SABRE Lite board</li>
       </ul>
       <p><a class="p-button" href="/download/iot">Explore Ubuntu reference platforms</a></p>
     </div>


### PR DESCRIPTION
## Done

- Added "Xilinx Evaluation Kits and SOMs" to reference platforms at `/embedded#hardware`

## QA

- View page at: https://ubuntu-com-10259.demos.haus/embedded#hardware
- Check against [copy doc](https://docs.google.com/document/d/15Tz87YRg4SnX4DWGOSl2TDTHLSStJoma879xHnF0nuo/edit#heading=h.ybs0qqava5l5) and resolve Thibaut's comment


## Issue / Card

Fixes [#4146](https://github.com/canonical-web-and-design/web-squad/issues/4146)
