### PR TITLE
Make covered texts visible on /cube

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -34,7 +34,7 @@
       <p class="p-heading--four">Earn your qualification one topic at a time, at your own pace, in any order.</p>
       <p class="u-sv3">The CUBE curriculum is perfectly portioned to accommodate your busy schedule. It consists of 15 separate microcerts, each covering a specific subject area, that can be taken in any order and at any time.</p>
       <p>All CUBE badges follow <a class="p-link--external" href="https://www.imsglobal.org/sites/default/files/Badges/OBv2p0Final/index.html">Open Badge specifications</a>.</p>
-      <p>
+      <p class="u-sv3">
         <a class="p-link--external" href="https://openbadges.org/about">
           Learn more about Open Badges
         </a>


### PR DESCRIPTION
## Done

- Updated margin to make covered texts visible on `/cube`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check if any texts are covered by any images on small screens 

## Issue / Card

Fixes #10333 

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/132702153-06e1da6e-440a-42ef-a032-cc1758fd6f3e.png)
