### PR TITLE
Modal form not working on /managed/apps

### DIFF
--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -16,7 +16,7 @@ coverage.{% endblock meta_description %}
       <h1>Performant open source with Managed Apps</h1>
       <p class="p-heading--four">One vendor, easy deployment, guaranteed uptime</p>
       <p>
-        <a href="/managed/contact-us" class="p-button--positive">Free deployment assessment</a>
+        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal">Free deployment assessment</a>
       </p>
     </div>
     <div class="col-6 u-embedded-media u-align--center">


### PR DESCRIPTION
## Done

- Fixed /managed/apps modal contact form not opening 

## QA

- Go to the website: https://ubuntu-com-10397.demos.haus/
- Click on the button "Free deployment assessment"
- Make sure that the modal form is shown instead of falling back to the page /managed/contact-us

## Issue / Card

Fixes #10377

## Screenshots

![Screenshot from 2021-09-17 12-41-00](https://user-images.githubusercontent.com/36013798/133769859-84e59863-03a3-4f87-becb-ca1c8280bb3d.png)

