### PR TITLE
Enable auto-import for JSX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     "plugin:cypress/recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react/jsx-runtime",
   ],
   globals: {
     Atomics: "readonly",

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,9 @@ module.exports = {
         },
       },
     ],
-    "@babel/preset-react",
+    ["@babel/preset-react", {
+      "runtime": "automatic"
+    }],
     "@babel/preset-typescript",
   ],
   plugins: [

--- a/build.js
+++ b/build.js
@@ -39,8 +39,11 @@ for (const [key, value] of Object.entries(entries)) {
         // 'production' in all other cases.
         process && process.env && process.env.NODE_ENV === "development"
           ? '"development"'
-          : '"production"'
-    }
+          : '"production"',
+    },
+    inject: value.match(/^.*\.(jsx|tsx)$/) ? [
+      "./react-shim.js"
+    ]: [],
   };
 
   esbuild

--- a/react-shim.js
+++ b/react-shim.js
@@ -1,0 +1,2 @@
+import * as React from "react";
+export { React };

--- a/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
+++ b/static/js/src/advantage/subscribe/react/PurchaseModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Row,
   Col,

--- a/static/js/src/advantage/subscribe/react/app.jsx
+++ b/static/js/src/advantage/subscribe/react/app.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom";
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";

--- a/static/js/src/advantage/subscribe/react/components/FormRow/FormRow.jsx
+++ b/static/js/src/advantage/subscribe/react/components/FormRow/FormRow.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Row, Col } from "@canonical/react-components";
 
 const formRow = ({ label, children, error }) => {

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 
 import {

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodSummary/PaymentMethodSummary.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodSummary/PaymentMethodSummary.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import { Row, Col, Button } from "@canonical/react-components";
 import useStripeCustomerInfo from "../../APICalls/useStripeCustomerInfo";

--- a/static/js/src/advantage/subscribe/react/components/Summary/Summary.jsx
+++ b/static/js/src/advantage/subscribe/react/components/Summary/Summary.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Row, Col } from "@canonical/react-components";
 import { add, format } from "date-fns";
 import { formatter } from "../../../renderers/form-renderer";

--- a/static/js/src/advantage/users/app.jsx
+++ b/static/js/src/advantage/users/app.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom";
 
 function App() {

--- a/static/js/src/openstack/react/app.jsx
+++ b/static/js/src/openstack/react/app.jsx
@@ -1,5 +1,4 @@
 import ReactDOM from "react-dom";
-import React from "react";
 
 import CostCalculatorForm from "./components/CostCalculatorForm";
 

--- a/static/js/src/openstack/react/components/CostCalculations.jsx
+++ b/static/js/src/openstack/react/components/CostCalculations.jsx
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import React from "react";
 import { Row, Col } from "@canonical/react-components";
 
 import TCO_CONSTANTS from "../utils/constants";

--- a/static/js/src/openstack/react/components/CostCalculatorForm.jsx
+++ b/static/js/src/openstack/react/components/CostCalculatorForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Row,
   Col,


### PR DESCRIPTION
## Done

- Enable auto-import for JSX
- run `npx react-codemod update-react-imports`
- create a file called react-shim.js and use esbuild's [inject feature](https://esbuild.github.io/api/#inject) to inject React into each file https://esbuild.github.io/content-types/#auto-import-for-jsx
- add "plugin:react/jsx-runtime" to "extends" to disable relevant rules. https://www.npmjs.com/package/eslint-plugin-react


## QA

- Verify that all pages built with React work correctly

## Output filesize
### `static/js/dist` size
- before: ` 6348kb`
- after: `6356kb`
