### PR TITLE
Select the most recently started subscription

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
@@ -5,6 +5,8 @@ import Content from "./Content";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { UserSubscription } from "advantage/api/types";
 import { userSubscriptionFactory } from "advantage/tests/factories/api";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
+import SubscriptionList from "../SubscriptionList";
 
 describe("Content", () => {
   let queryClient: QueryClient;
@@ -24,5 +26,61 @@ describe("Content", () => {
     );
     expect(wrapper.find("SubscriptionList").exists()).toBe(true);
     expect(wrapper.find("SubscriptionDetails").exists()).toBe(true);
+  });
+
+  it("selects the first UA subscription", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        start_date: new Date("2020-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.Free,
+        start_date: new Date("2021-09-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        start_date: new Date("2021-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        start_date: new Date("1999-08-11T02:56:54Z"),
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Content />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find(SubscriptionList).prop("selectedId")).toBe(
+      subscriptions[2].contract_id
+    );
+  });
+
+  it("selects the first non-UA sub if there are no UA subs", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.Free,
+        start_date: new Date("2020-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.Free,
+        start_date: new Date("2021-09-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.Free,
+        start_date: new Date("2021-08-11T02:56:54Z"),
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Content />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find(SubscriptionList).prop("selectedId")).toBe(
+      subscriptions[1].contract_id
+    );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
@@ -70,7 +70,7 @@ describe("Content", () => {
       </QueryClientProvider>
     );
     expect(wrapper.find(SubscriptionList).prop("selectedId")).toBe(
-      subscriptions[2].contract_id
+      subscriptions[2].id
     );
   });
 
@@ -96,7 +96,7 @@ describe("Content", () => {
       </QueryClientProvider>
     );
     expect(wrapper.find(SubscriptionList).prop("selectedId")).toBe(
-      subscriptions[1].contract_id
+      subscriptions[1].id
     );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,6 +1,8 @@
 import { Card } from "@canonical/react-components";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import { useScrollIntoView } from "advantage/react/hooks/useScrollIntoView";
+import { sortSubscriptionsByStartDate } from "advantage/react/utils";
 import React, { useCallback, useEffect, useState } from "react";
 
 import SubscriptionDetails from "../SubscriptionDetails";
@@ -30,11 +32,19 @@ const Content = () => {
   // Select a token on the first load.
   useEffect(() => {
     if (!selectedId && !isLoading && allSubscriptions?.length) {
-      // TODO: this should select the "most recently-started" or free token by default:
-      // https://github.com/canonical-web-and-design/commercial-squad/issues/101
+      const sortedSubscriptions = sortSubscriptionsByStartDate(
+        allSubscriptions
+      );
+      // Get the first UA subscription, or if there are none then get the first
+      // available.
+      const firstSubscription =
+        sortedSubscriptions.find(
+          ({ marketplace }) =>
+            marketplace === UserSubscriptionMarketplace.CanonicalUA
+        ) || sortedSubscriptions[0];
       // This only sets the selected token and does not set the modal to active
       // to prevent the modal appearing on first load on mobile.
-      setSelectedId(allSubscriptions[0].contract_id);
+      setSelectedId(firstSubscription.contract_id);
     }
   }, [selectedId, setSelectedId, allSubscriptions, isLoading]);
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,11 +1,10 @@
 import { Spinner } from "@canonical/react-components";
-import { UserSubscription } from "advantage/api/types";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import {
   selectFreeSubscription,
   selectUASubscriptions,
 } from "advantage/react/hooks/useUserSubscriptions";
-import { parseJSON } from "date-fns";
+import { sortSubscriptionsByStartDate } from "advantage/react/utils";
 import React from "react";
 import { SelectedId } from "../Content/types";
 
@@ -16,12 +15,6 @@ type Props = {
   selectedId?: SelectedId;
   onSetActive: (token: SelectedId) => void;
 };
-
-const sortSubscriptions = (subscriptions: UserSubscription[]) =>
-  subscriptions.sort(
-    (a, b) =>
-      parseJSON(b.start_date).getTime() - parseJSON(a.start_date).getTime()
-  );
 
 const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   const {
@@ -40,7 +33,9 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     return <Spinner />;
   }
   // Sort the subscriptions so that the most recently started subscription is first.
-  const sortedUASubscriptions = sortSubscriptions(uaSubscriptionsData);
+  const sortedUASubscriptions = sortSubscriptionsByStartDate(
+    uaSubscriptionsData
+  );
   const uaSubscriptions = sortedUASubscriptions.map((subscription, i) => (
     <ListCard
       data-test="ua-subscription"

--- a/static/js/src/advantage/react/utils/index.ts
+++ b/static/js/src/advantage/react/utils/index.ts
@@ -7,3 +7,4 @@ export { getSubscriptionCost } from "./getSubscriptionCost";
 export { isFreeSubscription } from "./isFreeSubscription";
 export { makeInteractiveProps } from "./makeInteractiveProps";
 export { removeFalsy } from "./removeFalsy";
+export { sortSubscriptionsByStartDate } from "./sortSubscriptionsByStartDate";

--- a/static/js/src/advantage/react/utils/sortSubscriptionsByStartDate.test.ts
+++ b/static/js/src/advantage/react/utils/sortSubscriptionsByStartDate.test.ts
@@ -1,0 +1,23 @@
+import { userSubscriptionFactory } from "advantage/tests/factories/api";
+import { sortSubscriptionsByStartDate } from "./sortSubscriptionsByStartDate";
+
+describe("sortSubscriptionsByStartDate", () => {
+  it("sorts the subscriptions", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        start_date: new Date("2020-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        start_date: new Date("2021-08-11T02:56:54Z"),
+      }),
+      userSubscriptionFactory.build({
+        start_date: new Date("1999-08-11T02:56:54Z"),
+      }),
+    ];
+    expect(sortSubscriptionsByStartDate(subscriptions)).toStrictEqual([
+      subscriptions[1],
+      subscriptions[0],
+      subscriptions[2],
+    ]);
+  });
+});

--- a/static/js/src/advantage/react/utils/sortSubscriptionsByStartDate.ts
+++ b/static/js/src/advantage/react/utils/sortSubscriptionsByStartDate.ts
@@ -1,0 +1,10 @@
+import { UserSubscription } from "advantage/api/types";
+import { parseJSON } from "date-fns";
+
+export const sortSubscriptionsByStartDate = (
+  subscriptions: UserSubscription[]
+) =>
+  [...subscriptions].sort(
+    (a, b) =>
+      parseJSON(b.start_date).getTime() - parseJSON(a.start_date).getTime()
+  );


### PR DESCRIPTION
## Done

- Select the most recently started subscription by default.

## QA

- Visit [/advantage?test_backend=true](/advantage?test_backend=true) and log in.
- The subscription at the top of the list should be selected on first load.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/101.

