### PR TITLE
Add pi4 to /download/raspberry-pi desktop 21.04

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -238,6 +238,7 @@
     <div class="u-hide--medium u-hide--large">
       <p>Works on:</p>
       <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Raspberry Pi 4</li>
         <li class="p-list__item is-ticked">Raspberry Pi 400</li>
         <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
       </ul>
@@ -251,6 +252,30 @@
   </h4>
 </div>
 <div class="row u-hide--small">
+  <div class="col-2">
+    <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+      Raspberry Pi 4
+    </p>
+    <hr>
+    <div>
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+        alt="",
+        height="48",
+        width="75",
+        hi_def=True,
+        attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+    <h6 class="u-text-light">
+      <em>
+        * At least 4 GB RAM required
+      </em>
+    </h6>
+  </div>
   <div class="col-2">
     <p class="u-no-padding--top" style="margin-bottom: .5rem;">
       Raspberry Pi 400
@@ -286,6 +311,11 @@
         ) | safe
       }}
     </div>
+    <h6 class="u-text-light">
+      <em>
+        * At least 4 GB RAM required
+      </em>
+    </h6>
   </div>
 </div>
 </section>


### PR DESCRIPTION
## Done

- Add pi4 to /download/raspberry-pi desktop 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- See that the pi 4 is added


## Issue / Card

Fixes #9796

## Screenshots

![image](https://user-images.githubusercontent.com/441217/132036571-7b2a88a2-a67c-478a-b32d-ee7d7f9cc017.png)

