### PR TITLE
Fix filter count on /certified search results

### DIFF
--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -11,6 +11,9 @@ function enableApplyFilters() {
   const filtersSelected = [];
   const filters = document.querySelectorAll(".js-enable-apply-filters");
   filters.forEach((filter) => {
+    if (filter.checked) {
+      filtersSelected.push(filter);
+    }
     filter.addEventListener("change", () => {
       if (!filtersSelected.includes(filter)) {
         filtersSelected.push(filter);


### PR DESCRIPTION
## Done

- Fix the count so it includes already applied filters and newly selected filters. 

## QA

- View page at: https://ubuntu-com-10278.demos.haus/certified?q=
- Select any filters and check when the accordion closes the filter count is correct. 
- Now click apply filters
- After the page reloads close the accordion again and check the count is correct
- Select some more filters and check these are added to the count as expected


## Issue / Card

Fixes [#4373](https://github.com/canonical-web-and-design/web-squad/issues/4373)
