### PR TITLE
Copy update on /security/docker-images

### DIFF
--- a/static/js/third-party/typer.js
+++ b/static/js/third-party/typer.js
@@ -1,0 +1,141 @@
+// Copied from this project:
+// https://steven.codes/typerjs/docs/index.html
+
+var Typer = function (element) {
+  this.element = element;
+  var delim = element.dataset.delim || ",";
+  var words = element.dataset.words || "override these,sample typing";
+  this.words = words.split(delim).filter((v) => v); // non empty words
+  this.delay = element.dataset.delay || 200;
+  this.loop = element.dataset.loop || "true";
+  if (this.loop === "false") {
+    this.loop = 1;
+  }
+  this.deleteDelay =
+    element.dataset.deletedelay || element.dataset.deleteDelay || 800;
+
+  this.progress = { word: 0, char: 0, building: true, looped: 0 };
+  this.typing = true;
+
+  var colors = element.dataset.colors || "black";
+  this.colors = colors.split(",");
+  this.element.style.color = this.colors[0];
+  this.colorIndex = 0;
+
+  this.doTyping();
+};
+
+Typer.prototype.start = function () {
+  if (!this.typing) {
+    this.typing = true;
+    this.doTyping();
+  }
+};
+Typer.prototype.stop = function () {
+  this.typing = false;
+};
+Typer.prototype.doTyping = function () {
+  var e = this.element;
+  var p = this.progress;
+  var w = p.word;
+  var c = p.char;
+  var currentDisplay = [...this.words[w]].slice(0, c).join("");
+  var atWordEnd;
+  if (this.cursor) {
+    this.cursor.element.style.opacity = "1";
+    this.cursor.on = true;
+    clearInterval(this.cursor.interval);
+    this.cursor.interval = setInterval(
+      () => this.cursor.updateBlinkState(),
+      400
+    );
+  }
+
+  e.innerHTML = currentDisplay;
+
+  if (p.building) {
+    atWordEnd = p.char === this.words[w].length;
+    if (atWordEnd) {
+      p.building = false;
+    } else {
+      p.char += 1;
+    }
+  } else {
+    if (p.char === 0) {
+      p.building = true;
+      p.word = (p.word + 1) % this.words.length;
+      this.colorIndex = (this.colorIndex + 1) % this.colors.length;
+      this.element.style.color = this.colors[this.colorIndex];
+    } else {
+      p.char -= 1;
+    }
+  }
+
+  if (p.word === this.words.length - 1) {
+    p.looped += 1;
+  }
+
+  if (!p.building && this.loop <= p.looped) {
+    this.typing = false;
+  }
+
+  var randomDelay = this.delay;
+  if (p.building) {
+    randomDelay =
+      parseInt(this.delay) + parseInt(Math.random() * 2 * this.delay);
+  }
+
+  if (this.words[w][c] === "") {
+    randomDelay = 0;
+  }
+
+  setTimeout(
+    () => {
+      if (this.typing) {
+        this.doTyping();
+      }
+    },
+    atWordEnd ? this.deleteDelay : randomDelay
+  );
+};
+
+var Cursor = function (element) {
+  this.element = element;
+  this.cursorDisplay =
+    element.dataset.cursordisplay || element.dataset.cursorDisplay || "_";
+  element.innerHTML = this.cursorDisplay;
+  this.on = true;
+  element.style.transition = "all 0.1s";
+  this.interval = setInterval(() => this.updateBlinkState(), 400);
+};
+Cursor.prototype.updateBlinkState = function () {
+  if (this.on) {
+    this.element.style.opacity = "0";
+    this.on = false;
+  } else {
+    this.element.style.opacity = "1";
+    this.on = true;
+  }
+};
+
+function TyperSetup() {
+  var typers = {};
+  for (let e of document.getElementsByClassName("typer")) {
+    typers[e.id] = new Typer(e);
+  }
+  for (let e of document.getElementsByClassName("typer-stop")) {
+    let owner = typers[e.dataset.owner];
+    e.onclick = () => owner.stop();
+  }
+  for (let e of document.getElementsByClassName("typer-start")) {
+    let owner = typers[e.dataset.owner];
+    e.onclick = () => owner.start();
+  }
+  for (let e of document.getElementsByClassName("cursor")) {
+    let t = new Cursor(e);
+    t.owner = typers[e.dataset.owner];
+    t.owner.cursor = t;
+  }
+}
+
+TyperSetup();

--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -1,6 +1,6 @@
 {% extends "security/base_security.html" %}
 
-{% block title %}LTS Docker Images | Security{% endblock %}
+{% block title %}LTS Docker Images{% endblock %}
 
 {% block meta_description %}The LTS Docker Image Portfolio on Docker Hub and public cloud container registries provides compliant, secure application images, with a long term maintenance commitment by Canonical.{% endblock meta_description %}
 
@@ -11,12 +11,14 @@
 <section class="p-strip--suru-topped">
   <div class="row u-equal-height">
     <div class="col-8">
-      <span class="u-sv3"><h1>LTS Docker Images</h1></span>
-      <p class="u-sv2">Hardened container images, with up to ten years guaranteed security maintenance.</p>
+      <span class="u-sv3"><h1>Long Term Supported<br/>OCI Images</h1></span>
+      <p class="u-sv2">Hardened container images, with stable tracks from development to production. Up to ten years guaranteed security maintenance from our trusted repositories.</p>
+      <p><pre><code>$ docker pull ubuntu/<span class="typer" id="main" data-words="nginx,redis,grafana,prometheus,cassandra,cortex,apache2,mysql" data-delay="50" data-deleteDelay="2000" data-colors="#111111">nginx</span></code></pre></p>
       <p>
-        <a href="/security/contact-us?product=docker" class="p-button--positive js-invoke-modal">Contact Us</a>
-        <a href="/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Read the announcement&nbsp;&rsaquo;</a>
-      </p>    </div>
+        <a href="/security/contact-us?product=docker" class="p-button--positive js-invoke-modal">Get commercial support</a>
+        <a href="/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Read the press release&nbsp;&rsaquo;</a>
+      </p>    
+    </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       {{
         image(
@@ -28,16 +30,13 @@
           loading="auto",
         ) | safe
       }}
-    </div>
+    </div> 
   </div>
 </section>
 
 <section class="p-strip--light">
-  <div class="u-fixed-width">
-
-  </div>
   <div class="row u-equal-height">
-        <div class="col-4 u-vertically-center u-align--center u-hide--small">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       {{
         image(
           url="https://assets.ubuntu.com/v1/50dea393-fixes+in+24hrs.svg",
@@ -50,9 +49,10 @@
       }}
     </div>
     <div class="col-8 u-vertically-center">
-      <h2 class="u-sv3">Critical CVE fixes in 24 hours</h2>
-      <p>Scanning container images for vulnerabilities is now widespread, but fixing them requires dedicated skills and infrastructure.</p>
+      <h2>Critical CVE fixes in 24 hours</h2>
+      <p>Scanning container images for vulnerabilities is now widespread, but fixing them requires dedicated skills and infrastructure. Trusted provenance is key.</p>
       <p>The LTS Docker Image Portfolio provides ready-to-use application base images, free of high and critical CVEs. Images are built on the same secure infrastructure that builds Ubuntu, and updated automatically when apps or dependencies are fixed.</p>
+      <a href="/security/cve">Explore our CVE-fixing track record&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>
@@ -65,7 +65,7 @@
       <li class="p-list__item is-ticked">Fixes for high and critical Common Vulnerabilities and Exposures (CVEs)</li>
       <li class="p-list__item is-ticked">The Ubuntu distribution base image and application layers</li>
       <li class="p-list__item is-ticked">All major architectures</li>
-      <li class="p-list__item is-ticked">Designed for layering - "<code>FROM lts/nginx</code>"</li>
+      <li class="p-list__item is-ticked">Designed for layering - "<code>FROM public.ecr.aws/lts/mysql</code>"</li>
     </ul>
     <p>
       <a href="/about/release-cycle">Learn more about the Ubuntu release cadence&nbsp;&rsaquo;</a>
@@ -85,13 +85,13 @@
     <ul>
       <li><a class="p-link--external" href="https://hub.docker.com/u/ubuntu/">Ubuntu on Docker Hub</a> and <a class="p-link--external" href="https://gallery.ecr.aws/?searchTerm=LTS">ECR Public</a> have development releases with security updates</li>
       <li>LTS ("Canonical") on <a class="p-link--external" href="https://gallery.ecr.aws/?searchTerm=LTS">ECR Public</a> has Free LTS images with up to five years fixes</li>
-      <li>Customer-only content with up to ten years of fixes</li>
+      <li>Customer-only content with up to ten years of fixes. <a href="/security/contact-us?product=docker" class="js-invoke-modal">Contact us</a>.</li>
     </ul>
     <p>All of our Docker Hub repositories are exempted from per-user rate limits.</p>
     <p class="p-heading--4"><strong>Is there a long-term commitment? How long?</strong></p>
     <p>LTS Images are security-maintained for the full ten year period of their underlying Ubuntu LTS release. Some applications will have versions on multiple Ubuntu LTS versions. In each case, the image is maintained for the full life of the underlying Ubuntu LTS.</p>
     <p class="p-heading--4"><strong>Can I use these images to build other applications?</strong></p>
-    <p>Yes. Our hardened images are optimised for the developer experience, layering, and minimality. Each image is engineered to be clean, without layering artifacts, making it an ideal foundation for enterprise continuous integration and golden images. For ISVs, Canonical offers embedded terms for redistribution.</p>
+    <p>Yes. Our hardened images are optimised for the developer experience, layering, and minimality. Each image is engineered to be clean, without layering artifacts, making it an ideal foundation for enterprise continuous integration and golden images. If you are an ISV, Canonical can offer embedded terms for redistribution and specific support. <a href="/security/contact-us?product=docker" class="js-invoke-modal">Get in touch</a>.</p>
   </div>
 </section>
 
@@ -124,8 +124,7 @@
 {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="3785" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=docker" data-lp-url="https://ubuntu.com/security/contact-us?product=docker">
-</div>
-
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="3785" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=docker" data-lp-url="https://ubuntu.com/security/contact-us?product=docker"></div>
+<script src="{{ versioned_static('js/third-party/typer.js') }}" defer></script>
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}


### PR DESCRIPTION
## Done
- Updated the page title 
- Updated `LTS Docker Images` to `Long Term Supported OCI Images`
- Added a code snippet and created the `typer.js`file  in the`js/dist` to make the code snippet animated.
- Set `$ docker pull ubuntu/nginx` as a default placeholder just in case js not working.
- Added a link with "Explore our CVE-fixing track record >" 
- Added `Contact` and `Get in touch` and linked them to the contact form.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/docker-images
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check page against [copy doc](https://docs.google.com/document/d/1zZibtjU141e4mBxo_0PtfYxJ6e5fyaaAdFZ6v945XAM/edit) and resolve comments


## Issue / Card

Fixes [#4402](https://github.com/canonical-web-and-design/web-squad/issues/4402#event-5260114797)

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/132221723-56e0faca-4a69-4ef5-bbb9-87415de610fa.png)
