### PR TITLE
Display contract features and docs links

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -110,7 +110,7 @@ const DetailsContent = ({ selectedId }: Props) => {
       ) : (
         tokenBlock
       )}
-      <DetailsTabs />
+      <DetailsTabs subscription={subscription} token={token} />
     </div>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -4,6 +4,7 @@ import { mount, shallow } from "enzyme";
 import DetailsTabs from "./DetailsTabs";
 import {
   contractTokenFactory,
+  freeSubscriptionFactory,
   userSubscriptionEntitlementFactory,
   userSubscriptionFactory,
 } from "advantage/tests/factories/api";
@@ -82,5 +83,17 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     expect(wrapper.find("[data-test='contract-token']").exists()).toBe(true);
+  });
+
+  it("does not display docs links for the free subscription", () => {
+    const wrapper = mount(
+      <DetailsTabs
+        subscription={freeSubscriptionFactory.build()}
+        token={contractTokenFactory.build()}
+      />
+    );
+    // Switch to the docs tab:
+    wrapper.find("[data-test='docs-tab']").simulate("click");
+    expect(wrapper.find("[data-test='doc-link']").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -2,18 +2,85 @@ import React from "react";
 import { mount, shallow } from "enzyme";
 
 import DetailsTabs from "./DetailsTabs";
+import {
+  contractTokenFactory,
+  userSubscriptionEntitlementFactory,
+  userSubscriptionFactory,
+} from "advantage/tests/factories/api";
+import { UserSubscription } from "advantage/api/types";
+import { EntitlementType } from "advantage/api/enum";
 
 describe("DetailsTabs", () => {
+  let subscription: UserSubscription;
+
+  beforeEach(async () => {
+    subscription = userSubscriptionFactory.build();
+  });
+
   it("defaults to the features tab", () => {
-    const wrapper = shallow(<DetailsTabs />);
+    const wrapper = shallow(<DetailsTabs subscription={subscription} />);
     expect(wrapper.find("[data-test='features-content']").exists()).toBe(true);
   });
 
   it("can change tabs", () => {
-    const wrapper = mount(<DetailsTabs />);
+    const wrapper = mount(<DetailsTabs subscription={subscription} />);
     expect(wrapper.find("[data-test='docs-content']").exists()).toBe(false);
     wrapper.find("[data-test='docs-tab']").simulate("click");
     wrapper.update();
     expect(wrapper.find("[data-test='docs-content']").exists()).toBe(true);
+  });
+
+  it("only displays one link to livepatch docs", () => {
+    subscription = userSubscriptionFactory.build({
+      entitlements: [
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.Livepatch,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.LivepatchOnprem,
+        }),
+      ],
+    });
+    const wrapper = mount(<DetailsTabs subscription={subscription} />);
+    // Switch to the docs tab:
+    wrapper.find("[data-test='docs-tab']").simulate("click");
+    const docsLinks = wrapper.find("[data-test='doc-link']");
+    expect(docsLinks.length).toBe(1);
+    expect(docsLinks.at(0).text()).toBe("Livepatch");
+  });
+
+  it("only displays one link to ESM docs", () => {
+    subscription = userSubscriptionFactory.build({
+      entitlements: [
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.EsmApps,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.EsmInfra,
+        }),
+      ],
+    });
+    const wrapper = mount(<DetailsTabs subscription={subscription} />);
+    // Switch to the docs tab:
+    wrapper.find("[data-test='docs-tab']").simulate("click");
+    const docsLinks = wrapper.find("[data-test='doc-link']");
+    expect(docsLinks.length).toBe(1);
+    expect(docsLinks.at(0).text()).toBe("ESM Infra & ESM Apps");
+  });
+
+  it("can display a contract token", () => {
+    const wrapper = mount(
+      <DetailsTabs
+        subscription={subscription}
+        token={contractTokenFactory.build()}
+      />
+    );
+    // Switch to the docs tab:
+    wrapper.find("[data-test='docs-tab']").simulate("click");
+    expect(wrapper.find("[data-test='contract-token']").exists()).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -6,7 +6,7 @@ import {
   UserSubscription,
   UserSubscriptionEntitlement,
 } from "advantage/api/types";
-import { getFeaturesDisplay } from "advantage/react/utils";
+import { getFeaturesDisplay, isFreeSubscription } from "advantage/react/utils";
 import { EntitlementType } from "advantage/api/enum";
 
 enum ActiveTab {
@@ -58,45 +58,43 @@ const generateDocLinks = (
 ): DocsLink[] =>
   entitlements.reduce<DocsLink[]>((collection, entitlement) => {
     let link: DocsLink | null = null;
-    if (entitlement.enabled_by_default) {
-      switch (entitlement.type) {
-        case EntitlementType.EsmApps:
-        case EntitlementType.EsmInfra:
-          link = {
-            label: "ESM Infra & ESM Apps",
-            url:
-              "https://support.canonical.com/staff/s/article/Obtaining-ESM-Credentials-And-Enabling-ESM-On-Ubuntu ",
-          };
-          break;
-        case EntitlementType.Livepatch:
-        case EntitlementType.LivepatchOnprem:
-          link = {
-            label: "Livepatch",
-            url: "https://ubuntu.com/security/livepatch/docs",
-          };
-          break;
-        case EntitlementType.Support:
-          link = { label: "Support", url: "https://support.canonical.com/" };
-          break;
-        case EntitlementType.Cis:
-          link = {
-            label: "CIS setup instructions",
-            url: "https://ubuntu.com/security/certifications/docs/cis",
-          };
-          break;
-        case EntitlementType.CcEal:
-          link = {
-            label: "CC-EAL2 setup instructions",
-            url: "https://ubuntu.com/security/certifications/docs/cc",
-          };
-          break;
-        case EntitlementType.Fips:
-          link = {
-            label: "FIPS setup instructions",
-            url: "https://ubuntu.com/security/certifications/docs/fips ",
-          };
-          break;
-      }
+    switch (entitlement.type) {
+      case EntitlementType.EsmApps:
+      case EntitlementType.EsmInfra:
+        link = {
+          label: "ESM Infra & ESM Apps",
+          url:
+            "https://support.canonical.com/staff/s/article/Obtaining-ESM-Credentials-And-Enabling-ESM-On-Ubuntu ",
+        };
+        break;
+      case EntitlementType.Livepatch:
+      case EntitlementType.LivepatchOnprem:
+        link = {
+          label: "Livepatch",
+          url: "/security/livepatch/docs",
+        };
+        break;
+      case EntitlementType.Support:
+        link = { label: "Support", url: "https://support.canonical.com/" };
+        break;
+      case EntitlementType.Cis:
+        link = {
+          label: "CIS setup instructions",
+          url: "/security/certifications/docs/cis",
+        };
+        break;
+      case EntitlementType.CcEal:
+        link = {
+          label: "CC-EAL2 setup instructions",
+          url: "/security/certifications/docs/cc",
+        };
+        break;
+      case EntitlementType.Fips:
+        link = {
+          label: "FIPS setup instructions",
+          url: "/security/certifications/docs/fips ",
+        };
+        break;
     }
     if (link && !collection.find(({ label }) => label === link?.label)) {
       collection.push(link);
@@ -108,7 +106,9 @@ const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.FEATURES);
   let content: ReactNode | null;
   const features = getFeaturesDisplay(subscription.entitlements);
-  const docs = generateDocLinks(subscription.entitlements);
+  const isFree = isFreeSubscription(subscription);
+  // Don't display any docs links for the free subscription.
+  const docs = isFree ? [] : generateDocLinks(subscription.entitlements);
   switch (activeTab) {
     case ActiveTab.DOCUMENTATION:
       content = (

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -1,13 +1,28 @@
 import { Col, Icon, List, Row, Tabs } from "@canonical/react-components";
 import React, { HTMLProps, useState } from "react";
 import type { ReactNode } from "react";
+import {
+  ContractToken,
+  UserSubscription,
+  UserSubscriptionEntitlement,
+} from "advantage/api/types";
+import { getFeaturesDisplay } from "advantage/react/utils";
+import { EntitlementType } from "advantage/api/enum";
 
 enum ActiveTab {
   DOCUMENTATION = "documentation",
   FEATURES = "features",
 }
 
-type Props = HTMLProps<HTMLDivElement>;
+type Props = {
+  subscription: UserSubscription;
+  token?: ContractToken;
+} & HTMLProps<HTMLDivElement>;
+
+type DocsLink = {
+  url: string;
+  label: string;
+};
 
 type ListItem = {
   icon?: string;
@@ -38,30 +53,93 @@ const generateList = (title: string, items: ListItem[]) => (
   </>
 );
 
-const DetailsTabs = (wrapperProps: Props) => {
+const generateDocLinks = (
+  entitlements: UserSubscriptionEntitlement[]
+): DocsLink[] =>
+  entitlements.reduce<DocsLink[]>((collection, entitlement) => {
+    let link: DocsLink | null = null;
+    if (entitlement.enabled_by_default) {
+      switch (entitlement.type) {
+        case EntitlementType.EsmApps:
+        case EntitlementType.EsmInfra:
+          link = {
+            label: "ESM Infra & ESM Apps",
+            url:
+              "https://support.canonical.com/staff/s/article/Obtaining-ESM-Credentials-And-Enabling-ESM-On-Ubuntu ",
+          };
+          break;
+        case EntitlementType.Livepatch:
+        case EntitlementType.LivepatchOnprem:
+          link = {
+            label: "Livepatch",
+            url: "https://ubuntu.com/security/livepatch/docs",
+          };
+          break;
+        case EntitlementType.Support:
+          link = { label: "Support", url: "https://support.canonical.com/" };
+          break;
+        case EntitlementType.Cis:
+          link = {
+            label: "CIS setup instructions",
+            url: "https://ubuntu.com/security/certifications/docs/cis",
+          };
+          break;
+        case EntitlementType.CcEal:
+          link = {
+            label: "CC-EAL2 setup instructions",
+            url: "https://ubuntu.com/security/certifications/docs/cc",
+          };
+          break;
+        case EntitlementType.Fips:
+          link = {
+            label: "FIPS setup instructions",
+            url: "https://ubuntu.com/security/certifications/docs/fips ",
+          };
+          break;
+      }
+    }
+    if (link && !collection.find(({ label }) => label === link?.label)) {
+      collection.push(link);
+    }
+    return collection;
+  }, []);
+
+const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.FEATURES);
   let content: ReactNode | null;
+  const features = getFeaturesDisplay(subscription.entitlements);
+  const docs = generateDocLinks(subscription.entitlements);
   switch (activeTab) {
     case ActiveTab.DOCUMENTATION:
       content = (
         <div data-test="docs-content">
-          {generateList("Documentation & tutorials", [
-            {
-              label: <a href="#">Getting started / UA client</a>,
-            },
-            {
-              label: <a href="#">Attaching machines</a>,
-            },
-            {
-              label: <a href="#">ESM Infra & ESM Apps</a>,
-            },
-            {
-              label: <a href="#">Livepatch</a>,
-            },
-            {
-              label: <a href="#">Certification</a>,
-            },
-          ])}
+          {generateList(
+            "Documentation & tutorials",
+            docs
+              .map((doc) => ({
+                label: (
+                  <a data-test="doc-link" href={doc.url}>
+                    {doc.label}
+                  </a>
+                ),
+              }))
+              .concat(
+                token
+                  ? [
+                      {
+                        label: (
+                          <>
+                            To attach a machine:{" "}
+                            <code data-test="contract-token">
+                              sudo ua attach {token?.contract_token}
+                            </code>
+                          </>
+                        ),
+                      },
+                    ]
+                  : []
+              )
+          )}
         </div>
       );
       break;
@@ -71,31 +149,31 @@ const DetailsTabs = (wrapperProps: Props) => {
         <>
           <Row className="u-sv1" data-test="features-content">
             <Col size={4}>
-              {generateList("Included", [
-                {
-                  icon: "success",
-                  label: "ESM Infra",
-                },
-                {
-                  icon: "success",
-                  label: "24/5 support",
-                },
-                {
-                  icon: "success",
-                  label: "Livepatch",
-                },
-              ])}
+              {features.included.length
+                ? generateList(
+                    "Included",
+                    features.included.map((feature) => ({
+                      icon: "success",
+                      label: feature,
+                    }))
+                  )
+                : null}
             </Col>
             <Col size={4}>
-              {generateList("Not included", [
-                {
-                  icon: "error",
-                  label: "ESM Apps",
-                },
-              ])}
+              {features.excluded.length
+                ? generateList(
+                    "Not included",
+                    features.excluded.map((feature) => ({
+                      icon: "error",
+                      label: feature,
+                    }))
+                  )
+                : null}
             </Col>
           </Row>
-          <a href="#">Service description &rsaquo;</a>
+          <a href="/legal/ubuntu-advantage-service-description">
+            Service description &rsaquo;
+          </a>
         </>
       );
       break;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
@@ -5,10 +5,15 @@ import RenewalSettings from "../RenewalSettings";
 
 type Props = {
   children: ReactNode;
+  showRenewalSettings?: boolean;
   title: string;
 };
 
-const ListGroup = ({ children, title }: Props): JSX.Element => {
+const ListGroup = ({
+  children,
+  showRenewalSettings = true,
+  title,
+}: Props): JSX.Element => {
   const positionNode = useRef<HTMLDivElement | null>(null);
   const [, setRefReady] = useState(false);
   return (
@@ -25,7 +30,9 @@ const ListGroup = ({ children, title }: Props): JSX.Element => {
         <span className="p-text--x-small-capitalised u-align-text--small-to-default u-no-margin--bottom">
           {title}
         </span>
-        <RenewalSettings positionNodeRef={positionNode} />
+        {showRenewalSettings ? (
+          <RenewalSettings positionNodeRef={positionNode} />
+        ) : null}
       </div>
       {children}
     </div>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -58,7 +58,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
       <div className="p-subscriptions__list-scroll">
         <ListGroup title="Ubuntu Advantage">{uaSubscriptions}</ListGroup>
         {freeSubscription ? (
-          <ListGroup title="Free personal token">
+          <ListGroup title="Free personal token" showRenewalSettings={false}>
             <ListCard
               data-test="free-subscription"
               isSelected={selectedId === freeSubscription.contract_id}


### PR DESCRIPTION
## Done

- Display contract features and docs links.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10357.demos.haus/advantage?test_backend=true) and log in.
- Click on the 'Features' and 'Documentation' tabs, you should see appropriate features/docs.
- Click on some different subscriptions on the left and check that they too have appropriate features/docs.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/134.

## Screenshots

<img width="627" alt="Screen Shot 2021-09-14 at 12 17 28 pm" src="https://user-images.githubusercontent.com/361637/133183682-451e96d1-bdde-4da4-be05-8b3328ebde12.png">

<img width="617" alt="Screen Shot 2021-09-14 at 12 18 56 pm" src="https://user-images.githubusercontent.com/361637/133183784-d2c48c0f-a1b4-43c9-93f3-51bef62b3678.png">


