### PR TITLE
Add `can_be_trialled` to product listings

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -118,14 +118,18 @@
 <script src="/static/js/dist/productSelector.js" type="module"></script>
 <script defer>
   var productList = {
-    {% for listing in product_listings %}
-    "{{ listing.id }}": {
-      name: "{{ listing.product.name }}",
-      price: {{ listing.price|tojson }},
-      period: "{{ listing.period }}",
-      productID: "{{ listing.product.id }}",
-      private: "{{ listing.privateForAccount }}"
-    },
+    {% for listing_id, listing in product_listings.items() %}
+      "{{ listing.id }}": {
+        name: "{{ listing.product.name }}",
+        price: {
+          value: "{{ listing.price }}",
+          currency: "{{ listing.currency }}"
+        },
+        period: "{{ listing.period }}",
+        productID: "{{ listing.product.id }}",
+        can_be_trialled: "{{ listing.can_be_trialled }}",
+        private: false,
+      },
     {% endfor %}
   };
 

--- a/tests/advantage/fixtures/subscription.json
+++ b/tests/advantage/fixtures/subscription.json
@@ -56,6 +56,7 @@
     "id": "sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
     "marketplace": "canonical-ua",
     "period": "yearly",
+    "startedWithTrial": true,
     "status": "active"
   }
 }

--- a/tests/advantage/helpers.py
+++ b/tests/advantage/helpers.py
@@ -68,6 +68,7 @@ def make_subscription(
     period: str = None,
     status: str = None,
     last_purchase_id: str = None,
+    started_with_trial: bool = None,
     pending_purchases: List[str] = None,
     items: List[SubscriptionItem] = None,
 ) -> Subscription:
@@ -80,6 +81,7 @@ def make_subscription(
         last_purchase_id=last_purchase_id or "pAaBbCcDdEeFfGg",
         pending_purchases=pending_purchases or [],
         items=items or [],
+        started_with_trial=started_with_trial,
     )
 
 

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -956,6 +956,29 @@ class TestGetPurchaseAccount(unittest.TestCase):
         self.assertEqual(response, json_account)
         self.assertEqual(session.request_kwargs, expected_args)
 
+    def test_convert_response(self):
+        json_account = get_fixture("account")
+        session = Session(
+            Response(
+                status_code=200,
+                content=json_account,
+            )
+        )
+        client = make_client(session, convert_response=True)
+
+        response = client.get_purchase_account()
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": None,
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/purchase-account",
+        }
+
+        self.assertIsInstance(response, Account)
+        self.assertEqual(session.request_kwargs, expected_args)
+
 
 class TestPurchaseFromMarketplace(unittest.TestCase):
     def test_errors(self):

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -592,6 +592,15 @@ class TestHelpers(unittest.TestCase):
 
         self.assertEqual(last_purchase_ids, expectation)
 
+        last_purchase_ids = extract_last_purchase_ids([])
+
+        expectation = {
+            "monthly": "",
+            "yearly": "",
+        }
+
+        self.assertEqual(last_purchase_ids, expectation)
+
     def test_get_subscription_by_period(self):
         subscriptions = [
             make_subscription(id="yearly_sub", period="yearly"),

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -25,6 +25,7 @@ from webapp.advantage.ua_contracts.helpers import (
     extract_last_purchase_ids,
     get_price_info,
     get_subscription_by_period,
+    set_listings_trial_status,
 )
 
 
@@ -643,3 +644,58 @@ class TestHelpers(unittest.TestCase):
         subscription = get_subscription_by_period(subscriptions, listing)
 
         self.assertEqual(subscription, None)
+
+    def test_set_listings_trial_status_to_true(self):
+        subscriptions = [
+            make_subscription(started_with_trial=False, status="deactivated"),
+        ]
+
+        listings = {
+            "lAbcABC": make_listing(trial_days=30),
+            "lBcdBCD": make_listing(trial_days=1)
+        }
+
+        set_listings_trial_status(listings, subscriptions)
+
+        for listing in listings.values():
+            self.assertEqual(listing.can_be_trialled, True)
+
+    def test_set_listings_trial_status_to_false_because_of_subscriptions(self):
+        subscriptions = [make_subscription(started_with_trial=True)]
+
+        listings = {
+            "lAbcABC": make_listing(trial_days=30),
+            "lBcdBCD": make_listing(trial_days=1)
+        }
+
+        set_listings_trial_status(listings, subscriptions)
+
+        for listing in listings.values():
+            self.assertEqual(listing.can_be_trialled, False)
+
+        subscriptions = [make_subscription()]
+
+        listings = {
+            "lAbcABC": make_listing(trial_days=30),
+            "lBcdBCD": make_listing(trial_days=1)
+        }
+
+        set_listings_trial_status(listings, subscriptions)
+
+        for listing in listings.values():
+            self.assertEqual(listing.can_be_trialled, False)
+
+    def test_set_listings_trial_status_to_false_due_to_listings(self):
+        subscriptions = [
+            make_subscription(started_with_trial=False, status="deactivated")
+        ]
+
+        listings = {
+            "lAbcABC": make_listing(trial_days=0),
+            "lBcdBCD": make_listing(trial_days=0)
+        }
+
+        set_listings_trial_status(listings, subscriptions)
+
+        for listing in listings.values():
+            self.assertEqual(listing.can_be_trialled, False)

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -652,7 +652,7 @@ class TestHelpers(unittest.TestCase):
 
         listings = {
             "lAbcABC": make_listing(trial_days=30),
-            "lBcdBCD": make_listing(trial_days=1)
+            "lBcdBCD": make_listing(trial_days=1),
         }
 
         set_listings_trial_status(listings, subscriptions)
@@ -665,7 +665,7 @@ class TestHelpers(unittest.TestCase):
 
         listings = {
             "lAbcABC": make_listing(trial_days=30),
-            "lBcdBCD": make_listing(trial_days=1)
+            "lBcdBCD": make_listing(trial_days=1),
         }
 
         set_listings_trial_status(listings, subscriptions)
@@ -677,7 +677,7 @@ class TestHelpers(unittest.TestCase):
 
         listings = {
             "lAbcABC": make_listing(trial_days=30),
-            "lBcdBCD": make_listing(trial_days=1)
+            "lBcdBCD": make_listing(trial_days=1),
         }
 
         set_listings_trial_status(listings, subscriptions)
@@ -692,7 +692,7 @@ class TestHelpers(unittest.TestCase):
 
         listings = {
             "lAbcABC": make_listing(trial_days=0),
-            "lBcdBCD": make_listing(trial_days=0)
+            "lBcdBCD": make_listing(trial_days=0),
         }
 
         set_listings_trial_status(listings, subscriptions)

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -121,6 +121,7 @@ class TestParsers(unittest.TestCase):
                     value=3,
                 ),
             ],
+            started_with_trial=True,
         )
 
         self.assertIsInstance(parsed_subscription, Subscription)
@@ -149,7 +150,8 @@ class TestParsers(unittest.TestCase):
                         value=3,
                     ),
                 ],
-            )
+                started_with_trial=None,
+            ),
         ]
 
         self.assertIsInstance(parsed_subscriptions, List)

--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -42,6 +42,11 @@ def advantage_decorator(permission=None, response="json"):
             if strtobool(os.getenv("STORE_MAINTENANCE", "false")):
                 return flask.render_template("advantage/maintenance.html")
 
+            # if logged in, get rid of guest token
+            if user_info(flask.session):
+                if flask.session.get("guest_authentication_token"):
+                    flask.session.pop("guest_authentication_token")
+
             test_backend = flask.request.args.get("test_backend", "false")
             is_test_backend = strtobool(test_backend)
             user_token = flask.session.get("authentication_token")

--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -45,6 +45,11 @@ class Listing:
         self.status = status
         self.trial_days = trial_days
         self.period = period
+        self.can_be_trialled = None
+
+    def set_can_be_trialled(self, can_be_trialled):
+        self.can_be_trialled = can_be_trialled
+
 
 
 class UserSubscription:

--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -51,7 +51,6 @@ class Listing:
         self.can_be_trialled = can_be_trialled
 
 
-
 class UserSubscription:
     def __init__(
         self,

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -7,6 +7,7 @@ from webapp.advantage.ua_contracts.parsers import (
     parse_subscriptions,
     parse_product_listings,
     parse_accounts,
+    parse_account,
 )
 
 
@@ -271,6 +272,9 @@ class UAContractsAPI:
             path="v1/purchase-account",
             error_rules=["default", "no-found"],
         )
+
+        if self.convert_response:
+            return parse_account(response.json())
 
         return response.json()
 

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -249,6 +249,25 @@ def get_subscription_by_period(
     return filtered_subscriptions[0] if filtered_subscriptions else None
 
 
+def set_listings_trial_status(
+    listings: Dict[str, Listing], subscriptions: List[Subscription]
+) -> Dict[str, Listing]:
+    user_can_trial = True
+    for subscription in subscriptions:
+        stated_with_trial = subscription.started_with_trial
+        status = subscription.status
+        if stated_with_trial or status in ["active", "locked"]:
+            user_can_trial = False
+
+            break
+
+    for listing_id, listing in listings.items():
+        listing_can_be_trialled = listing.trial_days and listing.trial_days > 0
+        listing.set_can_be_trialled(listing_can_be_trialled and user_can_trial)
+
+    return listings
+
+
 def to_dict(structure, class_key=None):
     """Converts structure to dictionary
 

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -179,16 +179,18 @@ def parse_subscription_items(
 def parse_subscription(raw_subscription: Dict) -> Subscription:
     subscription_id = raw_subscription.get("subscription").get("id")
     raw_items = raw_subscription.get("purchasedProductListings")
+    subscription = raw_subscription.get("subscription")
 
     return Subscription(
         id=subscription_id,
-        account_id=raw_subscription.get("subscription").get("accountID"),
-        marketplace=raw_subscription.get("subscription").get("marketplace"),
-        period=raw_subscription.get("subscription").get("period"),
-        status=raw_subscription.get("subscription").get("status"),
+        account_id=subscription.get("accountID"),
+        marketplace=subscription.get("marketplace"),
+        period=subscription.get("period"),
+        status=subscription.get("status"),
         last_purchase_id=raw_subscription.get("lastPurchaseID"),
         pending_purchases=raw_subscription.get("pendingPurchases"),
-        is_auto_renewing=raw_subscription.get("subscription").get("autoRenew"),
+        is_auto_renewing=subscription.get("autoRenew"),
+        started_with_trial=subscription.get("startedWithTrial"),
         items=parse_subscription_items(subscription_id, raw_items),
     )
 

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -95,6 +95,7 @@ class Subscription:
         last_purchase_id: str = None,
         is_auto_renewing: bool = None,
         pending_purchases: List[str] = None,
+        started_with_trial: bool = None,
     ):
         self.id = id
         self.account_id = account_id
@@ -105,6 +106,7 @@ class Subscription:
         self.pending_purchases = pending_purchases
         self.is_auto_renewing = is_auto_renewing
         self.items = items
+        self.started_with_trial = started_with_trial
 
 
 class Account:

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -23,6 +23,7 @@ from webapp.advantage.ua_contracts.builders import (
 from webapp.advantage.ua_contracts.helpers import (
     to_dict,
     extract_last_purchase_ids,
+    set_listings_trial_status,
 )
 from webapp.advantage.ua_contracts.api import (
     CannotCancelLastContractError,
@@ -390,51 +391,37 @@ def advantage_shop_view():
     g.api.set_convert_response(True)
 
     account = None
-    subscriptions = []
-
     if user_info(flask.session):
-        if flask.session.get("guest_authentication_token"):
-            flask.session.pop("guest_authentication_token")
-
         try:
             account = g.api.get_purchase_account()
         except UAContractsUserHasNoAccount:
             # There is no purchase account yet for this user.
-            # One will need to be created later, but this is an expected
-            # condition.
+            # One will need to be created later; expected condition.
             pass
 
-        if account:
-            subscriptions = g.api.get_account_subscriptions(
-                account_id=account["id"],
-                marketplace="canonical-ua",
-                filters={"status": "active"},
-            )
+    all_subscriptions = []
+    if account:
+        all_subscriptions = g.api.get_account_subscriptions(
+            account_id=account.id,
+            marketplace="canonical-ua",
+        )
 
-    previous_purchase_ids = extract_last_purchase_ids(subscriptions)
+    current_subscriptions = [
+        subscription
+        for subscription in all_subscriptions
+        if subscription.status in ["active", "locked"]
+    ]
+
     listings = g.api.get_product_listings("canonical-ua")
-    product_listings = listings.get("productListings")
-    if not product_listings:
-        # For the time being, no product listings means the shop has not been
-        # activated, so fallback to shopify. This should become an error later.
-        return flask.redirect("https://buy.ubuntu.com/")
 
-    products = {product["id"]: product for product in listings["products"]}
-
-    website_listing = []
-    for listing in product_listings:
-        if "price" not in listing:
-            continue
-
-        listing["product"] = products[listing["productID"]]
-
-        website_listing.append(listing)
+    previous_purchase_ids = extract_last_purchase_ids(current_subscriptions)
+    user_listings = set_listings_trial_status(listings, all_subscriptions)
 
     return flask.render_template(
         "advantage/subscribe/index.html",
         account=account,
         previous_purchase_ids=previous_purchase_ids,
-        product_listings=website_listing,
+        product_listings=user_listings,
     )
 
 


### PR DESCRIPTION
## Done

- Extracts the subscription `started_with_trial` attribute form subscription json
- Set `can_be_trialled` property to each product listing; 
- When can a user trial a product? 
  - has no active or locked subscription with us
  - no expired subscription started as a trial (meaning they trialled already a product) 
  - product listing `trial_days` is more than 0.

## QA

- Will be QA-able when the front-end is ready

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/217