### PR TITLE
Display a spinner for the initial load

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
@@ -16,12 +16,28 @@ describe("Content", () => {
     queryClient.setQueryData("userSubscriptions", [contract]);
   });
 
-  it("renders", () => {
+  it("displays a spinner when loading", () => {
+    // Remove the queries so that the query starts loading.
+    queryClient.removeQueries("userSubscriptions");
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <Content />
       </QueryClientProvider>
     );
+    expect(wrapper.find("[data-test='initial-load'] Spinner").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("SubscriptionList").exists()).toBe(false);
+    expect(wrapper.find("SubscriptionDetails").exists()).toBe(false);
+  });
+
+  it("displays the list and details when loaded", () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Content />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='initial-load']").exists()).toBe(false);
     expect(wrapper.find("SubscriptionList").exists()).toBe(true);
     expect(wrapper.find("SubscriptionDetails").exists()).toBe(true);
   });

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@canonical/react-components";
+import { Card, Spinner } from "@canonical/react-components";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import { useScrollIntoView } from "advantage/react/hooks/useScrollIntoView";
 import React, { useCallback, useEffect, useState } from "react";
@@ -37,6 +37,14 @@ const Content = () => {
       setSelectedId(allSubscriptions[0].contract_id);
     }
   }, [selectedId, setSelectedId, allSubscriptions, isLoading]);
+
+  if (isLoading) {
+    return (
+      <Card className="u-no-margin--bottom" data-test="initial-load">
+        <Spinner /> Loading&hellip;
+      </Card>
+    );
+  }
 
   return (
     <Card className="u-no-margin--bottom u-no-padding p-subscriptions__card">

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -35,7 +35,7 @@
   <div id="react-root">
     <section class="p-strip u-no-padding--top">
       <div class="row">
-        <div class="col-12"><i class="p-icon--spinner u-animation--spin"></i> Loading&hellip;</div>
+        <div class="col-12 u-no-margin--bottom p-card"><i class="p-icon--spinner u-animation--spin"></i> Loading&hellip;</div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Done

- Display a spinner for the initial load

## QA

- Visit /advantage?test_backend=true and log in.
- When the card initially appears you should see a nicer loading state.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/265.

## Screenshots

<img width="1069" alt="Screen Shot 2021-09-16 at 4 42 25 pm" src="https://user-images.githubusercontent.com/361637/133562893-9ad41f81-3617-4b8d-945c-fff63d2df12a.png">

