### PR TITLE
account users/delete user modal

### DIFF
--- a/static/js/src/advantage/tests/utils.ts
+++ b/static/js/src/advantage/tests/utils.ts
@@ -1,15 +1,15 @@
-import { screen } from "@testing-library/react";
+import { screen, MatcherFunction } from "@testing-library/react";
 
-const getTextContentMatcher = (textMatch: string | RegExp) => (
-  content,
+const getTextContentMatcher = (textMatch: string | RegExp): MatcherFunction => (
+  _content,
   node
 ) => {
-  const hasText = (node) =>
-    node.textContent === textMatch || node.textContent.match(textMatch);
+  const hasText = (node: Element | null) =>
+    node?.textContent === textMatch || !!node?.textContent?.match(textMatch);
   const nodeHasText = hasText(node);
-  const childrenDontHaveText = Array.from(node.children).every(
-    (child) => !hasText(child)
-  );
+  const childrenDontHaveText = node?.children
+    ? Array.from(node.children).every((child) => !hasText(child))
+    : true;
 
   return nodeHasText && childrenDontHaveText;
 };

--- a/static/js/src/advantage/tests/utils.ts
+++ b/static/js/src/advantage/tests/utils.ts
@@ -1,6 +1,9 @@
 import { screen } from "@testing-library/react";
 
-const getTextContentMatcher = (textMatch) => (content, node) => {
+const getTextContentMatcher = (textMatch: string | RegExp) => (
+  content,
+  node
+) => {
   const hasText = (node) =>
     node.textContent === textMatch || node.textContent.match(textMatch);
   const nodeHasText = hasText(node);
@@ -13,5 +16,5 @@ const getTextContentMatcher = (textMatch) => (content, node) => {
 
 // use only if a regular "getByText" query is not working, this is much slower
 // https://github.com/testing-library/dom-testing-library/issues/410#issuecomment-797486513
-export const getByTextContent = (text) =>
+export const getByTextContent = (text: string | RegExp) =>
   screen.getByText(getTextContentMatcher(text));

--- a/static/js/src/advantage/tests/utils.ts
+++ b/static/js/src/advantage/tests/utils.ts
@@ -1,0 +1,17 @@
+import { screen } from "@testing-library/react";
+
+const getTextContentMatcher = (textMatch) => (content, node) => {
+  const hasText = (node) =>
+    node.textContent === textMatch || node.textContent.match(textMatch);
+  const nodeHasText = hasText(node);
+  const childrenDontHaveText = Array.from(node.children).every(
+    (child) => !hasText(child)
+  );
+
+  return nodeHasText && childrenDontHaveText;
+};
+
+// use only if a regular "getByText" query is not working, this is much slower
+// https://github.com/testing-library/dom-testing-library/issues/410#issuecomment-797486513
+export const getByTextContent = (text) =>
+  screen.getByText(getTextContentMatcher(text));

--- a/static/js/src/advantage/users/AccountUsers.test.tsx
+++ b/static/js/src/advantage/users/AccountUsers.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { User } from "./types";
 import AccountUsers from "./AccountUsers";
 import { mockData } from "./mockData";
 
@@ -29,4 +30,43 @@ it("displays a success message after adding a user", async () => {
   expect(screen.getByRole("alert")).toHaveTextContent(
     /User added successfully/
   );
+});
+
+it("allows to edit only a single user at a time", async () => {
+  const mockUserBase = {
+    lastLoginAt: "2021-06-10T09:05:00Z",
+  };
+  const users: User[] = [
+    {
+      ...mockUserBase,
+      id: "1",
+      name: "Karen",
+      email: "karen@ecorp.com",
+      role: "billing",
+    },
+    {
+      ...mockUserBase,
+      id: "3",
+      name: "Angela",
+      email: "angela@ecorp.com",
+      role: "technical",
+    },
+  ];
+
+  render(<AccountUsers organisationName="ECorp" users={users} />);
+
+  const EDIT_KAREN = "Edit user karen@ecorp.com";
+  const EDIT_ANGELA = "Edit user angela@ecorp.com";
+
+  screen
+    .getAllByRole("button", { name: /Edit/ })
+    .forEach((button) => expect(button).toBeEnabled());
+
+  userEvent.click(screen.getByLabelText(EDIT_KAREN));
+  expect(screen.getByLabelText(EDIT_ANGELA)).toBeDisabled();
+
+  userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+  await waitFor(() => expect(screen.getByLabelText(EDIT_ANGELA)).toBeEnabled());
+  expect(screen.getByLabelText(EDIT_KAREN)).toBeEnabled();
 });

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -15,6 +15,10 @@ const AccountUsers = ({ organisationName, users }: Props) => {
   const [hasNewUserSuccessMessage, setHasNewUserSuccessMessage] = useState(
     false
   );
+  const [
+    hasUserDeletedSuccessMessage,
+    setHasUserDeletedSuccessMessage,
+  ] = useState(false);
   const handleAddNewUser = (value: string) => {
     return Promise.resolve(value).then(() => {
       setHasNewUserSuccessMessage(true);
@@ -26,8 +30,8 @@ const AccountUsers = ({ organisationName, users }: Props) => {
   ] = useState(false);
   const handleDelete = (userId: string) =>
     Promise.resolve(userId).then(() => {
-      handleDeleteConfirmationModalClose();
       dismissEditMode();
+      setHasUserDeletedSuccessMessage(true);
     });
 
   const [userInEditModeById, setUserInEditModeById] = useState<string | null>(
@@ -68,14 +72,16 @@ const AccountUsers = ({ organisationName, users }: Props) => {
             />
           </div>
         </div>
-        {hasNewUserSuccessMessage ? (
+        {hasNewUserSuccessMessage || hasUserDeletedSuccessMessage ? (
           <div className="row">
             <div className="col-12">
               <div className="p-notification--positive">
                 <div className="p-notification__content" aria-atomic="true">
                   <h5 className="p-notification__title">Success</h5>
                   <p className="p-notification__message" role="alert">
-                    User added successfully.
+                    {hasNewUserSuccessMessage
+                      ? "User added successfully."
+                      : "User deleted successfully."}
                   </p>
                 </div>
               </div>

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 
-import { Users, OrganisationName } from "./types";
+import { User, Users, OrganisationName } from "./types";
 import Organisation from "./components/Organisation";
 import AddNewUser from "./components/AddNewUser/AddNewUser";
 import TableView from "./components/TableView/TableView";
+import DeleteConfirmationModal from "./components/DeleteConfirmationModal/DeleteConfirmationModal";
 
 type Props = {
   organisationName: OrganisationName;
@@ -19,6 +20,31 @@ const AccountUsers = ({ organisationName, users }: Props) => {
       setHasNewUserSuccessMessage(true);
     });
   };
+  const [
+    isDeleteConfirmationModalOpen,
+    setIsDeleteConfirmationModalOpen,
+  ] = useState(false);
+  const handleDelete = (userId: string) =>
+    Promise.resolve(userId).then(() => {
+      handleDeleteConfirmationModalClose();
+      dismissEditMode();
+    });
+
+  const [userInEditModeById, setUserInEditModeById] = useState<string | null>(
+    null
+  );
+  const userInEditMode: User | undefined =
+    typeof userInEditModeById === "string"
+      ? users.find((user) => user.id === userInEditModeById)
+      : undefined;
+
+  const dismissEditMode = () => setUserInEditModeById(null);
+  const handleDeleteConfirmationModalClose = () => {
+    setIsDeleteConfirmationModalOpen(false);
+  };
+  const handleDeleteConfirmationModalOpen = () =>
+    setIsDeleteConfirmationModalOpen(true);
+
   return (
     <div>
       <div className="p-strip">
@@ -57,9 +83,24 @@ const AccountUsers = ({ organisationName, users }: Props) => {
           </div>
         ) : null}
 
+        {isDeleteConfirmationModalOpen && userInEditMode ? (
+          <DeleteConfirmationModal
+            user={userInEditMode}
+            handleConfirmDelete={handleDelete}
+            handleClose={handleDeleteConfirmationModalClose}
+          />
+        ) : null}
         <div className="row">
           <div className="col-12">
-            <TableView users={users} />
+            <TableView
+              users={users}
+              userInEditModeById={userInEditModeById}
+              setUserInEditModeById={setUserInEditModeById}
+              dismissEditMode={dismissEditMode}
+              handleDeleteConfirmationModalOpen={
+                handleDeleteConfirmationModalOpen
+              }
+            />
           </div>
         </div>
       </section>

--- a/static/js/src/advantage/users/components/AddNewUser/AddNewUserForm.tsx
+++ b/static/js/src/advantage/users/components/AddNewUser/AddNewUserForm.tsx
@@ -4,42 +4,23 @@ import {
   ActionButton,
   Input,
   Select,
-  ValueOf,
 } from "@canonical/react-components";
 import { Formik, Form, Field } from "formik";
 
 import { HandleNewUserSubmit, UserRole } from "../../types";
 import { userRoleOptions } from "../../constants";
+import {
+  getErrorMessage,
+  validateEmail,
+  validateRequired,
+  SubmissionErrorMessage,
+} from "../../utils";
 
 interface Values {
   email: string;
   role: UserRole;
   name: string;
 }
-
-const validateRequired = (value: string): string | undefined =>
-  !value ? "This field is required." : undefined;
-
-const validateEmail = (value: string): string | undefined =>
-  validateRequired(value) ||
-  !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
-    ? "Must be a valid email."
-    : undefined;
-
-const errorMessages = {
-  email_already_exists: "Account with this email address exists.",
-  default: "An unknown error has occurred.",
-} as const;
-
-type SubmissionErrorMessageKey = keyof typeof errorMessages;
-type SubmissionErrorMessage = ValueOf<typeof errorMessages>;
-
-const getErrorMessage = (
-  error: SubmissionErrorMessageKey | string = "default"
-): SubmissionErrorMessage =>
-  Object.keys(errorMessages).includes(error)
-    ? errorMessages[error as SubmissionErrorMessageKey]
-    : errorMessages.default;
 
 export const AddNewUserForm = ({
   handleClose,

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.test.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { getByTextContent } from "../../../tests/utils";
+
+import DeleteConfirmationModal from "./DeleteConfirmationModal";
+import { mockUser } from "../../mockData";
+
+it("displays confirmation message correctly", () => {
+  const mockHandleConfirmDelete = jest.fn();
+  const mockHandleClose = jest.fn();
+
+  render(
+    <DeleteConfirmationModal
+      user={mockUser}
+      handleConfirmDelete={mockHandleConfirmDelete}
+      handleClose={mockHandleClose}
+    />
+  );
+  expect(
+    getByTextContent(
+      "Are you sure you want to remove philip.p@ecorp.com from your organisation?"
+    )
+  ).toBeVisible();
+});
+
+it("makes a correct call to handleConfirmDelete", () => {
+  const mockHandleConfirmDelete = jest.fn();
+  const mockHandleClose = jest.fn();
+
+  render(
+    <DeleteConfirmationModal
+      user={mockUser}
+      handleConfirmDelete={mockHandleConfirmDelete}
+      handleClose={mockHandleClose}
+    />
+  );
+  userEvent.click(screen.getByText("Yes, remove user"));
+  expect(mockHandleConfirmDelete).toHaveBeenCalledWith(mockUser.id);
+});

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Modal, Button } from "@canonical/react-components";
 
 import { User } from "../../types";
+import { getErrorMessage, SubmissionErrorMessage } from "../../utils";
 
 type DeleteConfirmationModalProps = {
   user: User;
@@ -14,14 +15,17 @@ const DeleteConfirmationModal = ({
   handleConfirmDelete,
   handleClose,
 }: DeleteConfirmationModalProps) => {
-  const [hasError, setHasError] = useState(false);
+  const [
+    errorMessage,
+    setErrorMessage,
+  ] = useState<SubmissionErrorMessage | null>(null);
 
   const onSubmit = async () => {
     try {
       await handleConfirmDelete(user?.id);
       handleClose();
     } catch (error) {
-      setHasError(true);
+      setErrorMessage(getErrorMessage((error as any)?.message));
     }
   };
 
@@ -44,12 +48,12 @@ const DeleteConfirmationModal = ({
         </>
       }
     >
-      {hasError ? (
+      {errorMessage ? (
         <div className="p-notification--negative">
           <div className="p-notification__content" aria-atomic="true">
             <h5 className="p-notification__title">Error</h5>
             <p className="p-notification__message" role="alert">
-              An unknown error has occurred. Please try again later.
+              {errorMessage}
             </p>
           </div>
         </div>

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Modal, Button } from "@canonical/react-components";
+
+import { User } from "../../types";
+
+type DeleteConfirmationModalProps = {
+  user: User;
+  handleConfirmDelete: (userId: string) => void;
+  handleClose: () => void;
+};
+
+const DeleteConfirmationModal = ({
+  user,
+  handleConfirmDelete,
+  handleClose,
+}: DeleteConfirmationModalProps) => (
+  <Modal
+    close={handleClose}
+    title="Add a new user to this organisation"
+    buttonRow={
+      <>
+        <Button className="u-no-margin--bottom" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button
+          className="u-no-margin--bottom"
+          appearance="positive"
+          onClick={() => handleConfirmDelete(user?.id)}
+        >
+          Delete
+        </Button>
+      </>
+    }
+  >
+    Are you sure you want to remove <strong>{user?.name}</strong> from your
+    organisation?
+  </Modal>
+);
+
+export default DeleteConfirmationModal;

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
@@ -16,24 +16,26 @@ const DeleteConfirmationModal = ({
 }: DeleteConfirmationModalProps) => (
   <Modal
     close={handleClose}
-    title="Add a new user to this organisation"
+    title="Confirm"
     buttonRow={
       <>
         <Button className="u-no-margin--bottom" onClick={handleClose}>
-          Cancel
+          No, cancel
         </Button>
         <Button
           className="u-no-margin--bottom"
-          appearance="positive"
+          appearance="negative"
           onClick={() => handleConfirmDelete(user?.id)}
         >
-          Delete
+          Yes, remove user
         </Button>
       </>
     }
   >
-    Are you sure you want to remove <strong>{user?.name}</strong> from your
-    organisation?
+    <p>
+      Are you sure you want to remove <strong>{user?.email}</strong> from your
+      organisation?
+    </p>
   </Modal>
 );
 

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { Modal, Button } from "@canonical/react-components";
 
 import { User } from "../../types";
 
 type DeleteConfirmationModalProps = {
   user: User;
-  handleConfirmDelete: (userId: string) => void;
+  handleConfirmDelete: (userId: string) => Promise<any>;
   handleClose: () => void;
 };
 
@@ -13,30 +13,53 @@ const DeleteConfirmationModal = ({
   user,
   handleConfirmDelete,
   handleClose,
-}: DeleteConfirmationModalProps) => (
-  <Modal
-    close={handleClose}
-    title="Confirm"
-    buttonRow={
-      <>
-        <Button className="u-no-margin--bottom" onClick={handleClose}>
-          No, cancel
-        </Button>
-        <Button
-          className="u-no-margin--bottom"
-          appearance="negative"
-          onClick={() => handleConfirmDelete(user?.id)}
-        >
-          Yes, remove user
-        </Button>
-      </>
+}: DeleteConfirmationModalProps) => {
+  const [hasError, setHasError] = useState(false);
+
+  const onSubmit = async () => {
+    try {
+      await handleConfirmDelete(user?.id);
+      handleClose();
+    } catch (error) {
+      setHasError(true);
     }
-  >
-    <p>
-      Are you sure you want to remove <strong>{user?.email}</strong> from your
-      organisation?
-    </p>
-  </Modal>
-);
+  };
+
+  return (
+    <Modal
+      close={handleClose}
+      title="Confirm"
+      buttonRow={
+        <>
+          <Button className="u-no-margin--bottom" onClick={handleClose}>
+            No, cancel
+          </Button>
+          <Button
+            className="u-no-margin--bottom"
+            appearance="negative"
+            onClick={onSubmit}
+          >
+            Yes, remove user
+          </Button>
+        </>
+      }
+    >
+      {hasError ? (
+        <div className="p-notification--negative">
+          <div className="p-notification__content" aria-atomic="true">
+            <h5 className="p-notification__title">Error</h5>
+            <p className="p-notification__message" role="alert">
+              An unknown error has occurred. Please try again later.
+            </p>
+          </div>
+        </div>
+      ) : null}
+      <p>
+        Are you sure you want to remove <strong>{user?.email}</strong> from your
+        organisation?
+      </p>
+    </Modal>
+  );
+};
 
 export default DeleteConfirmationModal;

--- a/static/js/src/advantage/users/components/TableView/TableView.test.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 
 import { User } from "../../types";
 import TableView from "./TableView";
@@ -8,42 +7,24 @@ import TableView from "./TableView";
 it("displays user details in a correct format", () => {
   const testUser: User = {
     id: "1",
+    name: "User",
     email: "user@ecorp.com",
     role: "admin",
     lastLoginAt: "2021-02-15T13:45:00Z",
   };
 
-  render(<TableView users={[testUser]} />);
+  render(
+    <TableView
+      users={[testUser]}
+      userInEditModeById={null}
+      setUserInEditModeById={jest.fn()}
+      dismissEditMode={jest.fn()}
+      handleDeleteConfirmationModalOpen={jest.fn()}
+    />
+  );
 
   expect(screen.getByText("user@ecorp.com")).toBeInTheDocument();
   expect(screen.getByText("Admin", { ignore: "option" })).toBeInTheDocument();
   expect(screen.getByText("Admin", { selector: "option" })).not.toBeVisible();
   expect(screen.getByText("15/02/2021")).toBeInTheDocument();
-});
-
-it("allows to edit only a single user at a time", async () => {
-  const mockUserBase = {
-    lastLoginAt: "2021-06-10T09:05:00Z",
-  };
-  const users: User[] = [
-    { ...mockUserBase, id: "1", email: "karen@ecorp.com", role: "billing" },
-    { ...mockUserBase, id: "3", email: "angela@ecorp.com", role: "technical" },
-  ];
-
-  render(<TableView users={users} />);
-
-  const EDIT_KAREN = "Edit user karen@ecorp.com";
-  const EDIT_ANGELA = "Edit user angela@ecorp.com";
-
-  screen
-    .getAllByRole("button", { name: /Edit/ })
-    .forEach((button) => expect(button).toBeEnabled());
-
-  userEvent.click(screen.getByLabelText(EDIT_KAREN));
-  expect(screen.getByLabelText(EDIT_ANGELA)).toBeDisabled();
-
-  userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-
-  await waitFor(() => expect(screen.getByLabelText(EDIT_ANGELA)).toBeEnabled());
-  expect(screen.getByLabelText(EDIT_KAREN)).toBeEnabled();
 });

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 
-import { Users } from "../../types";
+import { Users, User } from "../../types";
 import { getUserRow } from "./components";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";
 
-type UserInEditMode = string | null;
 type UserId = string;
 
-const getVariant = (userId: UserId, userInEditMode: UserInEditMode) => {
+const getVariant = (userId: UserId, userInEditMode: UserId | null) => {
   if (userInEditMode === null) {
     return "regular";
   } else if (userId !== userInEditMode) {
@@ -21,12 +20,19 @@ const getVariant = (userId: UserId, userInEditMode: UserInEditMode) => {
 
 type Props = {
   users: Users;
+  userInEditModeById: UserId | null;
+  setUserInEditModeById: (userId: UserId | null) => void;
+  dismissEditMode: () => void;
+  handleDeleteConfirmationModalOpen: () => void;
 };
 
-const TableView = ({ users }: Props) => {
-  const [userInEditMode, setUserInEditMode] = useState<string | null>(null);
-  const dismissEditMode = () => setUserInEditMode(null);
-
+const TableView = ({
+  users,
+  userInEditModeById,
+  setUserInEditModeById,
+  dismissEditMode,
+  handleDeleteConfirmationModalOpen,
+}: Props) => {
   return (
     <MainTable
       responsive
@@ -47,9 +53,10 @@ const TableView = ({ users }: Props) => {
       rows={users.map((user) =>
         getUserRow({
           user,
-          variant: getVariant(user.id, userInEditMode),
-          setUserInEditMode,
+          variant: getVariant(user.id, userInEditModeById),
+          setUserInEditModeById,
           dismissEditMode,
+          handleDeleteConfirmationModalOpen,
         })
       )}
     />

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 
-import { Users, User } from "../../types";
+import { Users } from "../../types";
 import { getUserRow } from "./components";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";

--- a/static/js/src/advantage/users/components/TableView/components.tsx
+++ b/static/js/src/advantage/users/components/TableView/components.tsx
@@ -56,9 +56,15 @@ const UserActions = ({
   );
 };
 
-type UserEmailProps = UserVariantProps;
+type UserEmailProps = {
+  handleDeleteConfirmationModalOpen: () => void;
+} & UserVariantProps;
 
-const UserEmail = ({ user, variant }: UserEmailProps) => {
+const UserEmail = ({
+  user,
+  variant,
+  handleDeleteConfirmationModalOpen,
+}: UserEmailProps) => {
   return (
     <div style={{ display: "flex", alignItems: "center" }}>
       {user.email}
@@ -68,6 +74,7 @@ const UserEmail = ({ user, variant }: UserEmailProps) => {
           style={{
             marginLeft: "0.1rem",
           }}
+          onClick={handleDeleteConfirmationModalOpen}
         >
           <i className="p-icon--delete" aria-label="delete"></i>
         </button>
@@ -123,8 +130,9 @@ const FormattedDate = ({ dateISO }: { dateISO: string }) => (
 );
 
 type UserRowProps = {
-  setUserInEditMode: (id: string) => void;
+  setUserInEditModeById: (id: string) => void;
   dismissEditMode: () => void;
+  handleDeleteConfirmationModalOpen: () => void;
 } & UserVariantProps;
 
 const tdStyle = {
@@ -134,8 +142,9 @@ const tdStyle = {
 const getUserRow = ({
   user,
   variant,
-  setUserInEditMode,
+  setUserInEditModeById,
   dismissEditMode,
+  handleDeleteConfirmationModalOpen,
 }: UserRowProps): MainTableRow => {
   return {
     key: user.id,
@@ -146,7 +155,15 @@ const getUserRow = ({
     },
     columns: [
       {
-        content: <UserEmail user={user} variant={variant} />,
+        content: (
+          <UserEmail
+            user={user}
+            variant={variant}
+            handleDeleteConfirmationModalOpen={
+              handleDeleteConfirmationModalOpen
+            }
+          />
+        ),
         role: "rowheader",
         style: tdStyle,
       },
@@ -163,7 +180,7 @@ const getUserRow = ({
           <UserActions
             variant={variant}
             user={user}
-            handleEditOpen={setUserInEditMode}
+            handleEditOpen={setUserInEditModeById}
             handleCancel={dismissEditMode}
             handleEditSubmit={dismissEditMode}
           />

--- a/static/js/src/advantage/users/mockData.ts
+++ b/static/js/src/advantage/users/mockData.ts
@@ -3,6 +3,7 @@ import { User, AccountUsersData } from "./types";
 export const mockUser: User = {
   id: "1",
   email: "philip.p@ecorp.com",
+  name: "Philip",
   role: "admin",
   lastLoginAt: "2021-06-10T09:05:00Z",
 };
@@ -13,7 +14,19 @@ export const mockData: AccountUsersData = {
   organisationName,
   users: [
     mockUser,
-    { ...mockUser, id: "2", email: "karen@ecorp.com", role: "billing" },
-    { ...mockUser, id: "3", email: "angela@ecorp.com", role: "technical" },
+    {
+      ...mockUser,
+      id: "2",
+      name: "Karen",
+      email: "karen@ecorp.com",
+      role: "billing",
+    },
+    {
+      ...mockUser,
+      id: "3",
+      name: "Angela",
+      email: "angela@ecorp.com",
+      role: "technical",
+    },
   ],
 };

--- a/static/js/src/advantage/users/types.ts
+++ b/static/js/src/advantage/users/types.ts
@@ -2,6 +2,7 @@ export type UserRole = "admin" | "technical" | "billing";
 
 export type User = {
   id: string;
+  name: string;
   email: string;
   role: UserRole;
   lastLoginAt: string;

--- a/static/js/src/advantage/users/utils.ts
+++ b/static/js/src/advantage/users/utils.ts
@@ -1,0 +1,25 @@
+import { ValueOf } from "@canonical/react-components";
+
+const errorMessages = {
+  email_already_exists: "Account with this email address exists.",
+  default: "An unknown error has occurred.",
+} as const;
+
+type SubmissionErrorMessageKey = keyof typeof errorMessages;
+export type SubmissionErrorMessage = ValueOf<typeof errorMessages>;
+
+export const getErrorMessage = (
+  error: SubmissionErrorMessageKey | string = "default"
+): SubmissionErrorMessage =>
+  Object.keys(errorMessages).includes(error)
+    ? errorMessages[error as SubmissionErrorMessageKey]
+    : errorMessages.default;
+
+export const validateRequired = (value: string): string | undefined =>
+  !value ? "This field is required." : undefined;
+
+export const validateEmail = (value: string): string | undefined =>
+  validateRequired(value) ||
+  !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
+    ? "Must be a valid email."
+    : undefined;


### PR DESCRIPTION
## Done

- Add Delete User modal
- reorganise tests - move edit test up to AccountUsers.test.tsx
- add `getTextContentMatcher` test util

## QA
1. Go to https://ubuntu-com-10355.demos.haus/advantage/users?test_backend=true and login
2. Click edit in the actions column
3. Verify that the confirmation message includes the correct user email and closes when clicking a button

## Issue / Card

https://github.com/canonical-web-and-design/commercial-squad/issues/206

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/133105314-6132b120-1a25-4558-8fd7-86267ba18a56.png)
### error
![image](https://user-images.githubusercontent.com/7452681/133115823-43071fca-0866-400e-9090-e493379fc81f.png)
### success
![image](https://user-images.githubusercontent.com/7452681/133112630-a01ca72c-f072-4507-8054-63582c0895b2.png)
