### PR TITLE
API subscription cancel

### DIFF
--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -84,6 +84,17 @@ export async function getContractToken(contractId) {
   return await response.json();
 }
 
+export async function getLastPurchaseIds(accountId) {
+  const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
+  const response = await fetch(
+    `/advantage/last-purchase-ids/${accountId}${queryString}`,
+    {
+      cache: "no-store",
+    }
+  );
+  return await response.json();
+}
+
 export async function postInvoiceID(transactionType, transactionID, invoiceID) {
   const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
 

--- a/static/js/src/advantage/api/contracts.test.ts
+++ b/static/js/src/advantage/api/contracts.test.ts
@@ -1,25 +1,42 @@
+import {
+  contractTokenFactory,
+  lastPurchaseIdsFactory,
+  userSubscriptionFactory,
+} from "advantage/tests/factories/api";
 import fetch from "jest-fetch-mock";
 
-import { getContractToken, getUserSubscriptions } from "./contracts";
+import {
+  getContractToken,
+  getLastPurchaseIds,
+  getUserSubscriptions,
+} from "./contracts";
 
 describe("contracts", () => {
   afterEach(() => {
     fetch.resetMocks();
   });
 
-  it("can get user subscriptions", () => {
-    const contractData = { data: { test: "contract" } };
+  it("can get user subscriptions", async () => {
+    const contractData = { data: userSubscriptionFactory.buildList(2) };
     fetch.mockResponseOnce(JSON.stringify(contractData));
-    getUserSubscriptions().then((response) => {
-      expect(response).toStrictEqual(contractData);
+    await getUserSubscriptions().then((response) => {
+      expect(response).toStrictEqual(JSON.parse(JSON.stringify(contractData)));
     });
   });
 
-  it("can get contract tokens", () => {
-    const contractToken = { data: { contract_token: "abc123" } };
+  it("can get contract tokens", async () => {
+    const contractToken = { data: contractTokenFactory.build() };
     fetch.mockResponseOnce(JSON.stringify(contractToken));
-    getContractToken().then((response) => {
+    await getContractToken().then((response) => {
       expect(response).toStrictEqual(contractToken);
+    });
+  });
+
+  it("can get last purchase ids", async () => {
+    const lastPurchaseIds = { data: lastPurchaseIdsFactory.build() };
+    fetch.mockResponseOnce(JSON.stringify(lastPurchaseIds));
+    await getLastPurchaseIds().then((response) => {
+      expect(response).toStrictEqual(lastPurchaseIds);
     });
   });
 });

--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -50,3 +50,8 @@ export type UserSubscription = {
 export type ContractToken = {
   contract_token: string;
 };
+
+export type LastPurchaseIds = {
+  monthly: string;
+  yearly: string;
+};

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -1,4 +1,6 @@
+export { useCancelContract } from "./useCancelContract";
 export { useContractToken } from "./useContractToken";
+export { useLastPurchaseIds } from "./useLastPurchaseIds";
 export { useLoadWindowData } from "./useLoadWindowData";
 export { usePendingPurchaseId } from "./usePendingPurchaseId";
 export { useURLs } from "./useURLs";

--- a/static/js/src/advantage/react/hooks/useCancelContract.test.tsx
+++ b/static/js/src/advantage/react/hooks/useCancelContract.test.tsx
@@ -1,0 +1,95 @@
+import React, { PropsWithChildren } from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useCancelContract } from "./useCancelContract";
+
+import * as contracts from "advantage/api/contracts";
+import {
+  lastPurchaseIdsFactory,
+  userSubscriptionFactory,
+} from "advantage/tests/factories/api";
+import { LastPurchaseIds, UserSubscription } from "advantage/api/types";
+import { UserSubscriptionPeriod } from "advantage/api/enum";
+
+describe("useCancelContract", () => {
+  let cancelContractSpy: jest.SpyInstance;
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+  let subscription: UserSubscription;
+  let lastPurchaseIds: LastPurchaseIds;
+
+  beforeEach(() => {
+    cancelContractSpy = jest.spyOn(contracts, "cancelContract");
+    cancelContractSpy.mockImplementation(() => Promise.resolve({}));
+    lastPurchaseIds = lastPurchaseIdsFactory.build();
+    subscription = userSubscriptionFactory.build({
+      period: UserSubscriptionPeriod.Monthly,
+    });
+    queryClient = new QueryClient();
+    queryClient.setQueryData("userSubscriptions", [subscription]);
+    queryClient.setQueryData(
+      ["lastPurchaseIds", subscription.account_id],
+      lastPurchaseIds
+    );
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    wrapper = Wrapper;
+  });
+
+  it("can make the cancel request", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCancelContract(subscription),
+      { wrapper }
+    );
+    result.current.mutate(null);
+    await waitForNextUpdate();
+    expect(cancelContractSpy).toHaveBeenCalledWith(
+      subscription.account_id,
+      lastPurchaseIds.monthly,
+      subscription.listing_id
+    );
+  });
+
+  it("handles errors", async () => {
+    cancelContractSpy.mockImplementation(() =>
+      Promise.resolve({
+        errors: "Uh oh",
+      })
+    );
+    const onError = jest.fn();
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCancelContract(subscription),
+      { wrapper }
+    );
+    result.current.mutate(null, {
+      onError: (error) => onError(error.message),
+    });
+    await waitForNextUpdate();
+    expect(onError).toHaveBeenCalledWith("Uh oh");
+  });
+
+  it("invalidates queries when successful", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCancelContract(subscription),
+      { wrapper }
+    );
+    let userSubscriptionsState = queryClient.getQueryState("userSubscriptions");
+    let lastPurchaseIdsState = queryClient.getQueryState([
+      "lastPurchaseIds",
+      subscription.account_id,
+    ]);
+    expect(userSubscriptionsState?.isInvalidated).toBe(false);
+    expect(lastPurchaseIdsState?.isInvalidated).toBe(false);
+    result.current.mutate(null);
+    await waitForNextUpdate();
+    userSubscriptionsState = queryClient.getQueryState("userSubscriptions");
+    lastPurchaseIdsState = queryClient.getQueryState([
+      "lastPurchaseIds",
+      subscription.account_id,
+    ]);
+    expect(userSubscriptionsState?.isInvalidated).toBe(true);
+    expect(lastPurchaseIdsState?.isInvalidated).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/hooks/useCancelContract.ts
+++ b/static/js/src/advantage/react/hooks/useCancelContract.ts
@@ -1,0 +1,40 @@
+import { cancelContract } from "advantage/api/contracts";
+import { UserSubscription } from "advantage/api/types";
+import { useMutation, useQueryClient } from "react-query";
+import { useLastPurchaseIds } from ".";
+import { selectPurchaseIdsByPeriod } from "./useLastPurchaseIds";
+
+export const useCancelContract = (subscription?: UserSubscription) => {
+  const queryClient = useQueryClient();
+  const { data: lastPurchaseId } = useLastPurchaseIds(
+    subscription?.account_id,
+    {
+      select: selectPurchaseIdsByPeriod(subscription?.period),
+    }
+  );
+  const mutation = useMutation<unknown, Error, undefined | null>(
+    () =>
+      cancelContract(
+        subscription?.account_id,
+        lastPurchaseId,
+        subscription?.listing_id
+      ).then((response) => {
+        if (response.errors) {
+          throw new Error(response.errors);
+        }
+        return response;
+      }),
+    {
+      onSuccess: () => {
+        // Invalidate the subscriptions and last purchase ids so that
+        // they reload where required.
+        queryClient.invalidateQueries("userSubscriptions");
+        queryClient.invalidateQueries([
+          "lastPurchaseIds",
+          subscription?.account_id,
+        ]);
+      },
+    }
+  );
+  return mutation;
+};

--- a/static/js/src/advantage/react/hooks/useLastPurchaseIds.test.tsx
+++ b/static/js/src/advantage/react/hooks/useLastPurchaseIds.test.tsx
@@ -1,0 +1,57 @@
+import React, { PropsWithChildren } from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import {
+  selectPurchaseIdsByPeriod,
+  useLastPurchaseIds,
+} from "./useLastPurchaseIds";
+
+import { lastPurchaseIdsFactory } from "advantage/tests/factories/api";
+import { UserSubscriptionPeriod } from "advantage/api/enum";
+
+describe("useLastPurchaseIds", () => {
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    wrapper = Wrapper;
+  });
+
+  it("can return the last purchase ids from the store", async () => {
+    const lastPurchaseIds = lastPurchaseIdsFactory.build();
+    queryClient.setQueryData(
+      ["lastPurchaseIds", "account123"],
+      lastPurchaseIds
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () => useLastPurchaseIds("account123"),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.data).toStrictEqual(lastPurchaseIds);
+  });
+
+  it("can return last purchase id for a given period", async () => {
+    const lastPurchaseIds = lastPurchaseIdsFactory.build({
+      monthly: "monthly123",
+    });
+    queryClient.setQueryData(
+      ["lastPurchaseIds", "account123"],
+      lastPurchaseIds
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () =>
+        useLastPurchaseIds("account123", {
+          select: selectPurchaseIdsByPeriod(UserSubscriptionPeriod.Monthly),
+        }),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.data).toStrictEqual("monthly123");
+  });
+});

--- a/static/js/src/advantage/react/hooks/useLastPurchaseIds.ts
+++ b/static/js/src/advantage/react/hooks/useLastPurchaseIds.ts
@@ -1,0 +1,25 @@
+import { getLastPurchaseIds } from "advantage/api/contracts";
+import { LastPurchaseIds, UserSubscription } from "advantage/api/types";
+import { useQuery, UseQueryOptions } from "react-query";
+
+/**
+ * Get a the last purchase id by account id and period.
+ */
+export const selectPurchaseIdsByPeriod = (
+  period?: UserSubscription["period"] | null
+) => (lastPurchaseIds: LastPurchaseIds) =>
+  period && period in lastPurchaseIds ? lastPurchaseIds[period] : null;
+
+export const useLastPurchaseIds = <D = LastPurchaseIds>(
+  accountId?: UserSubscription["account_id"] | null,
+  options: UseQueryOptions<LastPurchaseIds, unknown, D> = {}
+) => {
+  // Don't fetch the data until the account id is provided.
+  options.enabled = !!accountId;
+  const query = useQuery(
+    ["lastPurchaseIds", accountId],
+    async () => await getLastPurchaseIds(accountId),
+    options
+  );
+  return query;
+};

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -1,6 +1,7 @@
 import { Factory } from "fishery";
 import {
   ContractToken,
+  LastPurchaseIds,
   UserSubscription,
   UserSubscriptionEntitlement,
   UserSubscriptionStatuses,
@@ -82,5 +83,12 @@ export const freeSubscriptionFactory = Factory.define<UserSubscription>(
 export const contractTokenFactory = Factory.define<ContractToken>(
   ({ sequence }) => ({
     contract_token: `zPyaGE9Z4DF9sf54ZfJt59AMwynub${sequence}`,
+  })
+);
+
+export const lastPurchaseIdsFactory = Factory.define<LastPurchaseIds>(
+  ({ sequence }) => ({
+    monthly: `Jt59AzPyaGE9Z4DF9sf54ZfMwynub${sequence}`,
+    yearly: `54ZfJ9AMwyzPyaGE9Z4DF9sf5tnub${sequence}`,
   })
 );


### PR DESCRIPTION
## Done

- Add support for fetch the last purchase ids from the API.
- Add support for cancelling a subscription via the API.

## QA

N/A CI should pass, it will be able to be QAed in https://github.com/canonical-web-and-design/ubuntu.com/pull/10369.


## Issue / Card

Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/139.
