### PR TITLE
Fix presentation issues on livepatch pages

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1553,7 +1553,7 @@ security:
       persist: True
 
       children:
-        - title: Security Livepatch Docs
+        - title: Docs
           path: /security/livepatch/docs
 
     - title: Certifications & Hardening

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -128,7 +128,7 @@ meta_copydoc %}
     <div class="col-6">
       <h2>Livepatch on-prem overview</h2>
       <p>Livepatch on-prem is designed for complex Enterprise environments that follow their own rollout policy and remain in control of which machines will get updated and when. Livepatch on-prem regularly syncs with the Canonical Livepatch service and obtains the latest patches. It then deploys the livepatches gradually in as many stages as required.</p>
-      <a href="https://discourse.ubuntu.com/t/livepatch-on-prem/22723" class="p-button">Read more</a>
+      <a href="https://ubuntu.com/security/livepatch/docs" class="p-button">Read more</a>
     </div>
     <div class="col-6">
       {{


### PR DESCRIPTION
This is an update related to the launch the next few days.

## Done

- Link to new documentation of livepatch
- Reduce the name of the docs sub-menu, it was too big and didn't reflect the actual name of the product (from "Security Livepatch Docs" -> "Docs"

Follows the [copydoc](https://docs.google.com/document/d/1g_Ip5MzlBRpbM2wULpSnsR5XaHJVWgLPLdq8_7fCHrs/edit#)
