### PR TITLE
Close the edit form when switching subscriptions or closing the modal

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Content/types.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/types.ts
@@ -1,3 +1,3 @@
-import type { ContractToken } from "advantage/api/types";
-
-export type SelectedToken = ContractToken | null;
+// TODO: Set this to the type of the token when it is available.
+// https://github.com/canonical-web-and-design/commercial-squad/issues/210
+export type SelectedToken = string | null;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -62,6 +62,9 @@ describe("SubscriptionDetails", () => {
     wrapper.find("Button[data-test='edit-button']").simulate("click");
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
     expect(wrapper.find("DetailsContent").exists()).toBe(false);
+    // The selected token state is handled in a parent component so update the
+    // component with a different selected token to make the component rerender
+    // with a new subscription:
     wrapper.setProps({ selectedToken: "1" });
     wrapper.update();
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { mount } from "enzyme";
 import { QueryClient, QueryClientProvider } from "react-query";
 
-import { freeSubscriptionFactory } from "advantage/tests/factories/api";
+import {
+  freeSubscriptionFactory,
+  userSubscriptionFactory,
+} from "advantage/tests/factories/api";
 import SubscriptionDetails from "./SubscriptionDetails";
 import { UserSubscription } from "advantage/api/types";
 import SubscriptionEdit from "../SubscriptionEdit";
@@ -13,26 +16,24 @@ describe("SubscriptionDetails", () => {
 
   beforeEach(async () => {
     queryClient = new QueryClient();
-    contract = freeSubscriptionFactory.build();
+    contract = userSubscriptionFactory.build();
     queryClient.setQueryData("userSubscriptions", [contract]);
   });
 
   it("initially shows the content", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} />
+        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
       </QueryClientProvider>
     );
     expect(wrapper.find("DetailsContent").exists()).toBe(true);
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
   });
 
-  // TODO: remove skip from these tests when the subscription details can load
-  // non-free subscriptions.
-  it.skip("can show the edit form", () => {
+  it("can show the edit form", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} />
+        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
       </QueryClientProvider>
     );
     wrapper.find("Button[data-test='edit-button']").simulate("click");
@@ -40,12 +41,65 @@ describe("SubscriptionDetails", () => {
     expect(wrapper.find("DetailsContent").exists()).toBe(false);
   });
 
-  // TODO: remove skip from these tests when the subscription details can load
-  // non-free subscriptions.
-  it.skip("disables the buttons when showing the edit form", () => {
+  it("closes the edit form when changing subscriptions", () => {
+    queryClient.setQueryData("userSubscriptions", [
+      userSubscriptionFactory.build(),
+      userSubscriptionFactory.build(),
+      freeSubscriptionFactory.build(),
+    ]);
+    // Create a wrapping component to pass props to the inner
+    // SubscriptionDetails component. This is needed so that setProps will
+    // update the inner component.
+    const ProxyComponent = ({ selectedToken }: { selectedToken: string }) => (
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedToken={selectedToken}
+        />
+      </QueryClientProvider>
+    );
+    const wrapper = mount(<ProxyComponent selectedToken="0" />);
+    wrapper.find("Button[data-test='edit-button']").simulate("click");
+    expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
+    expect(wrapper.find("DetailsContent").exists()).toBe(false);
+    wrapper.setProps({ selectedToken: "1" });
+    wrapper.update();
+    expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
+    expect(wrapper.find("DetailsContent").exists()).toBe(true);
+  });
+
+  it("closes the edit form when closing the modal", () => {
+    queryClient.setQueryData("userSubscriptions", [
+      userSubscriptionFactory.build(),
+      userSubscriptionFactory.build(),
+      freeSubscriptionFactory.build(),
+    ]);
+    // Create a wrapping component to pass props to the inner
+    // SubscriptionDetails component. This is needed so that setProps will
+    // update the inner component.
+    const ProxyComponent = ({ modalActive }: { modalActive: boolean }) => (
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          modalActive={modalActive}
+          onCloseModal={jest.fn()}
+          selectedToken="0"
+        />
+      </QueryClientProvider>
+    );
+    const wrapper = mount(<ProxyComponent modalActive={true} />);
+    wrapper.find("Button[data-test='edit-button']").simulate("click");
+    expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
+    expect(wrapper.find("DetailsContent").exists()).toBe(false);
+    wrapper.setProps({ modalActive: false });
+    wrapper.update();
+    expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
+    expect(wrapper.find("DetailsContent").exists()).toBe(true);
+  });
+
+  it("disables the buttons when showing the edit form", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} />
+        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
       </QueryClientProvider>
     );
     expect(
@@ -68,10 +122,12 @@ describe("SubscriptionDetails", () => {
     queryClient.setQueryData("userSubscriptions", [account]);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} />
+        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
       </QueryClientProvider>
     );
-    expect(wrapper.find("[data-test='edit-button']").exists()).toBe(false);
+    expect(wrapper.find("Button[data-test='edit-button']").exists()).toBe(
+      false
+    );
     expect(wrapper.find("[data-test='support-button']").exists()).toBe(false);
     expect(wrapper.find("DetailsContent").exists()).toBe(true);
   });
@@ -82,26 +138,32 @@ describe("SubscriptionDetails", () => {
     const onCloseModal = jest.fn();
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={onCloseModal} />
+        <SubscriptionDetails onCloseModal={onCloseModal} selectedToken="0" />
       </QueryClientProvider>
     );
     wrapper.find(".p-modal__close").simulate("click");
     expect(onCloseModal).toHaveBeenCalled();
   });
 
-  // TODO: remove skip from these tests when the subscription details can load
-  // non-free subscriptions.
-  it.skip("does not set the modal to active when the cancel modal is visible", () => {
+  it("does not set the modal to active when the cancel modal is visible", () => {
     const onCloseModal = jest.fn();
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails modalActive={true} onCloseModal={onCloseModal} />
+        <SubscriptionDetails
+          modalActive={true}
+          onCloseModal={onCloseModal}
+          selectedToken="0"
+        />
       </QueryClientProvider>
     );
     // Open the edit modal:
-    wrapper.find("[data-test='edit-button']").simulate("click");
-    expect(wrapper.hasClass("is-active")).toBe(true);
+    wrapper.find("Button[data-test='edit-button']").simulate("click");
+    expect(
+      wrapper.find(".p-subscriptions__details").hasClass("is-active")
+    ).toBe(true);
     wrapper.find(SubscriptionEdit).invoke("setShowingCancel")(true);
-    expect(wrapper.hasClass("is-active")).toBe(false);
+    expect(
+      wrapper.find(".p-subscriptions__details").hasClass("is-active")
+    ).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,5 +1,5 @@
 import { Button, Spinner } from "@canonical/react-components";
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 import classNames from "classnames";
 
 import DetailsContent from "./DetailsContent";
@@ -17,7 +17,7 @@ type Props = {
   selectedToken?: SelectedToken;
 };
 
-const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
+export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
   ({ modalActive, onCloseModal, selectedToken }: Props, ref) => {
     const [editing, setEditing] = useState(false);
     const [showingCancel, setShowingCancel] = useState(false);
@@ -25,6 +25,11 @@ const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
       select: selectSubscriptionByToken(selectedToken),
     });
     const isFree = isFreeSubscription(subscription);
+
+    useEffect(() => {
+      setEditing(false);
+    }, [selectedToken, modalActive]);
+
     if (isLoading || !subscription) {
       return <Spinner />;
     }


### PR DESCRIPTION
## Done

- Close the edit form when switching subscriptions or closing the modal.
- Enable tests for showing the cancel form.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10313.demos.haus/advantage?test_backend=true).
- Click on a non-free subscription.
- Click the edit button. You should see the form.
- Click on a different subscription. The edit form should close.
- Resize down to mobile.
- Click on a subscription to open the modal.
- Click the edit button and the form should open.
- Close the modal and click on the same subscription.
- The modal should appear and the edit form should be closed.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/208.
