### PR TITLE
Add trials label to /advantage table

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -91,9 +91,13 @@
           {% set expired_renewable = contract['renewal'] and contract['contractInfo']['daysTillExpiry'] < 0 %}
           <div class="p-card">
             <h4 class="p-card__title u-sv1 u-no-margin--bottom">
-              {% if contract["contractInfo"]["id"] == new_subscription_id %}
-                {% if "daysTillExpiry" in contract["contractInfo"] and contract["contractInfo"]["daysTillExpiry"] > 0 %}
-                  <div class="p-label--new">New</div>
+              {% if contract['is_trialled'] %}
+                <span class="p-label--new">Free trial</span>
+              {% else %}
+                {% if contract["contractInfo"]["id"] == new_subscription_id %}
+                    {% if "daysTillExpiry" in contract["contractInfo"] and contract["contractInfo"]["daysTillExpiry"] > 0 %}
+                      <div class="p-label--new">New</div>
+                    {% endif %}
                 {% endif %}
               {% endif %}
               {{ contract['contractInfo']['name'] }}
@@ -105,14 +109,21 @@
             <div class="row">
               {% with mobile="true" %}
 
-                {% if contract["period"] == "monthly" %}
+                {% if contract['is_trialled'] %}
 
-                  {% include "advantage/table/_manage-monthly.html" %}
+                  {% include "advantage/table/_free-trial.html" %}
 
                 {% else %}
 
-                  {% include "advantage/table/_manage-yearly.html" %}
+                  {% if contract["period"] == "monthly" %}
 
+                    {% include "advantage/table/_manage-monthly.html" %}
+
+                  {% else %}
+
+                    {% include "advantage/table/_manage-yearly.html" %}
+
+                  {% endif %}
                 {% endif %}
 
               {% endwith %}
@@ -225,7 +236,7 @@
               </thead>
               <tbody>
                 {% for contract in enterprise_contracts[account] %}
-                  {% if contract["contractInfo"]["status"] != 'expired' or contract["renewal"]["renewable"] %}
+                  {% if contract["contractInfo"]["status"] != 'expired' or contract["renewal"]["renewable"] or contract["is_trialled"] %}
                     {% set expired_renewable = contract['renewal'] and contract['contractInfo']['daysTillExpiry'] < 0 %}
                     {% if not open_subscription and not new_subscription_id and (loop.index == 1 and outer_loop.index == 1) %}
                       {% set default_open_cell = true %}
@@ -290,14 +301,21 @@
                       </td>
                       <td id="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" class="p-table-expanding__panel" aria-hidden="{% if open_subscription == contract['contractInfo']['id'] %}false{% else %}true{% endif %}">
                         <div class="row">
-                          {% if contract["period"] == "monthly" %}
+                          {% if contract['is_trialled'] %}
 
-                            {% include "advantage/table/_manage-monthly.html" %}
+                            {% include "advantage/table/_free-trial.html" %}
 
                           {% else %}
 
-                            {% include "advantage/table/_manage-yearly.html" %}
+                            {% if contract["period"] == "monthly" %}
 
+                              {% include "advantage/table/_manage-monthly.html" %}
+
+                            {% else %}
+
+                              {% include "advantage/table/_manage-yearly.html" %}
+
+                            {% endif %}
                           {% endif %}
                         </div>
                       </td>

--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -1,8 +1,12 @@
 <td class="u-no-padding p-table-title {% if open_subscription == contract['contractInfo']['id'] %} p-table--open{% endif %}">
   <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
-    {% if contract["contractInfo"]["id"] == new_subscription_id %}
-      {% if "daysTillExpiry" in contract["contractInfo"] and contract["contractInfo"]["daysTillExpiry"] > 0 %}
-        <div class="p-label--new">New</div>
+    {% if contract['is_trialled'] %}
+      <span class="p-label--new">Free trial</span>
+    {% else %}
+      {% if contract["contractInfo"]["id"] == new_subscription_id %}
+          {% if "daysTillExpiry" in contract["contractInfo"] and contract["contractInfo"]["daysTillExpiry"] > 0 %}
+            <div class="p-label--new">New</div>
+          {% endif %}
       {% endif %}
     {% endif %}
     

--- a/templates/advantage/table/_free-trial.html
+++ b/templates/advantage/table/_free-trial.html
@@ -1,0 +1,41 @@
+<div class="col-start-large-2 col-10">
+  {% if mobile %}
+    <hr class="p-separator" />
+  {% endif %}
+  <div class="row">
+    {% if contract['contractInfo']['status'] == "expired" %}
+
+      <div class="p-notification--caution">
+        <p class="p-notification__response">
+         <span class="p-notification__status">Your free trial expired.</span>You will lose access to this Ubuntu Advantage subscription on {{ contract['contractInfo']['grace_period_end'] }}.
+        </p>
+      </div>
+
+    {% endif %}
+
+    <div class="advantage-table-section">
+      <div class="advantage-table-instruction">
+        <span>Started on</span>
+        <p>{{ contract['contractInfo']['createdAtFormatted'] }}</p>
+        <hr />
+        <span>Free trial ends on</span>
+        <p>{{ contract['contractInfo']['effectiveToFormatted'] }}</p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-12 u-align--right">
+        <a 
+          class="p-button--positive u-no-margin--right" 
+          href="/advantage/subscribe?free_trial={{contract["productID"]}}&quantity={{ contract['rowMachineCount'] }}{% if is_test_backend %}&test_backend=true{% endif %}"
+        >
+          {% if contract['contractInfo']['status'] == "expired" %}
+            Buy this subscription
+          {% else %}
+            End trial and buy
+          {% endif %}
+        </a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Added back in the free trial row element
- Added a "Free trial label" before the free trial row

## QA

- Go to http://0.0.0.0:8001/advantage?test_backend=true with a free trial
- it should look like this
- it won't at the moment because the backend is not yet implemented


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/164

## Screenshots

![2021-09-01_16-36](https://user-images.githubusercontent.com/11927929/131690865-fe609390-e252-4124-8aae-612a06c48db5.png)
