### PR TITLE
Remove modal class to contact us CTA under /managed

### DIFF
--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -18,8 +18,8 @@
       <p><i>Now running Apache Cassandra 3.11</i></p>
       <p class="p-heading--four">Fully managed Cassandra for your mission-critical data needs</p>
       <p>
-        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
-        <a href="/managed/contact-us" class="p-button--neutral js-invoke-modal">Free deployment assessment</a>
+        <a href="/managed/contact-us" class="p-button--positive">Get in touch</a>
+        <a href="/managed/contact-us" class="p-button--neutral">Free deployment assessment</a>
       </p>
       <p>We automate the mundane tasks so you can focus on building your core apps with Cassandra. Managed Apache Cassandra database service deployable on the cloud of your choice or on-prem.</p>
     </div>
@@ -273,7 +273,7 @@
   <div class="row u-sv3">
     <div class="col-8">
       <h2>Cassandra on any kubernetes,<br /> any cloud and at any scale</h2>
-      <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+      <p><a href="/managed/contact-us" class="p-button--positive">Contact us</a></p>
     </div>
   </div>
   <div class="row u-sv3">
@@ -508,7 +508,7 @@
               <td colspan="2">Yes</td>
             </tr>
           </table>
-          <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+          <p><a href="/managed/contact-us" class="p-button--positive">Contact us</a></p>
         </div>
       </div>
     </section>
@@ -653,7 +653,7 @@
             Still have open questions?
           </p>
           <p>
-            <a class="p-button--positive js-invoke-modal" href="/managed/contact-us">
+            <a class="p-button--positive" href="/managed/contact-us">
               Contact us
             </a>
           </p>

--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -19,7 +19,6 @@
       <p class="p-heading--four">Fully managed Cassandra for your mission-critical data needs</p>
       <p>
         <a href="/managed/contact-us" class="p-button--positive">Get in touch</a>
-        <a href="/managed/contact-us" class="p-button--neutral">Free deployment assessment</a>
       </p>
       <p>We automate the mundane tasks so you can focus on building your core apps with Cassandra. Managed Apache Cassandra database service deployable on the cloud of your choice or on-prem.</p>
     </div>
@@ -658,7 +657,7 @@
             </a>
           </p>
           <p>
-            Or get in touch with sales@canonical.com or ask a question in our chat.
+            Or get in touch with <a href="mailto:sales@canonical.com">sales@canonical.com</a> or ask a question in our chat.
           </p>
         </div>
       </div>

--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -625,7 +625,7 @@
           <p>
             We manage applications at both the host and the guest level. All prices are dependent on current cloud architecture and requirements.
           </p>
-          <p><a href="/managed/cassandra#get-in-touch">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a></p>
+          <p><a href="/managed/contact-us">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a></p>
         </div>
       </div>
       {% include '/shared/pricing/_managed-pricing.html' %}

--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -139,7 +139,7 @@
         <h3>
           Upstream Cassandra on-rails, fully automated and integrated into your infrastructure.
         </h3>
-        <p><a href="/managed/contact-us" class="js-invoke-modal">Get started with a free architecture assessment&nbsp;&rsaquo;</a></p>
+        <p><a href="/managed/contact-us">Get started with a free architecture assessment&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -295,7 +295,7 @@
           <td><strong>Versions managed</strong></td>
           <td colspan="2">
             Apache Cassandra 3.11 by default<br/>
-            We can support your specific version &mdash; <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>.
+            We can support your specific version &mdash; <a href="/managed/contact-us">contact us</a>.
           </td>
         </tr>
       </table>
@@ -324,7 +324,7 @@
         <tr>
           <td><strong>Public Clouds</strong></td>
           <td colspan="2">AWS, GCP, Azure<br />
-          <a href="/managed/contact-us" class="js-invoke-modal">Contact us</a> for managed Cassandra on other clouds
+          <a href="/managed/contact-us">Contact us</a> for managed Cassandra on other clouds
           </td>
         </tr>
         <tr>

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -590,7 +590,7 @@ coverage.{% endblock meta_description %}
             attrs={"class": "p-heading-icon__img"},
             ) | safe
           }}
-          <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Open source, simplified</hh43>
+          <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Open source, simplified</h4>
         </div>
         <ul class="p-list">
           <li class="p-list__item is-ticked">Bring your own cloud</li>
@@ -654,7 +654,7 @@ coverage.{% endblock meta_description %}
         Our Managed Apps portfolio is constantly evolving and expanding. Speak to us today about your specific needs.
       </p>
       <p>
-        <a class="js-invoke-modal" href="/managed/contact-us">
+        <a href="/managed/contact-us">
           Contact us about your unique requirements&nbsp;&rsaquo;
         </a>
       </p>

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -16,7 +16,7 @@ coverage.{% endblock meta_description %}
       <h1>Performant open source with Managed Apps</h1>
       <p class="p-heading--four">One vendor, easy deployment, guaranteed uptime</p>
       <p>
-        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Free deployment assessment</a>
+        <a href="/managed/contact-us" class="p-button--positive">Free deployment assessment</a>
       </p>
     </div>
     <div class="col-6 u-embedded-media u-align--center">
@@ -265,7 +265,7 @@ coverage.{% endblock meta_description %}
 
     <div class="row">
       <div class="col-8">
-        <p><a href="/managed/contact-us" class="p-button js-invoke-modal">Contact us</a></p>
+        <p><a href="/managed/contact-us" class="p-button">Contact us</a></p>
       </div>
     </div>
   </div>
@@ -502,7 +502,7 @@ coverage.{% endblock meta_description %}
   </div>
   <div class="row">
     <div class="col-8">
-      <p><a href="/managed/contact-us" class="p-button js-invoke-modal">Contact us</a></p>
+      <p><a href="/managed/contact-us" class="p-button">Contact us</a></p>
     </div>
   </div>
   <div class="row p-divider">

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -634,7 +634,7 @@
           <p>
             We manage applications at both the host and the guest level. All prices are dependent on current cloud architecture and requirements.
           </p>
-          <p><a href="/managed/kafka#get-in-touch">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a></p>
+          <p><a href="/managed/contact-us">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a></p>
         </div>
       </div>
       {% include '/shared/pricing/_managed-pricing.html' %}

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -695,7 +695,7 @@
             </a>
           </p>
           <p>
-            Or get in touch with sales@canonical.com or ask a question in our chat.
+            Or get in touch with <a href="mailto:sales@canonical.com">sales@canonical.com</a> or ask a question in our chat.
           </p>
         </div>
       </div>

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -134,7 +134,7 @@
         <h3>
           Upstream Kafka on-rails, fully automated and integrated into your infrastructure.
         </h3>
-        <p><a href="/managed/contact-us" class="js-invoke-modal">Get started with a free architecture assessment&nbsp;&rsaquo;</a></p>
+        <p><a href="/managed/contact-us">Get started with a free architecture assessment&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -289,7 +289,7 @@
           <td><strong>Versions managed</strong></td>
           <td colspan="2">
             Kafka 2.8 by default<br/>
-            We can support your specific version &mdash; <a href="/managed/contact-us" class="js-invoke-modal">contact us</a>.
+            We can support your specific version &mdash; <a href="/managed/contact-us">contact us</a>.
           </td>
         </tr>
         <tr>
@@ -334,7 +334,7 @@
         <tr>
           <td><strong>On-premise</strong></td>
           <td colspan="2">Any OpenStack, bare metal and key third-party providers such as VMWare.<br />
-           <a href="/managed/contact-us" class="js-invoke-modal">Contact us</a> for managed kafka on other clouds</td>
+           <a href="/managed/contact-us">Contact us</a> for managed kafka on other clouds</td>
           </tr>
           <tr>
             <td><strong>Hybrid-cloud</strong></td>

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -16,7 +16,7 @@
       <p><i>Now running Kafka 2.8</i></p>
       <p class="p-heading--four">Fully managed Apache Kafka anywhere, on-prem and multi-cloud environments.</p>
       <p>Spend less time managing infrastructure, more time building applications. Highly available, secure and fully managed Apache Kafka for frictionless innovation.</p>
-      <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
+      <p><a href="/managed/contact-us" class="p-button--positive">Get in touch</a></p>
     </div>
     <div class="col-5 u-hide--small u-align--center">
       {{
@@ -267,7 +267,7 @@
   <div class="row u-sv3">
     <div class="col-8">
       <h2>Kafka on any Kubernetes, <br />any cloud and at any scale</h2>
-      <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+      <p><a href="/managed/contact-us" class="p-button--positive">Contact us</a></p>
     </div>
   </div>
   <div class="row u-sv3">
@@ -517,7 +517,7 @@
               <td colspan="2">Yes</td>
             </tr>
           </table>
-          <p><a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
+          <p><a href="/managed/contact-us" class="p-button--positive">Contact us</a></p>
         </div>
       </div>
     </section>
@@ -690,7 +690,7 @@
             Still have open questions?
           </p>
           <p>
-            <a class="p-button--positive js-invoke-modal" href="/managed/contact-us">
+            <a class="p-button--positive" href="/managed/contact-us">
               Contact us
             </a>
           </p>

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -16,7 +16,7 @@
             <P>Accelerate your cloud journey from months to weeks and minimise your spend to keep the lights on.</P>
             <p>Transform your IT into a business-centric model that cuts down costs, drives innovation and eliminates nonstrategic hiring or training of in-house specialists.</p>
             <p>
-                <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Let’s discuss your annual savings</a>
+                <a href="/managed/contact-us" class="p-button--positive">Let’s discuss your annual savings</a>
             </p>
             <p>
                 <a href="/blog/managed-it-services-like-the-fortune-500" class="p-link--inverted">Learn how to use managed IT services like the Fortune 500&nbsp;&rsaquo;</a>
@@ -38,8 +38,7 @@
 <section class="row p-strip">
     <div class="u-fixed-width">
         <div class="col-10">
-            <p class="p-logo-section__title u-align--center">We manage clouds for
-                world leaders</p>
+            <p class="p-logo-section__title u-align--center">We manage clouds for world leaders</p>
             <div class="p-logo-section">
                 <div class="p-logo-section__items">
                     <div class="p-logo-section__item">
@@ -241,11 +240,11 @@
             <p> You can’t improve what you can’t see, so we provide you with better visibility to give you more control over your cloud costs.</p>
             <p> We build a robust cloud solution for you that provides dashboards for logging, monitoring and alerting. This provides you with the full visibility that enables predictive capacity planning to avoid surprises. </p>
             <p>
-                <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Talk to an expert</a>
+                <a href="/managed/contact-us" class="p-button--positive">Talk to an expert</a>
             </p>
         </div>
         <div class="col-6 u-align--center u-hide--small">
-            {{ 
+            {{
                 image(
                 url="https://assets.ubuntu.com/v1/7088df48-dashboards.png",
                 alt="Dashboards",
@@ -365,7 +364,7 @@
     </div>
     <div class="u-fixed-width">
         <p>
-            <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+            <a href="/managed/contact-us" class="p-button--positive">Contact us</a>
         </p>
         <p>
             <a href="/blog/managed-openstack-cheaper-than-self-managed">Learn how a Managed private cloud is cheaper than self managed&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Removed `js-invoke-modal` so cta's go to /managed/contact-us instead of modal per PdM request

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed
- See the contact us cta's open http://0.0.0.0:8001/managed/contact-us


## Issue / Card

Fixes [#4396](https://github.com/canonical-web-and-design/web-squad/issues/4396)


