### PR TITLE
Expiry notification border

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -34,7 +34,7 @@ type Messages = Record<
 >;
 
 // The expiry status keys in priority order.
-const ORDERED_STATUS_KEYS = [
+export const ORDERED_STATUS_KEYS = [
   StatusKey.IsExpired,
   StatusKey.IsInGracePeriod,
   StatusKey.IsExpiring,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -53,6 +53,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               </button>
             </header>
             <ExpiryNotification
+              borderless
               className="p-subscriptions__details-notification"
               size={ExpiryNotificationSize.Large}
               statuses={subscription.statuses}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -1,5 +1,5 @@
 import { Card, Col, List, Row } from "@canonical/react-components";
-import React from "react";
+import React, { ReactNode } from "react";
 import classNames from "classnames";
 import {
   formatDate,
@@ -9,7 +9,10 @@ import {
 } from "advantage/react/utils";
 import { UserSubscription } from "advantage/api/types";
 import ExpiryNotification from "../../ExpiryNotification";
-import { ExpiryNotificationSize } from "../../ExpiryNotification/ExpiryNotification";
+import {
+  ExpiryNotificationSize,
+  ORDERED_STATUS_KEYS,
+} from "../../ExpiryNotification/ExpiryNotification";
 
 type Props = {
   isSelected?: boolean;
@@ -23,60 +26,83 @@ const ListCard = ({
   subscription,
 }: Props): JSX.Element => {
   const isFree = isFreeSubscription(subscription);
+  // If the subscription statuses is true for any of the expiry status keys then
+  // a notification will be displayed.
+  const hasExpiryNotification = !!ORDERED_STATUS_KEYS.find(
+    (status) => subscription.statuses[status]
+  );
+  let expiryNotification: ReactNode = null;
+  if (hasExpiryNotification) {
+    expiryNotification = (
+      <>
+        <div className="p-card__inner u-no-padding--top u-no-padding--bottom">
+          <ExpiryNotification
+            className="u-no-margin--bottom"
+            size={ExpiryNotificationSize.Small}
+            statuses={subscription.statuses}
+          />
+        </div>
+        <hr />
+      </>
+    );
+  }
   return (
     <Card
-      className={classNames("p-subscriptions__list-card", {
+      className={classNames("p-subscriptions__list-card u-no-padding", {
         "is-active": isSelected,
       })}
       {...makeInteractiveProps(onClick)}
     >
-      <ExpiryNotification
-        className="p-subscriptions__list-card-notification is-dense"
-        size={ExpiryNotificationSize.Small}
-        statuses={subscription.statuses}
-      />
-      <div className="p-subscriptions__list-card-title">
-        <h5
-          className="u-no-padding--top u-no-margin--bottom"
-          data-test="card-title"
-        >
-          {isFree ? "Free Personal Token" : subscription.product_name}
-        </h5>
-        <span
-          className="p-text--x-small-capitalised u-text--muted p-subscriptions__list-card-period"
-          data-test="card-type"
-        >
-          {subscription.type}
-        </span>
+      {expiryNotification}
+      <div
+        className={classNames("p-card__inner", {
+          "u-no-padding--top": hasExpiryNotification,
+        })}
+        data-test="subscription-card-content"
+      >
+        <div className="p-subscriptions__list-card-title">
+          <h5
+            className="u-no-padding--top u-no-margin--bottom"
+            data-test="card-title"
+          >
+            {isFree ? "Free Personal Token" : subscription.product_name}
+          </h5>
+          <span
+            className="p-text--x-small-capitalised u-text--muted p-subscriptions__list-card-period"
+            data-test="card-type"
+          >
+            {subscription.type}
+          </span>
+        </div>
+        <Row>
+          <Col medium={3} size={3} small={1}>
+            <p className="u-text--muted u-no-margin--bottom">Machines</p>
+            <span data-test="card-machines">
+              {subscription.number_of_machines}
+            </span>
+          </Col>
+          <Col medium={3} size={4} small={1}>
+            <p className="u-text--muted u-no-margin--bottom">Created</p>
+            <span data-test="card-start-date">
+              {formatDate(subscription.start_date)}
+            </span>
+          </Col>
+          <Col medium={3} size={4} small={1}>
+            <p className="u-text--muted u-no-margin--bottom">Expires</p>
+            <span data-test="card-end-date">
+              {subscription.end_date
+                ? formatDate(subscription.end_date)
+                : "Never"}
+            </span>
+          </Col>
+        </Row>
+        <List
+          className="p-subscriptions__list-card-features p-text--x-small-capitalised u-text--muted u-no-margin--bottom"
+          data-test="card-entitlements"
+          inline
+          items={getFeaturesDisplay(subscription.entitlements).included}
+        />
       </div>
-      <Row>
-        <Col medium={3} size={3} small={1}>
-          <p className="u-text--muted u-no-margin--bottom">Machines</p>
-          <span data-test="card-machines">
-            {subscription.number_of_machines}
-          </span>
-        </Col>
-        <Col medium={3} size={4} small={1}>
-          <p className="u-text--muted u-no-margin--bottom">Created</p>
-          <span data-test="card-start-date">
-            {formatDate(subscription.start_date)}
-          </span>
-        </Col>
-        <Col medium={3} size={4} small={1}>
-          <p className="u-text--muted u-no-margin--bottom">Expires</p>
-          <span data-test="card-end-date">
-            {subscription.end_date
-              ? formatDate(subscription.end_date)
-              : "Never"}
-          </span>
-        </Col>
-      </Row>
-      <List
-        className="p-subscriptions__list-card-features p-text--x-small-capitalised u-text--muted u-no-margin--bottom"
-        data-test="card-entitlements"
-        inline
-        items={getFeaturesDisplay(subscription.entitlements).included}
-      />
     </Card>
   );
 };

--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -171,18 +171,6 @@
     }
   }
 
-  // Remove the extra space between the top of the card and the title and
-  // between the icon and the message.
-  .p-subscriptions__list-card-notification.is-dense {
-    background-position-y: center;
-    margin-bottom: 0;
-    padding-left: $sph-inner--large;
-
-    .p-notification__content {
-      padding-top: 0;
-    }
-  }
-
   .p-subscriptions__details-title {
     margin-bottom: $sp-unit;
   }


### PR DESCRIPTION
## Done

- Display a border under the expiry notification in the subscription card.

## QA

- You will need some expiring subscriptions to QA this, I'm not sure exactly how you can set that up (maybe ask @albertkol). I have some monthly subscriptions that are in that status.
- Visit [/advantage?test_backend=true](https://ubuntu-com-10389.demos.haus/advantage?test_backend=true) and log in
- Find an expiring sub in the list on the left.
- You should see a border between the expiring notification and the rest of the card content.
- The non-expiring subs should have even space inside the card.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/222.

## Screenshots

<img width="423" alt="Screen Shot 2021-09-17 at 1 37 09 pm" src="https://user-images.githubusercontent.com/361637/133721237-0f37dff0-a6fd-4907-b8bd-a5d82417b0b7.png">

