### PR TITLE
[Certified] - Keep query string when filters are cleared

### DIFF
--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -2,8 +2,17 @@
 
 function clearFilters() {
   hideDrawerPageReload();
+
   let objUrl = new URL(window.location);
-  objUrl.search = "";
+  const href = window.location.href;
+  if (href.includes("q=") && !href.includes("q=&")) {
+    const startOfQuery = href.indexOf("q");
+    const endOfQuery = href.indexOf("&");
+    const searchQuery = href.substring(startOfQuery, endOfQuery);
+    objUrl.search = searchQuery;
+  } else {
+    objUrl.search = "";
+  }
   window.location.assign(objUrl);
   return false;
 }

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -93,17 +93,21 @@ function updateResultsPerPage() {
   const pageSizeTop = document.getElementById("page-size-top");
   const pageSizeBottom = document.getElementById("page-size-bottom");
 
-  pageSizeTop.addEventListener("change", (e) => {
-    // Needs to be set because the other dropdown is a dummy
-    searchResults.submit();
-  });
+  if (pageSizeTop) {
+    pageSizeTop.addEventListener("change", (e) => {
+      // Needs to be set because the other dropdown is a dummy
+      searchResults.submit();
+    });
+  }
 
-  pageSizeBottom.addEventListener("change", (e) => {
-    // Avoids submitting 2 redundant fields
-    let pageSizeTopChange = new Event("change");
-    pageSizeTop.value = e.target.value;
-    pageSizeTop.dispatchEvent(pageSizeTopChange);
-  });
+  if (pageSizeBottom) {
+    pageSizeBottom.addEventListener("change", (e) => {
+      // Avoids submitting 2 redundant fields
+      let pageSizeTopChange = new Event("change");
+      pageSizeTop.value = e.target.value;
+      pageSizeTop.dispatchEvent(pageSizeTopChange);
+    });
+  }
 }
 
 function toggleVendorsList() {

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -4,7 +4,7 @@ function clearFilters() {
   hideDrawerPageReload();
 
   let objUrl = new URL(window.location);
-  const href = window.location.href;
+  const { href } = window.location;
   if (href.includes("q=") && !href.includes("q=&")) {
     const startOfQuery = href.indexOf("q");
     const endOfQuery = href.indexOf("&");
@@ -103,7 +103,7 @@ function updateResultsPerPage() {
   if (pageSizeBottom) {
     pageSizeBottom.addEventListener("change", (e) => {
       // Avoids submitting 2 redundant fields
-      let pageSizeTopChange = new Event("change");
+      const pageSizeTopChange = new Event("change");
       pageSizeTop.value = e.target.value;
       pageSizeTop.dispatchEvent(pageSizeTopChange);
     });

--- a/tests/cypress/certified_spec.js
+++ b/tests/cypress/certified_spec.js
@@ -1,0 +1,53 @@
+/// <reference types="cypress" />
+
+context("Certified search results", () => {
+  beforeEach(() => {
+    cy.setCookie("_cookies_accepted", "all");
+  });
+
+  it("should update results per page when pagination is selected", () => {
+    cy.visit("/certified?q=dell");
+
+    cy.findAllByLabelText("Results per page").first().select("40");
+    cy.location("href", { timeout: 6000 }).should("include", "limit=40");
+    cy.findByText(/results/).should("contain", "40");
+  });
+
+  it("should update results when Apply is selected", () => {
+    cy.visit("/certified/laptops");
+
+    cy.findByRole("checkbox", { name: /Dell/i }).click({ force: true });
+    cy.findByRole("button", { name: /Apply/i }).click();
+
+    cy.location("href", { timeout: 6000 }).should("include", "vendor=Dell");
+    cy.findAllByText(/Dell/).should("be.visible");
+  });
+
+  it("should clear filters when clear is selected", () => {
+    cy.visit("/certified/socs");
+
+    cy.findByRole("checkbox", { name: /20.04 LTS/i }).click({ force: true });
+    cy.findByRole("button", { name: /Apply/i }).click();
+    cy.findByRole("button", { name: /Clear/i }).click();
+    cy.findAllByRole("checkbox").should("not.be.checked");
+  });
+
+  it("should keep query string when filters are cleared", () => {
+    cy.visit("/certified?q=hp");
+
+    cy.findByRole("checkbox", { name: /20.04 LTS/i }).click({ force: true });
+    cy.findByRole("button", { name: /Apply/i }).click();
+    cy.findByRole("button", { name: /Clear/i }).click();
+    cy.findByPlaceholderText("Search hardware")
+      .invoke("val")
+      .should("include", "hp");
+  });
+
+  it("should take you to seach results page when search bar is used", () => {
+    cy.visit("/certified");
+
+    cy.findByPlaceholderText("Search hardware").type("dell{enter}");
+    cy.findByText(/results/).should("be.visible");
+    cy.findAllByText(/Dell/).should("be.visible");
+  });
+});


### PR DESCRIPTION
## Done

- Ensure that the "Clear" button clears only the filters applied - not the typed query string
- Add some tests for /certified search results
- Fix console errors when the pagination drop downs don't exist when there are no results 

## QA
1. 
- View page at: https://ubuntu-com-10353.demos.haus/certified
- In the search bar search for something i.e. "dell"
- When you land on the search results page, apply a filter i.e. "Desktop"
- Select "Apply"
- Then select "Clear"
- You should remain on the search results page, with no filters applied but with the query string still present

2.
- Go to the live site: https://ubuntu.com/certified?q=dell&limit=20&vendor=Ampere+Computing%2C+LLC and see the error in the console.
- Go to the demo: https://ubuntu-com-10353.demos.haus/certified?q=dell&limit=20&vendor=Ampere+Computing%2C+LLC and see the error is no longer there


## Issue / Card

Fixes #10325 

