### PR TITLE
added fix for search function on /tutorials

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -567,7 +567,7 @@ def build_tutorials_index(session, tutorials_docs):
                     identifier = result["link"][start:end]
                     if start != -1:
                         for doc in tutorials:
-                            if identifier in doc["topic"]:
+                            if identifier in doc["link"]:
                                 temp_metadata.append(doc)
             tutorials = temp_metadata
 


### PR DESCRIPTION
## Done

Changed key in `views.py` line 570 from "topic" to "link" to stop search from returning 505 on /tutorials

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10336.demos.haus/tutorials
- Run a search


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10323

