### PR TITLE
Removed /robotics from IoT subnav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1189,8 +1189,6 @@ iot:
       path: /internet-of-things
     - title: Digital signage
       path: /internet-of-things/digital-signage
-    - title: Robotics
-      path: /robotics
     - title: Gateways
       path: /internet-of-things/gateways
     - title: App store

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -876,6 +876,9 @@ tutorial/(?P<path>.*)/?: /tutorials/{path}
 # Image builder
 build: /core/build
 
+# IoT robotics
+internet-of-things/robotics/?: /robotics
+
 # Redirect navigation templates
 templates/_(?P<path>.*)/?: /templates/{path}
 shared/forms/interactive/_(?P<path>.*)/?: /shared/forms/interactive/{path}

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -873,9 +873,6 @@ tutorials/tutorial/(?P<path>.*)/?: /tutorials/{path}
 t/(?P<path>.*)/?: /tutorials/{path}
 tutorial/(?P<path>.*)/?: /tutorials/{path}
 
-# IoT robotics
-internet-of-things/robotics/?: /robotics
-
 # Image builder
 build: /core/build
 


### PR DESCRIPTION
## Done

- Removed /robotics from IoT subnav 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10341.demos.haus/internet-of-things
- **NOTE: The same issue is happening for `/embedded` and `/automotive`, I will submit a separate PR to fix the subnav not persisting on these** 


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9504

## Screenshots
![Screenshot 2021-09-10 at 16 20 22](https://user-images.githubusercontent.com/17607612/132868430-2467cd54-dd98-4351-9597-6d96e233b4ef.png)
