### PR TITLE
New advantage user info endpoint

### DIFF
--- a/tests/advantage/fixtures/subscriptions.json
+++ b/tests/advantage/fixtures/subscriptions.json
@@ -54,6 +54,7 @@
       "id": "sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
       "marketplace": "canonical-ua",
       "period": "monthly",
+      "autoRenew": true,
       "status": "active"
     }
   }

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -327,6 +327,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": False,
                     "is_trialled": False,
                     "is_renewable": False,
+                    "has_pending_purchases": False,
                 },
             },
             "test_yearly_user_subscription": {
@@ -346,6 +347,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": False,
                     "is_trialled": False,
                     "is_renewable": False,
+                    "has_pending_purchases": False,
                 },
             },
             "test_monthly_user_subscription": {
@@ -373,6 +375,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": False,
                     "is_trialled": False,
                     "is_renewable": False,
+                    "has_pending_purchases": False,
                 },
             },
             "test_cancelled_user_subscription": {
@@ -400,6 +403,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": False,
                     "is_trialled": False,
                     "is_renewable": False,
+                    "has_pending_purchases": False,
                 },
             },
             "test_expired_user_subscription": {
@@ -419,6 +423,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": True,
                     "is_trialled": False,
                     "is_renewable": False,
+                    "has_pending_purchases": False,
                 },
             },
             "test_trial_user_subscription": {
@@ -438,6 +443,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": False,
                     "is_trialled": True,
                     "is_renewable": False,
+                    "has_pending_purchases": False,
                 },
             },
             "test_pending_purchases_user_subscription": {
@@ -461,6 +467,7 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": False,
                     "is_trialled": False,
                     "is_renewable": False,
+                    "has_pending_purchases": True,
                 },
             },
         }

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -140,6 +140,7 @@ class TestParsers(unittest.TestCase):
                 period="monthly",
                 status="active",
                 last_purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                is_renewing=True,
                 items=[
                     SubscriptionItem(
                         subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -140,7 +140,7 @@ class TestParsers(unittest.TestCase):
                 period="monthly",
                 status="active",
                 last_purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-                is_renewing=True,
+                is_auto_renewing=True,
                 items=[
                     SubscriptionItem(
                         subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -1,4 +1,6 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
+
+from dateutil.parser import parse
 
 from webapp.advantage.ua_contracts.helpers import (
     group_items_by_listing,
@@ -132,3 +134,21 @@ def build_final_user_subscriptions(
         user_subscriptions.append(user_subscription)
 
     return user_subscriptions
+
+
+def build_get_user_info(user_summary: dict = None) -> dict:
+    subscription: Optional[Subscription] = user_summary["subscription"]
+
+    if subscription is None:
+        return {"has_monthly_subscription": False}
+
+    renewal_info = user_summary["renewal_info"]
+
+    return {
+        "has_monthly_subscription": True,
+        "is_renewing": subscription.is_renewing,
+        "last_payment_date": renewal_info["subscriptionStartOfCycle"],
+        "next_payment_date": renewal_info["subscriptionEndOfCycle"],
+        "total": renewal_info["total"],
+        "currency": renewal_info["currency"],
+    }

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -1,7 +1,5 @@
 from typing import List, Dict, Optional
 
-from dateutil.parser import parse
-
 from webapp.advantage.ua_contracts.helpers import (
     group_items_by_listing,
     get_items_aggregated_values,

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -146,9 +146,9 @@ def build_get_user_info(user_summary: dict = None) -> dict:
 
     return {
         "has_monthly_subscription": True,
-        "is_renewing": subscription.is_renewing,
+        "is_auto_renewing": subscription.is_auto_renewing,
         "last_payment_date": renewal_info["subscriptionStartOfCycle"],
         "next_payment_date": renewal_info["subscriptionEndOfCycle"],
         "total": renewal_info["total"],
-        "currency": renewal_info["currency"],
+        "currency": renewal_info["currency"].upper(),
     }

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -91,6 +91,7 @@ def get_user_subscription_statuses(
         "is_expired": False,
         "is_trialled": False,
         "is_renewable": False,
+        "has_pending_purchases": False,
     }
 
     if type == "free":
@@ -101,8 +102,12 @@ def get_user_subscription_statuses(
     statuses["is_in_grace_period"] = date_statuses["is_in_grace_period"]
     statuses["is_expired"] = date_statuses["is_expired"]
 
+    if statuses["is_expired"]:
+        return statuses
+
     subscriptions = subscriptions or []
-    if has_pending_purchases(subscriptions) or statuses["is_expired"]:
+    if has_pending_purchases(subscriptions):
+        statuses["has_pending_purchases"] = True
         return statuses
 
     if type == "trial":

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -164,6 +164,7 @@ def parse_subscription(raw_subscription: Dict) -> Subscription:
         status=raw_subscription.get("subscription").get("status"),
         last_purchase_id=raw_subscription.get("lastPurchaseID"),
         pending_purchases=raw_subscription.get("pendingPurchases"),
+        is_renewing=raw_subscription.get("subscription").get("autoRenew"),
         items=parse_subscription_items(subscription_id, raw_items),
     )
 

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -164,7 +164,7 @@ def parse_subscription(raw_subscription: Dict) -> Subscription:
         status=raw_subscription.get("subscription").get("status"),
         last_purchase_id=raw_subscription.get("lastPurchaseID"),
         pending_purchases=raw_subscription.get("pendingPurchases"),
-        is_renewing=raw_subscription.get("subscription").get("autoRenew"),
+        is_auto_renewing=raw_subscription.get("subscription").get("autoRenew"),
         items=parse_subscription_items(subscription_id, raw_items),
     )
 

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -87,6 +87,7 @@ class Subscription:
         period: str = None,
         items: List[SubscriptionItem] = None,
         last_purchase_id: str = None,
+        is_renewing: bool = None,
         pending_purchases: List[str] = None,
     ):
         self.id = id
@@ -96,6 +97,7 @@ class Subscription:
         self.status = status
         self.last_purchase_id = last_purchase_id
         self.pending_purchases = pending_purchases
+        self.is_renewing = is_renewing
         self.items = items
 
 

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -87,7 +87,7 @@ class Subscription:
         period: str = None,
         items: List[SubscriptionItem] = None,
         last_purchase_id: str = None,
-        is_renewing: bool = None,
+        is_auto_renewing: bool = None,
         pending_purchases: List[str] = None,
     ):
         self.id = id
@@ -97,7 +97,7 @@ class Subscription:
         self.status = status
         self.last_purchase_id = last_purchase_id
         self.pending_purchases = pending_purchases
-        self.is_renewing = is_renewing
+        self.is_auto_renewing = is_auto_renewing
         self.items = items
 
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -416,7 +416,7 @@ def get_user_info(**kwargs):
     )
 
     renewal_info = None
-    if monthly_subscription and monthly_subscription.is_renewing:
+    if monthly_subscription and monthly_subscription.is_auto_renewing:
         renewal_info = advantage.get_subscription_auto_renewal(
             monthly_subscription.id
         )
@@ -426,9 +426,7 @@ def get_user_info(**kwargs):
         "renewal_info": renewal_info,
     }
 
-    user_info = build_get_user_info(user_summary)
-
-    return user_info
+    return build_get_user_info(user_summary)
 
 
 @advantage_checks(check_list=["is_maintenance"])

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -2,6 +2,8 @@
 from datetime import datetime, timedelta, timezone
 
 # Packages
+from typing import Optional
+
 from dateutil.parser import parse
 import flask
 import talisker.requests
@@ -10,10 +12,14 @@ from requests.exceptions import HTTPError
 from webargs.fields import String, Boolean
 
 # Local
+from webapp.advantage.ua_contracts.primitives import Subscription
 from webapp.decorators import advantage_checks
 from webapp.login import user_info
 from webapp.advantage.flaskparser import use_kwargs
-from webapp.advantage.ua_contracts.builders import build_user_subscriptions
+from webapp.advantage.ua_contracts.builders import (
+    build_user_subscriptions,
+    build_get_user_info,
+)
 from webapp.advantage.ua_contracts.helpers import (
     to_dict,
     extract_last_purchase_ids,
@@ -379,6 +385,50 @@ def get_contract_token(contract_id, **kwargs):
     contract_token = advantage.get_contract_token(contract_id)
 
     return flask.jsonify({"contract_token": contract_token})
+
+
+@advantage_checks(["need_user"])
+def get_user_info(**kwargs):
+    token = kwargs.get("token")
+    api_url = kwargs.get("api_url")
+
+    advantage = UAContractsAPI(
+        session,
+        token,
+        api_url=api_url,
+        convert_response=True,
+    )
+
+    try:
+        account = advantage.get_purchase_account()
+    except UAContractsUserHasNoAccount as error:
+        # if no account throw 404
+        raise UAContractsAPIError(error)
+
+    subscriptions = advantage.get_account_subscriptions(
+        account_id=account["id"],
+        marketplace="canonical-ua",
+        filters={"status": "active", "period": "monthly"},
+    )
+
+    monthly_subscription: Optional[Subscription] = (
+        subscriptions[0] if len(subscriptions) > 0 else None
+    )
+
+    renewal_info = None
+    if monthly_subscription and monthly_subscription.is_renewing:
+        renewal_info = advantage.get_subscription_auto_renewal(
+            monthly_subscription.id
+        )
+
+    user_summary = {
+        "subscription": monthly_subscription,
+        "renewal_info": renewal_info,
+    }
+
+    user_info = build_get_user_info(user_summary)
+
+    return user_info
 
 
 @advantage_checks(check_list=["is_maintenance"])

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -98,6 +98,7 @@ from webapp.advantage.views import (
     get_user_subscriptions,
     get_last_purchase_ids,
     get_contract_token,
+    get_user_info,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -310,6 +311,7 @@ app.add_url_rule(
     "/advantage/contracts/<contract_id>/token", view_func=get_contract_token
 )
 app.add_url_rule("/advantage/users", view_func=advantage_account_users_view)
+app.add_url_rule("/advantage/user-info", view_func=get_user_info)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)
 app.add_url_rule(


### PR DESCRIPTION
## Done

- Add `/advantage/user-info` endpoint: Endpoint that returns overall user information like auto renewal status ~~and other global warnings (i.e. pending purchases)~~. 
- Global warnings will have to be deduced from looking at all user subscriptions: `/advanage/user-subscriptions`. 
- Added `statuses.has_pending_purchase` to `UserSubscription` to determine if there are pending purchases for the user

Schema if user has monthly subscriptions:
```
{
  has_monthly_subscription: Boolean(),
  is_auto_renewing: Boolean(),
  last_payment_date: Date(),
  next_payment_date: Date(),
  total: Int(),
  currency:["usd"],
}
``` 

Schema if user has no monthly subscriptions:
```
{
  has_monthly_subscription: Boolean(),
}
``` 

It can return 404 if user has no purchase account. Meaning they have never made a purchase with us before.

## QA

- Login at: https://ubuntu-com-10269.demos.haus/advantage
- Go to: https://ubuntu-com-10269.demos.haus/advantage/user-info
- You should see the user info


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/187