### PR TITLE
Account Users/Add TableView

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,4 +40,12 @@ module.exports = {
     "@typescript-eslint/no-var-requires": "off",
     "no-prototype-builtins": "off",
   },
+  overrides: [
+    {
+      files: ["**/*.tsx"],
+      rules: {
+        "react/prop-types": "off",
+      },
+    },
+  ],
 };

--- a/static/js/src/advantage/users/AccountUsers.test.tsx
+++ b/static/js/src/advantage/users/AccountUsers.test.tsx
@@ -1,9 +1,27 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
+import { User } from "./types";
 import AccountUsers from "./AccountUsers";
+import { mockData } from "./mockData";
 
 it("displays organisation name", () => {
-  render(<AccountUsers organisationName="Canonical" />);
+  render(<AccountUsers organisationName="Canonical" users={mockData.users} />);
   screen.getByText("Canonical");
+});
+
+it("displays user details in a correct format", () => {
+  const testUser: User = {
+    email: "user@ecorp.com",
+    role: "Admin",
+    createdAt: "2020-01-10T10:00:00Z",
+    lastLoginAt: "2021-02-15T13:45:00Z",
+  };
+
+  render(<AccountUsers organisationName="Canonical" users={[testUser]} />);
+
+  screen.getByText("user@ecorp.com");
+  screen.getByText("Admin");
+  screen.getByText("10/01/2020");
+  screen.getByText("15/02/2021");
 });

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 
+import { Users, OrganisationName } from "./types";
 import Organisation from "./components/Organisation";
+import TableView from "./components/TableView";
 
-const AccountUsers = ({ organisationName }: { organisationName: string }) => {
+const AccountUsers: React.FC<{
+  organisationName: OrganisationName;
+  users: Users;
+}> = ({ organisationName, users }) => {
   return (
     <div>
       <div className="p-strip">
@@ -16,6 +21,11 @@ const AccountUsers = ({ organisationName }: { organisationName: string }) => {
         <div className="row">
           <div className="col-6">
             <Organisation name={organisationName} />
+          </div>
+        </div>
+        <div className="row">
+          <div className="col-12">
+            <TableView users={users} />
           </div>
         </div>
       </section>

--- a/static/js/src/advantage/users/app.tsx
+++ b/static/js/src/advantage/users/app.tsx
@@ -3,12 +3,15 @@ import ReactDOM from "react-dom";
 import AccountUsers from "./AccountUsers";
 
 // TODO: replace with real data once API integration is complete
-const mockData = {
-  organisationName: "myOrganisation",
-};
+import { mockData } from "./mockData";
 
 function App() {
-  return <AccountUsers organisationName={mockData.organisationName} />;
+  return (
+    <AccountUsers
+      organisationName={mockData.organisationName}
+      users={mockData.users}
+    />
+  );
 }
 
 ReactDOM.render(

--- a/static/js/src/advantage/users/components/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { format } from "date-fns";
+import MainTable from "@canonical/react-components/dist/components/MainTable";
+import Button from "@canonical/react-components/dist/components/Button";
+
+import { Users } from "../app";
+
+const DATE_FORMAT = "dd/MM/yyyy";
+
+const TableView: React.FC<{ users: Users }> = ({ users }) => {
+  return (
+    <MainTable
+      responsive
+      headers={[
+        {
+          content: "email",
+        },
+        {
+          content: "role",
+        },
+        {
+          content: "date added",
+        },
+        {
+          content: "last sign in",
+        },
+        {
+          content: "actions",
+        },
+      ]}
+      rows={users.map((user, index) => ({
+        key: index,
+        columns: [
+          {
+            content: user.email,
+            role: "rowheader",
+          },
+          {
+            content: user.role,
+          },
+          {
+            content: format(new Date(user.createdAt), DATE_FORMAT),
+          },
+          {
+            content: format(new Date(user.lastLoginAt), DATE_FORMAT),
+          },
+          {
+            content: (
+              <Button small dense>
+                Edit
+              </Button>
+            ),
+          },
+        ],
+      }))}
+    />
+  );
+};
+
+export default TableView;

--- a/static/js/src/advantage/users/components/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import Button from "@canonical/react-components/dist/components/Button";
 
-import { Users } from "../app";
+import { Users } from "../types";
 
 const DATE_FORMAT = "dd/MM/yyyy";
 

--- a/static/js/src/advantage/users/mockData.ts
+++ b/static/js/src/advantage/users/mockData.ts
@@ -1,0 +1,15 @@
+import { User, AccountUsersData } from "./types";
+
+export const mockUser: User = {
+  email: "philip.p@ecorp.com",
+  role: "Admin",
+  createdAt: "2020-01-10T12:00:00Z",
+  lastLoginAt: "2021-06-10T09:05:00Z",
+};
+
+const organisationName = "ECorp";
+
+export const mockData: AccountUsersData = {
+  organisationName,
+  users: [mockUser],
+};

--- a/static/js/src/advantage/users/types.ts
+++ b/static/js/src/advantage/users/types.ts
@@ -1,0 +1,15 @@
+export type User = {
+  email: string;
+  role: "Admin" | "Technical" | "Billing";
+  createdAt: string;
+  lastLoginAt: string;
+};
+
+export type Users = User[];
+
+export type OrganisationName = string;
+
+export type AccountUsersData = {
+  organisationName: OrganisationName;
+  users: Users;
+};


### PR DESCRIPTION
## Done

- Add TableView to Account Users

## QA

- Log in
- Go to https://ubuntu-com-10309.demos.haus/advantage/users
- make sure philip.p@ecorp.com user is displayed

## Screenshots

#### Example with 2 users

##### desktop
![image](https://user-images.githubusercontent.com/7452681/132211351-81e499e1-897d-4039-9069-7d6ca8099daf.png)

##### mobile
![image](https://user-images.githubusercontent.com/7452681/132211342-ef16a0ff-b4fc-4132-9734-f07991790f80.png)

