### PR TITLE
Add advantage/users route

### DIFF
--- a/build.js
+++ b/build.js
@@ -18,6 +18,7 @@ let entries = {
   chassisAnimation: "./static/js/src/chassis-animation.js",
   cve: "./static/js/src/cve/cve.js",
   productSelector: "./static/js/src/advantage/subscribe/product-selector.js",
+  advantageAccountUsers: "./static/js/src/advantage/users/app.jsx",
   openstackChart: "./static/js/src/openstack-chart.js",
   uaSubscribe: "./static/js/src/advantage/subscribe/react/app.jsx",
   "cloud-price-slider": "./static/js/src/cloud-price-slider.js",

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1154,6 +1154,12 @@ support:
     - title: Your subscriptions
       path: /advantage
       persist: True
+
+      children:
+        - title: Account users
+          path: /advantage/users
+          hidden: True
+
     - title: Community support
       path: /support/community-support
     - title: Contact us

--- a/static/js/src/advantage/users/app.jsx
+++ b/static/js/src/advantage/users/app.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+function App() {
+  return (
+    <div>
+      <section className="p-strip">
+        <div className="row">
+          <div className="col-12">
+            <h1>Account users</h1>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+ReactDOM.render(
+  <App />,
+  document.getElementById("advantage-account-users-app")
+);

--- a/templates/advantage/users/index.html
+++ b/templates/advantage/users/index.html
@@ -1,0 +1,11 @@
+{% extends "advantage/base_advantage.html" %} 
+
+{% block title %}Account users{% endblock %}
+
+{% block content %}
+
+<div id="advantage-account-users-app"></div>
+
+<script src="/static/js/dist/advantageAccountUsers.js" type="module"></script>
+
+{% endblock %}

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -449,6 +449,11 @@ def advantage_shop_view(**kwargs):
 
 
 @advantage_checks(check_list=["is_maintenance", "view_need_user"])
+def advantage_account_users_view(**kwargs):
+    return flask.render_template("advantage/users/index.html")
+
+
+@advantage_checks(check_list=["is_maintenance", "view_need_user"])
 def payment_methods_view(**kwargs):
     stripe_publishable_key = kwargs["stripe_publishable_key"]
     api_url = kwargs.get("api_url")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -77,6 +77,7 @@ from webapp.views import (
 from webapp.advantage.views import (
     accept_renewal,
     advantage_view,
+    advantage_account_users_view,
     advantage_shop_view,
     payment_methods_view,
     advantage_thanks_view,
@@ -308,6 +309,7 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/contracts/<contract_id>/token", view_func=get_contract_token
 )
+app.add_url_rule("/advantage/users", view_func=advantage_account_users_view)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)
 app.add_url_rule(


### PR DESCRIPTION
## Done

- add advantage/users route
  - create a dummy advantage_account_users_view
  - create empty React app mounted at #advantage-account-users-app
  - add "Account users" child item to navigation

## QA

- When logged out, go to `https://ubuntu-com-10271.demos.haus/advantage/users`
- Confirm you were redirected to `/advantage`
- Log in
- go to `https://ubuntu-com-10271.demos.haus/advantage/users`
- Confirm a page with content "Account users" has been displayed

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/131685758-ee0a9cbf-d544-4bd9-bb3f-cbff77533eb9.png)

## References
- [Account management architecture - Proposed URL structure](https://docs.google.com/document/d/1BwKC43kx-keG3vS5YDYHBRgCN_T0cSfCtsSxeavnhHc/edit#heading=h.ywle6en6olpl)
- https://app.zeplin.io/project/610280dbf760649f5868dfc7/screen/6102811bc3850a9b98915c0c