### PR TITLE
Subscription loading failed message

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
@@ -1,19 +1,32 @@
 import React from "react";
 import { mount } from "enzyme";
 
+import * as contracts from "advantage/api/contracts";
 import Content from "./Content";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { UserSubscription } from "advantage/api/types";
 import { userSubscriptionFactory } from "advantage/tests/factories/api";
+import { act } from "react-dom/test-utils";
 
 describe("Content", () => {
   let queryClient: QueryClient;
   let contract: UserSubscription;
+  let getUserSubscriptionsSpy: jest.SpyInstance;
 
   beforeEach(async () => {
-    queryClient = new QueryClient();
+    getUserSubscriptionsSpy = jest.spyOn(contracts, "getUserSubscriptions");
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
     contract = userSubscriptionFactory.build();
     queryClient.setQueryData("userSubscriptions", [contract]);
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   it("renders", () => {
@@ -24,5 +37,25 @@ describe("Content", () => {
     );
     expect(wrapper.find("SubscriptionList").exists()).toBe(true);
     expect(wrapper.find("SubscriptionDetails").exists()).toBe(true);
+  });
+
+  it("displays a message if the contracts can't be loaded", async () => {
+    // Mock the hook to simulate a failed request.
+    getUserSubscriptionsSpy.mockImplementation(() => Promise.reject("Uh oh"));
+    // Remove the current queries so that the hook attempts to refetch the subs.
+    queryClient.removeQueries("userSubscriptions");
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Content />
+      </QueryClientProvider>
+    );
+    // Use act and wrapper.update to force waiting  for the component to finish rendering.
+    await act(async () => {});
+    wrapper.update();
+    expect(
+      wrapper.find("Notification[data-test='loading-error']").exists()
+    ).toBe(true);
+    expect(wrapper.find("SubscriptionList").exists()).toBe(false);
+    expect(wrapper.find("SubscriptionDetails").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -1,4 +1,8 @@
-import { Card } from "@canonical/react-components";
+import {
+  Card,
+  Notification,
+  NotificationSeverity,
+} from "@canonical/react-components";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import { useScrollIntoView } from "advantage/react/hooks/useScrollIntoView";
 import React, { useCallback, useEffect, useState } from "react";
@@ -13,7 +17,7 @@ const Content = () => {
   const [scrollTargetRef, scrollIntoView] = useScrollIntoView<HTMLDivElement>(
     20
   );
-  const { data: allSubscriptions, isLoading } = useUserSubscriptions();
+  const { data: allSubscriptions, isError, isLoading } = useUserSubscriptions();
   const onSetActive = useCallback(
     (token: SelectedId) => {
       // Only set the token if it has changed to another token. The selected
@@ -37,6 +41,19 @@ const Content = () => {
       setSelectedId(allSubscriptions[0].contract_id);
     }
   }, [selectedId, setSelectedId, allSubscriptions, isLoading]);
+
+  if (isError) {
+    return (
+      <Notification
+        data-test="loading-error"
+        severity={NotificationSeverity.NEGATIVE}
+        title="Loading failed:"
+      >
+        Your subscriptions could not be loaded. Please refresh the page or try
+        again later.
+      </Notification>
+    );
+  }
 
   return (
     <Card className="u-no-margin--bottom u-no-padding p-subscriptions__card">

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import {
   freeSubscriptionFactory,
   userSubscriptionFactory,
+  userSubscriptionStatusesFactory,
 } from "advantage/tests/factories/api";
 import SubscriptionDetails from "./SubscriptionDetails";
 import { UserSubscription } from "advantage/api/types";
@@ -17,7 +18,11 @@ describe("SubscriptionDetails", () => {
 
   beforeEach(() => {
     queryClient = new QueryClient();
-    contract = userSubscriptionFactory.build();
+    contract = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({
+        is_upsizeable: true,
+      }),
+    });
     queryClient.setQueryData("userSubscriptions", [contract]);
   });
 


### PR DESCRIPTION
## Done

- Display a message if the subscriptions can't be loaded.

## QA

- Open your network dev tools and load [/advantage?test_backend=true](https://ubuntu-com-10386.demos.haus/advantage?test_backend=true) and log in.
- Find the entry for `/advantage/user-subscriptions?test_backend=true`.
- Right click on the entry and click "block" (don't forget to unblock at the end).
- Reload the page.
- The page should load and you should see a message about the subscriptions not loading.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10384.

## Screenshots

<img width="1075" alt="Screen Shot 2021-09-17 at 10 09 57 am" src="https://user-images.githubusercontent.com/361637/133706957-4192448f-1818-4327-a22a-4400bb15e023.png">

