### PR TITLE
Include Xilinx on /download/iot

### DIFF
--- a/templates/download/contact-us.html
+++ b/templates/download/contact-us.html
@@ -1,0 +1,29 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Contact us | Download{% endblock %}
+
+{% block content %}
+
+{% if product == 'supported-platforms' %}
+
+{% with h1='Contact us about supported platforms',
+  intro_text="Can't find your board of choice? Fill out the form and a member of our team will be in touch",
+  formid="4126",
+  lpId="",
+  returnURL="https://www.ubuntu.com/download/thank-you?product=supported-platforms" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+{% else %}
+
+{% with h1="Contact Canonical about downloads",
+  intro_text="",
+  formid="1257",
+  lpId="",
+  returnURL="https://www.ubuntu.com/download/thank-you" %}
+  {% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+{% endif %}
+
+{% endblock content %}

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -64,7 +64,7 @@
             width="120",
             height="45",
             hi_def=True,
-            loading="lazy",
+            loading="auto",
           ) | safe
         }}
         <p>
@@ -79,11 +79,25 @@
             width="63",
             height="45",
             hi_def=True,
-            loading="lazy",
+            loading="auto",
           ) | safe
         }}
         <p>
           <a href="/download/intel-nuc-desktop">Install Ubuntu Server&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-3">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/8a8c250f-xilinx-logo.svg",
+          alt="",
+          width="163",
+          height="45",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+        }}
+        <p>
+          <a href="/download/xilinx">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -132,9 +146,19 @@
           <img src="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg" width="163" height="45" alt="Intel IEI TANK 870">
           <p><a href="/download/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
         </div>
+      </div>
+      <div class="row">
         <div class="col-3">
           <img src="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg" width="139" height="45" alt="Qualcomm Snapdragon">
           <p><a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="col-3">
+          <img src="https://assets.ubuntu.com/v1/8a8c250f-xilinx-logo.svg" width="163" height="45" alt="Xilinx">
+          <p><a href="/download/xilinx">Install Ubuntu Core 20&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="col-3">
+          <p>Can't find your board of choice?</p>
+          <a class="p-button--positive" href="">Get in touch</a>
         </div>
       </div>
       <div class="u-fixed-width" style="margin-top: 2rem;">

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -158,7 +158,7 @@
         </div>
         <div class="col-3">
           <p>Can't find your board of choice?</p>
-          <a class="p-button--positive" href="">Get in touch</a>
+          <a class="p-button--positive js-invoke-modal" href="/download/contact-us">Get in touch</a>
         </div>
       </div>
       <div class="u-fixed-width" style="margin-top: 2rem;">
@@ -173,6 +173,10 @@
     <section class="p-strip--light is-deep">
       {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual machine" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
     </section>
+
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="4126" data-lp-id="" data-return-url="https://www.ubuntu.com/download/thank-you?product=supported-platforms" data-lp-url="https://ubuntu.com/download/contact-us?product=supported-platforms">
+    </div>
 
 
     {% with heading="Not finding the board you want? " %}{% include "/pricing/shared/_enablement-strip.html" %}{% endwith %}

--- a/templates/download/thank-you.html
+++ b/templates/download/thank-you.html
@@ -1,0 +1,40 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Thank you | Download{% endblock %}
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+{% block meta_description %}Download Ubuntu desktop, Ubuntu Server, Ubuntu for Raspberry Pi and IoT devices, Ubuntu Core and all the Ubuntu flavours.  Ubuntu is an open-source software platform that runs everywhere from the PC to the server and the cloud.{% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block content %}
+
+{% if product == 'supported-platforms' %}
+
+  {% with thanks_context="contacting us about supported platforms" %}{% include "shared/_thank_you.html" %}{% endwith %}
+
+{% else %}
+
+  {% with thanks_context="contacting us about Ubuntu downloads" %}{% include "shared/_thank_you.html" %}{% endwith %}
+
+{% endif %}
+
+{% endblock content %}
+{% block footer_extra %}
+<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+<script>
+  /* <![CDATA[ */
+  var google_conversion_id = 1012391776;
+  var google_conversion_language = "en";
+  var google_conversion_format = "3";
+  var google_conversion_color = "ffffff";
+  var google_conversion_label = "utP4CMDOwQMQ4L7f4gM";
+  var google_conversion_value = 0;
+  /* ]]> */
+</script>
+<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+  <div style="display:inline;">
+    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+  </div>
+</noscript>
+{% endblock footer_extra %}


### PR DESCRIPTION
## Done

- Included Xilinx in two places on `/download/iot`
- The page isn't live yet so the PR is blocked until it's built

## QA

- View page at: https://ubuntu-com-10262.demos.haus/download/iot
- Check page against [copy doc](https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit#heading=h.v1842hnm1pef) and resolve comments
- The Xilinx image needs to be 45px high to keep inline with other logos - but this makes it too wide. Could a design suggestion be given please.
- Also - not sure of the best position for the "Can't find your board of choice?" text


## Issue / Card

Fixes [#4149](https://github.com/canonical-web-and-design/web-squad/issues/4149)

## Screenshots

![Screenshot 2021-08-31 at 13 54 55](https://user-images.githubusercontent.com/58959073/131519536-5e563221-5c90-4f99-85d8-473e581ab5ca.png)


![Screenshot 2021-08-31 at 13 55 01](https://user-images.githubusercontent.com/58959073/131519507-88e3b239-ede7-4596-a859-9bf083a9e09c.png)

