### PR TITLE
Ensure drawer is closed on page reload (small screens)

### DIFF
--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -143,10 +143,10 @@ function toggleShowAllLinks() {
 }
 
 function hideDrawerPageReload() {
-  const closeDrawerButton = document.querySelector(
-    ".p-side-navigation__toggle--in-drawer"
-  );
-  closeDrawerButton.click();
+  if (window.location.href.includes("drawer")) {
+    const closeDrawerButton = document.querySelector("#toggle-filters");
+    closeDrawerButton.click();
+  }
 }
 
 enableApplyFilters();
@@ -154,3 +154,4 @@ toggleVersionsList();
 toggleVendorsList();
 toggleShowAllLinks();
 updateResultsPerPage();
+hideDrawerPageReload();

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 function clearFilters() {
+  hideDrawerPageReload();
   let objUrl = new URL(window.location);
   objUrl.search = "";
   window.location.assign(objUrl);
@@ -139,6 +140,13 @@ function toggleShowAllLinks() {
       }
     });
   });
+}
+
+function hideDrawerPageReload() {
+  const closeDrawerButton = document.querySelector(
+    ".p-side-navigation__toggle--in-drawer"
+  );
+  closeDrawerButton.click();
 }
 
 enableApplyFilters();

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -136,9 +136,9 @@
               </ul>
               <hr style="margin-bottom: 1rem;">
             </aside>
-            <div class="u-align--right">
+            <div class="u-align--right" style="padding-right: 0.5rem">
               <button class="p-button--neutral p-update-results u-no-margin--right" onclick="return clearFilters()">Clear</button>
-              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
+              <button class="p-button--positive p-update-results js-apply-filters" type="submit" onclick="hideDrawerPageReload()" disabled>Apply</button>
             </div>
           </div>
         </nav>

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -56,11 +56,11 @@
     </div>
     <div class="row">
       <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <a href="#drawer" class="p-side-navigation__toggle" aria-controls="drawer">Toggle filters</a>
+        <div class="p-side-navigation__overlay" aria-controls="drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
           <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+            <a href="#" class="p-side-navigation__toggle--in-drawer" aria-controls="drawer" id="toggle-filters">
               Toggle filters
             </a>
           </div>
@@ -138,7 +138,7 @@
             </aside>
             <div class="u-align--right" style="padding-right: 0.5rem">
               <button class="p-button--neutral p-update-results u-no-margin--right" onclick="return clearFilters()">Clear</button>
-              <button class="p-button--positive p-update-results js-apply-filters" type="submit" onclick="hideDrawerPageReload()" disabled>Apply</button>
+              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
             </div>
           </div>
         </nav>

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -48,11 +48,11 @@
     </div>
     <div class="row">
       <div class="col-3 p-side-navigation" id="drawer">
-        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">Toggle filters</a>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="Example side navigation">
+        <a href="#drawer" class="p-side-navigation__toggle" aria-controls="drawer">Toggle filters</a>
+        <div class="p-side-navigation__overlay" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="Filter list">
           <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+            <a href="#" class="p-side-navigation__toggle--in-drawer" aria-controls="drawer">
               Toggle filters
             </a>
           </div>
@@ -113,9 +113,9 @@
               </ul>
               <hr style="margin-bottom: 1rem;">
             </aside>
-            <div class="u-align--right">
+            <div class="u-align--right" style="padding-right: 0.5rem">
               <button class="p-button--neutral p-update-results u-no-margin--right" onclick="return clearFilters()">Clear</button>
-              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
+              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled onclick="hideDrawerPageReload()">Apply</button>
             </div>
           </div>
         </nav>
@@ -185,3 +185,4 @@
 </form>
 
 <script src="{{ versioned_static('js/src/certified-search-results.js') }}" defer></script>
+

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -52,7 +52,7 @@
         <div class="p-side-navigation__overlay" aria-controls="drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="Filter list">
           <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer" aria-controls="drawer">
+            <a href="#" class="p-side-navigation__toggle--in-drawer" aria-controls="drawer" id="toggle-filters">
               Toggle filters
             </a>
           </div>
@@ -115,7 +115,7 @@
             </aside>
             <div class="u-align--right" style="padding-right: 0.5rem">
               <button class="p-button--neutral p-update-results u-no-margin--right" onclick="return clearFilters()">Clear</button>
-              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled onclick="hideDrawerPageReload()">Apply</button>
+              <button class="p-button--positive p-update-results js-apply-filters" type="submit" disabled>Apply</button>
             </div>
           </div>
         </nav>


### PR DESCRIPTION
## Done

- Added a small amount of right padding to the buttons to ensure there is space between them and the right side of the drawer on small screens
- Added a function to ensure the drawer closes when the page reloads after applying/clearing filters
- Noticed the clear filters button on the generic search page takes you back to `/certified` which isn't the expected behaviour but this is out of scope for this PR. Issue created [here](https://github.com/canonical-web-and-design/ubuntu.com/issues/10325)

## QA

- View page at: https://ubuntu-com-10326.demos.haus/certified/desktops or /certified/laptops or /certified/devices (any in the secondary nav)
- Reduce your screen size until you see the toggle drawer button. 
- Click the button to open the filter drawer
- Apply some filters and click "Apply"
- When the page reloads with the new filters applied the filter drawer should be closed. 
- Click toggle drawer button again and select "Clear" to clear the filters
- On page reload the drawer should close.


## Issue / Card

Fixes #10305 

