### PR TITLE
Update the Ceph webinar link

### DIFF
--- a/templates/ceph/managed.html
+++ b/templates/ceph/managed.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Canonical is the leading managed ceph provider, we build, support and manage ceph clusters in any location. {% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1Qv379nYnod9e4jMrsdDND8D7mbPyqELi2lowjkfD-gU{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ff3TDYBsukagu85dNZuK0FDdPRSjXEwS6Tv6JphXUvY{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--suru-bottomed">
@@ -26,7 +26,7 @@
 			<p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
       <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a>
 			<p>
-				<a href="https://www.brighttalk.com/webcast/6793/428078h" class="p-link--external">Watch the webinar - Redefine your enterprise storage with Ceph</a>
+				<a href="https://www.brighttalk.com/webcast/6793/428078" class="p-link--external">Watch the webinar &mdash; Redefine your enterprise storage with Ceph</a>
 			</p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
@@ -158,7 +158,7 @@
 		<p>
 			There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.
 		</p>
-		</div>	
+		</div>
 	</div>
 	<div class="u-fixed-width">
 		<div class="p-logo-section">


### PR DESCRIPTION
## Done
- Update the Ceph webinar link
- Update the copy doc link

## QA
- Go to /ceph/managed and click the "Watch the webinar" link in the hero section and see if loads the correct page
- Check the copy doc link is not point to Ceph not K8s
