### PR TITLE
Sync with copydoc for FIPS and CIS pages

### DIFF
--- a/templates/security/cis.html
+++ b/templates/security/cis.html
@@ -13,7 +13,8 @@
       <h1>CIS Benchmark on Ubuntu</h1>
       <h4>Comply with the most widely accepted baseline</h4>
       <p>The CIS benchmark has hundreds of configuration recommendations, so hardening and auditing a system manually can be very tedious. To drastically improve this process for enterprises, Canonical provides certified tooling for audit and automated compliance with the CIS benchmarks with <a href="/advantage">Ubuntu Advantage</a> and <a href="/public-cloud">Ubuntu Pro</a>.</p>
-      <a href="/security/certifications#get-in-touch" class="p-button--positive js-invoke-modal">Access the tooling for audit and automated CIS compliance</a>
+      <a href="/security/certifications#get-in-touch" class="p-button--positive js-invoke-modal">Contact us</a>
+      <a href="/advantage" class="p-button--neutral">Get Ubuntu Advantage</a>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small">
       {{ image (
@@ -73,7 +74,7 @@
 <section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
     <h2>Which versions of Ubuntu have CIS tooling?</h2>
-    <p>Canonical provides OpenSCAP content for auditing systems for CIS benchmark compliance, as well as tooling to automate compliance.</p>
+    <p>Canonical provides certified OpenSCAP content for auditing systems for CIS benchmark compliance, as well as tooling to automate compliance.</p>
     <table>
       <thead>
         <tr>
@@ -99,7 +100,7 @@
       </tbody>
     </table>
     <p>
-      <a href="/security/certifications#get-in-touch" class="p-button--positive js-invoke-modal">Access the Ubuntu CIS benchmark tooling</a>
+      <a href="/advantage" class="p-button--positive">Access the Ubuntu CIS benchmark tooling</a>
       <a href="/security/certifications/docs/cis" class="p-button--neutral">Learn more about our tools</a>
     </p>
     <h3>What is CIS?</h3>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -2,7 +2,7 @@
 
 
 {% block title %}Canonical fips certifications | Security{% endblock %}
-{% block meta_description %}Technical details on the FIPS security certification for Ubuntu Advantage subscribers.{% endblock %}
+{% block meta_description %}Details on the FIPS security certification for Ubuntu Advantage subscribers.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1moTJCAtFXKD7ZXrxB-EB7GPVyZRTSIdkP-0BhPZl69M/edit#{% endblock meta_copydoc %}
 
 {% block content %}
@@ -13,7 +13,11 @@
      <h1>FIPS 140</h1>
      <h2 class="p-heading--4">FIPS 140 validated cryptography for Linux workloads</h2>
      <p>Developing and running workloads for U.S. government regulated and high security environments requires a long and expensive validation process. Reduce your accreditation timeline and pass on your validation costs with the FIPS 140 certified cryptographic packages of <a href="/public-cloud">Ubuntu Pro</a> and <a href="/advantage">Ubuntu Advantage</a>.</p>
-     <p><a class="p-button--positive js-invoke-modal" href="/security/certifications">Get Ubuntu with the FIPS140 validated modules</a></p>
+     <p>
+      <a href="/security/certifications#get-in-touch" class="p-button--positive js-invoke-modal">Contact us</a>
+      <a href="/advantage" class="p-button--neutral">Get Ubuntu Advantage</a>
+     </p>
+
    </div>
    <div class="col-4 u-hide--small u-align--center">
       {{ image (
@@ -55,7 +59,7 @@
   </div>
   <div class="u-fixed-width">
     <p>
-      <a class="p-button--neutral" href="/security/certifications/docs/fips">Read more about the FIPS certification</a>
+      <a class="p-button--neutral" href="/security/certifications/docs/fips">Read more about FIPS</a>
       <a class="p-button--positive js-invoke-modal" href="/security/certifications">Contact us</a>
     </p>
   </div>
@@ -69,7 +73,7 @@
     <hr class="p-separator">
 
     <h2>Access FIPS images on the public cloud</h2>
-    <p class="u-sv3">We make available Ubuntu Pro FIPS cloud images preconfigured with FIPS 140 certified packages, on popular clouds. You can quickly navigate on the marketplace images below.</p>
+    <p class="u-sv3">FIPS can be enabled on Ubuntu Pro cloud images, while Ubuntu Pro FIPS cloud images simplify the experience as they come preconfigured with FIPS 140 certified packages optimized for the cloud. You can quickly navigate on the marketplace FIPS-enabled images below.</p>
   </div>
   <div class="row">
     <div class="col-3">
@@ -100,7 +104,7 @@
       <p>Ubuntu Pro FIPS 20.04</p>
       <hr>
       <div style="padding-top: 1rem;">
-        <a class="p-link--external" style="padding-top: 1rem;" href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List">In progress</a>
+        In progress
       </div>
     </div>
   </div>
@@ -139,7 +143,7 @@
       </thead>
       <tbody>
         <tr>
-          <th>Linux Kernel Crypto API</th>
+          <th>Linux Kernel (GA) Crypto API</th>
           <td>
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/2962">#2962</a>, 
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3724">#3724</a>
@@ -182,6 +186,7 @@
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3725">#3725</a>
           </td>
           <td>
+            <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3622">#3622</a>,
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3980">#3980</a>
           </td>
           <td>
@@ -213,7 +218,7 @@
       </tbody>
     </table>
     <a class="p-button--neutral js-invoke-modal" href="/security/certifications/docs/fips">Read more about the FIPS certification</a>
-    <a class="p-button--positive js-invoke-modal" href="/support/contact-us">Access the FIPS140 validated modules</a>
+    <a class="p-button--positive" href="/advantage">Access the FIPS140 validated modules</a>
   </div>
 </section>
 
@@ -221,7 +226,7 @@
   <div class="u-fixed-width">
     <h2>Canonical patches vulnerabilities</h2>
     <p>Each FIPS 140 certificate is valid for 5 years, however vulnerabilities happen, and it is our intention to publish fixed packages quickly, irrespective of their certification status. We therefore provide two alternative options. An option to remain with the certified cryptographic packages (called the 'fips' option), and an option to use the certified packages but include security fixes (called the 'fips-updates' option) when available. Check <a class="p-link--external" href="https://security-certs.docs.ubuntu.com/en/fips">our security pages on how to enable these options</a>.</p>
-    <p>We recommend enabling the 'fips-updates' option that includes the security fixes. The packages from 'fips-updates' option are updated to include high and critical security fixes during the whole product lifecycle including the <a href="/security/esm">Extended Security Maintenance phase</a>.</p>
+    <p>We recommend enabling the 'fips-updates' option that includes the security fixes. The packages from 'fips-updates' option are updated to include high and critical security fixes during the whole product lifecycle including the <a href="/security/esm">Extended Security Maintenance (ESM)</a> phase.</p>
   </div>
 </section>
 
@@ -237,7 +242,7 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2>FIPS 140-3 and Ubuntu</h2>
-    <p class="u-sv3">In September 2021 NIST is phasing out FIPS 140. Certifications under FIPS 140 remain valid until September 2026, and new products are expected to be certified <a class="p-link--external" href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/fips-140-3-standards">under FIPS 140-3</a>. FIPS 140-3 is a combined effort of NIST and ISO with the Security and Testing requirements for cryptographic modules being published as ISO/IEC 19790 and ISO/IEC 24759. Canonical is preparing Ubuntu for the new certification, and intends to provide FIPS 140-3 certified cryptographic packages on a future LTS release of Ubuntu.</p>
+    <p class="u-sv3">In September 2021 NIST is phasing out FIPS 140-2. Certifications under FIPS 140-2 remain valid no longer than September 2026, and new products are expected to be certified <a class="p-link--external" href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/fips-140-3-standards">under FIPS 140-3</a>. FIPS 140-3 is a combined effort of NIST and ISO with the Security and Testing requirements for cryptographic modules being published as ISO/IEC 19790 and ISO/IEC 24759. Canonical is preparing Ubuntu for the new certification, and intends to provide FIPS 140-3 certified cryptographic packages on a future LTS release of Ubuntu.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Sync with [copydoc](https://docs.google.com/document/d/1bSv8lV9BJoBYh5yog2eYKtvNMitKZetSSBQ3k2Cu5Cw/edit#) for cis.html
- Sync with copydoc for fips.html

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)



