### PR TITLE
Remove release notes on Xilnix page

### DIFF
--- a/templates/download/xilinx/index.html
+++ b/templates/download/xilinx/index.html
@@ -38,7 +38,6 @@
       <p>
         <a class="p-button--positive" href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz">Download 64-bit</a>
       </p>
-      <p><a href="https://assets.ubuntu.com/v1/9961eed6-Xilinx-Limerick-Ubuntu-Desktop-Image-desktop-zu07-ReleaseNotes.pdf">Xilinx Ubuntu 20.04 LTS release notes&nbsp;&rsaquo;</a></p>
       <p>Works on:</p>
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Xilinx ZCU102</li>


### PR DESCRIPTION
## Done

-Remove release notes on Xilinx page 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
-  Accepts chagnes against copy doc: https://docs.google.com/document/d/1DZxf-ZbJtyS69XQBslJry3Ien1FSHYLB2Qt78iRkhOs/edit#

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
