### PR TITLE
Remove inline muted heading content strip styles

### DIFF
--- a/templates/0_docs/content_strips.html
+++ b/templates/0_docs/content_strips.html
@@ -44,7 +44,7 @@
               attrs={"class": "p-heading-icon__img"},
             ) | safe
           }}
-          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">CASE STUDY</p>
+          <p class="p-heading--4">Case study</p>
         </div>
         <h4>ITstrategen keeps their applications secure with ESM</h4>
         <p>The security of customer data is of utmost importance to ITstrategen. That's why Ubuntu is their server
@@ -73,7 +73,7 @@
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <h4 class="p-heading-icon__title">Datasheet</h4>
+            <h4>Datasheet</h4>
           </div>
           <h3 class="p-heading--four"><a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/8db65a1e-Kubernetes-for-the-Enterprise.pdf">Kubernetes for the enterprise</a></h3>
         </div>
@@ -92,7 +92,7 @@
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <h4 class="p-heading-icon__title">Webinar</h4>
+            <h4>Webinar</h4>
           </div>
           <h3 class="p-heading--four"><a class="p-link--external p-link--inverted" href="/blog/kubernetes-for-the-enterprise-1-2-3-go" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'Kubernetes for the Enterprise: 1, 2, 3, Go!', 'eventValue' : undefined });">Kubernetes for the Enterprise: 1, 2, 3, Go!</a></h3>
         </div>
@@ -111,7 +111,7 @@
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <h4 class="p-heading-icon__title">Whitepaper</h4>
+            <h4>Whitepaper</h4>
           </div>
           <h3 class="p-heading--four"><a class="p-link--external p-link--inverted" href="https://pages.ubuntu.com/container-whitepaper.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Managed cloud', 'eventLabel' : 'The no-nonsense way to accelerate your business with containers', 'eventValue' : undefined });">The no-nonsense way to accelerate your business with containers</a></h3>
         </div>

--- a/templates/containers/shared/_whitepaper.html
+++ b/templates/containers/shared/_whitepaper.html
@@ -28,7 +28,7 @@
               attrs={"class": "p-heading-icon__img"},
             ) | safe
           }}
-          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">Whitepaper</p>
+          <p class="p-heading--4">Whitepaper</p>
         </div>
         
         <h2 class="p-heading--four">For CTOs: The no-nonsense way to accelerate your business with containers</h2>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -287,7 +287,7 @@
             ) | safe
             }}
           </div>
-          <p class="p-heding--4">Whitepaper</p>
+          <p class="p-heading--4">Whitepaper</p>
         </div>
         <h2 class="p-heading--4">Embedded Linux: make or buy?</h2>
         <p>Commercial support vs. roll-your-own distribution: a dilemma.</p>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -287,7 +287,7 @@
             ) | safe
             }}
           </div>
-          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">whitepaper</p>
+          <p class="p-heding--4">Whitepaper</p>
         </div>
         <h2 class="p-heading--4">Embedded Linux: make or buy?</h2>
         <p>Commercial support vs. roll-your-own distribution: a dilemma.</p>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -641,7 +641,7 @@
   <div class="row">
     <h2>Kubernetes resources</h2>
   </div>
-  <div class="row p-divider">
+  <div class="row p-divider is-dark">
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
@@ -655,7 +655,7 @@
             loading="lazy",
             ) | safe
           }}
-          <p class="p-heading-icon__title p-muted-heading" style="color: #fff;">Data Sheet</p>
+          <p class="p-heading--4">Data Sheet</p>
         </div>
       </div>
       <a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Kubernetes for the enterprise</a>
@@ -673,7 +673,7 @@
             loading="lazy",
             ) | safe
           }}
-          <p class="p-heading-icon__title p-muted-heading" style="color: #fff;">CASE STUDY</p>
+          <p class="p-heading--4">Case study</p>
         </div>
       </div>
       <a class="p-link--inverted" href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain’s OTT media market with Charmed Kubernetes</a>
@@ -691,7 +691,7 @@
             loading="lazy",
             ) | safe
           }}
-          <p class="p-heading-icon__title p-muted-heading" style="color: #fff;">Industry Report</p>
+          <p class="p-heading--4">Industry Report</p>
         </div>
       </div>
       <a class="p-link--inverted p-link--external" href="https://juju.is/cloud-native-kubernetes-usage-report-2021">The Kubernetes and cloud native operations report 2021</a>

--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -175,7 +175,7 @@
               attrs={"class": "p-heading-icon__img"},
             ) | safe
           }}
-          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">WEBINAR</p>
+          <p class="p-heading--4">Webinar</p>
         </div>
         <h4>Plan and optimise your Cassandra deployment</h4>
         <p>Watch this webinar to understand the architecture, configuration and security recommendations for Cassandra deployments on private cloud, container and public cloud environments</p>

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -170,7 +170,7 @@
               attrs={"class": "p-heading-icon__img"},
             ) | safe
           }}
-          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">WEBINAR</p>
+          <p class="p-heading--4">Webinar</p>
         </div>
         <h4>Kafka can be challenging. Learn how we simplify it.</h4>
         <p><a href="https://www.brighttalk.com/webcast/6793/410402" class="p-button--neutral p-link--external">Watch the webinar on BrightTALK</a></p>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -540,7 +540,7 @@
             loading="lazy"
             ) | safe
           }}
-          <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">Case study</p>
+          <p class="p-heading--4">Case study</p>
         </div>
         <h2 class="p-heading--4">We bring infrastructure costs down</h2>
         <p>Read how Charmed OpenStack helped SBI Group to optimise their CapEx and OpEx costs</p>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -61,7 +61,7 @@
               attrs={"class": "p-heading-icon__img"},
               ) | safe
             }}
-            <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">CASE STUDY</p>
+            <p class="p-heading--4">Case study</p>
           </div>
           <h4>
             Interana uses ESM while planning public cloud upgrades to 18.04
@@ -86,7 +86,7 @@
               attrs={"class": "p-heading-icon__img"},
               ) | safe
             }}
-            <p class="p-muted-heading u-sv3" style="color: #fff; line-height: 1.5rem;">CASE STUDY</p>
+            <p class="p-heading--4">Case study</p>
           </div>
           <h4>
             TIM maintains system security and client confidence with ESM

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -346,7 +346,7 @@ meta_copydoc %}
             attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
             ) | safe
             }}
-            <h4 class="p-heading-icon__title">Datasheet</h4>
+            <h4>Datasheet</h4>
           </div>
         </div>
         <h3>Learn more about Livepatch</h3>


### PR DESCRIPTION
## Done

- This was something we were going to add to Vanilla - but it was [decided](https://github.com/canonical-web-and-design/vanilla-framework/pull/3935#issuecomment-905288532) that the muted heading doesn't work with this size of icon. Therefore it needs to be replaced with a `<h4>`.

## QA

- View demo at: 
  - /0_docs/content-strips
  - /core
  - /managed/cassandra
  - /managed/kafka
  - /openstack
  - /security/esm
  - /kubernetes
  - /security/livepatch
- Check it replicates this [suggestion](https://github.com/canonical-web-and-design/vanilla-framework/pull/3935#issuecomment-903651888)


## Issue / Card

Fixes #10237 

## Screenshots

Example on /security/esm

![Screenshot 2021-09-02 at 14 07 15](https://user-images.githubusercontent.com/58959073/131848927-bf7e8372-e1ce-4d68-934c-6d40b3c6a94a.png)

