### PR TITLE
Adds security-livepatch docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1483,7 +1483,6 @@ security:
       path: /security/certifications
       persist: True
 
-
       children:
         - title: FIPS
           path: /security/fips

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1478,9 +1478,11 @@ security:
       path: /security/esm
     - title: Livepatch
       path: /security/livepatch
+      persist: True
     - title: Certifications & Hardening
       path: /security/certifications
       persist: True
+
 
       children:
         - title: FIPS

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1479,6 +1479,11 @@ security:
     - title: Livepatch
       path: /security/livepatch
       persist: True
+
+      children:
+        - title: Security Livepatch Docs
+          path: /security/livepatch/docs
+
     - title: Certifications & Hardening
       path: /security/certifications
       persist: True

--- a/templates/security/livepatch/docs/document.html
+++ b/templates/security/livepatch/docs/document.html
@@ -1,0 +1,10 @@
+{% with
+  document=document,
+  nav_items=nav_items,
+  search_action="/security/livepatch/docs/search",
+  siteSearch="https://ubuntu.com/security/livepatch/docs",
+  placeholder="Search on Security Livepatch Docs",
+  navigation=navigation
+%}
+  {% include "templates/docs/shared/_docs.html" %}
+{% endwith %}

--- a/templates/security/livepatch/docs/search-results.html
+++ b/templates/security/livepatch/docs/search-results.html
@@ -1,0 +1,12 @@
+{% with
+  title="Ubuntu Security Livepatch Docs",
+  query=query,
+  results=results,
+  search_action="/security/livepatch/docs/search",
+  siteSearch="https://ubuntu.com/security/livepatch/docs",
+  placeholder="Search on Security Livepatch Docs",
+  search_path="/security/livepatch/docs/search",
+  forum_link="https://https://https://discourse.ubuntu.com/c/security/livepatch/82"
+%}
+  {% include "templates/docs/shared/_search-results.html" %}
+{% endwith %}

--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -24,4 +24,7 @@
   <sitemap>
     <loc>https://ubuntu.com/security/cve/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+   <loc>https://ubuntu.com/security/livepatch/docs/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -810,6 +810,31 @@ app.add_url_rule(
 
 openstack_docs.init_app(app)
 
+# Security Livepatch docs
+security_livepatch_docs = Docs(
+    parser=DocParser(
+        api=discourse_api,
+        index_topic_id=22723,
+        url_prefix="/security/livepatch/docs",
+    ),
+    document_template="/security/livepatch/docs/document.html",
+    url_prefix="/security/livepatch/docs",
+    blueprint_name="security-livepatch-docs",
+)
+
+# Security Livepatch search
+app.add_url_rule(
+    "/security/livepatch/docs/search",
+    "security-livepatch-docs-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/security/livepatch/docs",
+        template_path="/security/livepatch/docs/search-results.html",
+    ),
+)
+
+security_livepatch_docs.init_app(app)
+
 # Security Certifications docs
 security_certs_docs = Docs(
     parser=DocParser(


### PR DESCRIPTION
## Done

- Adds security/livepatch/docs to ubuntu with search feature.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/livepatch/docs/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check all the different pages load.
- Test the search feature is working.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4393
