### PR TITLE
Copy update on /pricing/consulting

### DIFF
--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,48 +1,50 @@
 <div class="row u-equal-height">
   <div class="col-4 p-card">
     <h2 class="p-heading--four">Explorer</h2>
-    <p><span class="p-heading--two">$19,500</span><br />Basic workshop</p>
+    <p><span class="p-heading--two">$19,500</span><br />Training & onboarding package</p>
     <hr class="u-sv1" />
-    <p>Three-day training on Kubernetes deployment and operations. Ramp up team on Kubernetes and enable your team to deploy on VMware and public clouds.</p>
-    <p>What's included:</p>
+    <p>Three-day Kubernetes training to ramp up your team’s skills, including:</p>
     <ul class="p-list">
-      <li class="p-list__item is-ticked">K8s and container basics</li>
-      <li class="p-list__item is-ticked">Reference architecture</li>
-      <li class="p-list__item is-ticked">Multi-cloud approach</li>
-      <li class="p-list__item is-ticked">Security and patching</li>
+      <li class="p-list__item is-ticked">Kubernetes fundamentals</li>
+      <li class="p-list__item is-ticked">Container development basics</li>
+      <li class="p-list__item is-ticked">MicroK8s enablement</li>
+      <li class="p-list__item is-ticked">Charmed Kubernetes enablement</li>
       <li class="p-list__item is-ticked">Monitoring and logging</li>
-      <li class="p-list__item is-ticked">Lifecycle management</li>
-      <li class="p-list__item is-ticked">Backup and recovery</li>
+      <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
+      <li class="p-list__item is-ticked">Security essentials</li>
     </ul>
   </div>
   <div class="col-4 p-card">
     <h2 class="p-heading--four">Discoverer</h2>
-    <p><span class="p-heading--two">$45,000</span><br />Workshop and reference architecture</p>
+    <p><span class="p-heading--two">$45,000</span><br />Reference architecture design & deployment</p>
     <hr class="u-sv1" />
-    <p>Three-day training plus five days of deployment of a reference k8s architecture on VMware, private and public clouds.</p>
-    <p>What's included:</p>
+    <p>Three-day training & 2-week deployment of reference K8s architecture, including:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">High availability</li>
-      <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
-      <li class="p-list__item is-ticked">Logging, monitoring,  alerting</li>
-      <li class="p-list__item is-ticked">Calico and Flannel</li>
-      <li class="p-list__item is-ticked">Three days standard training</li>
+      <li class="p-list__item is-ticked"><a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">Openstack</a></li>
+      <li class="p-list__item is-ticked">Storage & SDN basic options</li>
+      <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
+      <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
+      <li class="p-list__item is-ticked">Security essentials</li>
+      <li class="p-list__item is-ticked">Supported or Fully Managed</li>
     </ul>
   </div>
   <div class="col-4 p-card">
     <h2 class="p-heading--four">Discoverer Plus</h2>
-    <p><span class="p-heading--two">$95,000</span><br />Co-design and full enterprise production deployment</p>
+    <p><span class="p-heading--two">$95,000</span><br />Custom architecture design & deployment</p>
     <hr class="u-sv1" />
-    <p>Three weeks including on-site workshop, design and implementation of a custom architecture across bare metal, virtual and cloud environments.</p>
-    <p>What's included:</p>
+    <p>Three-week custom architecture deployment project and knowledge transfer, including:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">High availability</li>
+      <li class="p-list__item is-ticked"><a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">Openstack</a>, <a class="p-link--external" href="https://maas.io/">Bare metal</a></li>
+      <li class="p-list__item is-ticked">Storage & SDN extensive options</li>
+      <li class="p-list__item is-ticked">Third-party integrations</li>
+      <li class="p-list__item is-ticked">GPU Acceleration</li>
+      <li class="p-list__item is-ticked">Private registry options</li>
       <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
-      <li class="p-list__item is-ticked">Cloud, VMware, OpenStack</li>
-      <li class="p-list__item is-ticked">Bare metal</li>
-      <li class="p-list__item is-ticked">GPU acceleration</li>
-      <li class="p-list__item is-ticked">Persistent storage volumes</li>
-      <li class="p-list__item is-ticked">Hands-on in-person knowledge transfer</li>
+      <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
+      <li class="p-list__item is-ticked">Security essentials</li>
+      <li class="p-list__item is-ticked">Supported or Fully Managed</li>
     </ul>
   </div>
 </div>

--- a/templates/shared/pricing/_kubernetes-consulting.html
+++ b/templates/shared/pricing/_kubernetes-consulting.html
@@ -1,7 +1,7 @@
 <div class="row u-equal-height">
   <div class="col-4 p-card">
     <h2 class="p-heading--four">Explorer</h2>
-    <p><span class="p-heading--two">$19,500</span><br />Training & onboarding package</p>
+    <p><span class="p-heading--two">$19,500</span><br />Training &amp; onboarding package</p>
     <hr class="u-sv1" />
     <p>Three-day Kubernetes training to ramp up your team’s skills, including:</p>
     <ul class="p-list">
@@ -16,13 +16,13 @@
   </div>
   <div class="col-4 p-card">
     <h2 class="p-heading--four">Discoverer</h2>
-    <p><span class="p-heading--two">$45,000</span><br />Reference architecture design & deployment</p>
+    <p><span class="p-heading--two">$45,000</span><br />Reference architecture design &amp; deployment</p>
     <hr class="u-sv1" />
-    <p>Three-day training & 2-week deployment of reference K8s architecture, including:</p>
+    <p>Three-day training &amp; 2-week deployment of reference K8s architecture, including:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">High availability</li>
       <li class="p-list__item is-ticked"><a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">Openstack</a></li>
-      <li class="p-list__item is-ticked">Storage & SDN basic options</li>
+      <li class="p-list__item is-ticked">Storage &amp; SDN basic options</li>
       <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
       <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
       <li class="p-list__item is-ticked">Security essentials</li>
@@ -31,13 +31,13 @@
   </div>
   <div class="col-4 p-card">
     <h2 class="p-heading--four">Discoverer Plus</h2>
-    <p><span class="p-heading--two">$95,000</span><br />Custom architecture design & deployment</p>
+    <p><span class="p-heading--two">$95,000</span><br />Custom architecture design &amp; deployment</p>
     <hr class="u-sv1" />
     <p>Three-week custom architecture deployment project and knowledge transfer, including:</p>
     <ul class="p-list">
       <li class="p-list__item is-ticked">High availability</li>
       <li class="p-list__item is-ticked"><a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">Openstack</a>, <a class="p-link--external" href="https://maas.io/">Bare metal</a></li>
-      <li class="p-list__item is-ticked">Storage & SDN extensive options</li>
+      <li class="p-list__item is-ticked">Storage &amp; SDN extensive options</li>
       <li class="p-list__item is-ticked">Third-party integrations</li>
       <li class="p-list__item is-ticked">GPU Acceleration</li>
       <li class="p-list__item is-ticked">Private registry options</li>


### PR DESCRIPTION
## Done

- Updated Kubernetes cards and list items

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/consulting
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check page against [copy doc](https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY/edit#heading=h.z516x9uv6lts).


## Issue / Card

Fixes [#4391](https://github.com/canonical-web-and-design/web-squad/issues/4391l)

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/131529406-da4ea26d-9332-4cfd-8a87-33efc2f25ff3.png)
