### PR TITLE
Add account users endpoint

### DIFF
--- a/tests/advantage/fixtures/user.json
+++ b/tests/advantage/fixtures/user.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "Joe Doe",
+  "email": "joe.doe@canonical.com",
+  "firstLogin": "2021-09-10T12:00:00Z",
+  "id": "aAbBcCdD",
+  "lastLogin": "2021-09-10T12:00:00Z",
+  "name": "joedoe2021",
+  "verified": true
+}

--- a/tests/advantage/fixtures/users.json
+++ b/tests/advantage/fixtures/users.json
@@ -1,0 +1,21 @@
+[
+  {
+    "displayName": "Joe Doe",
+    "email": "joe.doe@canonical.com",
+    "firstLogin": "2021-09-10T12:00:00Z",
+    "id": "aAbBcCdD",
+    "lastLogin": "2021-09-10T12:00:00Z",
+    "name": "joedoe2021",
+    "verified": true,
+    "userRoleOnAccount": "admin"
+  },
+  {
+    "displayName": "Jane Doe",
+    "email": "jane.doe@canonical.com",
+    "firstLogin": "2021-09-10T12:00:00Z",
+    "id": "aAbBcCdD2",
+    "lastLogin": "2021-09-10T12:00:00Z",
+    "name": "janedoe2021",
+    "verified": false
+  }
+]

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -14,6 +14,7 @@ from webapp.advantage.ua_contracts.primitives import (
     Account,
     Contract,
     Subscription,
+    User,
 )
 
 
@@ -1347,4 +1348,87 @@ class TestEnsurePurchaseAccount(unittest.TestCase):
         }
 
         self.assertEqual(response, json_ensure_account)
+        self.assertEqual(session.request_kwargs, expected_args)
+
+
+class TestGetAccountUsers(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            response_content = {"code": "bad request"}
+            response = Response(status_code=code, content=response_content)
+            session = Session(response=response)
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error) as error:
+                client.get_account_users(account_id="aAbBcCdD")
+
+            self.assertEqual(error.exception.response.json(), response_content)
+
+    def test_success(self):
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={
+                    "accountInfo": get_fixture("account"),
+                    "users": [
+                        {
+                            "accountInfo": get_fixture("account"),
+                            "userInfo": get_fixture("user"),
+                        }
+                    ],
+                },
+            )
+        )
+        client = make_client(session)
+
+        response = client.get_account_users(account_id="aAbBcCdD")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": {},
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/accounts/aAbBcCdD/users",
+        }
+
+        self.assertEqual(response, [get_fixture("user")])
+        self.assertEqual(session.request_kwargs, expected_args)
+
+    def test_convert_response_returns_list_of_users(self):
+        session = Session(
+            Response(
+                status_code=200,
+                content={
+                    "accountInfo": get_fixture("account"),
+                    "users": [
+                        {
+                            "accountInfo": get_fixture("account"),
+                            "userInfo": get_fixture("user"),
+                        }
+                    ],
+                },
+            )
+        )
+
+        client = make_client(session, convert_response=True)
+
+        response = client.get_account_users(account_id="aAbBcCdD")
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": {},
+            "method": "get",
+            "params": None,
+            "url": "https://1.2.3.4/v1/accounts/aAbBcCdD/users",
+        }
+
+        self.assertIsInstance(response, List)
+        for item in response:
+            self.assertIsInstance(item, User)
+
         self.assertEqual(session.request_kwargs, expected_args)

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -18,6 +18,8 @@ from webapp.advantage.ua_contracts.parsers import (
     parse_contract,
     parse_contracts,
     parse_renewal,
+    parse_user,
+    parse_users,
 )
 from webapp.advantage.ua_contracts.primitives import (
     Account,
@@ -26,6 +28,7 @@ from webapp.advantage.ua_contracts.primitives import (
     ContractItem,
     Contract,
     Renewal,
+    User,
 )
 
 
@@ -492,3 +495,51 @@ class TestParsers(unittest.TestCase):
 
         self.assertIsInstance(parsed_contracts, List)
         self.assertEqual(to_dict(expectation), to_dict(parsed_contracts))
+
+    def test_parse_user(self):
+        raw_user = get_fixture("user")
+
+        parsed_user = parse_user(raw_user)
+
+        expectation = User(
+            display_name="Joe Doe",
+            name="joedoe2021",
+            email="joe.doe@canonical.com",
+            id="aAbBcCdD",
+            last_login="2021-09-10T12:00:00Z",
+            first_login="2021-09-10T12:00:00Z",
+            verified=True,
+        )
+
+        self.assertEqual(to_dict(parsed_user), to_dict(expectation))
+
+    def test_parse_users(self):
+        raw_users = get_fixture("users")
+
+        parsed_users = parse_users(raw_users)
+
+        joe = User(
+            display_name="Joe Doe",
+            name="joedoe2021",
+            email="joe.doe@canonical.com",
+            id="aAbBcCdD",
+            last_login="2021-09-10T12:00:00Z",
+            first_login="2021-09-10T12:00:00Z",
+            verified=True,
+        )
+        joe.set_user_role_on_account("admin")
+
+        expectation = [
+            joe,
+            User(
+                display_name="Jane Doe",
+                name="janedoe2021",
+                email="jane.doe@canonical.com",
+                id="aAbBcCdD2",
+                last_login="2021-09-10T12:00:00Z",
+                first_login="2021-09-10T12:00:00Z",
+                verified=False,
+            ),
+        ]
+
+        self.assertEqual(to_dict(parsed_users), to_dict(expectation))

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -8,6 +8,7 @@ from webapp.advantage.ua_contracts.parsers import (
     parse_product_listings,
     parse_accounts,
     parse_account,
+    parse_users,
 )
 
 
@@ -91,6 +92,21 @@ class UAContractsAPI:
             return parse_contracts(contracts)
 
         return contracts
+
+    def get_account_users(self, account_id: str):
+        response = self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/users",
+            json={},
+            error_rules=["default"],
+        )
+
+        users = [user.get("userInfo") for user in response.json().get("users")]
+
+        if self.convert_response:
+            return parse_users(users)
+
+        return users
 
     def get_contract_token(self, contract_id: str) -> Optional[str]:
         response = self._request(

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -8,6 +8,7 @@ from webapp.advantage.ua_contracts.primitives import (
     SubscriptionItem,
     Account,
     Renewal,
+    User,
 )
 from webapp.advantage.models import Listing, Product
 
@@ -200,3 +201,25 @@ def parse_subscriptions(raw_subscriptions: Dict) -> List[Subscription]:
         parse_subscription(raw_subscription)
         for raw_subscription in raw_subscriptions
     ]
+
+
+def parse_user(raw_user: Dict) -> User:
+    user = User(
+        display_name=raw_user.get("displayName"),
+        name=raw_user.get("name"),
+        email=raw_user.get("email"),
+        id=raw_user.get("id"),
+        last_login=raw_user.get("lastLogin"),
+        first_login=raw_user.get("firstLogin"),
+        verified=raw_user.get("verified"),
+    )
+
+    user_role_on_account = raw_user.get("userRoleOnAccount")
+    if user_role_on_account:
+        user.set_user_role_on_account(user_role_on_account)
+
+    return user
+
+
+def parse_users(raw_users: List) -> List[User]:
+    return [parse_user(raw_user) for raw_user in raw_users]

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -117,3 +117,27 @@ class Account:
     ):
         self.id = id
         self.name = name
+
+
+class User:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        display_name: str,
+        email: str,
+        last_login: str,
+        first_login: str,
+        verified: bool,
+    ):
+        self.first_login = first_login
+        self.last_login = last_login
+        self.email = email
+        self.id = id
+        self.name = name
+        self.display_name = display_name
+        self.verified = verified
+        self.user_role_on_account = None
+
+    def set_user_role_on_account(self, user_role_on_account):
+        self.user_role_on_account = user_role_on_account

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -385,6 +385,26 @@ def get_last_purchase_ids(account_id):
 
 
 @advantage_decorator(permission="user", response="json")
+def get_account_users():
+    g.api.set_convert_response(True)
+
+    try:
+        account = g.api.get_purchase_account()
+    except UAContractsUserHasNoAccount as error:
+        # if no account throw 404
+        raise UAContractsAPIError(error)
+
+    account_users = g.api.get_account_users(account_id=account.id)
+
+    return flask.jsonify(
+        {
+            "account_id": account.id,
+            "users": to_dict(account_users),
+        }
+    )
+
+
+@advantage_decorator(permission="user", response="json")
 @use_kwargs({"contract_id": String()}, location="query")
 def get_contract_token(contract_id):
     g.api.set_convert_response(True)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -99,6 +99,7 @@ from webapp.advantage.views import (
     get_contract_token,
     get_user_info,
     cancel_trial,
+    get_account_users,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -296,6 +297,7 @@ app.add_url_rule(
 )
 app.add_url_rule("/advantage/users", view_func=advantage_account_users_view)
 app.add_url_rule("/advantage/user-info", view_func=get_user_info)
+app.add_url_rule("/advantage/account-users", view_func=get_account_users)
 app.add_url_rule("/advantage/subscribe", view_func=advantage_shop_view)
 app.add_url_rule("/account/payment-methods", view_func=payment_methods_view)
 app.add_url_rule(


### PR DESCRIPTION
## Done

- Add `/advantage/account-users` endpoint following the docs: https://docs.google.com/document/d/1BwKC43kx-keG3vS5YDYHBRgCN_T0cSfCtsSxeavnhHc/edit#heading=h.tlxxyux070vs

## QA

- Login on: https://ubuntu-com-10345.demos.haus
- Go to: https://ubuntu-com-10345.demos.haus/advantage/account-users
- Get 200.


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/229