### PR TITLE
Update logos on /core page

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1,10 +1,8 @@
 {% extends "core/base_core.html" %}
 
 {% block title %}Ubuntu Core{% endblock %}
-{% block meta_description %}Ubuntu Core is Ubuntu for embedded environments, optimised for security and reliable
-updates. Run snaps in a high-security confined sandbox with bulletproof upgrades.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock
-meta_copydoc %}
+{% block meta_description %}Ubuntu Core is Ubuntu for embedded environments, optimised for security and reliable updates. Run snaps in a high-security confined sandbox with bulletproof upgrades.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -217,6 +215,7 @@ meta_copydoc %}
         width="128",
         height="40",
         hi_def=True,
+        loading= "lazy",
         ) | safe
         }}
       </li>
@@ -227,6 +226,7 @@ meta_copydoc %}
         width="128",
         height="50",
         hi_def=True,
+        loading="lazy"
         ) | safe
         }}
       </li>
@@ -237,7 +237,7 @@ meta_copydoc %}
           width="150",
           height="150",
           hi_def=True,
-          loading="auto|lazy"
+          loading="lazy"
           ) | safe
         }}
       </li>
@@ -248,6 +248,7 @@ meta_copydoc %}
         width="200",
         height="80",
         hi_def=True,
+        loading="lazy"
         ) | safe
         }}
       </li>
@@ -267,7 +268,7 @@ meta_copydoc %}
         width="512",
         height="288",
         hi_def=True,
-        loading="auto|lazy"
+        loading="lazy"
         ) | safe
         }}
       </div>
@@ -427,8 +428,7 @@ meta_copydoc %}
       <h4>Tamper-resistant and hardened against corruption</h4>
       <p class='p-heading--five'>Every aspect of the system is checked and verified.</p>
       <p>You need to know your software is pristine; not just for installation, but for the lifetime of the device.</p>
-      <p>Immutable packages and persistent digital signatures mean Ubuntu Core can verify any software component at any
-        time, to guard against corruption and attack.</p>
+      <p>Immutable packages and persistent digital signatures mean Ubuntu Core can verify any software component at any time, to guard against corruption and attack.</p>
       <p>
         <a href="/core/features/full-disk-encryption">Learn more about full disk encryption&nbsp;&rsaquo;</a>
       </p>
@@ -467,8 +467,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Strict confinement everywhere</h4>
       <p class='p-heading--five'>Keep a bad app in its box</p>
-      <p>You trust your developers, but anybody can make a mistake. We created and integrated a whole new armoury of
-        Linux security capabilities to ensure applications stay confined to their own data.</p>
+      <p>You trust your developers, but anybody can make a mistake. We created and integrated a whole new armoury of Linux security capabilities to ensure applications stay confined to their own data.</p>
       <p><a class="p-link--external" href="https://snapcraft.io/docs/snap-confinement">Learn more about confinement</a>
       </p>
     </div>
@@ -482,8 +481,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>10 year security update commitment</h4>
       <p class='p-heading--five'>That's a decade of sleeping soundly</p>
-      <p>Ubuntu Core gets 10 years of Canonical maintenance.<br /> Your smallest devices are now as secure as your
-        servers.<br /> No other embedded Linux comes close.</p>
+      <p>Ubuntu Core gets 10 years of Canonical maintenance.<br /> Your smallest devices are now as secure as your servers.<br /> No other embedded Linux comes close.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
@@ -519,8 +517,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Minimal core, minimal risk, minimal bugs</h4>
       <p class='p-heading--five'>We stripped Ubuntu Core down to bare essentials</p>
-      <p>Fewer packages to attack, fewer bugs to fix, fewer forced changes. We reduced the OS to reduce the attack
-        surface. That leaves more disk for your applications and data.</p>
+      <p>Fewer packages to attack, fewer bugs to fix, fewer forced changes. We reduced the OS to reduce the attack surface. That leaves more disk for your applications and data.</p>
     </div>
   </div>
 
@@ -532,8 +529,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Vulnerability scanning</h4>
       <p class='p-heading--five'>We check for known weaknesses or risks</p>
-      <p>Automatic scanning of all snaps for vulnerable libraries and problematic code keeps the Ubuntu Core ecosystem
-        clean and healthy.</p>
+      <p>Automatic scanning of all snaps for vulnerable libraries and problematic code keeps the Ubuntu Core ecosystem clean and healthy.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
@@ -568,8 +564,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Secure boot</h4>
       <p class='p-heading--five'>System integrity with hardware trust</p>
-      <p>Guarantee your entire fleet of devices runs the system software you select, and resist low-level boot attacks
-        on X86 and ARM.</p>
+      <p>Guarantee your entire fleet of devices runs the system software you select, and resist low-level boot attacks on X86 and ARM.</p>
       <p>
         <a href="/core/features/secure-boot">Learn more about secure boot&nbsp;&rsaquo;</a>
       </p>
@@ -584,8 +579,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Full disk encryption</h4>
       <p class='p-heading--five'>Protect sensitive customer data</p>
-      <p>Lock data to devices with hardware keys in TPM or TEE, and unlock disks for your system software only, to block
-        a physical attack on sensitive information.</p>
+      <p>Lock data to devices with hardware keys in TPM or TEE, and unlock disks for your system software only, to block a physical attack on sensitive information.</p>
       <p>
         <a href="/core/features/full-disk-encryption">Learn more about full disk encryption&nbsp;&rsaquo;</a>
       </p>
@@ -618,8 +612,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Manufacturer update control</h4>
       <p class='p-heading--five'>Decide which updates go to your devices.</p>
-      <p>As a device manufacturer or a snap publisher, you decide which updates are signed, certified and delivered to
-        your devices, when they happen and to which devices.</p>
+      <p>As a device manufacturer or a snap publisher, you decide which updates are signed, certified and delivered to your devices, when they happen and to which devices.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
@@ -655,8 +648,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>App store included</h4>
       <p class='p-heading--five'>Your own app store and software curation</p>
-      <p>Every device built with Ubuntu Core has a secure app store. Use the global store for access to all the standard
-        apps, or curate your own collection.</p>
+      <p>Every device built with Ubuntu Core has a secure app store. Use the global store for access to all the standard apps, or curate your own collection.</p>
       <p><a class="p-button--neutral is-inline" href="/internet-of-things/appstore" style="margin-left: 0;"><span
             class="p-link--external">See what an app store can do for your things</span></a></p>
     </div>
@@ -670,8 +662,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Enterprise management</h4>
       <p class='p-heading--five'>Absolute control over every device in the building.</p>
-      <p>Enterprises gain complete control over every app on every device on the network, regardless of manufacturer.
-        Know exactly which kernel version and which apps are running.</p>
+      <p>Enterprises gain complete control over every app on every device on the network, regardless of manufacturer. Know exactly which kernel version and which apps are running.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{
@@ -707,8 +698,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>License compliance</h4>
       <p class='p-heading--five'>Keep track of the licenses you depend on</p>
-      <p>Standard license metadata simplifies compliance. Ubuntu Core uses open source packages from the world’s most
-        widely deployed Linux, and we track licenses in each system component, so you don’t have to.</p>
+      <p>Standard license metadata simplifies compliance. Ubuntu Core uses open source packages from the world’s most widely deployed Linux, and we track licenses in each system component, so you don’t have to.</p>
     </div>
   </div>
 
@@ -720,10 +710,8 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Software ecosystem, ready to go</h4>
       <p class='p-heading--five'>Thousands of applications built to work across devices</p>
-      <p>A standard platform helps publishers support multiple devices without recompiling. Everybody wants to support
-        Ubuntu - it’s the most widely deployed Linux in the world.</p>
-      <p><a class="p-button--neutral is-inline" href="https://snapcraft.io/store" style="margin-left: 0;"><span
-            class="p-link--external">Visit the Snap Store</span></a></p>
+      <p>A standard platform helps publishers support multiple devices without recompiling. Everybody wants to support Ubuntu - it’s the most widely deployed Linux in the world.</p>
+      <p><a class="p-button--neutral is-inline" href="https://snapcraft.io/store" style="margin-left: 0;"><span class="p-link--external">Visit the Snap Store</span></a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
@@ -760,8 +748,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Mission critical support</h4>
       <p class='p-heading--five'>Canonical supports Ubuntu Core devices</p>
-      <p>World class support - for product teams and enterprise customers. Get to the heart of a problem faster, get
-        fixes straight from the source.</p>
+      <p>World class support - for product teams and enterprise customers. Get to the heart of a problem faster, get fixes straight from the source.</p>
       <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
     </div>
   </div>
@@ -792,10 +779,8 @@ meta_copydoc %}
     <div class="col-6">
       <h4>One platform from cloud to device</h4>
       <p class='p-heading--five'>Bring apps from Ubuntu Server to Ubuntu Core</p>
-      <p>Snaps run on Ubuntu Server, Desktop and Core. One platform, one process. Your developer workstation, your build
-        farm, your cloud and servers all use snaps. Your appliances can too, with extra security.</p>
-      <p><a class="p-button--neutral" href="https://snapcraft.io/"><span class="p-link--external">Build your IoT
-            application with Snapcraft</span></a></p>
+      <p>Snaps run on Ubuntu Server, Desktop and Core. One platform, one process. Your developer workstation, your build farm, your cloud and servers all use snaps. Your appliances can too, with extra security.</p>
+      <p><a class="p-button--neutral" href="https://snapcraft.io/"><span class="p-link--external">Build your IoT application with Snapcraft</span></a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
@@ -831,8 +816,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Embedded Linux is easy on Ubuntu</h4>
       <p class='p-heading--five'>We handle the board, you handle the apps</p>
-      <p>No bad BSPs. No maintenance nightmares. No integration delays. Just develop on Ubuntu. Embedded, but not as you
-        knew it.</p>
+      <p>No bad BSPs. No maintenance nightmares. No integration delays. Just develop on Ubuntu. Embedded, but not as you knew it.</p>
     </div>
   </div>
 
@@ -844,11 +828,9 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Deploy to devices as fast as the cloud</h4>
       <p class='p-heading--five'>Continuous deployment on devices</p>
-      <p>Put your devices on rails for rapid iteration with continuous deployment pipelines, beta testing and canary
-        updates. Featuring Travis integration and a multi-arch build service.</p>
+      <p>Put your devices on rails for rapid iteration with continuous deployment pipelines, beta testing and canary updates. Featuring Travis integration and a multi-arch build service.</p>
       <p>
-        <a href="https://snapcraft.io/build" class="p-button--neutral"><span class="p-link--external">More about CI/CD
-            with Snapcraft</span></a>
+        <a href="https://snapcraft.io/build" class="p-button--neutral"><span class="p-link--external">More about CI/CD with Snapcraft</span></a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
@@ -885,8 +867,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Harness all things open source</h4>
       <p class='p-heading--five'>From GitHub to Ubuntu Core in minutes.</p>
-      <p>Ride the open source wave, or build your own community. Open source projects default to Ubuntu, so building is
-        easy.</p>
+      <p>Ride the open source wave, or build your own community. Open source projects default to Ubuntu, so building is easy.</p>
       <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
     </div>
   </div>
@@ -908,8 +889,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Transactional updates everywhere</h4>
       <p class='p-heading--five'>Preserve data, and rollback on error automatically</p>
-      <p>Your power supply may not be reliable. Your devices will be. Resilience to adversity saves money and
-        reputations. Bank on Ubuntu Core to deliver your updates safely.</p>
+      <p>Your power supply may not be reliable. Your devices will be. Resilience to adversity saves money and reputations. Bank on Ubuntu Core to deliver your updates safely.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
@@ -945,8 +925,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Backup boot paths</h4>
       <p class='p-heading--five'>Low-level updates preserve the prior boot path.</p>
-      <p>When you have to update the kernel or the operating system you want to know you can go back if needed. Ubuntu
-        Core keeps the last working boot so you always have a safety net.</p>
+      <p>When you have to update the kernel or the operating system you want to know you can go back if needed. Ubuntu Core keeps the last working boot so you always have a safety net.</p>
     </div>
   </div>
 
@@ -958,8 +937,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Snapshots for application data</h4>
       <p class='p-heading--five'>Standard mechanisms for application data management.</p>
-      <p>Every device has apps which keep track of critical data. We make sure you can manage the data which matters to
-        you, consistently, across all your Ubuntu Core devices. Backup and restore anything, anywhere.</p>
+      <p>Every device has apps which keep track of critical data. We make sure you can manage the data which matters to you, consistently, across all your Ubuntu Core devices. Backup and restore anything, anywhere.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
@@ -1005,8 +983,7 @@ meta_copydoc %}
     <div class='col-8'>
       <h2>Reduce the cost of Linux</h2>
       <p class="p-heading--four">Use Ubuntu Core for free. Pay only for extra services.</p>
-      <p>The reference images of Ubuntu Core are free to redistribute. Engage Canonical for enablement and custom
-        service levels. We'll get you to market faster.</p>
+      <p>The reference images of Ubuntu Core are free to redistribute. Engage Canonical for enablement and custom service levels. We'll get you to market faster.</p>
     </div>
   </div>
 </section>
@@ -1052,8 +1029,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Ubuntu board support by Canonical</h4>
       <p class='p-heading--five'>First class enablement for widely used boards and silicon</p>
-      <p>Low-level development is a distraction in the race to market. Focus all your effort on differentiation, not
-        Linux. Pre-certified boards keep you out of the weeds.</p>
+      <p>Low-level development is a distraction in the race to market. Focus all your effort on differentiation, not Linux. Pre-certified boards keep you out of the weeds.</p>
       <p><a href="/download/iot#core">See our supported boards&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -1066,8 +1042,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Right-size your silicon</h4>
       <p class='p-heading--five'>Finish your apps, then choose your chips.</p>
-      <p>A standard platform means you can develop your software and polish your industrial design first, then choose
-        the right size chips for your experience based on real code and data.</p>
+      <p>A standard platform means you can develop your software and polish your industrial design first, then choose the right size chips for your experience based on real code and data.</p>
       <p>Get the best deal when you're ready to ship.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small">
@@ -1104,8 +1079,7 @@ meta_copydoc %}
     <div class="col-6">
       <h4>Choice of ARM or x86</h4>
       <p class='p-heading--five'>Unified application build experience</p>
-      <p>We support both 32-bit and 64-bit apps on both architectures. If it doesn’t compile and run the same, we’ll fix
-        it.</p>
+      <p>We support both 32-bit and 64-bit apps on both architectures. If it doesn't compile and run the same, we'll fix it.</p>
     </div>
   </div>
 </section>
@@ -1136,9 +1110,7 @@ meta_copydoc %}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/embedded-linux-make-or-buy/' onclick='dataLayer.push({' event'
-          : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel'
-          : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });'>Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/embedded-linux-make-or-buy/' onclick='dataLayer.push({' event'  : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });'>Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">
@@ -1159,10 +1131,7 @@ meta_copydoc %}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-security-audit' onclick='dataLayer.push({' event'
-          : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction' : 'core - left' , 'eventLabel'
-          : 'Whitepaper - IMS Evolve ' , 'eventValue' : '1' });'>An independent security audit of Ubuntu
-          Core&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-security-audit' onclick='dataLayer.push({' event'  : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction' : 'core - left' , 'eventLabel' : 'Whitepaper - IMS Evolve ' , 'eventValue' : '1' });'>An independent security audit of Ubuntu Core&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block u-no-padding--bottom">
@@ -1183,10 +1152,7 @@ meta_copydoc %}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='engage/ubuntu-core-and-kura' onclick='dataLayer.push({' event' : 'GAEvent'
-          , 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel'
-          : 'Whitepaper - Ubuntu Core and Kura - a framework for IoT gateways' , 'eventValue' : '1' });'>Ubuntu Core and
-          Kura &mdash; a framework for IoT gateways&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='engage/ubuntu-core-and-kura' onclick='dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel' : 'Whitepaper - Ubuntu Core and Kura - a framework for IoT gateways' , 'eventValue' : '1' });'>Ubuntu Core and Kura &mdash; a framework for IoT gateways&nbsp;&rsaquo;</a></h3>
       <!-- rtp section center end -->
     </div>
   </div>
@@ -1212,10 +1178,7 @@ meta_copydoc %}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-20-webinar' onclick='dataLayer.push({' event' : 'GAEvent'
-          , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel'
-          : 'Webinar - Introuction to Ubuntu Core 20 ' , 'eventValue' : '1' });'>Introduction to Ubuntu Core
-          20&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-20-webinar' onclick='dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Webinar - Introuction to Ubuntu Core 20 ' , 'eventValue' : '1' });'>Introduction to Ubuntu Core 20&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">
@@ -1234,11 +1197,7 @@ meta_copydoc %}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class="p-link--external"
-          href='https://www.brighttalk.com/webcast/6793/402503/ubuntu-core-a-cybersecurity-analysis'
-          onclick='dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction'
-          : 'core - left' , 'eventLabel' : 'Webinar - a cybersecurity analysis' , 'eventValue' : '1' });'>Ubuntu Core: a
-          cybersecurity analysis</a></h3>
+      <h3 class='p-heading--four'><a class="p-link--external" href='https://www.brighttalk.com/webcast/6793/402503/ubuntu-core-a-cybersecurity-analysis' onclick='dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction' : 'core - left' , 'eventLabel' : 'Webinar - a cybersecurity analysis' , 'eventValue' : '1' });'>Ubuntu Core: a cybersecurity analysis</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">
@@ -1257,10 +1216,7 @@ meta_copydoc %}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class="p-link--external"
-          href='https://www.brighttalk.com/webcast/6793/373030/migrating-to-ubuntu-core' onclick='dataLayer.push({'
-          event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel'
-          : 'Webinar - Migrating to Ubuntu Core' , 'eventValue' : '1' });'>Migrating to Ubuntu Core</a></h3>
+      <h3 class='p-heading--four'><a class="p-link--external" href='https://www.brighttalk.com/webcast/6793/373030/migrating-to-ubuntu-core' onclick='dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel' : 'Webinar - Migrating to Ubuntu Core' , 'eventValue' : '1' });'>Migrating to Ubuntu Core</a></h3>
       <!-- rtp section center end -->
     </div>
   </div>
@@ -1280,8 +1236,7 @@ meta_copydoc %}
     <div class="col-4 p-divider__block">
       <h4>Download Ubuntu Core</h4>
       <p>Try Ubuntu Core 20 on one of a popular development board</p>
-      <p><a class="p-button--neutral p-link--external"
-          href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">Download and install Ubuntu Core 20</a></p>
+      <p><a class="p-button--neutral p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">Download and install Ubuntu Core 20</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h4>Make your own Ubuntu Core device</h4>
@@ -1344,13 +1299,10 @@ meta_copydoc %}
   }
 </style>
 
-{% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include
-"shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things"
-  data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you"
-  data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1,8 +1,10 @@
 {% extends "core/base_core.html" %}
 
 {% block title %}Ubuntu Core{% endblock %}
-{% block meta_description %}Ubuntu Core is Ubuntu for embedded environments, optimised for security and reliable updates. Run snaps in a high-security confined sandbox with bulletproof upgrades.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock meta_copydoc %}
+{% block meta_description %}Ubuntu Core is Ubuntu for embedded environments, optimised for security and reliable
+updates. Run snaps in a high-security confined sandbox with bulletproof upgrades.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock
+meta_copydoc %}
 
 {% block content %}
 
@@ -15,44 +17,46 @@
         <a class="p-button--positive" href="/engage/ubuntu-core-20-webinar">Watch the webinar</a>
       </p>
       <p class="u-sv3">
-        <a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/b2c770ea-Ubuntu+Core20+Datasheet.pdf">Read the Ubuntu Core datasheet</a>
+        <a class="p-link--external p-link--inverted"
+          href="https://assets.ubuntu.com/v1/b2c770ea-Ubuntu+Core20+Datasheet.pdf">Read the Ubuntu Core datasheet</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-embedded-media">
-      <iframe title="UC20 video" class="u-embedded-media__element" src="https://www.youtube.com/embed/qjmj2cy4LLA" allowfullscreen=""></iframe>
+      <iframe title="UC20 video" class="u-embedded-media__element" src="https://www.youtube.com/embed/qjmj2cy4LLA"
+        allowfullscreen=""></iframe>
     </div>
   </div>
 </section>
 <section class="p-strip--light u-no-padding--top">
-  <div class="row u-vertically-center u-align--center" style="position: relative; top: -2rem;" >
+  <div class="row u-vertically-center u-align--center" style="position: relative; top: -2rem;">
     <p class="p-muted-heading u-no-max-width p-heading--5">Get to market fast with our device partners</p>
-  <ul class="p-inline-images">
-    <li class="p-inline-images__item">
-      {{
+    <ul class="p-inline-images">
+      <li class="p-inline-images__item">
+        {{
         image(
-          url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
-          alt="Intel",
-          height="60",
-          width="91",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
+        alt="Intel",
+        height="60",
+        width="91",
+        hi_def=True,
+        loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
         image(
-          url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
-          alt="Raspberry Pi",
-          height="80",
-          width="68",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
+        alt="Raspberry Pi",
+        height="80",
+        width="68",
+        hi_def=True,
+        loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/731aab6c-logo-amd.svg",
         alt="AMD",
         width="115",
@@ -60,10 +64,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/1ac0e434-Nvidia_Logo_Horizontal.svg",
         alt="NVIDIA",
         width="152",
@@ -71,10 +75,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/3cf238fd-Qualcomm-Logo.svg",
         alt="QUALCOMM",
         width="158",
@@ -82,10 +86,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/c95e6028-rigado-logo.png",
         alt="RIGADO",
         width="133",
@@ -93,10 +97,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/e9dabb1f-adlink+logo.png",
         alt="ADLINK",
         width="185",
@@ -104,10 +108,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/582bee22-avantech-logo.png",
         alt="Avantech",
         width="145",
@@ -115,10 +119,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/185a14f4-Avnet.png",
         alt="Avnet",
         width="150",
@@ -126,22 +130,22 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{
         image(
-          url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
-          alt="Dell",
-          height="90",
-          width="90",
-          hi_def=True,
-          loading="lazy"
+        url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
+        alt="Dell",
+        height="90",
+        width="90",
+        hi_def=True,
+        loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/53de61ea-honeywell-logo.png",
         alt="Honeywell",
         width="156",
@@ -149,10 +153,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg",
         alt="rexroth",
         width="131",
@@ -160,10 +164,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/255a3171-abb-logo.svg",
         alt="ABB",
         width="120",
@@ -171,10 +175,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/2234031b-Siemens-logo.svg.png",
         alt="Siemens",
         width="128",
@@ -182,10 +186,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/3ba27c02-osram-logo.svg",
         alt="osram",
         width="128",
@@ -193,10 +197,10 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-    <li class="p-inline-images__item">
-      {{ image (
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
         url="https://assets.ubuntu.com/v1/24bd5aaf-dfi-logo.png",
         alt="DFI",
         width="80",
@@ -204,9 +208,50 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
-    </li>
-  </ul>
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+        url="https://assets.ubuntu.com/v1/b5352dc1-logo-arm.svg",
+        alt="ARM",
+        width="128",
+        height="40",
+        hi_def=True,
+        ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+        url="https://assets.ubuntu.com/v1/75502e5c-NXP-Logo.svg",
+        alt="NXP",
+        width="128",
+        height="50",
+        hi_def=True,
+        ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/e4ac6657-xilinx-inc-logo-vector.svg",
+          alt="Xilink",
+          width="150",
+          height="150",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </li>
+      <li class="p-inline-images__item">
+        {{ image (
+        url="https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg",
+        alt="MediaTek",
+        width="200",
+        height="80",
+        hi_def=True,
+        ) | safe
+        }}
+      </li>
+    </ul>
   </div>
 </section>
 
@@ -216,22 +261,22 @@
   <div class="row">
     <div class="col-3 p-card u-hide--small u-vertically-center">
       <div>
-          {{ image (
-            url="https://assets.ubuntu.com/v1/9c973273-YOCTO_BUILDROOT.png",
-            alt="",
-            width="234",
-            height="200",
-            hi_def=True,
-            loading="auto"
-            ) | safe
-          }}
+        {{ image (
+        url="https://assets.ubuntu.com/v1/4109a017-yocto.jpeg",
+        alt="Yocto",
+        width="512",
+        height="288",
+        hi_def=True,
+        loading="auto|lazy"
+        ) | safe
+        }}
       </div>
     </div>
     <div class="col-8 col-start-large-5">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <div class=" lazyloaded" data-noscript="">
-          {{ image (
+            {{ image (
             url="https://assets.ubuntu.com/v1/4ab8ff35-Whitepaper+-+white.svg",
             alt="",
             width="32",
@@ -239,7 +284,7 @@
             hi_def=True,
             loading="auto"
             ) | safe
-          }}
+            }}
           </div>
           <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">whitepaper</p>
         </div>
@@ -259,7 +304,7 @@
   <div class="row u-equal-height u-align--center u-vertically-center u-hide--small">
     <div class="col-4">
       <div class="u-sv2">
-      {{ image (
+        {{ image (
         url="https://assets.ubuntu.com/v1/ec2d60d0-IoT_Digital_Signage.svg",
         alt="Linux",
         width="100",
@@ -267,12 +312,12 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
+        }}
       </div>
     </div>
     <div class="col-4">
       <div class="u-sv2">
-      {{ image (
+        {{ image (
         url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
         alt="Linux",
         width="156",
@@ -280,12 +325,12 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
+        }}
       </div>
     </div>
     <div class="col-4">
       <div class="u-sv2">
-      {{ image (
+        {{ image (
         url="https://assets.ubuntu.com/v1/e39199bc-Internet+of+Things_digital-gateways.svg",
         alt="Digital gateways",
         width="144",
@@ -293,7 +338,7 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
+        }}
       </div>
     </div>
   </div>
@@ -313,39 +358,39 @@
     <div class="col-4">
       <div class="u-sv2">
         {{ image (
-          url="https://assets.ubuntu.com/v1/af98e3d6-automotive_car-network.svg",
-          alt="Automotive",
-          width="184",
-          height="107",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
+        url="https://assets.ubuntu.com/v1/af98e3d6-automotive_car-network.svg",
+        alt="Automotive",
+        width="184",
+        height="107",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
         }}
       </div>
     </div>
     <div class="col-4">
       <div class="u-sv3">
         {{ image (
-          url="https://assets.ubuntu.com/v1/26e28883-Industrial+ML.svg",
-          alt="Industrial",
-          width="192",
-          height="110",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
+        url="https://assets.ubuntu.com/v1/26e28883-Industrial+ML.svg",
+        alt="Industrial",
+        width="192",
+        height="110",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
         }}
       </div>
     </div>
     <div class="col-4">
       <div class="u-sv2">
         {{ image (
-          url="https://assets.ubuntu.com/v1/f84b4cec-robot-arm.svg",
-          alt="Robotics",
-          width="120",
-          height="121",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
+        url="https://assets.ubuntu.com/v1/f84b4cec-robot-arm.svg",
+        alt="Robotics",
+        width="120",
+        height="121",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
         }}
       </div>
     </div>
@@ -363,7 +408,7 @@
   </div>
 </section>
 
-<section class='p-strip--image p-banner-core' id="security-first" >
+<section class='p-strip--image p-banner-core' id="security-first">
   <div class='row u-vertically-center'>
     <div class='col-8'>
       <h2>Security first</h2>
@@ -382,21 +427,22 @@
       <h4>Tamper-resistant and hardened against corruption</h4>
       <p class='p-heading--five'>Every aspect of the system is checked and verified.</p>
       <p>You need to know your software is pristine; not just for installation, but for the lifetime of the device.</p>
-      <p>Immutable packages and persistent digital signatures mean Ubuntu Core can verify any software component at any time, to guard against corruption and attack.</p>
+      <p>Immutable packages and persistent digital signatures mean Ubuntu Core can verify any software component at any
+        time, to guard against corruption and attack.</p>
       <p>
         <a href="/core/features/full-disk-encryption">Learn more about full disk encryption&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -408,21 +454,23 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Strict confinement everywhere</h4>
       <p class='p-heading--five'>Keep a bad app in its box</p>
-      <p>You trust your developers, but anybody can make a mistake. We created and integrated a whole new armoury of Linux security capabilities to ensure applications stay confined to their own data.</p>
-      <p><a class="p-link--external" href="https://snapcraft.io/docs/snap-confinement">Learn more about confinement</a></p>
+      <p>You trust your developers, but anybody can make a mistake. We created and integrated a whole new armoury of
+        Linux security capabilities to ensure applications stay confined to their own data.</p>
+      <p><a class="p-link--external" href="https://snapcraft.io/docs/snap-confinement">Learn more about confinement</a>
+      </p>
     </div>
   </div>
 
@@ -434,18 +482,19 @@
     <div class="col-6">
       <h4>10 year security update commitment</h4>
       <p class='p-heading--five'>That's a decade of sleeping soundly</p>
-      <p>Ubuntu Core gets 10 years of Canonical maintenance.<br /> Your smallest devices are now as secure as your servers.<br /> No other embedded Linux comes close.</p>
+      <p>Ubuntu Core gets 10 years of Canonical maintenance.<br /> Your smallest devices are now as secure as your
+        servers.<br /> No other embedded Linux comes close.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/ceb481d1-10+years.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/ceb481d1-10+years.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -457,20 +506,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/3505cd01-GRAPHIC_os_image_size.svg",
-          alt="Ubuntu Core: 260 MB. Red Hat coreOS: 807 MB.",
-          height="195",
-          width="335",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/3505cd01-GRAPHIC_os_image_size.svg",
+      alt="Ubuntu Core: 260 MB. Red Hat coreOS: 807 MB.",
+      height="195",
+      width="335",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Minimal core, minimal risk, minimal bugs</h4>
       <p class='p-heading--five'>We stripped Ubuntu Core down to bare essentials</p>
-      <p>Fewer packages to attack, fewer bugs to fix, fewer forced changes. We reduced the OS to reduce the attack surface. That leaves more disk for your applications and data.</p>
+      <p>Fewer packages to attack, fewer bugs to fix, fewer forced changes. We reduced the OS to reduce the attack
+        surface. That leaves more disk for your applications and data.</p>
     </div>
   </div>
 
@@ -482,18 +532,19 @@
     <div class="col-6">
       <h4>Vulnerability scanning</h4>
       <p class='p-heading--five'>We check for known weaknesses or risks</p>
-      <p>Automatic scanning of all snaps for vulnerable libraries and problematic code keeps the Ubuntu Core ecosystem clean and healthy.</p>
+      <p>Automatic scanning of all snaps for vulnerable libraries and problematic code keeps the Ubuntu Core ecosystem
+        clean and healthy.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/7e5a3ee1-scan.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/7e5a3ee1-scan.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -505,26 +556,27 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/6ed19d21-UC20_Secure_boot.svg",
-        alt="Secure boot",
-        width="250",
-        height="250",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
+      url="https://assets.ubuntu.com/v1/6ed19d21-UC20_Secure_boot.svg",
+      alt="Secure boot",
+      width="250",
+      height="250",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Secure boot</h4>
       <p class='p-heading--five'>System integrity with hardware trust</p>
-      <p>Guarantee your entire fleet of devices runs the system software you select, and resist low-level boot attacks on X86 and ARM.</p>
+      <p>Guarantee your entire fleet of devices runs the system software you select, and resist low-level boot attacks
+        on X86 and ARM.</p>
       <p>
         <a href="/core/features/secure-boot">Learn more about secure boot&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
 
-<div class="u-fixed-width">
+  <div class="u-fixed-width">
     <hr class="p-separator" />
   </div>
 
@@ -532,20 +584,21 @@
     <div class="col-6">
       <h4>Full disk encryption</h4>
       <p class='p-heading--five'>Protect sensitive customer data</p>
-      <p>Lock data to devices with hardware keys in TPM or TEE, and unlock disks for your system software only, to block a physical attack on sensitive information.</p>
+      <p>Lock data to devices with hardware keys in TPM or TEE, and unlock disks for your system software only, to block
+        a physical attack on sensitive information.</p>
       <p>
         <a href="/core/features/full-disk-encryption">Learn more about full disk encryption&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/1fbe51df-UC20_Full-disc-encryption.svg",
-        alt="Full disk encryption",
-        width="200",
-        height="200",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
+      url="https://assets.ubuntu.com/v1/1fbe51df-UC20_Full-disc-encryption.svg",
+      alt="Full disk encryption",
+      width="200",
+      height="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -565,18 +618,19 @@
     <div class="col-6">
       <h4>Manufacturer update control</h4>
       <p class='p-heading--five'>Decide which updates go to your devices.</p>
-      <p>As a device manufacturer or a snap publisher, you decide which updates are signed, certified and delivered to your devices, when they happen and to which devices.</p>
+      <p>As a device manufacturer or a snap publisher, you decide which updates are signed, certified and delivered to
+        your devices, when they happen and to which devices.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -588,21 +642,23 @@
   <div class="row u-vertically-center u-equal-height">
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>App store included</h4>
       <p class='p-heading--five'>Your own app store and software curation</p>
-      <p>Every device built with Ubuntu Core has a secure app store. Use the global store for access to all the standard apps, or curate your own collection.</p>
-      <p><a class="p-button--neutral is-inline" href="/internet-of-things/appstore" style="margin-left: 0;"><span class="p-link--external">See what an app store can do for your things</span></a></p>
+      <p>Every device built with Ubuntu Core has a secure app store. Use the global store for access to all the standard
+        apps, or curate your own collection.</p>
+      <p><a class="p-button--neutral is-inline" href="/internet-of-things/appstore" style="margin-left: 0;"><span
+            class="p-link--external">See what an app store can do for your things</span></a></p>
     </div>
   </div>
 
@@ -614,18 +670,19 @@
     <div class="col-6">
       <h4>Enterprise management</h4>
       <p class='p-heading--five'>Absolute control over every device in the building.</p>
-      <p>Enterprises gain complete control over every app on every device on the network, regardless of manufacturer. Know exactly which kernel version and which apps are running.</p>
+      <p>Enterprises gain complete control over every app on every device on the network, regardless of manufacturer.
+        Know exactly which kernel version and which apps are running.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/3db02edd-enterprise+management+.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/3db02edd-enterprise+management+.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -637,20 +694,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/69aaa876-compliance.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/69aaa876-compliance.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>License compliance</h4>
       <p class='p-heading--five'>Keep track of the licenses you depend on</p>
-      <p>Standard license metadata simplifies compliance. Ubuntu Core uses open source packages from the world’s most widely deployed Linux, and we track licenses in each system component, so you don’t have to.</p>
+      <p>Standard license metadata simplifies compliance. Ubuntu Core uses open source packages from the world’s most
+        widely deployed Linux, and we track licenses in each system component, so you don’t have to.</p>
     </div>
   </div>
 
@@ -662,20 +720,22 @@
     <div class="col-6">
       <h4>Software ecosystem, ready to go</h4>
       <p class='p-heading--five'>Thousands of applications built to work across devices</p>
-      <p>A standard platform helps publishers support multiple devices without recompiling. Everybody wants to support Ubuntu - it’s the most widely deployed Linux in the world.</p>
-      <p><a class="p-button--neutral is-inline" href="https://snapcraft.io/store" style="margin-left: 0;"><span class="p-link--external">Visit the Snap Store</span></a></p>
+      <p>A standard platform helps publishers support multiple devices without recompiling. Everybody wants to support
+        Ubuntu - it’s the most widely deployed Linux in the world.</p>
+      <p><a class="p-button--neutral is-inline" href="https://snapcraft.io/store" style="margin-left: 0;"><span
+            class="p-link--external">Visit the Snap Store</span></a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/26e55529-snapstore.png",
-          alt="",
-          height="255",
-          width="477",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-image--bordered"}
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/26e55529-snapstore.png",
+      alt="",
+      height="255",
+      width="477",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "p-image--bordered"}
+      ) | safe
       }}
     </div>
   </div>
@@ -687,20 +747,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/4e20332d-mission+critical+support.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/4e20332d-mission+critical+support.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Mission critical support</h4>
       <p class='p-heading--five'>Canonical supports Ubuntu Core devices</p>
-      <p>World class support - for product teams and enterprise customers. Get to the heart of a problem faster, get fixes straight from the source.</p>
+      <p>World class support - for product teams and enterprise customers. Get to the heart of a problem faster, get
+        fixes straight from the source.</p>
       <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
     </div>
   </div>
@@ -731,19 +792,21 @@
     <div class="col-6">
       <h4>One platform from cloud to device</h4>
       <p class='p-heading--five'>Bring apps from Ubuntu Server to Ubuntu Core</p>
-      <p>Snaps run on Ubuntu Server, Desktop and Core. One platform, one process. Your developer workstation, your build farm, your cloud and servers all use snaps. Your appliances can too, with extra security.</p>
-      <p><a class="p-button--neutral" href="https://snapcraft.io/"><span class="p-link--external">Build your IoT application with Snapcraft</span></a></p>
+      <p>Snaps run on Ubuntu Server, Desktop and Core. One platform, one process. Your developer workstation, your build
+        farm, your cloud and servers all use snaps. Your appliances can too, with extra security.</p>
+      <p><a class="p-button--neutral" href="https://snapcraft.io/"><span class="p-link--external">Build your IoT
+            application with Snapcraft</span></a></p>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
-          alt="",
-          height="230",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
+      alt="",
+      height="230",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -755,20 +818,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Embedded Linux is easy on Ubuntu</h4>
       <p class='p-heading--five'>We handle the board, you handle the apps</p>
-      <p>No bad BSPs. No maintenance nightmares. No integration delays. Just develop on Ubuntu. Embedded, but not as you knew it.</p>
+      <p>No bad BSPs. No maintenance nightmares. No integration delays. Just develop on Ubuntu. Embedded, but not as you
+        knew it.</p>
     </div>
   </div>
 
@@ -780,21 +844,23 @@
     <div class="col-6">
       <h4>Deploy to devices as fast as the cloud</h4>
       <p class='p-heading--five'>Continuous deployment on devices</p>
-      <p>Put your devices on rails for rapid iteration with continuous deployment pipelines, beta testing and canary updates. Featuring Travis integration and a multi-arch build service.</p>
+      <p>Put your devices on rails for rapid iteration with continuous deployment pipelines, beta testing and canary
+        updates. Featuring Travis integration and a multi-arch build service.</p>
       <p>
-        <a href="https://snapcraft.io/build" class="p-button--neutral"><span class="p-link--external">More about CI/CD with Snapcraft</span></a>
+        <a href="https://snapcraft.io/build" class="p-button--neutral"><span class="p-link--external">More about CI/CD
+            with Snapcraft</span></a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -806,20 +872,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg",
-          alt="",
-          height="54",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg",
+      alt="",
+      height="54",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Harness all things open source</h4>
       <p class='p-heading--five'>From GitHub to Ubuntu Core in minutes.</p>
-      <p>Ride the open source wave, or build your own community. Open source projects default to Ubuntu, so building is easy.</p>
+      <p>Ride the open source wave, or build your own community. Open source projects default to Ubuntu, so building is
+        easy.</p>
       <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
     </div>
   </div>
@@ -841,18 +908,19 @@
     <div class="col-6">
       <h4>Transactional updates everywhere</h4>
       <p class='p-heading--five'>Preserve data, and rollback on error automatically</p>
-      <p>Your power supply may not be reliable. Your devices will be. Resilience to adversity saves money and reputations. Bank on Ubuntu Core to deliver your updates safely.</p>
+      <p>Your power supply may not be reliable. Your devices will be. Resilience to adversity saves money and
+        reputations. Bank on Ubuntu Core to deliver your updates safely.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/fc3ca86d-bullet+proof.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/fc3ca86d-bullet+proof.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -864,20 +932,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Backup boot paths</h4>
       <p class='p-heading--five'>Low-level updates preserve the prior boot path.</p>
-      <p>When you have to update the kernel or the operating system you want to know you can go back if needed. Ubuntu Core keeps the last working boot so you always have a safety net.</p>
+      <p>When you have to update the kernel or the operating system you want to know you can go back if needed. Ubuntu
+        Core keeps the last working boot so you always have a safety net.</p>
     </div>
   </div>
 
@@ -889,18 +958,19 @@
     <div class="col-6">
       <h4>Snapshots for application data</h4>
       <p class='p-heading--five'>Standard mechanisms for application data management.</p>
-      <p>Every device has apps which keep track of critical data. We make sure you can manage the data which matters to you, consistently, across all your Ubuntu Core devices. Backup and restore anything, anywhere.</p>
+      <p>Every device has apps which keep track of critical data. We make sure you can manage the data which matters to
+        you, consistently, across all your Ubuntu Core devices. Backup and restore anything, anywhere.</p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/7de21966-snapshot.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/7de21966-snapshot.svg",
+      alt="",
+      height="200",
+      width="200",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -912,13 +982,13 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/3bbf268f-UC20_Device_Recovery.svg",
-        alt="Device recovery",
-        width="220",
-        height="260",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
+      url="https://assets.ubuntu.com/v1/3bbf268f-UC20_Device_Recovery.svg",
+      alt="Device recovery",
+      width="220",
+      height="260",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
@@ -935,7 +1005,8 @@
     <div class='col-8'>
       <h2>Reduce the cost of Linux</h2>
       <p class="p-heading--four">Use Ubuntu Core for free. Pay only for extra services.</p>
-      <p>The reference images of Ubuntu Core are free to redistribute. Engage Canonical for enablement and custom service levels. We'll get you to market faster.</p>
+      <p>The reference images of Ubuntu Core are free to redistribute. Engage Canonical for enablement and custom
+        service levels. We'll get you to market faster.</p>
     </div>
   </div>
 </section>
@@ -949,14 +1020,14 @@
     </div>
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/58e11dd2-delta+updates.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/58e11dd2-delta+updates.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -968,20 +1039,21 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/aec863e2-Off+the+shelf.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/aec863e2-Off+the+shelf.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Ubuntu board support by Canonical</h4>
       <p class='p-heading--five'>First class enablement for widely used boards and silicon</p>
-      <p>Low-level development is a distraction in the race to market. Focus all your effort on differentiation, not Linux. Pre-certified boards keep you out of the weeds.</p>
+      <p>Low-level development is a distraction in the race to market. Focus all your effort on differentiation, not
+        Linux. Pre-certified boards keep you out of the weeds.</p>
       <p><a href="/download/iot#core">See our supported boards&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -994,19 +1066,20 @@
     <div class="col-6">
       <h4>Right-size your silicon</h4>
       <p class='p-heading--five'>Finish your apps, then choose your chips.</p>
-      <p>A standard platform means you can develop your software and polish your industrial design first, then choose the right size chips for your experience based on real code and data.</p>
+      <p>A standard platform means you can develop your software and polish your industrial design first, then choose
+        the right size chips for your experience based on real code and data.</p>
       <p>Get the best deal when you're ready to ship.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/47ced1e2-right+size.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/47ced1e2-right+size.svg",
+      alt="",
+      height="200",
+      width="350",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
   </div>
@@ -1018,20 +1091,21 @@
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/de23ae0e-logos.svg",
-          alt="",
-          height="156",
-          width="270",
-          hi_def=True,
-          loading="lazy"
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/de23ae0e-logos.svg",
+      alt="",
+      height="156",
+      width="270",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
       }}
     </div>
     <div class="col-6">
       <h4>Choice of ARM or x86</h4>
       <p class='p-heading--five'>Unified application build experience</p>
-      <p>We support both 32-bit and 64-bit apps on both architectures. If it doesn’t compile and run the same, we’ll fix it.</p>
+      <p>We support both 32-bit and 64-bit apps on both architectures. If it doesn’t compile and run the same, we’ll fix
+        it.</p>
     </div>
   </div>
 </section>
@@ -1049,20 +1123,22 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           {{
-            image(
-              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-              alt="",
-              height="28",
-              width="32",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
-            ) | safe
+          image(
+          url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+          alt="",
+          height="28",
+          width="32",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+          ) | safe
           }}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/embedded-linux-make-or-buy/' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - left', 'eventLabel' : 'Whitepaper - Embedded Linux ', 'eventValue' : '1' });'>Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/embedded-linux-make-or-buy/' onclick='dataLayer.push({' event'
+          : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel'
+          : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });'>Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">
@@ -1070,20 +1146,23 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           {{
-            image(
-              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-              alt="",
-              height="28",
-              width="32",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
-            ) | safe
+          image(
+          url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+          alt="",
+          height="28",
+          width="32",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+          ) | safe
           }}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-security-audit' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Independent security audit', 'eventAction' : 'core - left', 'eventLabel' : 'Whitepaper - IMS Evolve ', 'eventValue' : '1' });'>An independent security audit of Ubuntu Core&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-security-audit' onclick='dataLayer.push({' event'
+          : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction' : 'core - left' , 'eventLabel'
+          : 'Whitepaper - IMS Evolve ' , 'eventValue' : '1' });'>An independent security audit of Ubuntu
+          Core&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block u-no-padding--bottom">
@@ -1091,26 +1170,29 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           {{
-            image(
-              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-              alt="",
-              height="28",
-              width="32",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
-            ) | safe
+          image(
+          url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+          alt="",
+          height="28",
+          width="32",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+          ) | safe
           }}
           <h4 class='p-heading-icon__title'>Whitepaper</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='engage/ubuntu-core-and-kura' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - center', 'eventLabel' : 'Whitepaper - Ubuntu Core and Kura - a framework for IoT gateways', 'eventValue' : '1' });'>Ubuntu Core and Kura &mdash; a framework for IoT gateways&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='engage/ubuntu-core-and-kura' onclick='dataLayer.push({' event' : 'GAEvent'
+          , 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel'
+          : 'Whitepaper - Ubuntu Core and Kura - a framework for IoT gateways' , 'eventValue' : '1' });'>Ubuntu Core and
+          Kura &mdash; a framework for IoT gateways&nbsp;&rsaquo;</a></h3>
       <!-- rtp section center end -->
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr class="p-separator"/>
+    <hr class="p-separator" />
   </div>
 
   <div class="row p-divider">
@@ -1119,18 +1201,21 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           {{ image (
-            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-            alt="",
-            width="88",
-            height="72",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
+          url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+          alt="",
+          width="88",
+          height="72",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
           }}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-20-webinar' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - left', 'eventLabel' : 'Webinar - Introuction to Ubuntu Core 20 ', 'eventValue' : '1' });'>Introduction to Ubuntu Core 20&nbsp;&rsaquo;</a></h3>
+      <h3 class='p-heading--four'><a href='/engage/ubuntu-core-20-webinar' onclick='dataLayer.push({' event' : 'GAEvent'
+          , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel'
+          : 'Webinar - Introuction to Ubuntu Core 20 ' , 'eventValue' : '1' });'>Introduction to Ubuntu Core
+          20&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">
@@ -1138,18 +1223,22 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           {{ image (
-            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-            alt="",
-            width="88",
-            height="72",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
+          url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+          alt="",
+          width="88",
+          height="72",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
           }}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class="p-link--external" href='https://www.brighttalk.com/webcast/6793/402503/ubuntu-core-a-cybersecurity-analysis' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Independent security audit', 'eventAction' : 'core - left', 'eventLabel' : 'Webinar - a cybersecurity analysis', 'eventValue' : '1' });'>Ubuntu Core: a cybersecurity analysis</a></h3>
+      <h3 class='p-heading--four'><a class="p-link--external"
+          href='https://www.brighttalk.com/webcast/6793/402503/ubuntu-core-a-cybersecurity-analysis'
+          onclick='dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction'
+          : 'core - left' , 'eventLabel' : 'Webinar - a cybersecurity analysis' , 'eventValue' : '1' });'>Ubuntu Core: a
+          cybersecurity analysis</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">
@@ -1157,18 +1246,21 @@
       <div class='p-heading-icon--muted'>
         <div class='p-heading-icon__header'>
           {{ image (
-            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-            alt="",
-            width="88",
-            height="72",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
+          url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+          alt="",
+          width="88",
+          height="72",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
           }}
           <h4 class='p-heading-icon__title'>Webinar</h4>
         </div>
       </div>
-      <h3 class='p-heading--four'><a class="p-link--external" href='https://www.brighttalk.com/webcast/6793/373030/migrating-to-ubuntu-core' onclick='dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'product page', 'eventAction' : 'core - center', 'eventLabel' : 'Webinar - Migrating to Ubuntu Core', 'eventValue' : '1' });'>Migrating to Ubuntu Core</a></h3>
+      <h3 class='p-heading--four'><a class="p-link--external"
+          href='https://www.brighttalk.com/webcast/6793/373030/migrating-to-ubuntu-core' onclick='dataLayer.push({'
+          event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel'
+          : 'Webinar - Migrating to Ubuntu Core' , 'eventValue' : '1' });'>Migrating to Ubuntu Core</a></h3>
       <!-- rtp section center end -->
     </div>
   </div>
@@ -1188,7 +1280,8 @@
     <div class="col-4 p-divider__block">
       <h4>Download Ubuntu Core</h4>
       <p>Try Ubuntu Core 20 on one of a popular development board</p>
-      <p><a class="p-button--neutral p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">Download and install Ubuntu Core 20</a></p>
+      <p><a class="p-button--neutral p-link--external"
+          href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">Download and install Ubuntu Core 20</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h4>Make your own Ubuntu Core device</h4>
@@ -1198,7 +1291,8 @@
     <div class="col-4 p-divider__block">
       <h4>Let's work together</h4>
       <p>Talk to us about using Ubuntu Core for your next project.</p>
-      <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Get in touch</a></p>
+      <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Get in touch</a>
+      </p>
     </div>
   </div>
 </section>
@@ -1220,7 +1314,8 @@
   @media only screen and (max-width: 460px) {
     .p-banner-core-hero {
       background-color: #333333;
-      background-image: linear-gradient(-225deg, #333333 0%, #111111 50%, #1D1D1D 100%);;
+      background-image: linear-gradient(-225deg, #333333 0%, #111111 50%, #1D1D1D 100%);
+      ;
     }
   }
 
@@ -1249,11 +1344,14 @@
   }
 </style>
 
-{% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include
+"shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-  </div>
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things"
+  data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you"
+  data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
 
 
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -15,7 +15,7 @@
         <a class="p-button--positive" href="/engage/ubuntu-core-20-webinar">Watch the webinar</a>
       </p>
       <p class="u-sv3">
-        <a class="p-link--external p-link--inverted"
+        <a class="p-link--inverted"
           href="https://assets.ubuntu.com/v1/b2c770ea-Ubuntu+Core20+Datasheet.pdf">Read the Ubuntu Core datasheet</a>
       </p>
     </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -210,10 +210,10 @@
       </li>
       <li class="p-inline-images__item">
         {{ image (
-        url="https://assets.ubuntu.com/v1/b5352dc1-logo-arm.svg",
+        url="https://assets.ubuntu.com/v1/f6a59799-partner-logo-arm.svg",
         alt="ARM",
-        width="128",
-        height="40",
+        width="112",
+        height="34",
         hi_def=True,
         loading= "lazy",
         ) | safe


### PR DESCRIPTION
## Done

- Added ARM, NXP, Xilinx, and Mediatek logos to /core page
- Updated Yocto image 

Copydoc: 
https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit#
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4390

## Screenshots
<img width="773" alt="Screenshot 2021-08-31 at 14 32 32" src="https://user-images.githubusercontent.com/17607612/131503121-8ef75311-4370-46c2-925c-5e5838613a21.png">
[If relevant, please include a screenshot.]
