### PR TITLE
Select subscriptions via contract id

### DIFF
--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -31,16 +31,20 @@ export type UserSubscriptionStatuses = {
 
 export type UserSubscription = {
   account_id: string;
+  contract_id: string;
+  currency: string;
   end_date: Date | null;
   entitlements: UserSubscriptionEntitlement[];
   listing_id: string | null;
-  marketplace: UserSubscriptionMarketplace;
   machine_type: UserSubscriptionMachineType;
+  marketplace: UserSubscriptionMarketplace;
   number_of_machines: number;
   period: UserSubscriptionPeriod | null;
-  price_per_unit: number | null;
+  price: number | null;
   product_name: string | null;
+  renewal_id: string | null;
   start_date: Date;
   statuses: UserSubscriptionStatuses;
+  subscription_id: string | null;
   type: UserSubscriptionType;
 };

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
@@ -1,11 +1,27 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 
 import Content from "./Content";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { UserSubscription } from "advantage/api/types";
+import { userSubscriptionFactory } from "advantage/tests/factories/api";
 
 describe("Content", () => {
+  let queryClient: QueryClient;
+  let contract: UserSubscription;
+
+  beforeEach(async () => {
+    queryClient = new QueryClient();
+    contract = userSubscriptionFactory.build();
+    queryClient.setQueryData("userSubscriptions", [contract]);
+  });
+
   it("renders", () => {
-    const wrapper = shallow(<Content />);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Content />
+      </QueryClientProvider>
+    );
     expect(wrapper.find("SubscriptionList").exists()).toBe(true);
     expect(wrapper.find("SubscriptionDetails").exists()).toBe(true);
   });

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,54 +1,53 @@
 import { Card } from "@canonical/react-components";
+import { useUserSubscriptions } from "advantage/react/hooks";
 import { useScrollIntoView } from "advantage/react/hooks/useScrollIntoView";
 import React, { useCallback, useEffect, useState } from "react";
 
 import SubscriptionDetails from "../SubscriptionDetails";
 import SubscriptionList from "../SubscriptionList";
-import { SelectedToken } from "./types";
+import { SelectedId } from "./types";
 
 const Content = () => {
   const [modalActive, setModalActive] = useState(false);
-  const [selectedToken, setSelectedToken] = useState<SelectedToken>(null);
+  const [selectedId, setSelectedId] = useState<SelectedId>(null);
   const [scrollTargetRef, scrollIntoView] = useScrollIntoView<HTMLDivElement>(
     20
   );
+  const { data: allSubscriptions, isLoading } = useUserSubscriptions();
   const onSetActive = useCallback(
-    (token: SelectedToken) => {
+    (token: SelectedId) => {
       // Only set the token if it has changed to another token. The selected
       // token is always needed for large screens.
       if (token) {
-        setSelectedToken(token);
+        setSelectedId(token);
         scrollIntoView();
       }
       setModalActive(!!token);
     },
-    [setSelectedToken]
+    [setSelectedId]
   );
 
   // Select a token on the first load.
   useEffect(() => {
-    if (!selectedToken) {
+    if (!selectedId && !isLoading && allSubscriptions?.length) {
       // TODO: this should select the "most recently-started" or free token by default:
       // https://github.com/canonical-web-and-design/commercial-squad/issues/101
       // This only sets the selected token and does not set the modal to active
       // to prevent the modal appearing on first load on mobile.
-      setSelectedToken("ua-sub-0");
+      setSelectedId(allSubscriptions[0].contract_id);
     }
-  }, [selectedToken, setSelectedToken]);
+  }, [selectedId, setSelectedId, allSubscriptions, isLoading]);
 
   return (
     <Card className="u-no-margin--bottom u-no-padding p-subscriptions__card">
-      <SubscriptionList
-        selectedToken={selectedToken}
-        onSetActive={onSetActive}
-      />
+      <SubscriptionList selectedId={selectedId} onSetActive={onSetActive} />
       <SubscriptionDetails
         modalActive={modalActive}
         onCloseModal={() => {
           onSetActive(null);
         }}
         ref={scrollTargetRef}
-        selectedToken={selectedToken}
+        selectedId={selectedId}
       />
     </Card>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/Content/types.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/types.ts
@@ -1,3 +1,3 @@
-// TODO: Set this to the type of the token when it is available.
-// https://github.com/canonical-web-and-design/commercial-squad/issues/210
-export type SelectedToken = string | null;
+import { UserSubscription } from "advantage/api/types";
+
+export type SelectedId = UserSubscription["contract_id"] | null;

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -11,9 +11,6 @@ const Notifications = () => {
   const urls = useURLs();
   const { pendingPurchaseId } = usePendingPurchaseId();
   const { data: statusesSummary } = useUserSubscriptions({
-    // TODO: Get the selected subscription once the subscription token is
-    // available.
-    // https://github.com/canonical-web-and-design/commercial-squad/issues/210
     select: selectStatusesSummary,
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
@@ -21,7 +21,7 @@ describe("DetailsContent", () => {
     queryClient.setQueryData("userSubscriptions", [contract]);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <DetailsContent selectedToken="0" />
+        <DetailsContent selectedId={contract.contract_id} />
       </QueryClientProvider>
     );
     expect(wrapper.find("[data-test='expires-col']").text()).toBe("Never");
@@ -34,18 +34,18 @@ describe("DetailsContent", () => {
       end_date: new Date("2022-07-09T07:21:21Z"),
       number_of_machines: 2,
       period: UserSubscriptionPeriod.Yearly,
-      price_per_unit: 150000,
+      price: 150000,
     });
     queryClient.setQueryData("userSubscriptions", [contract]);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <DetailsContent selectedToken="0" />
+        <DetailsContent selectedId={contract.contract_id} />
       </QueryClientProvider>
     );
     expect(wrapper.find("[data-test='expires-col']").text()).toBe("09.07.2022");
     expect(wrapper.find("[data-test='billing-col']").text()).toBe("Yearly");
     expect(wrapper.find("[data-test='cost-col']").text()).toBe(
-      "$300,000 USD/yr"
+      "$150,000 USD/yr"
     );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -8,7 +8,7 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useUserSubscriptions } from "advantage/react/hooks";
-import { selectSubscriptionByToken } from "advantage/react/hooks/useUserSubscriptions";
+import { selectSubscriptionById } from "advantage/react/hooks/useUserSubscriptions";
 import {
   formatDate,
   getMachineTypeDisplay,
@@ -19,10 +19,10 @@ import {
 import React, { ReactNode } from "react";
 
 import DetailsTabs from "../DetailsTabs";
-import { SelectedToken } from "../../Content/types";
+import { SelectedId } from "../../Content/types";
 
 type Props = {
-  selectedToken?: SelectedToken;
+  selectedId?: SelectedId;
 };
 
 type Feature = {
@@ -45,9 +45,9 @@ const generateFeatures = (features: Feature[]) =>
     </Col>
   ));
 
-const DetailsContent = ({ selectedToken }: Props) => {
+const DetailsContent = ({ selectedId }: Props) => {
   const { data: subscription, isLoading } = useUserSubscriptions({
-    select: selectSubscriptionByToken(selectedToken),
+    select: selectSubscriptionById(selectedId),
   });
   const isFree = isFreeSubscription(subscription);
   if (isLoading || !subscription) {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -23,7 +23,10 @@ describe("SubscriptionDetails", () => {
   it("initially shows the content", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.contract_id}
+        />
       </QueryClientProvider>
     );
     expect(wrapper.find("DetailsContent").exists()).toBe(true);
@@ -33,7 +36,10 @@ describe("SubscriptionDetails", () => {
   it("can show the edit form", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.contract_id}
+        />
       </QueryClientProvider>
     );
     wrapper.find("Button[data-test='edit-button']").simulate("click");
@@ -42,41 +48,36 @@ describe("SubscriptionDetails", () => {
   });
 
   it("closes the edit form when changing subscriptions", () => {
-    queryClient.setQueryData("userSubscriptions", [
+    const contracts = [
       userSubscriptionFactory.build(),
       userSubscriptionFactory.build(),
       freeSubscriptionFactory.build(),
-    ]);
+    ];
+    queryClient.setQueryData("userSubscriptions", contracts);
     // Create a wrapping component to pass props to the inner
     // SubscriptionDetails component. This is needed so that setProps will
     // update the inner component.
-    const ProxyComponent = ({ selectedToken }: { selectedToken: string }) => (
+    const ProxyComponent = ({ selectedId }: { selectedId: string }) => (
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails
-          onCloseModal={jest.fn()}
-          selectedToken={selectedToken}
-        />
+        <SubscriptionDetails onCloseModal={jest.fn()} selectedId={selectedId} />
       </QueryClientProvider>
     );
-    const wrapper = mount(<ProxyComponent selectedToken="0" />);
+    const wrapper = mount(
+      <ProxyComponent selectedId={contracts[0].contract_id} />
+    );
     wrapper.find("Button[data-test='edit-button']").simulate("click");
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
     expect(wrapper.find("DetailsContent").exists()).toBe(false);
-    // The selected token state is handled in a parent component so update the
-    // component with a different selected token to make the component rerender
-    // with a new subscription:
-    wrapper.setProps({ selectedToken: "1" });
+    // The selected subscription state is handled in a parent component so
+    // update the component with a different selected id to make the component
+    // rerender with a new subscription:
+    wrapper.setProps({ selectedId: contracts[1].contract_id });
     wrapper.update();
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
     expect(wrapper.find("DetailsContent").exists()).toBe(true);
   });
 
   it("closes the edit form when closing the modal", () => {
-    queryClient.setQueryData("userSubscriptions", [
-      userSubscriptionFactory.build(),
-      userSubscriptionFactory.build(),
-      freeSubscriptionFactory.build(),
-    ]);
     // Create a wrapping component to pass props to the inner
     // SubscriptionDetails component. This is needed so that setProps will
     // update the inner component.
@@ -85,7 +86,7 @@ describe("SubscriptionDetails", () => {
         <SubscriptionDetails
           modalActive={modalActive}
           onCloseModal={jest.fn()}
-          selectedToken="0"
+          selectedId={contract.contract_id}
         />
       </QueryClientProvider>
     );
@@ -102,7 +103,10 @@ describe("SubscriptionDetails", () => {
   it("disables the buttons when showing the edit form", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.contract_id}
+        />
       </QueryClientProvider>
     );
     expect(
@@ -125,7 +129,10 @@ describe("SubscriptionDetails", () => {
     queryClient.setQueryData("userSubscriptions", [account]);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} selectedToken="0" />
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={account.contract_id}
+        />
       </QueryClientProvider>
     );
     expect(wrapper.find("Button[data-test='edit-button']").exists()).toBe(
@@ -141,7 +148,10 @@ describe("SubscriptionDetails", () => {
     const onCloseModal = jest.fn();
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={onCloseModal} selectedToken="0" />
+        <SubscriptionDetails
+          onCloseModal={onCloseModal}
+          selectedId={account.contract_id}
+        />
       </QueryClientProvider>
     );
     wrapper.find(".p-modal__close").simulate("click");
@@ -155,7 +165,7 @@ describe("SubscriptionDetails", () => {
         <SubscriptionDetails
           modalActive={true}
           onCloseModal={onCloseModal}
-          selectedToken="0"
+          selectedId={contract.contract_id}
         />
       </QueryClientProvider>
     );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -5,30 +5,30 @@ import classNames from "classnames";
 import DetailsContent from "./DetailsContent";
 import SubscriptionEdit from "../SubscriptionEdit";
 import { useUserSubscriptions } from "advantage/react/hooks";
-import { selectSubscriptionByToken } from "advantage/react/hooks/useUserSubscriptions";
+import { selectSubscriptionById } from "advantage/react/hooks/useUserSubscriptions";
 import { isFreeSubscription } from "advantage/react/utils";
 import ExpiryNotification from "../ExpiryNotification";
 import { ExpiryNotificationSize } from "../ExpiryNotification/ExpiryNotification";
-import { SelectedToken } from "../Content/types";
+import { SelectedId } from "../Content/types";
 
 type Props = {
   modalActive?: boolean;
   onCloseModal: () => void;
-  selectedToken?: SelectedToken;
+  selectedId?: SelectedId;
 };
 
 export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
-  ({ modalActive, onCloseModal, selectedToken }: Props, ref) => {
+  ({ modalActive, onCloseModal, selectedId }: Props, ref) => {
     const [editing, setEditing] = useState(false);
     const [showingCancel, setShowingCancel] = useState(false);
     const { data: subscription, isLoading } = useUserSubscriptions({
-      select: selectSubscriptionByToken(selectedToken),
+      select: selectSubscriptionById(selectedId),
     });
     const isFree = isFreeSubscription(subscription);
 
     useEffect(() => {
       setEditing(false);
-    }, [selectedToken, modalActive]);
+    }, [selectedId, modalActive]);
 
     if (isLoading || !subscription) {
       return <Spinner />;
@@ -87,7 +87,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               onClose={() => setEditing(false)}
             />
           ) : (
-            <DetailsContent selectedToken={selectedToken} />
+            <DetailsContent selectedId={selectedId} />
           )}
         </section>
       </div>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -60,7 +60,7 @@ describe("SubscriptionList", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <SubscriptionList
-          selectedToken="free-subscription"
+          selectedId={freeSubscription.contract_id}
           onSetActive={jest.fn()}
         />
       </QueryClientProvider>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -5,17 +5,17 @@ import {
   selectUASubscriptions,
 } from "advantage/react/hooks/useUserSubscriptions";
 import React from "react";
-import { SelectedToken } from "../Content/types";
+import { SelectedId } from "../Content/types";
 
 import ListCard from "./ListCard";
 import ListGroup from "./ListGroup";
 
 type Props = {
-  selectedToken?: SelectedToken;
-  onSetActive: (token: SelectedToken) => void;
+  selectedId?: SelectedId;
+  onSetActive: (token: SelectedId) => void;
 };
 
-const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
+const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   const {
     data: freeSubscription,
     isLoading: isLoadingFree,
@@ -34,12 +34,10 @@ const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
   const uaSubscriptions = uaSubscriptionsData.map((subscription, i) => (
     <ListCard
       data-test="ua-subscription"
-      isSelected={selectedToken === `ua-sub-${i}`}
+      isSelected={selectedId === subscription.contract_id}
       key={i}
       onClick={() => {
-        // TODO: update this to use the sub token when it is available.
-        // https://github.com/canonical-web-and-design/commercial-squad/issues/210
-        onSetActive(`ua-sub-${i}`);
+        onSetActive(subscription.contract_id);
       }}
       subscription={subscription}
     />
@@ -53,15 +51,9 @@ const SubscriptionList = ({ selectedToken, onSetActive }: Props) => {
           <ListGroup title="Free personal token">
             <ListCard
               data-test="free-subscription"
-              isSelected={
-                // TODO: update this to use the sub token when it is available.
-                // https://github.com/canonical-web-and-design/commercial-squad/issues/210
-                selectedToken === "free-subscription"
-              }
+              isSelected={selectedId === freeSubscription.contract_id}
               onClick={() => {
-                // TODO: update this to use the sub token when it is available.
-                // https://github.com/canonical-web-and-design/commercial-squad/issues/210
-                onSetActive("free-subscription");
+                onSetActive(freeSubscription.contract_id);
               }}
               subscription={freeSubscription}
             />

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import {
   selectFreeSubscription,
   selectStatusesSummary,
-  selectSubscriptionByToken,
+  selectSubscriptionById,
   selectUASubscriptions,
   useUserSubscriptions,
 } from "./useUserSubscriptions";
@@ -93,19 +93,14 @@ describe("useUserSubscriptions", () => {
   });
 
   it("can get a subscription by its token", async () => {
-    // TODO: Get the matching subscription once the subscription token is
-    // available. For now this gets the subscription by the position provided by
-    // the fake token.
-    // https://github.com/canonical-web-and-design/commercial-squad/issues/210
     const subscriptions = [
       userSubscriptionFactory.build(),
-      userSubscriptionFactory.build(),
+      userSubscriptionFactory.build({ contract_id: "abc123" }),
       userSubscriptionFactory.build(),
     ];
     queryClient.setQueryData("userSubscriptions", subscriptions);
     const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useUserSubscriptions({ select: selectSubscriptionByToken("ua-sub-1") }),
+      () => useUserSubscriptions({ select: selectSubscriptionById("abc123") }),
       { wrapper }
     );
     await waitForNextUpdate();

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -12,18 +12,9 @@ import { useQuery, UseQueryOptions } from "react-query";
 /**
  * Get a subscription by token.
  */
-export const selectSubscriptionByToken = (token?: string | null) => (
+export const selectSubscriptionById = (id?: string | null) => (
   subscriptions: UserSubscription[]
-) => {
-  // TODO: Get the matching subscription once the subscription token is
-  // available. For now this gets the subscription by the position provided by
-  // the fake token.
-  // https://github.com/canonical-web-and-design/commercial-squad/issues/210
-  const position = Number(token?.replace("ua-sub-", ""));
-  return Number.isNaN(position) || position >= subscriptions.length
-    ? selectFreeSubscription(subscriptions)
-    : subscriptions[position];
-};
+) => subscriptions.find(({ contract_id }) => contract_id === id);
 
 /**
  * Find the subscription that matches the free token.

--- a/static/js/src/advantage/react/utils/getSubscriptionCost.test.ts
+++ b/static/js/src/advantage/react/utils/getSubscriptionCost.test.ts
@@ -14,8 +14,8 @@ describe("getSubscriptionCost", () => {
     expect(
       getSubscriptionCost(
         userSubscriptionFactory.build({
-          number_of_machines: 2,
-          price_per_unit: 1000,
+          currency: "USD",
+          price: 2000,
           period: UserSubscriptionPeriod.Yearly,
         })
       )
@@ -26,8 +26,8 @@ describe("getSubscriptionCost", () => {
     expect(
       getSubscriptionCost(
         userSubscriptionFactory.build({
-          number_of_machines: 2,
-          price_per_unit: 1000,
+          currency: "USD",
+          price: 2000,
           period: UserSubscriptionPeriod.Monthly,
         })
       )

--- a/static/js/src/advantage/react/utils/getSubscriptionCost.ts
+++ b/static/js/src/advantage/react/utils/getSubscriptionCost.ts
@@ -9,15 +9,16 @@ export const getSubscriptionCost = (
     return "Free";
   }
   const formatter = new Intl.NumberFormat("en-US", {
-    currency: "USD",
+    currency: subscription.currency,
     maximumFractionDigits: 0,
     minimumFractionDigits: 0,
     style: "currency",
   });
-  let price =
-    subscription.number_of_machines * (subscription.price_per_unit || 0);
+  let price = subscription.price || 0;
   if (subscription.period === UserSubscriptionPeriod.Monthly) {
     price *= 12;
   }
-  return price ? `${formatter.format(price)} USD/yr` : null;
+  return price
+    ? `${formatter.format(price)} ${subscription.currency}/yr`
+    : null;
 };

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -37,17 +37,21 @@ export const userSubscriptionStatusesFactory = Factory.define<UserSubscriptionSt
 export const userSubscriptionFactory = Factory.define<UserSubscription>(
   ({ sequence }) => ({
     account_id: `aBWF0x8vv5S684ZTeXMnJmUuVO7AyCYZzvjY3J${sequence}`,
+    contract_id: `mUuVO7AyCYZzvjY3JaBWF0x8vv5S684ZTeXMnJ${sequence}`,
+    currency: "USD",
     end_date: new Date("2022-07-09T07:21:21Z"),
     entitlements: [],
     listing_id: `lADzAkHCZRIASpBZ8YiAiCT2XbDpBSyER7j9vj${sequence}`,
-    marketplace: UserSubscriptionMarketplace.CanonicalUA,
     machine_type: UserSubscriptionMachineType.Physical,
+    marketplace: UserSubscriptionMarketplace.CanonicalUA,
     number_of_machines: 1,
     period: UserSubscriptionPeriod.Yearly,
-    price_per_unit: 150000,
+    price: 150000,
     product_name: "UA Applications - Standard (Physical)",
+    renewal_id: `jY3JaBWF0x8vv5S68mUuVO7AyCYZzv4ZTeXMnJ${sequence}`,
     start_date: new Date("2021-08-11T02:56:54Z"),
     statuses: userSubscriptionStatusesFactory.build(),
+    subscription_id: `VO7AyCYZzvjY3JaBWF0xmUu8vv5S684ZTeXMnJ${sequence}`,
     type: UserSubscriptionType.Yearly,
   })
 );
@@ -55,17 +59,21 @@ export const userSubscriptionFactory = Factory.define<UserSubscription>(
 export const freeSubscriptionFactory = Factory.define<UserSubscription>(
   ({ sequence }) => ({
     account_id: `F9sf54ZfJt59AMwynubzPyaGE9Z4D${sequence}`,
+    contract_id: `mUuVO7AyCYZzvjY3JaBWF0x8vv5S684ZTeXMnJ${sequence}`,
+    currency: "USD",
     end_date: null,
     entitlements: [],
     listing_id: null,
-    marketplace: UserSubscriptionMarketplace.Free,
     machine_type: UserSubscriptionMachineType.Physical,
+    marketplace: UserSubscriptionMarketplace.Free,
     number_of_machines: 3,
     period: null,
-    price_per_unit: null,
+    price: null,
     product_name: null,
+    renewal_id: null,
     start_date: new Date("2021-07-09T07:14:56Z"),
     statuses: userSubscriptionStatusesFactory.build(),
+    subscription_id: null,
     type: UserSubscriptionType.Free,
   })
 );


### PR DESCRIPTION
## Done

- Update subscription types to latest API shape.
- Use the contract id to identify subscriptions.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10322.demos.haus/advantage?test_backend=true) and log in.
- Click on subscriptions on the left, the same subscription should get displayed on the right.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/210.