### PR TITLE
Update xilinx links on people.c.c

### DIFF
--- a/templates/download/xilinx/index.html
+++ b/templates/download/xilinx/index.html
@@ -36,7 +36,7 @@
       <h3 class="p-heading--4">Ubuntu Desktop {{ releases.lts.full_version }} LTS</h3>
       <p class="u-sv1">The version of Ubuntu with up to 10 years of long term support, until April 2030.</p>
       <p>
-        <a class="p-button--positive" href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85.img.xz">Download 64-bit</a>
+        <a class="p-button--positive" href="https://people.canonical.com/~platform/images/xilinx/iot-zcu10x-classic-desktop-2004-x07-20210728-85.img.xz">Download 64-bit</a>
       </p>
       <p>Works on:</p>
       <ul class="p-list">
@@ -79,19 +79,19 @@
       </thead>
       <tbody>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/limerick/iot-limerick-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz">iot-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/iot-zcu10x-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz">iot-zcu10x-classic-desktop-2004-x07-20210728-85-sysroot.tar.xz</a></th>
           <td colspan="2">Sysroot for cross-compilation</td>
         </tr>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/limerick/rootfs.ext4.xz">roofts.ext4.xz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/rootfs.ext4.xz">roofts.ext4.xz</a></th>
           <td colspan="2">EXT4 formatted partition containing entire raw rootfs</td>
         </tr>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/limerick/rootfs.tar.gz">rootfs.tar.gz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/rootfs.tar.gz">rootfs.tar.gz</a></th>
           <td colspan="2">Raw Root filesystem</td>
         </tr>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/limerick/system-boot.tar.gz">system-boot.tar.gz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/system-boot.tar.gz">system-boot.tar.gz</a></th>
           <td colspan="2">FAT Partition Contents</td>
         </tr>
       </tbody>


### PR DESCRIPTION
## Done

- Updated the /download/xilinx page with new link and file locations
- Updated the [copy doc](https://docs.google.com/document/d/1DZxf-ZbJtyS69XQBslJry3Ien1FSHYLB2Qt78iRkhOs/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/xilin
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that it points to https://people.canonical.com/~platform/images/xilinx and the renamed images


