### PR TITLE
Ua subs window title

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -1,6 +1,6 @@
 {% extends "advantage/base_advantage.html" %}
 
-{% block title %}Ubuntu Advantage for Infrastructure{% endblock %}
+{% block title %}{% if user_info %}Ubuntu Advantage Dashboard{% else %}Ubuntu Advantage for Infrastructure{% endif %}{% endblock %}
 {% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1So3n5HEpBX39xxEkkChnve09gKSr9TgYUcbfdOTCevk/edit{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

- Change the window title when logged in.

## QA

- Visit [/advantage?test_backend=true](/advantage?test_backend=true) when logged out.
- The window title should be "Ubuntu Advantage for Infrastructure | Ubuntu".
- Log in.
- The window title should now be "Ubuntu Advantage Dashboard | Ubuntu".


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/227.

