### PR TITLE
Fix user subscriptions endpoint

### DIFF
--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -626,3 +626,11 @@ class TestHelpers(unittest.TestCase):
         subscription = get_subscription_by_period(subscriptions, listing)
 
         self.assertEqual(subscription, None)
+
+    def test_get_subscription_by_period_with_no_listing(self):
+        subscriptions = None
+        listing = None
+
+        subscription = get_subscription_by_period(subscriptions, listing)
+
+        self.assertEqual(subscription, None)

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -235,8 +235,11 @@ def extract_last_purchase_ids(subscriptions: List[Subscription]) -> Dict:
 
 
 def get_subscription_by_period(
-    subscriptions: List[Subscription], listing: Listing
+    subscriptions: List[Subscription] = None, listing: Listing = None
 ) -> Optional[Subscription]:
+    if not listing or not subscriptions:
+        return None
+
     filtered_subscriptions = [
         subscription
         for subscription in subscriptions

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -298,6 +298,8 @@ def advantage_view(**kwargs):
 @advantage_decorator(permission="user", response="json")
 @use_kwargs({"email": String()}, location="query")
 def get_user_subscriptions(**kwargs):
+    g.api.set_convert_response(True)
+
     email = kwargs.get("email")
 
     listings = g.api.get_product_listings("canonical-ua")


### PR DESCRIPTION
## Done

- Fix `get_subscription_by_period` in case listing is None, it should return None instead of 500
- Make make `g.api.convert_reponse(True)`. This converts the API responses from json to List of Objects. `/advatnage/user-subscription` expects the responses to be converted, not having it set to `True` breaks the endpoint.

## QA

- Login on https://ubuntu-com-10318.demos.haus
- Go to https://ubuntu-com-10318.demos.haus/advantage/user-subscriptions
- You should get a 200