### PR TITLE
Free trial error states

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
@@ -6,6 +6,7 @@ import {
   CheckboxInput,
 } from "@canonical/react-components";
 import * as Sentry from "@sentry/react";
+import {useFormikContext} from "formik";
 
 import useStripeCustomerInfo from "../../APICalls/useStripeCustomerInfo";
 import PaymentMethodSummary from "../PaymentMethodSummary";
@@ -22,6 +23,7 @@ import Summary from "../../components/Summary";
 import FreeTrialRadio from "../../components/FreeTrialRadio";
 import { checkoutEvent, purchaseEvent } from "../../../../ecom-events";
 import { getSessionData } from "../../../../../utils/getSessionData";
+import { FormValues } from "../../utils/utils";
 
 type StepOneProps = {
   setStep: React.Dispatch<React.SetStateAction<number>>;

--- a/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
@@ -36,13 +36,13 @@ type StepOneProps = {
 function StepOne({ setStep, error, setError }: StepOneProps) {
   const { values } = useFormikContext<FormValues>();
   const [areTermsChecked, setTermsChecked] = useState(false);
-  const [isUsingFreeTrial, setIsUsingFreeTrial] = useState(true);
   const {
     data: userInfo,
     isLoading: isUserInfoLoading,
   } = useStripeCustomerInfo();
   const { isLoading: isPreviewLoading } = usePreview();
   const { isLoading: isProductLoading, product, quantity } = useProduct();
+  const [isUsingFreeTrial, setIsUsingFreeTrial] = useState(product?.canBeTrialled);
 
   const purchaseMutation = usePurchase();
   const freeTrialMutation = useFreeTrial();
@@ -226,7 +226,7 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
       >
         <>
           <Summary />
-          {!product?.canBeTrialled && (
+          {product?.canBeTrialled && (
             <FreeTrialRadio
               isUsingFreeTrial={isUsingFreeTrial}
               setIsUsingFreeTrial={setIsUsingFreeTrial}

--- a/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
@@ -5,8 +5,6 @@ import {
   ActionButton,
   CheckboxInput,
 } from "@canonical/react-components";
-import { useFormikContext } from "formik";
-
 import * as Sentry from "@sentry/react";
 
 import useStripeCustomerInfo from "../../APICalls/useStripeCustomerInfo";
@@ -25,8 +23,6 @@ import FreeTrialRadio from "../../components/FreeTrialRadio";
 import { checkoutEvent, purchaseEvent } from "../../../../ecom-events";
 import { getSessionData } from "../../../../../utils/getSessionData";
 
-import { FormValues } from "../../utils/utils";
-
 type StepOneProps = {
   setStep: React.Dispatch<React.SetStateAction<number>>;
   error: React.ReactNode | null;
@@ -42,7 +38,9 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
   } = useStripeCustomerInfo();
   const { isLoading: isPreviewLoading } = usePreview();
   const { isLoading: isProductLoading, product, quantity } = useProduct();
-  const [isUsingFreeTrial, setIsUsingFreeTrial] = useState(product?.canBeTrialled);
+  const [isUsingFreeTrial, setIsUsingFreeTrial] = useState(
+    product?.canBeTrialled
+  );
 
   const purchaseMutation = usePurchase();
   const freeTrialMutation = useFreeTrial();
@@ -226,11 +224,23 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
       >
         <>
           <Summary />
-          {product?.canBeTrialled && (
+          {product?.canBeTrialled ? (
             <FreeTrialRadio
               isUsingFreeTrial={isUsingFreeTrial}
               setIsUsingFreeTrial={setIsUsingFreeTrial}
             />
+          ) : (
+            <Row>
+              <Col size={10} emptyLarge={2}>
+                <p>
+                  <strong>
+                    Free Trial is not available for this account.{" "}
+                    <a href="/contact-us">Contact us</a> for further
+                    information.
+                  </strong>
+                </p>
+              </Col>
+            </Row>
           )}
           <PaymentMethodSummary setStep={setStep} />
           <Row className="u-no-padding">

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -157,6 +157,9 @@ function renderSummary(state) {
   const summarySection = form.querySelector("#summary-section");
   const saveMessage = summarySection.querySelector("#summary-save-with-annual");
   const billingSection = summarySection.querySelector(".js-summary-billing");
+  const trialUnavailableSection = summarySection.querySelector(
+    ".js-trial-unavailable"
+  );
   const billingSelect = summarySection.querySelector("select#billing-period");
   const buyButton = summarySection.querySelector("#buy-now-button");
 
@@ -191,13 +194,21 @@ function renderSummary(state) {
 
     const previous_purchase_id = window.previousPurchaseIds[billing];
 
-    // We add the data to the button so the modal can pick it up
+    // Show a message if the product can't be trialled
+    if (state.product.canBeTrialled) {
+      trialUnavailableSection.classList.add("u-hide");
+    } else {
+      trialUnavailableSection.classList.remove("u-hide");
+    }
+
+    // The button stays disabled if the users is already trialling a product.
     if (!window.isTrialling) {
       buyButton.classList.remove("u-disable");
     } else {
       buyButton.classList.add("u-disable");
     }
 
+    // We add the data to the button so the modal can pick it up
     const productObject = JSON.stringify(state.product);
     buyButton.dataset.product = productObject;
     buyButton.dataset.quantity = quantity;

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -192,7 +192,12 @@ function renderSummary(state) {
     const previous_purchase_id = window.previousPurchaseIds[billing];
 
     // We add the data to the button so the modal can pick it up
-    buyButton.classList.remove("u-disable");
+    if (!window.isTrialling) {
+      buyButton.classList.remove("u-disable");
+    } else {
+      buyButton.classList.add("u-disable");
+    }
+
     const productObject = JSON.stringify(state.product);
     buyButton.dataset.product = productObject;
     buyButton.dataset.quantity = quantity;

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -185,21 +185,16 @@ function renderSummary(state) {
     title.innerHTML = state.product.name;
     if (state.product.canBeTrialled) {
       freeTrialLabel.classList.remove("u-hide");
+      trialUnavailableSection.classList.add("u-hide");
     } else {
       freeTrialLabel.classList.add("u-hide");
+      trialUnavailableSection.classList.remove("u-hide");
     }
     costElement.innerHTML = `${formatter.format((price / 100) * quantity)} / ${
       billing === "monthly" ? "month" : "year"
     }`;
 
     const previous_purchase_id = window.previousPurchaseIds[billing];
-
-    // Show a message if the product can't be trialled
-    if (state.product.canBeTrialled) {
-      trialUnavailableSection.classList.add("u-hide");
-    } else {
-      trialUnavailableSection.classList.remove("u-hide");
-    }
 
     // The button stays disabled if the users is already trialling a product.
     if (!window.isTrialling) {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -107,6 +107,11 @@
           Buy now
         </button>
       </div>
+      {% if is_trialling %}
+        <div class="col-8 col-start-large-4">
+          <p><strong>You cannot purchase a new subscription while a Free Trial is active.</strong></p>
+        </div>
+      {% endif %}
     </div>
   </section>
 </form>
@@ -139,6 +144,7 @@
 
   var accountId = "{% if account %}{{ account.id }}{% endif %}";
   var isGuest = {% if account %}false{% else %}true{% endif %};
+  var isTrialling = {% if is_trialling %}true{% else %}false{% endif %};
   var accountName = "{% if account %}{{ account.name }}{% endif %}";
   var previousPurchaseIds = {
     {% for period, id in previous_purchase_ids.items() %}

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -107,6 +107,9 @@
           Buy now
         </button>
       </div>
+      <div class="col-8 col-start-large-4 js-trial-unavailable">
+        <p><strong>Free Trial is not available for this account. <a href="/contact-us">Contact us</a> for further information.</strong></p>
+      </div>
       {% if is_trialling %}
         <div class="col-8 col-start-large-4">
           <p><strong>You cannot purchase a new subscription while a Free Trial is active.</strong></p>
@@ -136,7 +139,7 @@
         },
         period: "{{ listing.period }}",
         productID: "{{ listing.product.id }}",
-        can_be_trialled: "{{ listing.can_be_trialled }}",
+        can_be_trialled: {% if listing.can_be_trialled %}true{% else %}false{% endif %},
         private: false,
       },
     {% endfor %}

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -139,7 +139,7 @@
         },
         period: "{{ listing.period }}",
         productID: "{{ listing.product.id }}",
-        can_be_trialled: {% if listing.can_be_trialled %}true{% else %}false{% endif %},
+        canBeTrialled: {% if listing.can_be_trialled %}true{% else %}false{% endif %},
         private: false,
       },
     {% endfor %}


### PR DESCRIPTION
## Done

- Added the error states listed [here](https://miro.com/app/board/o9J_lSky0cQ=/)

## QA

- Go to https://ubuntu-com-10363.demos.haus/advantage/subscribe?test_backend=true
- Log in
- You should not be able to start a trial
- You should see error messages telling you your account is not eligible on the bottom of the wizard and on step 2 of the modal


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/169

## Screenshots
![image](https://user-images.githubusercontent.com/11927929/133273037-59d9f97f-e33a-47f3-a2c3-f0afcb18fa9c.png)
![image](https://user-images.githubusercontent.com/11927929/133273091-4721cd38-c6de-4973-8ba5-d57f4ea40cc6.png)
![image](https://user-images.githubusercontent.com/11927929/133273677-179c67b1-3e1f-407a-b75d-b4b82aedeefe.png)


