### PR TITLE
Add trial endpoints

### DIFF
--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -36,6 +36,7 @@ post_advantage_subscriptions = {
     "previous_purchase_id": String(required=True),
     "products": List(Nested(ProductSchema), required=True),
     "resizing": Boolean(),
+    "trialling": Boolean(),
 }
 
 cancel_advantage_subscriptions = {

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -98,6 +98,7 @@ from webapp.advantage.views import (
     get_last_purchase_ids,
     get_contract_token,
     get_user_info,
+    cancel_trial,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -358,7 +359,11 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/renewals/<renewal_id>", view_func=get_renewal, methods=["GET"]
 )
-
+app.add_url_rule(
+    "/advantage/trial/<subscription_id>",
+    view_func=cancel_trial,
+    methods=["DELETE"],
+)
 app.add_url_rule(
     "/advantage/customer-info/<account_id>",
     view_func=get_customer_info,


### PR DESCRIPTION
## Done

Start a trial endpoint:
```
{
        "accountID": account_id,
        "purchaseItems": [
            {
                "productListingID": product_listing_id,
                "metric": "active-machines",
                "value": 1
            }
        ],
        "previousPurchaseID": "",
        "inTrial": True
}

POST /advantage/subscribe
```
Cancel a trial endpoint:
`DELETE /advantage/trial/<subscription_id>`

## QA

- Make a purchase using https://ubuntu-com-10316.demos.haus 
- Everything should still work
- We can QA the trials easier when the front-end is ready


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/219