### PR TITLE
Updates to /download/xilinx

### DIFF
--- a/templates/download/xilinx/index.html
+++ b/templates/download/xilinx/index.html
@@ -36,24 +36,22 @@
       <h3 class="p-heading--4">Ubuntu Desktop {{ releases.lts.full_version }} LTS</h3>
       <p class="u-sv1">The version of Ubuntu with up to 10 years of long term support, until April 2030.</p>
       <p>
-        <a class="p-button--positive" href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz">Download 64-bit</a>
+        <a class="p-button--positive" href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85.img.xz">Download 64-bit</a>
       </p>
       <p>Works on:</p>
-      <ul class="p-list is-split">
+      <ul class="p-list">
         <li class="p-list__item is-ticked">Xilinx ZCU102</li>
         <li class="p-list__item is-ticked">Xilinx ZCU104</li>
         <li class="p-list__item is-ticked">Xilinx ZCU106</li>
-        <li class="p-list__item is-ticked">Xilinx Kria</li>
-        <li class="p-list__item is-ticked">KV260 Vision</li>
-        <li class="p-list__item is-ticked">AI Starter Kit&nbsp;&nbsp;<div class="p-label">Coming soon</div></li>
+        <li class="p-list__item is-ticked">Xilinx Kria KV260 Vision AI Starter Kit&nbsp;&nbsp;<div class="p-label">Coming soon</div></li>
       </ul>
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{ image (
-        url="https://assets.ubuntu.com/v1/4ede62b5-Xilinx-board.png",
+        url="https://assets.ubuntu.com/v1/24e23fbe-zcu106-evaluation-board.png",
         alt="",
-        width="399",
-        height="352",
+        width="400",
+        height="273",
         hi_def=True,
         loading="auto"
         ) | safe
@@ -81,7 +79,7 @@
       </thead>
       <tbody>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz">iot-limerick-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz">iot-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz</a></th>
           <td colspan="2">Sysroot for cross-compilation</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Done

- Updates requested by xilinx
- Pointed to the correct download image
- Condensed Kira board options from 3 list items to 1
- Removed code name from download text (not the actual link yet)
- Updated image of the board

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/xilinx
- See that the above items have been updates
