### PR TITLE
Add Xilinx to mega nav

### DIFF
--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -49,6 +49,9 @@
             <li class='p-list__item'><a class='p-link' href='/download/intel-iei-tank-870'>
               Intel IEI TANK 870
             </a></li>
+            <li class='p-list__item'><a class='p-link' href='/download/xilinx'>
+              Xilinx Evaluation kits & SOMs
+            </a></li>
           </ul>
         </div>
         <div class="col-3">


### PR DESCRIPTION
## Done

- Add "Xilinx Evaluation kits & SOMs" under "Ubuntu IoT" section of download meganav 

## QA

- View demo at: https://ubuntu-com-10284.demos.haus
- Select download section of mega nav and check the new Xilinx link is there as referenced in the[ copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit)

## Issue / Card

Fixes [#4395](https://github.com/canonical-web-and-design/web-squad/issues/4395)

## Screenshots

<img width="294" alt="Screenshot 2021-09-02 at 16 42 15" src="https://user-images.githubusercontent.com/58959073/131874800-a338d079-3ec0-4bb6-85dd-ac61193e32d9.png">
