### PR TITLE
Cancel a subscription via the API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "typescript": "4.3.5",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.0",
-    "vanilla-framework": "2.35.0"
+    "vanilla-framework": "2.35.0",
+    "yup": "0.32.9"
   },
   "resolutions": {
     "lodash": "4.17.21",

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -42,6 +42,11 @@ const Content = () => {
     <Card className="u-no-margin--bottom u-no-padding p-subscriptions__card">
       <SubscriptionList selectedId={selectedId} onSetActive={onSetActive} />
       <SubscriptionDetails
+        // Give the component a key so that the internal state gets reset when
+        // changing subscriptions. This is to prevent displaying notifications,
+        // showing the cancel form or retaining other state that should not be
+        // kept when clicking on a different subscription.
+        key={selectedId}
         modalActive={modalActive}
         onCloseModal={() => {
           onSetActive(null);

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.test.tsx
@@ -1,14 +1,283 @@
-import { Modal } from "@canonical/react-components";
+import { ActionButton, Modal, Notification } from "@canonical/react-components";
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 
+import * as contracts from "advantage/api/contracts";
 import SubscriptionCancel from "./SubscriptionCancel";
+import { QueryClient, QueryClientProvider } from "react-query";
+import {
+  lastPurchaseIdsFactory,
+  userSubscriptionFactory,
+} from "advantage/tests/factories/api";
+import { LastPurchaseIds, UserSubscription } from "advantage/api/types";
+import { act } from "react-dom/test-utils";
+import { UserSubscriptionPeriod } from "advantage/api/enum";
 
 describe("SubscriptionCancel", () => {
-  it("handles closing the modal", () => {
+  let cancelContractSpy: jest.SpyInstance;
+  let queryClient: QueryClient;
+  let subscription: UserSubscription;
+  let lastPurchaseIds: LastPurchaseIds;
+
+  beforeEach(() => {
+    cancelContractSpy = jest.spyOn(contracts, "cancelContract");
+    cancelContractSpy.mockImplementation(() => Promise.resolve({}));
+    queryClient = new QueryClient();
+    subscription = userSubscriptionFactory.build({
+      period: UserSubscriptionPeriod.Monthly,
+    });
+    lastPurchaseIds = lastPurchaseIdsFactory.build();
+    queryClient.setQueryData("userSubscriptions", [subscription]);
+    queryClient.setQueryData(
+      ["lastPurchaseIds", subscription.account_id],
+      lastPurchaseIds
+    );
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("handles closing the modal", async () => {
     const onClose = jest.fn();
-    const wrapper = shallow(<SubscriptionCancel onClose={onClose} />);
-    wrapper.find(Modal).invoke("close")!();
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={onClose}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      const close = wrapper.find(Modal).invoke("close");
+      close && close();
+    });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("displays a spinner when loading the data", () => {
+    queryClient.removeQueries("userSubscriptions");
+    queryClient.removeQueries("lastPurchaseIds");
+    const onClose = jest.fn();
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={onClose}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("Spinner[data-test='form-loading']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("Formik").exists()).toBe(false);
+  });
+
+  it("displays the form when the data has loaded", async () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      expect(wrapper.find("Spinner[data-test='form-loading']").exists()).toBe(
+        false
+      );
+      expect(wrapper.find("Formik").exists()).toBe(true);
+    });
+  });
+
+  it("disables the cancel button when the input does not contain the correct text", async () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { name: "cancel", value: "notcancel" });
+    });
+    wrapper.update();
+    expect(wrapper.find(ActionButton).prop("disabled")).toBe(true);
+  });
+
+  it("enables the cancel button when the input contains the correct text", async () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    });
+    expect(wrapper.find(ActionButton).prop("disabled")).toBe(false);
+  });
+
+  it("disables submitting the form when the input does not contain the correct text", async () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper.find("Formik form").simulate("submit");
+    });
+    expect(cancelContractSpy).not.toHaveBeenCalled();
+  });
+
+  it("can submit the form via the cancel button", async () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper.find(ActionButton).simulate("click");
+    });
+    wrapper.update();
+    expect(cancelContractSpy).toHaveBeenCalled();
+  });
+
+  it("calls the cancel-success callback when the cancel is successful", async () => {
+    const onCancelSuccess = jest.fn();
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={onCancelSuccess}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper.find("Formik form").simulate("submit");
+    });
+    wrapper.update();
+    expect(onCancelSuccess).toHaveBeenCalled();
+  });
+
+  it("can display an error when the subscription is missing", async () => {
+    cancelContractSpy.mockImplementation(() =>
+      Promise.resolve({ errors: "no monthly subscription" })
+    );
+    const onCancelSuccess = jest.fn();
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={onCancelSuccess}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper.find("Formik form").simulate("submit");
+    });
+    wrapper.update();
+    const notification = wrapper.find(Notification);
+    expect(notification.exists()).toBe(true);
+    expect(notification.prop("data-test")).toBe("cancel-error");
+    expect(notification.text().includes("you have a pending payment")).toBe(
+      true
+    );
+  });
+
+  it("can display an error when cancelling failed", async () => {
+    cancelContractSpy.mockImplementation(() =>
+      Promise.resolve({ errors: "Uh oh" })
+    );
+    const onCancelSuccess = jest.fn();
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={onCancelSuccess}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper.find("Formik form").simulate("submit");
+    });
+    wrapper.update();
+    const notification = wrapper.find(Notification);
+    expect(notification.exists()).toBe(true);
+    expect(notification.prop("data-test")).toBe("cancel-error");
+    expect(notification.text().includes("you have a pending payment")).toBe(
+      false
+    );
+  });
+
+  it("displays the action button success state when the cancel has finished", async () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionCancel
+          selectedId={subscription.contract_id}
+          onCancelSuccess={jest.fn()}
+          onClose={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    await act(async () => {
+      wrapper
+        .find("input[name='cancel']")
+        .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper.find("Formik form").simulate("submit");
+    });
+    wrapper.update();
+    expect(wrapper.find(ActionButton).prop("loading")).toBe(false);
+    expect(wrapper.find(ActionButton).prop("success")).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.test.tsx
@@ -56,7 +56,7 @@ describe("SubscriptionCancel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("displays a spinner when loading the data", () => {
+  it("displays a spinner when loading the data", async () => {
     queryClient.removeQueries("userSubscriptions");
     queryClient.removeQueries("lastPurchaseIds");
     const onClose = jest.fn();
@@ -72,7 +72,7 @@ describe("SubscriptionCancel", () => {
     expect(wrapper.find("Spinner[data-test='form-loading']").exists()).toBe(
       true
     );
-    expect(wrapper.find("Formik").exists()).toBe(false);
+    expect(wrapper.find("SubscriptionCancelFields").exists()).toBe(false);
   });
 
   it("displays the form when the data has loaded", async () => {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import SubscriptionCancelFields from "./SubscriptionCancelFields";
+
+describe("SubscriptionCancelFields", () => {
+  it("calls the is valid callback when the fields are filled out", () => {
+    const setIsValid = jest.fn();
+    const wrapper = mount(
+      <Formik initialValues={{ cancel: "" }} onSubmit={jest.fn()}>
+        <SubscriptionCancelFields setIsValid={setIsValid} />
+      </Formik>
+    );
+    wrapper
+      .find("input[name='cancel']")
+      .simulate("change", { target: { name: "cancel", value: "cancel" } });
+    expect(setIsValid).toHaveBeenCalledWith(true);
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
@@ -1,0 +1,51 @@
+import { Col, Row } from "@canonical/react-components";
+import React, { useEffect } from "react";
+import { useFormikContext } from "formik";
+import FormikField from "../../../FormikField";
+
+type Props = {
+  setIsValid: (isValid: boolean) => void;
+};
+
+export type SubscriptionCancelValues = {
+  cancel: string;
+};
+
+const SubscriptionCancelFields = ({ setIsValid }: Props) => {
+  const { handleSubmit, isValid } = useFormikContext();
+
+  useEffect(() => {
+    setIsValid(isValid);
+  }, [isValid]);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <p>If you cancel this subscription:</p>
+      <ul>
+        <li>No additional charge will be incurred.</li>
+        <li>
+          The <strong>10 machines</strong> will stop receiving updates and
+          services at the end of the billing period.
+        </li>
+      </ul>
+      <p>
+        Want help or advice? <a href="/contact-us">Chat with us</a>.
+      </p>
+      <Row className="u-no-padding--left">
+        <Col size={8}>
+          <FormikField
+            label={
+              <>
+                Please type <strong>cancel</strong> to confirm.
+              </>
+            }
+            name="cancel"
+            type="text"
+          />
+        </Col>
+      </Row>
+    </form>
+  );
+};
+
+export default SubscriptionCancelFields;

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubscriptionCancelFields";

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -9,12 +9,13 @@ import {
 import SubscriptionDetails from "./SubscriptionDetails";
 import { UserSubscription } from "advantage/api/types";
 import SubscriptionEdit from "../SubscriptionEdit";
+import { Notification } from "@canonical/react-components";
 
 describe("SubscriptionDetails", () => {
   let queryClient: QueryClient;
   let contract: UserSubscription;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     queryClient = new QueryClient();
     contract = userSubscriptionFactory.build();
     queryClient.setQueryData("userSubscriptions", [contract]);
@@ -45,36 +46,6 @@ describe("SubscriptionDetails", () => {
     wrapper.find("Button[data-test='edit-button']").simulate("click");
     expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
     expect(wrapper.find("DetailsContent").exists()).toBe(false);
-  });
-
-  it("closes the edit form when changing subscriptions", () => {
-    const contracts = [
-      userSubscriptionFactory.build(),
-      userSubscriptionFactory.build(),
-      freeSubscriptionFactory.build(),
-    ];
-    queryClient.setQueryData("userSubscriptions", contracts);
-    // Create a wrapping component to pass props to the inner
-    // SubscriptionDetails component. This is needed so that setProps will
-    // update the inner component.
-    const ProxyComponent = ({ selectedId }: { selectedId: string }) => (
-      <QueryClientProvider client={queryClient}>
-        <SubscriptionDetails onCloseModal={jest.fn()} selectedId={selectedId} />
-      </QueryClientProvider>
-    );
-    const wrapper = mount(
-      <ProxyComponent selectedId={contracts[0].contract_id} />
-    );
-    wrapper.find("Button[data-test='edit-button']").simulate("click");
-    expect(wrapper.find("SubscriptionEdit").exists()).toBe(true);
-    expect(wrapper.find("DetailsContent").exists()).toBe(false);
-    // The selected subscription state is handled in a parent component so
-    // update the component with a different selected id to make the component
-    // rerender with a new subscription:
-    wrapper.setProps({ selectedId: contracts[1].contract_id });
-    wrapper.update();
-    expect(wrapper.find("SubscriptionEdit").exists()).toBe(false);
-    expect(wrapper.find("DetailsContent").exists()).toBe(true);
   });
 
   it("closes the edit form when closing the modal", () => {
@@ -169,7 +140,7 @@ describe("SubscriptionDetails", () => {
         />
       </QueryClientProvider>
     );
-    // Open the edit modal:
+    // Open the edit form:
     wrapper.find("Button[data-test='edit-button']").simulate("click");
     expect(
       wrapper.find(".p-subscriptions__details").hasClass("is-active")
@@ -178,5 +149,24 @@ describe("SubscriptionDetails", () => {
     expect(
       wrapper.find(".p-subscriptions__details").hasClass("is-active")
     ).toBe(false);
+  });
+
+  it("can show a notification", () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.contract_id}
+        />
+      </QueryClientProvider>
+    );
+    // Open the edit form:
+    wrapper.find("Button[data-test='edit-button']").simulate("click");
+    wrapper.find(SubscriptionEdit).invoke("setNotification")({
+      title: "Test notification",
+    });
+    const notification = wrapper.find(Notification);
+    expect(notification.exists()).toBe(true);
+    expect(notification.prop("title")).toBe("Test notification");
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -1,4 +1,9 @@
-import { Button, Spinner } from "@canonical/react-components";
+import {
+  Button,
+  Notification,
+  NotificationProps,
+  Spinner,
+} from "@canonical/react-components";
 import React, { forwardRef, useEffect, useState } from "react";
 import classNames from "classnames";
 
@@ -21,14 +26,21 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
   ({ modalActive, onCloseModal, selectedId }: Props, ref) => {
     const [editing, setEditing] = useState(false);
     const [showingCancel, setShowingCancel] = useState(false);
+    const [notification, setNotification] = useState<NotificationProps | null>(
+      null
+    );
     const { data: subscription, isLoading } = useUserSubscriptions({
       select: selectSubscriptionById(selectedId),
     });
     const isFree = isFreeSubscription(subscription);
 
     useEffect(() => {
-      setEditing(false);
-    }, [selectedId, modalActive]);
+      if (!modalActive) {
+        // Close the edit form when the modal is closed so that if the modal for
+        //the same subscription is opened then the edit form won't remain open.
+        setEditing(false);
+      }
+    }, [modalActive]);
 
     if (isLoading || !subscription) {
       return <Spinner />;
@@ -57,6 +69,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               size={ExpiryNotificationSize.Large}
               statuses={subscription.statuses}
             />
+            {notification ? <Notification {...notification} /> : null}
             {isFree ? null : (
               <>
                 <Button
@@ -83,8 +96,10 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
           </div>
           {editing ? (
             <SubscriptionEdit
-              setShowingCancel={setShowingCancel}
               onClose={() => setEditing(false)}
+              setNotification={setNotification}
+              selectedId={selectedId}
+              setShowingCancel={setShowingCancel}
             />
           ) : (
             <DetailsContent selectedId={selectedId} />

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
@@ -1,12 +1,75 @@
 import React from "react";
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 
 import SubscriptionEdit from "./SubscriptionEdit";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { UserSubscription } from "advantage/api/types";
+import {
+  userSubscriptionFactory,
+  userSubscriptionStatusesFactory,
+} from "advantage/tests/factories/api";
+import { act } from "react-dom/test-utils";
 
 describe("SubscriptionEdit", () => {
+  let queryClient: QueryClient;
+  let subscription: UserSubscription;
+
+  beforeEach(async () => {
+    queryClient = new QueryClient();
+    subscription = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({ is_cancellable: true }),
+    });
+    queryClient.setQueryData("userSubscriptions", [subscription]);
+  });
+
+  it("shows a cancel link if the subscription is cancellable", () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionEdit
+          onClose={jest.fn()}
+          selectedId={subscription.contract_id}
+          setNotification={jest.fn()}
+          setShowingCancel={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("Button[data-test='cancel-button']").exists()).toBe(
+      true
+    );
+  });
+
+  it("does not show a cancel link if the subscription is not cancellable", () => {
+    subscription = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({
+        is_cancellable: false,
+      }),
+    });
+    queryClient.setQueryData("userSubscriptions", [subscription]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionEdit
+          onClose={jest.fn()}
+          selectedId={subscription.contract_id}
+          setNotification={jest.fn()}
+          setShowingCancel={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("Button[data-test='cancel-button']").exists()).toBe(
+      false
+    );
+  });
+
   it("initially hides the cancel modal", () => {
-    const wrapper = shallow(
-      <SubscriptionEdit onClose={jest.fn()} setShowingCancel={jest.fn()} />
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionEdit
+          onClose={jest.fn()}
+          selectedId={subscription.contract_id}
+          setNotification={jest.fn()}
+          setShowingCancel={jest.fn()}
+        />
+      </QueryClientProvider>
     );
     expect(wrapper.find("SubscriptionCancel").exists()).toBe(false);
   });
@@ -14,18 +77,25 @@ describe("SubscriptionEdit", () => {
   it("can show the cancel modal", async () => {
     const setShowingCancel = jest.fn();
     const wrapper = mount(
-      <SubscriptionEdit
-        onClose={jest.fn()}
-        setShowingCancel={setShowingCancel}
-      />
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionEdit
+          onClose={jest.fn()}
+          selectedId={subscription.contract_id}
+          setNotification={jest.fn()}
+          setShowingCancel={setShowingCancel}
+        />
+      </QueryClientProvider>
     );
     // The portal currently requires a fake event, this should be able to be
     // removed when this issue is resolved:
     // https://github.com/alex-cory/react-useportal/issues/36
     const fakeEvent = { currentTarget: true };
-    wrapper
-      .find("Button[data-test='cancel-button']")
-      .simulate("click", fakeEvent);
+    await act(async () => {
+      wrapper
+        .find("Button[data-test='cancel-button']")
+        .simulate("click", fakeEvent);
+    });
+    wrapper.update();
     expect(wrapper.find("SubscriptionCancel").exists()).toBe(true);
     expect(setShowingCancel).toHaveBeenCalledWith(true);
   });

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -1,6 +1,7 @@
 import { getUserSubscriptions } from "advantage/api/contracts";
 import {
   UserSubscriptionMarketplace,
+  UserSubscriptionPeriod,
   UserSubscriptionType,
 } from "advantage/api/enum";
 import {
@@ -62,7 +63,13 @@ export const useUserSubscriptions = <D = UserSubscription[]>(
 ) => {
   const query = useQuery(
     "userSubscriptions",
-    async () => await getUserSubscriptions(),
+    async () => {
+      const subs = await getUserSubscriptions();
+      return subs.filter(
+        ({ period }: UserSubscription) =>
+          period === UserSubscriptionPeriod.Monthly
+      );
+    },
     options
   );
   return query;

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.5":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
@@ -1590,6 +1597,11 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
+"@types/lodash@^4.14.165":
+  version "4.14.172"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
+  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
 
 "@types/mdast@^3.0.0":
   version "3.0.3"
@@ -5497,7 +5509,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.14:
+lodash-es@^4.17.14, lodash-es@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -5856,6 +5868,11 @@ nano-time@1.0.0:
   integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
   dependencies:
     big-integer "^1.6.16"
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@3.1.25:
   version "3.1.25"
@@ -6604,6 +6621,11 @@ prop-types@15.7.2, prop-types@^15.7.0, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+property-expr@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
+  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
 
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
@@ -7893,6 +7915,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 tough-cookie@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
@@ -8508,6 +8535,19 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yup@0.32.9:
+  version "0.32.9"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.9.tgz#9367bec6b1b0e39211ecbca598702e106019d872"
+  integrity sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    "@types/lodash" "^4.14.165"
+    lodash "^4.17.20"
+    lodash-es "^4.17.15"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## Done

- Add support for fetching the last purchase ids from the API.
- Add support for cancelling a contract via the API.
- Update the cancel component to cancel the contract.

## QA

- Visit [/advantage?test_backend=true](/advantage?test_backend=true) and log in.
- Click on a monthly contract (there is an issue at the moment where you can't select a monthly contract that you also have a yearly subscription for: https://github.com/canonical-web-and-design/commercial-squad/issues/253).
- Click 'Edit subscription'
- Click the 'You can cancel this subscription online or contact us.' link at the bottom.
- Type cancel and then click the red button.
- You subscription should get cancelled.


## Issue / Card

Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/116.

