### PR TITLE
200/account users/edit view

### DIFF
--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -54,24 +54,25 @@ const AccountUsers = ({
     }
   );
 
-  const handleUpdateUser = ({ newUserRole }: { newUserRole: UserRole }) => {
-    if (userInEditMode) {
-      userUpdateMutation
-        .mutateAsync({ email: userInEditMode.email, role: newUserRole })
-        .then(() => {
-          dismissEditMode();
-          setNotification({ severity: "positive", message: "User updated" });
-        })
-        .catch((error) => {
-          setNotification({
-            severity: "negative",
-            message: getErrorMessage((error as any)?.message),
-          });
+  const handleUpdateUser = ({
+    email,
+    newUserRole,
+  }: {
+    email: string;
+    newUserRole: UserRole;
+  }): Promise<any> =>
+    userUpdateMutation
+      .mutateAsync({ email, role: newUserRole })
+      .then(() => {
+        dismissEditMode();
+        setNotification({ severity: "positive", message: "User updated" });
+      })
+      .catch((error) => {
+        setNotification({
+          severity: "negative",
+          message: getErrorMessage((error as any)?.message),
         });
-    } else {
-      setNotification({ severity: "negative", message: "User not updated" });
-    }
-  };
+      });
 
   const handleAddNewUser = (user: NewUserValues) =>
     userAddMutation.mutateAsync(user).then(() => {

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -156,7 +156,6 @@ const AccountUsers = ({
           <div className="col-12">
             <TableView
               users={users}
-              userInEditMode={userInEditMode}
               userInEditModeById={userInEditModeById}
               setUserInEditModeById={setUserInEditModeById}
               dismissEditMode={dismissEditMode}

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -12,6 +12,7 @@ import AddNewUser from "./components/AddNewUser/AddNewUser";
 import TableView from "./components/TableView/TableView";
 import DeleteConfirmationModal from "./components/DeleteConfirmationModal/DeleteConfirmationModal";
 import { requestAddUser, requestDeleteUser, requestUpdateUser } from "./api";
+import { getErrorMessage } from "./utils";
 
 export type AccountUsersProps = {
   organisationName: OrganisationName;
@@ -60,6 +61,12 @@ const AccountUsers = ({
         .then(() => {
           dismissEditMode();
           setNotification({ severity: "positive", message: "User updated" });
+        })
+        .catch((error) => {
+          setNotification({
+            severity: "negative",
+            message: getErrorMessage((error as any)?.message),
+          });
         });
     } else {
       setNotification({ severity: "negative", message: "User not updated" });

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -24,20 +24,10 @@ const AccountUsers = ({
   organisationName,
   users,
 }: AccountUsersProps) => {
-  const [hasNewUserSuccessMessage, setHasNewUserSuccessMessage] = useState(
-    false
-  );
-  const [
-    hasUserDeletedSuccessMessage,
-    setHasUserDeletedSuccessMessage,
-  ] = useState(false);
-  const [
-    hasUserUpdatedSuccessMessage,
-    setHasUserUpdatedSuccessMessage,
-  ] = useState(false);
-  const [hasUserUpdatedErrorMessage, setHasUserUpdatedErrorMessage] = useState(
-    false
-  );
+  const [notification, setNotification] = useState<{
+    severity: string;
+    message: string;
+  } | null>(null);
 
   const queryClient = useQueryClient();
 
@@ -69,16 +59,19 @@ const AccountUsers = ({
         .mutateAsync({ email: userInEditMode.email, role: newUserRole })
         .then(() => {
           dismissEditMode();
-          setHasUserUpdatedSuccessMessage(true);
+          setNotification({ severity: "positive", message: "User updated" });
         });
     } else {
-      setHasUserUpdatedErrorMessage(true);
+      setNotification({ severity: "negative", message: "User not updated" });
     }
   };
 
   const handleAddNewUser = (user: NewUserValues) =>
     userAddMutation.mutateAsync(user).then(() => {
-      setHasNewUserSuccessMessage(true);
+      setNotification({
+        severity: "positive",
+        message: "User added successfully",
+      });
     });
 
   const [
@@ -88,7 +81,7 @@ const AccountUsers = ({
   const handleDeleteUser = (userId: string) =>
     userDeleteMutation.mutateAsync(userId).then(() => {
       dismissEditMode();
-      setHasUserDeletedSuccessMessage(true);
+      setNotification({ severity: "positive", message: "User deleted" });
     });
 
   const [userInEditModeById, setUserInEditModeById] = useState<string | null>(
@@ -125,45 +118,26 @@ const AccountUsers = ({
           <div className="col-6">
             <AddNewUser
               handleSubmit={handleAddNewUser}
-              onAfterModalOpen={() => setHasNewUserSuccessMessage(false)}
+              onAfterModalOpen={() => setNotification(null)}
             />
           </div>
         </div>
-        {hasUserUpdatedErrorMessage ? (
+        {notification ? (
           <div className="row">
             <div className="col-12">
-              <div className="p-notification--negative">
+              <div className={`p-notification--${notification.severity}`}>
                 <div className="p-notification__content" aria-atomic="true">
-                  <h5 className="p-notification__title">Error</h5>
+                  <h5 className="p-notification__title">
+                    {notification.severity === "positive" ? "Success" : "Error"}
+                  </h5>
                   <p className="p-notification__message" role="alert">
-                    Something went wrong. Please try again.
+                    {notification.message}
                   </p>
                 </div>
               </div>
             </div>
           </div>
         ) : null}
-        {hasNewUserSuccessMessage ||
-        hasUserDeletedSuccessMessage ||
-        hasUserUpdatedSuccessMessage ? (
-          <div className="row">
-            <div className="col-12">
-              <div className="p-notification--positive">
-                <div className="p-notification__content" aria-atomic="true">
-                  <h5 className="p-notification__title">Success</h5>
-                  <p className="p-notification__message" role="alert">
-                    {hasUserUpdatedSuccessMessage
-                      ? "User updated successfully."
-                      : hasNewUserSuccessMessage
-                      ? "User added successfully."
-                      : "User deleted successfully."}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : null}
-
         {isDeleteConfirmationModalOpen && userInEditMode ? (
           <DeleteConfirmationModal
             user={userInEditMode}

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
@@ -19,13 +19,17 @@ const DeleteConfirmationModal = ({
     errorMessage,
     setErrorMessage,
   ] = useState<SubmissionErrorMessage | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const onSubmit = async () => {
+    setIsLoading(true);
     try {
       await handleConfirmDelete(user?.id);
       handleClose();
     } catch (error) {
       setErrorMessage(getErrorMessage((error as any)?.message));
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -41,6 +45,7 @@ const DeleteConfirmationModal = ({
           <Button
             className="u-no-margin--bottom"
             appearance="negative"
+            disabled={isLoading}
             onClick={onSubmit}
           >
             Yes, remove user

--- a/static/js/src/advantage/users/components/TableView/TableView.test.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.test.tsx
@@ -18,6 +18,7 @@ it("displays user details in a correct format", () => {
       users={[testUser]}
       userInEditModeById={null}
       setUserInEditModeById={jest.fn()}
+      handleEditSubmit={jest.fn()}
       dismissEditMode={jest.fn()}
       handleDeleteConfirmationModalOpen={jest.fn()}
     />
@@ -25,6 +26,5 @@ it("displays user details in a correct format", () => {
 
   expect(screen.getByText("user@ecorp.com")).toBeInTheDocument();
   expect(screen.getByText("Admin", { ignore: "option" })).toBeInTheDocument();
-  expect(screen.getByText("Admin", { selector: "option" })).not.toBeVisible();
   expect(screen.getByText("15/02/2021")).toBeInTheDocument();
 });

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -42,12 +42,15 @@ const TableView = ({
         },
         {
           content: "role",
+          width: "20%",
         },
         {
           content: "last sign in",
+          width: "15%",
         },
         {
           content: "actions",
+          width: "20%",
         },
       ]}
       rows={users.map((user) =>

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -24,7 +24,13 @@ type Props = {
   userInEditModeById: UserId | null;
   setUserInEditModeById: (userId: UserId | null) => void;
   dismissEditMode: () => void;
-  handleEditSubmit: ({ newUserRole }: { newUserRole: UserRole }) => void;
+  handleEditSubmit: ({
+    email,
+    newUserRole,
+  }: {
+    email: string;
+    newUserRole: UserRole;
+  }) => void;
   handleDeleteConfirmationModalOpen: () => void;
 };
 

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { Formik } from "formik";
+
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 
-import { Users } from "../../types";
+import { User, UserRole, Users } from "../../types";
 import { getUserRow } from "./components";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";
@@ -20,49 +22,63 @@ const getVariant = (userId: UserId, userInEditMode: UserId | null) => {
 
 type Props = {
   users: Users;
+  userInEditMode?: User;
   userInEditModeById: UserId | null;
   setUserInEditModeById: (userId: UserId | null) => void;
   dismissEditMode: () => void;
+  handleEditSubmit: ({ newUserRole }: { newUserRole: UserRole }) => void;
   handleDeleteConfirmationModalOpen: () => void;
 };
 
 const TableView = ({
   users,
+  userInEditMode,
   userInEditModeById,
   setUserInEditModeById,
   dismissEditMode,
+  handleEditSubmit,
   handleDeleteConfirmationModalOpen,
 }: Props) => {
   return (
-    <MainTable
-      responsive
-      headers={[
-        {
-          content: "email",
-        },
-        {
-          content: "role",
-          width: "20%",
-        },
-        {
-          content: "last sign in",
-          width: "15%",
-        },
-        {
-          content: "actions",
-          width: "20%",
-        },
-      ]}
-      rows={users.map((user) =>
-        getUserRow({
-          user,
-          variant: getVariant(user.id, userInEditModeById),
-          setUserInEditModeById,
-          dismissEditMode,
-          handleDeleteConfirmationModalOpen,
-        })
+    <Formik
+      initialValues={{ newUserRole: userInEditMode?.role }}
+      onSubmit={(values) => {
+        handleEditSubmit(values);
+      }}
+    >
+      {({ handleSubmit }) => (
+        <MainTable
+          responsive
+          headers={[
+            {
+              content: "email",
+            },
+            {
+              content: "role",
+              width: "20%",
+            },
+            {
+              content: "last sign in",
+              width: "15%",
+            },
+            {
+              content: "actions",
+              width: "20%",
+            },
+          ]}
+          rows={users.map((user) =>
+            getUserRow({
+              user,
+              variant: getVariant(user.id, userInEditModeById),
+              setUserInEditModeById,
+              dismissEditMode,
+              handleEditSubmit: handleSubmit,
+              handleDeleteConfirmationModalOpen,
+            })
+          )}
+        />
       )}
-    />
+    </Formik>
   );
 };
 

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { Formik } from "formik";
 
-import MainTable from "@canonical/react-components/dist/components/MainTable";
+import { Table, TableHeader, TableRow } from "@canonical/react-components";
 
-import { User, UserRole, Users } from "../../types";
-import { getUserRow } from "./components";
+import { UserRole, Users } from "../../types";
+import { UserRow } from "./components";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";
 
@@ -22,7 +21,6 @@ const getVariant = (userId: UserId, userInEditMode: UserId | null) => {
 
 type Props = {
   users: Users;
-  userInEditMode?: User;
   userInEditModeById: UserId | null;
   setUserInEditModeById: (userId: UserId | null) => void;
   dismissEditMode: () => void;
@@ -32,7 +30,6 @@ type Props = {
 
 const TableView = ({
   users,
-  userInEditMode,
   userInEditModeById,
   setUserInEditModeById,
   dismissEditMode,
@@ -40,45 +37,31 @@ const TableView = ({
   handleDeleteConfirmationModalOpen,
 }: Props) => {
   return (
-    <Formik
-      initialValues={{ newUserRole: userInEditMode?.role }}
-      onSubmit={(values) => {
-        handleEditSubmit(values);
-      }}
-    >
-      {({ handleSubmit }) => (
-        <MainTable
-          responsive
-          headers={[
-            {
-              content: "email",
-            },
-            {
-              content: "role",
-              width: "20%",
-            },
-            {
-              content: "last sign in",
-              width: "15%",
-            },
-            {
-              content: "actions",
-              width: "20%",
-            },
-          ]}
-          rows={users.map((user) =>
-            getUserRow({
-              user,
-              variant: getVariant(user.id, userInEditModeById),
-              setUserInEditModeById,
-              dismissEditMode,
-              handleEditSubmit: handleSubmit,
-              handleDeleteConfirmationModalOpen,
-            })
-          )}
-        />
-      )}
-    </Formik>
+    <Table responsive={true}>
+      <thead>
+        <TableRow>
+          <TableHeader>email</TableHeader>
+          <TableHeader width="20%">role</TableHeader>
+          <TableHeader width="15%">last sign in</TableHeader>
+          <TableHeader width="20%">actions</TableHeader>
+        </TableRow>
+      </thead>
+      <tbody>
+        {users.map((user) => (
+          <UserRow
+            key={user.id}
+            user={user}
+            variant={getVariant(user.id, userInEditModeById)}
+            setUserInEditModeById={setUserInEditModeById}
+            dismissEditMode={dismissEditMode}
+            handleEditSubmit={handleEditSubmit}
+            handleDeleteConfirmationModalOpen={
+              handleDeleteConfirmationModalOpen
+            }
+          />
+        ))}
+      </tbody>
+    </Table>
   );
 };
 

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Table, TableHeader, TableRow } from "@canonical/react-components";
 
 import { UserRole, Users } from "../../types";
-import { UserRow } from "./components";
+import UserRow from "./UserRow";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";
 

--- a/static/js/src/advantage/users/components/TableView/UserRow.test.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { User } from "../../types";
+import UserRow from "./UserRow";
+
+const testUser: User = {
+  id: "1",
+  name: "User",
+  email: "user@ecorp.com",
+  role: "admin",
+  lastLoginAt: "2021-02-15T13:45:00Z",
+};
+
+it("regular variant renders correctly", () => {
+  render(
+    <table>
+      <tbody>
+        <UserRow
+          user={testUser}
+          variant="regular"
+          setUserInEditModeById={jest.fn()}
+          dismissEditMode={jest.fn()}
+          handleEditSubmit={jest.fn()}
+          handleDeleteConfirmationModalOpen={jest.fn()}
+        />
+      </tbody>
+    </table>
+  );
+
+  expect(screen.getByText("user@ecorp.com")).toBeInTheDocument();
+  expect(screen.getByText("Admin")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /Edit/ })).toBeInTheDocument();
+
+  // check that 'editing' buttons are not visible
+  expect(
+    screen.getByTestId("hidden-select-to-prevent-layout-shifting")
+  ).not.toBeVisible();
+  expect(
+    screen.queryByRole("button", { name: "Cancel" })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Save" })
+  ).not.toBeInTheDocument();
+});
+
+it("editing variant renders correctly", () => {
+  render(
+    <table>
+      <tbody>
+        <UserRow
+          user={testUser}
+          variant="editing"
+          setUserInEditModeById={jest.fn()}
+          dismissEditMode={jest.fn()}
+          handleEditSubmit={jest.fn()}
+          handleDeleteConfirmationModalOpen={jest.fn()}
+        />
+      </tbody>
+    </table>
+  );
+
+  expect(screen.getByText("user@ecorp.com")).toBeInTheDocument();
+  expect(screen.getByLabelText(/delete/)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "Admin" })).toBeInTheDocument();
+
+  // check that elements from 'regular' variant are not visible
+  expect(screen.getByText("Admin", { ignore: "option" })).not.toBeVisible();
+  expect(
+    screen.queryByTestId("hidden-select-to-prevent-layout-shifting")
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: /Edit/ })
+  ).not.toBeInTheDocument();
+});

--- a/static/js/src/advantage/users/components/TableView/UserRow.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.tsx
@@ -10,7 +10,7 @@ import {
   TableRow,
 } from "@canonical/react-components";
 
-import { User, UserRole } from "../../types";
+import { User, UserRole as UserRoleType } from "../../types";
 import { UserRowVariant } from "./TableView";
 import { userRoleOptions } from "../../constants";
 
@@ -49,13 +49,14 @@ const UserEmail = ({
       </span>
       {variant === "editing" ? (
         <button
+          aria-label="delete"
           className="p-button--base u-no-margin--bottom"
           style={{
             marginLeft: "0.1rem",
           }}
           onClick={handleDeleteConfirmationModalOpen}
         >
-          <i className="p-icon--delete" aria-label="delete"></i>
+          <i className="p-icon--delete"></i>
         </button>
       ) : null}
     </div>
@@ -91,7 +92,6 @@ const UserRole = ({ user, variant }: UserRoleProps) => {
           position: "static",
         }}
       >
-        {/* display an empty <select /> to prevent layout shifting on toggle */}
         {variant === "editing" ? (
           <Field
             as={Select}
@@ -100,7 +100,10 @@ const UserRole = ({ user, variant }: UserRoleProps) => {
             options={userRoleOptions}
           />
         ) : (
-          <Select className="u-no-margin--bottom" />
+          <Select
+            className="u-no-margin--bottom"
+            data-testid="hidden-select-to-prevent-layout-shifting"
+          />
         )}
       </div>
     </div>
@@ -116,7 +119,7 @@ const FormattedDate = ({ dateISO }: { dateISO: string }) => (
 type UserRowProps = {
   setUserInEditModeById: (id: string) => void;
   dismissEditMode: () => void;
-  handleEditSubmit: ({ newUserRole }: { newUserRole: UserRole }) => void;
+  handleEditSubmit: ({ newUserRole }: { newUserRole: UserRoleType }) => void;
   handleDeleteConfirmationModalOpen: () => void;
 } & UserVariantProps;
 
@@ -222,4 +225,4 @@ const UserRow = (props: UserRowProps) =>
     <UserRowNonEditable {...props} />
   );
 
-export { UserRow };
+export default UserRow;

--- a/static/js/src/advantage/users/components/TableView/UserRow.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.tsx
@@ -113,7 +113,13 @@ const FormattedDate = ({ dateISO }: { dateISO: string }) => (
 type UserRowProps = {
   setUserInEditModeById: (id: string) => void;
   dismissEditMode: () => void;
-  handleEditSubmit: ({ newUserRole }: { newUserRole: UserRoleType }) => void;
+  handleEditSubmit: ({
+    email,
+    newUserRole,
+  }: {
+    email: string;
+    newUserRole: UserRoleType;
+  }) => void;
   handleDeleteConfirmationModalOpen: () => void;
 } & UserVariantProps;
 
@@ -130,11 +136,14 @@ const UserRowEditable = ({
   return (
     <Formik
       initialValues={{ newUserRole: user?.role }}
-      onSubmit={(values) => {
-        handleEditSubmit(values);
+      onSubmit={async (values) => {
+        await handleEditSubmit({
+          email: user.email,
+          newUserRole: values.newUserRole,
+        });
       }}
     >
-      {({ handleSubmit }) => (
+      {({ handleSubmit, isSubmitting }) => (
         <TableRow>
           <TableCell role="rowheader" style={tdStyle}>
             <UserEmail
@@ -159,6 +168,7 @@ const UserRowEditable = ({
               small
               dense
               appearance="positive"
+              disabled={isSubmitting}
               onClick={() => handleSubmit()}
             >
               Save

--- a/static/js/src/advantage/users/components/TableView/UserRow.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.tsx
@@ -21,12 +21,6 @@ type UserVariantProps = {
   variant: UserRowVariant;
 };
 
-type UserActionsProps = {
-  handleEditOpen: (id: string) => void;
-  handleEditSubmit: () => void;
-  handleCancel: () => void;
-} & UserVariantProps;
-
 type UserEmailProps = {
   handleDeleteConfirmationModalOpen: () => void;
 } & UserVariantProps;

--- a/static/js/src/advantage/users/components/TableView/components.tsx
+++ b/static/js/src/advantage/users/components/TableView/components.tsx
@@ -8,6 +8,7 @@ import { MainTableRow } from "@canonical/react-components/dist/components/MainTa
 import { User } from "../../types";
 import { UserRowVariant } from "./TableView";
 import { userRoleOptions } from "../../constants";
+import { Field } from "formik";
 
 const DATE_FORMAT = "dd/MM/yyyy";
 
@@ -18,7 +19,7 @@ type UserVariantProps = {
 
 type UserActionsProps = {
   handleEditOpen: (id: string) => void;
-  handleEditSubmit: (id: string) => void;
+  handleEditSubmit: () => void;
   handleCancel: () => void;
 } & UserVariantProps;
 
@@ -44,12 +45,7 @@ const UserActions = ({
       <Button small dense onClick={handleCancel}>
         Cancel
       </Button>
-      <Button
-        small
-        dense
-        appearance="positive"
-        onClick={() => handleEditSubmit(user.id)}
-      >
+      <Button small dense appearance="positive" onClick={handleEditSubmit}>
         Save
       </Button>
     </>
@@ -120,12 +116,20 @@ const UserRole = ({ user, variant }: UserRoleProps) => {
           position: "static",
         }}
       >
-        <Select
-          defaultValue={user.role}
-          name="user-role"
-          className="u-no-margin--bottom"
-          options={userRoleOptions}
-        />
+        {/* display an empty <select /> to prevent layout shifting on toggle */}
+        {variant === "editing" ? (
+          <>
+            <Field
+              defaultValue={user.role}
+              as={Select}
+              name="newUserRole"
+              className="u-no-margin--bottom"
+              options={userRoleOptions}
+            />
+          </>
+        ) : (
+          <Select className="u-no-margin--bottom" />
+        )}
       </div>
     </div>
   );
@@ -152,6 +156,7 @@ const getUserRow = ({
   variant,
   setUserInEditModeById,
   dismissEditMode,
+  handleEditSubmit,
   handleDeleteConfirmationModalOpen,
 }: UserRowProps): MainTableRow => {
   return {
@@ -190,7 +195,7 @@ const getUserRow = ({
             user={user}
             handleEditOpen={setUserInEditModeById}
             handleCancel={dismissEditMode}
-            handleEditSubmit={dismissEditMode}
+            handleEditSubmit={handleEditSubmit}
           />
         ),
         style: tdStyle,

--- a/static/js/src/advantage/users/components/TableView/components.tsx
+++ b/static/js/src/advantage/users/components/TableView/components.tsx
@@ -67,7 +67,15 @@ const UserEmail = ({
 }: UserEmailProps) => {
   return (
     <div style={{ display: "flex", alignItems: "center" }}>
-      {user.email}
+      <span
+        style={{
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {user.email}
+      </span>
       {variant === "editing" ? (
         <button
           className="p-button--base u-no-margin--bottom"

--- a/static/js/src/advantage/users/utils.ts
+++ b/static/js/src/advantage/users/utils.ts
@@ -3,6 +3,8 @@ import { ValueOf } from "@canonical/react-components";
 const errorMessages = {
   ["email already exists"]:
     "Cannot add user. User already exists in your organisation.",
+  ["cannot remove last verified admin from account"]:
+    "Cannot remove last verified admin from account",
   default: "An unknown error has occurred.",
 } as const;
 
@@ -12,9 +14,11 @@ export type SubmissionErrorMessage = ValueOf<typeof errorMessages>;
 export const getErrorMessage = (
   error: SubmissionErrorMessageKey | string = "default"
 ): SubmissionErrorMessage =>
-  Object.keys(errorMessages).includes(error)
-    ? errorMessages[error as SubmissionErrorMessageKey]
-    : errorMessages.default;
+  errorMessages[
+    Object.keys(errorMessages).find((message) =>
+      error.includes(message)
+    ) as SubmissionErrorMessageKey
+  ] || errorMessages.default;
 
 export const validateRequired = (value: string): string | undefined =>
   !value ? "This field is required." : undefined;


### PR DESCRIPTION
## Done

- handle user editing
  -  refactor TableView to use React components - wrap only a single editable row with Formik
  - fix long email overflow
  - fix column widths
  - refactor to use a single notification
  - display last admin error message
  - display last admin error on failed update

## QA

- Go to https://ubuntu-com-10381.demos.haus/advantage/users?test_backend=true and login
- Add a new user
- Edit a role of that user
- Delete a user
- Make sure error/success messages are displayed on each action


## Issue / Card

https://github.com/canonical-web-and-design/commercial-squad/issues/200

## Screenshots
## error messages
![image](https://user-images.githubusercontent.com/7452681/133642528-8278b5ad-5fad-474b-814a-c1796ab5e9cb.png)
![image](https://user-images.githubusercontent.com/7452681/133642549-6ed206ad-1cea-4238-8109-15db05920d6d.png)
### email overflow fix - delete button still visible
![image](https://user-images.githubusercontent.com/7452681/133642589-200bfecf-9b73-47fb-83b6-24eda1f41035.png)

