### PR TITLE
Display the renewal settings

### DIFF
--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -65,6 +65,14 @@ export async function getCustomerInfo(accountId) {
   return data;
 }
 
+export async function getUserInfo() {
+  const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
+  const response = await fetch(`/advantage/user-info${queryString}`, {
+    cache: "no-store",
+  });
+  return await response.json();
+}
+
 export async function getUserSubscriptions() {
   const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
   const response = await fetch(`/advantage/user-subscriptions${queryString}`, {

--- a/static/js/src/advantage/api/contracts.test.ts
+++ b/static/js/src/advantage/api/contracts.test.ts
@@ -1,10 +1,23 @@
+import { userInfoFactory } from "advantage/tests/factories/api";
 import fetch from "jest-fetch-mock";
 
-import { getContractToken, getUserSubscriptions } from "./contracts";
+import {
+  getContractToken,
+  getUserInfo,
+  getUserSubscriptions,
+} from "./contracts";
 
 describe("contracts", () => {
   afterEach(() => {
     fetch.resetMocks();
+  });
+
+  it("can get user info", async () => {
+    const userInfoData = userInfoFactory.build();
+    fetch.mockResponseOnce(JSON.stringify(userInfoData));
+    await getUserInfo().then((response) => {
+      expect(response).toStrictEqual(JSON.parse(JSON.stringify(userInfoData)));
+    });
   });
 
   it("can get user subscriptions", () => {

--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -47,6 +47,15 @@ export type UserSubscription = {
   type: UserSubscriptionType;
 };
 
+export type UserInfo = {
+  currency: string;
+  has_monthly_subscription: boolean;
+  is_auto_renewing: boolean;
+  last_payment_date: Date;
+  next_payment_date: Date;
+  total: number;
+};
+
 export type ContractToken = {
   contract_token: string;
 };

--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -49,12 +49,12 @@ export type UserSubscription = {
 };
 
 export type UserInfo = {
-  currency: string;
+  currency?: string;
   has_monthly_subscription: boolean;
   is_auto_renewing: boolean;
-  last_payment_date: Date;
-  next_payment_date: Date;
-  total: number;
+  last_payment_date?: Date;
+  next_payment_date?: Date;
+  total?: number;
 };
 
 export type ContractToken = {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import {
   freeSubscriptionFactory,
   userSubscriptionFactory,
+  userSubscriptionStatusesFactory,
 } from "advantage/tests/factories/api";
 import SubscriptionDetails from "./SubscriptionDetails";
 import { UserSubscription } from "advantage/api/types";
@@ -17,7 +18,11 @@ describe("SubscriptionDetails", () => {
 
   beforeEach(() => {
     queryClient = new QueryClient();
-    contract = userSubscriptionFactory.build();
+    contract = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({
+        is_upsizeable: true,
+      }),
+    });
     queryClient.setQueryData("userSubscriptions", [contract]);
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.test.tsx
@@ -4,10 +4,19 @@ import { shallow } from "enzyme";
 import ListGroup from "./ListGroup";
 
 describe("ListGroup", () => {
-  it("renders", () => {
+  it("does not display the renewal settings by default", () => {
     const wrapper = shallow(
       <ListGroup title="free personal token">Group content</ListGroup>
     );
-    expect(wrapper.find(".p-subscriptions__list-group").exists()).toBe(true);
+    expect(wrapper.find("RenewalSettings").exists()).toBe(false);
+  });
+
+  it("can display the renewal settings", () => {
+    const wrapper = shallow(
+      <ListGroup title="free personal token" showRenewalSettings>
+        Group content
+      </ListGroup>
+    );
+    expect(wrapper.find("RenewalSettings").exists()).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const ListGroup = ({
   children,
-  showRenewalSettings = true,
+  showRenewalSettings = false,
   title,
 }: Props): JSX.Element => {
   const positionNode = useRef<HTMLDivElement | null>(null);

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.test.tsx
@@ -1,13 +1,192 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
+import fetch from "jest-fetch-mock";
 
 import RenewalSettings from "./RenewalSettings";
+import { UserInfo, UserSubscription } from "advantage/api/types";
+import { QueryClient, QueryClientProvider } from "react-query";
+import {
+  userInfoFactory,
+  userSubscriptionFactory,
+} from "advantage/tests/factories/api";
+import { UserSubscriptionPeriod } from "advantage/api/enum";
+import * as contracts from "advantage/api/contracts";
+import { act } from "react-dom/test-utils";
 
 describe("RenewalSettings", () => {
-  it("renders", () => {
-    const wrapper = shallow(
-      <RenewalSettings positionNodeRef={{ current: null }} />
+  let queryClient: QueryClient;
+  let contract: UserSubscription;
+  let userInfo: UserInfo;
+  let getUserInfoSpy: jest.SpyInstance;
+  let getUserSubscriptionsSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    fetch.mockResponse(JSON.stringify(""));
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          // Disable calling the fetch requests.
+          enabled: false,
+          // Don't retry fetching the queries so it fails in the test.
+          retry: false,
+        },
+      },
+    });
+    contract = userSubscriptionFactory.build({
+      period: UserSubscriptionPeriod.Monthly,
+    });
+    userInfo = userInfoFactory.build();
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    queryClient.setQueryData("userInfo", userInfo);
+    getUserInfoSpy = jest.spyOn(contracts, "getUserInfo");
+    getUserSubscriptionsSpy = jest.spyOn(contracts, "getUserSubscriptions");
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("displays the correct plural for 1 monthly subscription", () => {
+    queryClient.setQueryData("userSubscriptions", [
+      userSubscriptionFactory.build({
+        period: UserSubscriptionPeriod.Monthly,
+      }),
+      userSubscriptionFactory.build({
+        period: UserSubscriptionPeriod.Yearly,
+      }),
+    ]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
     );
-    expect(wrapper.find("ContextualMenu").exists()).toBe(true);
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find("[data-test='subscription-count']")
+        .text()
+        .includes("1 monthly subscription is")
+    ).toBe(true);
+  });
+
+  it("displays the correct plural for multiple monthly subscriptions", () => {
+    queryClient.setQueryData("userSubscriptions", [
+      userSubscriptionFactory.build({
+        period: UserSubscriptionPeriod.Monthly,
+      }),
+      userSubscriptionFactory.build({
+        period: UserSubscriptionPeriod.Monthly,
+      }),
+      userSubscriptionFactory.build({
+        period: UserSubscriptionPeriod.Yearly,
+      }),
+    ]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
+    );
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find("[data-test='subscription-count']")
+        .text()
+        .includes("2 monthly subscriptions are")
+    ).toBe(true);
+  });
+
+  it("formats the date", () => {
+    queryClient.setQueryData(
+      "userInfo",
+      userInfoFactory.build({
+        next_payment_date: new Date("2023-02-09T07:14:56Z"),
+      })
+    );
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
+    );
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find("[data-test='next-payment']").text()).toBe(
+      "9 February 2023"
+    );
+  });
+
+  it("formats the price", () => {
+    queryClient.setQueryData(
+      "userInfo",
+      userInfoFactory.build({
+        total: 2200,
+      })
+    );
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
+    );
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find("[data-test='monthly-price']").text()).toBe("$22.00");
+  });
+
+  it("sets the inital auto renew value from the API response", async () => {
+    userInfo = userInfoFactory.build({
+      is_auto_renewing: true,
+    });
+    queryClient.setQueryData("userInfo", userInfo);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
+    );
+    // Use act to force waiting  for the component to finish rendering.
+    await act(async () => {});
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper.find("input[name='should_auto_renew']").prop("checked")
+    ).toBe(true);
+  });
+
+  it("displays an error if there is a problem loading the user info", async () => {
+    getUserInfoSpy.mockImplementation(() => Promise.reject("Uh oh"));
+    // Remove the current queries so that the hook attempts to refetch the user info.
+    queryClient.removeQueries("userInfo");
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
+    );
+    // Use act to force waiting  for the component to finish rendering.
+    await act(async () => {});
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper.find("Notification[data-test='user-info-loading-error']").exists()
+    ).toBe(true);
+  });
+
+  it("displays an error if there is a problem loading the subscriptions", async () => {
+    getUserSubscriptionsSpy.mockImplementation(() => Promise.reject("Uh oh"));
+    // Remove the current queries so that the hook attempts to refetch the subs.
+    queryClient.removeQueries("userSubscriptions");
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <RenewalSettings positionNodeRef={{ current: null }} />
+      </QueryClientProvider>
+    );
+    // Use act to force waiting  for the component to finish rendering.
+    await act(async () => {});
+    // Open the menu so that the content gets rendered inside the portal.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find("Notification[data-test='subscriptions-loading-error']")
+        .exists()
+    ).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.tsx
@@ -1,15 +1,106 @@
-import { ContextualMenu } from "@canonical/react-components";
-import React, { RefObject, useState } from "react";
+import {
+  ContextualMenu,
+  Notification,
+  NotificationSeverity,
+  Spinner,
+} from "@canonical/react-components";
+import React, { ReactNode, RefObject, useState } from "react";
 import { Formik } from "formik";
 
 import RenewalSettingsFields from "./RenewalSettingsFields";
+import { useUserInfo, useUserSubscriptions } from "advantage/react/hooks";
+import { selectSubscriptionsForPeriod } from "advantage/react/hooks/useUserSubscriptions";
+import { UserSubscriptionPeriod } from "advantage/api/enum";
+import { UserInfo } from "advantage/api/types";
+import { formatDate } from "advantage/react/utils";
 
 type Props = {
   positionNodeRef: RefObject<HTMLDivElement>;
 };
 
+const generatePrice = (userInfo: UserInfo): string => {
+  const formatter = new Intl.NumberFormat("en-US", {
+    currency: userInfo.currency,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    style: "currency",
+  });
+  // The total is in cents so it needs to be divided by 100.
+  return formatter.format(userInfo.total / 100);
+};
+
 const RenewalSettings = ({ positionNodeRef }: Props): JSX.Element => {
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
+  const {
+    data: userInfo,
+    isError: isUserInfoError,
+    isLoading: isLoadingUserInfo,
+  } = useUserInfo();
+  const {
+    data: monthlySubscriptions,
+    isError: isSubscriptionsError,
+    isLoading: isLoadingSubscriptions,
+  } = useUserSubscriptions({
+    select: selectSubscriptionsForPeriod(UserSubscriptionPeriod.Monthly),
+  });
+  let content: ReactNode = null;
+  if (isLoadingUserInfo || isLoadingSubscriptions) {
+    content = <Spinner text="Loading..." />;
+  } else if (isUserInfoError || !userInfo) {
+    content = (
+      <Notification
+        data-test="user-info-loading-error"
+        severity={NotificationSeverity.NEGATIVE}
+      >
+        There was a problem fetching your auto renewal settings. Please refresh
+        the page or try again later.
+      </Notification>
+    );
+  } else if (isSubscriptionsError || !monthlySubscriptions) {
+    content = (
+      <Notification
+        data-test="subscriptions-loading-error"
+        severity={NotificationSeverity.NEGATIVE}
+      >
+        There was a problem loading your subscription information. Please
+        refresh the page or try again later.
+      </Notification>
+    );
+  } else {
+    content = (
+      <>
+        <p className="u-no-padding--top u-no-margin--bottom u-sv1">
+          <strong data-test="subscription-count">
+            {monthlySubscriptions.length} monthly subscription
+            {monthlySubscriptions.length === 1 ? " is" : "s are"} affected by
+            auto-renew settings.
+          </strong>
+        </p>
+        <hr />
+        <p className="u-no-margin--bottom u-sv1">
+          Your next recurring payment of{" "}
+          <strong data-test="monthly-price">{generatePrice(userInfo)}</strong>{" "}
+          will be taken on{" "}
+          <strong data-test="next-payment">
+            {formatDate(userInfo.next_payment_date, "d MMMM yyyy")}
+          </strong>
+          .
+        </p>
+        <Formik
+          initialValues={{
+            should_auto_renew: userInfo?.is_auto_renewing,
+          }}
+          onSubmit={() => {
+            // TODO: Implement updating the renewal settings:
+            // https://github.com/canonical-web-and-design/commercial-squad/issues/99
+          }}
+        >
+          <RenewalSettingsFields setMenuOpen={setMenuOpen} />
+        </Formik>
+      </>
+    );
+  }
+
   return (
     <ContextualMenu
       constrainPanelWidth
@@ -22,28 +113,7 @@ const RenewalSettings = ({ positionNodeRef }: Props): JSX.Element => {
       toggleLabel="Renewal settings"
       visible={menuOpen}
     >
-      <p className="u-no-padding--top u-no-margin--bottom u-sv1">
-        <strong>
-          2 monthly subscriptions are affected by auto-renew settings.
-        </strong>
-      </p>
-      <hr />
-      <p className="u-no-margin--bottom u-sv1">
-        Your next recurring payment of <strong>$30.00</strong> will be taken on{" "}
-        <strong>17 July 2021</strong>.
-      </p>
-      <Formik
-        initialValues={{
-          // TODO: use the initial value from the subscription.
-          should_auto_renew: false,
-        }}
-        onSubmit={() => {
-          // TODO: Implement updating the renewal settings:
-          // https://github.com/canonical-web-and-design/commercial-squad/issues/99
-        }}
-      >
-        <RenewalSettingsFields setMenuOpen={setMenuOpen} />
-      </Formik>
+      {content}
     </ContextualMenu>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -5,19 +5,24 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import SubscriptionList from "./SubscriptionList";
 import {
   freeSubscriptionFactory,
+  userInfoFactory,
   userSubscriptionFactory,
 } from "advantage/tests/factories/api";
-import { UserSubscription } from "advantage/api/types";
+import { UserInfo, UserSubscription } from "advantage/api/types";
 import ListCard from "./ListCard";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
+import ListGroup from "./ListGroup";
 
 describe("SubscriptionList", () => {
   let queryClient: QueryClient;
   let freeSubscription: UserSubscription;
+  let userInfo: UserInfo;
 
   beforeEach(async () => {
     queryClient = new QueryClient();
     freeSubscription = freeSubscriptionFactory.build();
+    userInfo = userInfoFactory.build();
+    queryClient.setQueryData("userInfo", userInfo);
     queryClient.setQueryData("userSubscriptions", [freeSubscription]);
   });
 
@@ -100,5 +105,37 @@ describe("SubscriptionList", () => {
     expect(
       wrapper.find("[data-test='free-subscription']").prop("isSelected")
     ).toBe(true);
+  });
+
+  it("shows the renewal settings if there are monthly subs", () => {
+    userInfo = userInfoFactory.build({ has_monthly_subscription: true });
+    queryClient.setQueryData("userInfo", userInfo);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionList
+          selectedId={freeSubscription.contract_id}
+          onSetActive={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find(ListGroup).first().prop("showRenewalSettings")).toBe(
+      true
+    );
+  });
+
+  it("does not show the renewal settings if there are no monthly subs", () => {
+    userInfo = userInfoFactory.build({ has_monthly_subscription: false });
+    queryClient.setQueryData("userInfo", userInfo);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionList
+          selectedId={freeSubscription.contract_id}
+          onSetActive={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find(ListGroup).first().prop("showRenewalSettings")).toBe(
+      false
+    );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { UserSubscription } from "advantage/api/types";
-import { useUserSubscriptions } from "advantage/react/hooks";
+import { useUserInfo, useUserSubscriptions } from "advantage/react/hooks";
 import {
   selectFreeSubscription,
   selectUASubscriptions,
@@ -36,7 +36,8 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   } = useUserSubscriptions({
     select: selectUASubscriptions,
   });
-  if (isLoadingFree || isLoadingUA) {
+  const { data: userInfo, isLoading: isLoadingUserInfo } = useUserInfo();
+  if (isLoadingFree || isLoadingUA || isLoadingUserInfo) {
     return <Spinner />;
   }
   // Sort the subscriptions so that the most recently started subscription is first.
@@ -56,7 +57,12 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">
-        <ListGroup title="Ubuntu Advantage">{uaSubscriptions}</ListGroup>
+        <ListGroup
+          title="Ubuntu Advantage"
+          showRenewalSettings={userInfo?.has_monthly_subscription}
+        >
+          {uaSubscriptions}
+        </ListGroup>
         {freeSubscription ? (
           <ListGroup title="Free personal token" showRenewalSettings={false}>
             <ListCard

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -2,4 +2,5 @@ export { useContractToken } from "./useContractToken";
 export { useLoadWindowData } from "./useLoadWindowData";
 export { usePendingPurchaseId } from "./usePendingPurchaseId";
 export { useURLs } from "./useURLs";
+export { useUserInfo } from "./useUserInfo";
 export { useUserSubscriptions } from "./useUserSubscriptions";

--- a/static/js/src/advantage/react/hooks/useUserInfo.test.tsx
+++ b/static/js/src/advantage/react/hooks/useUserInfo.test.tsx
@@ -1,0 +1,30 @@
+import React, { PropsWithChildren } from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useUserInfo } from "./useUserInfo";
+
+import { userInfoFactory } from "advantage/tests/factories/api";
+
+describe("useUserInfo", () => {
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    wrapper = Wrapper;
+  });
+
+  it("can return the user subscriptions from the store", async () => {
+    const userInfo = userInfoFactory.build();
+    queryClient.setQueryData("userInfo", userInfo);
+    const { result, waitForNextUpdate } = renderHook(() => useUserInfo(), {
+      wrapper,
+    });
+    await waitForNextUpdate();
+    expect(result.current.data).toStrictEqual(userInfo);
+  });
+});

--- a/static/js/src/advantage/react/hooks/useUserInfo.ts
+++ b/static/js/src/advantage/react/hooks/useUserInfo.ts
@@ -1,0 +1,10 @@
+import { getUserInfo } from "advantage/api/contracts";
+import { UserInfo } from "advantage/api/types";
+import { useQuery, UseQueryOptions } from "react-query";
+
+export const useUserInfo = <D = UserInfo>(
+  options?: UseQueryOptions<UserInfo, unknown, D>
+) => {
+  const query = useQuery("userInfo", async () => await getUserInfo(), options);
+  return query;
+};

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -1,6 +1,7 @@
 import { getUserSubscriptions } from "advantage/api/contracts";
 import {
   UserSubscriptionMarketplace,
+  UserSubscriptionPeriod,
   UserSubscriptionType,
 } from "advantage/api/enum";
 import {
@@ -58,12 +59,25 @@ export const selectUASubscriptions = (subscriptions: UserSubscription[]) =>
   );
 
 /**
- * Find the UA subscriptions.
+ * Find the subscriptions with for period.
  */
 export const selectSubscriptionsForPeriod = (
   period: UserSubscriptionPeriod
 ) => (subscriptions: UserSubscription[]) =>
   subscriptions.filter((subscription) => subscription.period === period);
+
+/**
+ * Find the auto renewable subscriptions.
+ */
+export const selectAutoRenewableUASubscriptions = (
+  subscriptions: UserSubscription[]
+) =>
+  selectUASubscriptions(subscriptions).filter(
+    ({ period, statuses }) =>
+      period === UserSubscriptionPeriod.Monthly &&
+      !statuses.is_cancelled &&
+      !statuses.is_expired
+  );
 
 export const useUserSubscriptions = <D = UserSubscription[]>(
   options?: UseQueryOptions<UserSubscription[], unknown, D>

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -1,6 +1,7 @@
 import { getUserSubscriptions } from "advantage/api/contracts";
 import {
   UserSubscriptionMarketplace,
+  UserSubscriptionPeriod,
   UserSubscriptionType,
 } from "advantage/api/enum";
 import {
@@ -56,6 +57,14 @@ export const selectUASubscriptions = (subscriptions: UserSubscription[]) =>
   subscriptions.filter(
     ({ marketplace }) => marketplace === UserSubscriptionMarketplace.CanonicalUA
   );
+
+/**
+ * Find the UA subscriptions.
+ */
+export const selectSubscriptionsForPeriod = (
+  period: UserSubscriptionPeriod
+) => (subscriptions: UserSubscription[]) =>
+  subscriptions.filter((subscription) => subscription.period === period);
 
 export const useUserSubscriptions = <D = UserSubscription[]>(
   options?: UseQueryOptions<UserSubscription[], unknown, D>

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -1,6 +1,7 @@
 import { Factory } from "fishery";
 import {
   ContractToken,
+  UserInfo,
   UserSubscription,
   UserSubscriptionEntitlement,
   UserSubscriptionStatuses,
@@ -78,6 +79,15 @@ export const freeSubscriptionFactory = Factory.define<UserSubscription>(
     type: UserSubscriptionType.Free,
   })
 );
+
+export const userInfoFactory = Factory.define<UserInfo>(() => ({
+  currency: "USD",
+  has_monthly_subscription: false,
+  is_auto_renewing: false,
+  last_payment_date: new Date("2021-02-09T07:14:56Z"),
+  next_payment_date: new Date("2022-02-09T07:14:56Z"),
+  total: 2000,
+}));
 
 export const contractTokenFactory = Factory.define<ContractToken>(
   ({ sequence }) => ({


### PR DESCRIPTION
## Done

- Fetch user info from the API.
- Display the renewal settings data.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10387.demos.haus/advantage?test_backend=true) and log in.
- Click on "Renewal settings" at the top of the list.
- The number of subs, price and renewal date are displayed from the API data.
- The 'Auto-renewal' checkbox should reflect the state of your auto renewal settings (probably on).
- Note: the form doesn't update your settings yet (will be done in https://github.com/canonical-web-and-design/commercial-squad/issues/272).

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/99.

## Screenshots


<img width="455" alt="Screen Shot 2021-09-17 at 1 16 13 pm" src="https://user-images.githubusercontent.com/361637/133718819-ea2e05d9-ff96-4aa3-93f8-fc821c258d1b.png">
