### PR TITLE
New advantage contract token endpoint

### DIFF
--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from requests.exceptions import HTTPError
 
 from webapp.advantage.ua_contracts.parsers import (
@@ -83,23 +85,13 @@ class UAContractsAPI:
 
         return contracts
 
-    def get_contract_token(self, contract_id: str):
-        try:
-            response = self._request(
-                method="post",
-                path=f"v1/contracts/{contract_id}/token",
-                json={},
-            )
-        except HTTPError as error:
-            if error.response.status_code == 401:
-                if self.is_for_view:
-                    raise UAContractsAPIAuthErrorView(error)
-                raise UAContractsAPIAuthError(error)
-
-            if self.is_for_view:
-                raise UAContractsAPIErrorView(error)
-
-            raise UAContractsAPIError(error)
+    def get_contract_token(self, contract_id: str) -> Optional[str]:
+        response = self._request(
+            method="post",
+            path=f"v1/contracts/{contract_id}/token",
+            json={},
+            error_rules=["default", "auth"],
+        )
 
         return response.json().get("contractToken")
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -363,6 +363,24 @@ def get_last_purchase_ids(account_id, **kwargs):
     return flask.jsonify(last_purchase_ids)
 
 
+@advantage_checks(["need_user"])
+@use_kwargs({"contract_id": String()}, location="query")
+def get_contract_token(contract_id, **kwargs):
+    token = kwargs.get("token")
+    api_url = kwargs.get("api_url")
+
+    advantage = UAContractsAPI(
+        session,
+        token,
+        api_url=api_url,
+        convert_response=True,
+    )
+
+    contract_token = advantage.get_contract_token(contract_id)
+
+    return flask.jsonify({"contract_token": contract_token})
+
+
 @advantage_checks(check_list=["is_maintenance"])
 def advantage_shop_view(**kwargs):
     api_url = kwargs.get("api_url")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -96,6 +96,7 @@ from webapp.advantage.views import (
     download_invoice,
     get_user_subscriptions,
     get_last_purchase_ids,
+    get_contract_token,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -303,6 +304,9 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/last-purchase-ids/<account_id>",
     view_func=get_last_purchase_ids,
+)
+app.add_url_rule(
+    "/advantage/contracts/<contract_id>/token", view_func=get_contract_token
 )
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)


### PR DESCRIPTION
## Done

- Create endpoint /advantage/contracts/`contract-id`/token
- Returns `{"contract_token":  <token>}`
- Refactor `ua_contracts/api.py > get_contract_token` function:
  -  It uses now `error_rules` property to catch exceptions allowing us to delete a lot of bespoke exception catching
  - Add tests to cover the funciton

## QA

- Be logged in
- Go to: https://ubuntu-com-10267.demos.haus/advantage/contracts/<contract_id>/token?test_backend=true
- You will see your contract token

### How to find out your `contract_id`?
1) Find your token:
Go to:  https://ubuntu-com-10267.demos.haus/account.json
2) Make CURL request to find your `account_id`:
`curl -H "Authorization: Macaroon <token>" https://contracts.staging.canonical.com/v1/accounts`
Make sure you do not choose your free token account_id (it's usually the first one)
3) Make a CURL request to find a `countract_id`:
`curl -H "Authorization: Macaroon <token>" https://contracts.staging.canonical.com/v1/accounts/<account_id>/contracts`
Choose any contract id you want.


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/212
