### PR TITLE
Sort the subscriptions by most recently started

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -45,6 +45,38 @@ describe("SubscriptionList", () => {
     );
   });
 
+  it("sorts the UA subscriptions by most recently started", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        start_date: new Date("2020-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        start_date: new Date("2021-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        start_date: new Date("1999-08-11T02:56:54Z"),
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionList onSetActive={jest.fn()} />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find(ListCard).at(0).prop("subscription")).toStrictEqual(
+      subscriptions[1]
+    );
+    expect(wrapper.find(ListCard).at(1).prop("subscription")).toStrictEqual(
+      subscriptions[0]
+    );
+    expect(wrapper.find(ListCard).at(2).prop("subscription")).toStrictEqual(
+      subscriptions[2]
+    );
+  });
+
   it("displays a free subscription", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,9 +1,11 @@
 import { Spinner } from "@canonical/react-components";
+import { UserSubscription } from "advantage/api/types";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import {
   selectFreeSubscription,
   selectUASubscriptions,
 } from "advantage/react/hooks/useUserSubscriptions";
+import { parseJSON } from "date-fns";
 import React from "react";
 import { SelectedToken } from "../Content/types";
 
@@ -14,6 +16,12 @@ type Props = {
   selectedToken?: SelectedToken;
   onSetActive: (token: SelectedToken) => void;
 };
+
+const sortSubscriptions = (subscriptions: UserSubscription[]) =>
+  subscriptions.sort(
+    (a, b) =>
+      parseJSON(b.start_date).getTime() - parseJSON(a.start_date).getTime()
+  );
 
 const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
   const {
@@ -31,7 +39,9 @@ const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
   if (isLoadingFree || isLoadingUA) {
     return <Spinner />;
   }
-  const uaSubscriptions = uaSubscriptionsData.map((subscription, i) => (
+  // Sort the subscriptions so that the most recently started subscription is first.
+  const sortedUASubscriptions = sortSubscriptions(uaSubscriptionsData);
+  const uaSubscriptions = sortedUASubscriptions.map((subscription, i) => (
     <ListCard
       data-test="ua-subscription"
       isSelected={selectedToken === `ua-sub-${i}`}


### PR DESCRIPTION
## Done

- Sort the subscriptions by most recently started.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10314.demos.haus/advantage?test_backend=true).
- Look through the "Created" dates of your subscriptions in the list on the left (ignoring the free token), they should be in descending order (i.e. the most recently created should be at the top).


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/120.