### PR TITLE
exclude test files from watch-js glob pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "yarn run build-css && yarn run build-js && yarn build-global-nav",
     "watch": "concurrently --kill-others --raw 'yarn run watch-css' 'yarn run watch-js'",
     "watch-css": "watch -p 'static/sass/**/*.scss' -p 'node_modules/vanilla-framework/scss/**/*.scss' -c 'yarn run build-css'",
-    "watch-js": "watch -p 'static/js/src/**/*.{js,jsx,ts,tsx}' -p 'static/js/data/**/*.js' -p 'static/js/third-party/**/*.js' -c 'yarn run build-js && tsc -noEmit'",
+    "watch-js": "watch -p 'static/js/src/**/!(*.test)*.{js,jsx,ts,tsx}' -p 'static/js/data/**/*.js' -p 'static/js/third-party/**/*.js' -c 'yarn run build-js && tsc -noEmit'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/js/dist etc/",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch-css' 'yarn run watch-js' 'yarn run serve'",


### PR DESCRIPTION
## Done

- make `watch-js` ignore `.test` files - the build was triggered unnecessarely every time a test file would change
  - exclude *.test* files from watch-js glob pattern

## QA

- check out this branch
- run `dotrun`
- make a change to a `.tsx` file, e.g. `static/js/src/advantage/users/components/AddNewUser/AddNewUser.tsx`
- javascript should be rebuilt
- make a change to a  `.test.tsx` file, e.g. `static/js/src/advantage/users/components/AddNewUser/AddNewUser.test.tsx`
- javascript should not be rebuilt

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]
