### PR TITLE
Add a space

### DIFF
--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -346,7 +346,7 @@
       <p>Instead of relying on random interconnected tools, Canonical leverages the concept of operators for OpenStack deployments, operations and upgrades. <a class="p-link--external" href="https://docs.openstack.org/charm-guide/latest/">OpenStack Charms</a> enable model-driven architecture and abstract the entire OpenStack complexity. This results in a simpler OpenStack platform, fewer resources required to maintain it and reduced operational costs.</p>
       <p>
         <a href="https://assets.ubuntu.com/v1/a08e868a-Charmed+OpenStack_15.03.21.pdf">
-          Learn more in ourdatasheet&nbsp;&rsaquo;
+          Learn more in our datasheet&nbsp;&rsaquo;
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- Added a space between "our" and "datasheet"
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/compare
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check this [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/10254#event-5231050605) as there was no copy doc

## Issue / Card

Fixes #10254 

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/131523177-ddfc60d2-dfb2-48f2-8154-00d095937b60.png)
