### PR TITLE
Update releases.yaml for bionic to point 6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -20,7 +20,7 @@ openstack_lts:
 previous_lts:
   name: "Bionic Beaver"
   short_version: "18.04"
-  full_version: "18.04.5"
+  full_version: "18.04.6"
   release_date: "April 2018"
   eol: "April 2023"
 previous_previous_lts:


### PR DESCRIPTION
## Done

- Ubuntu 18.04.6 was released, so we have to update the releases.yaml, or the bit torrents break on /download/alternative-downloads

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/alternative-downloads
- See that the 18.04.6 bitorrents all work


## Screenshots

![image](https://user-images.githubusercontent.com/441217/133757439-797ed797-a185-4855-b82b-0ab810e73f92.png)

