### PR TITLE
Fix user info page

### DIFF
--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -214,11 +214,17 @@ def build_get_user_info(user_summary: dict = None) -> dict:
 
     renewal_info = user_summary["renewal_info"]
 
+    if renewal_info is None:
+        return {
+            "has_monthly_subscription": True,
+            "is_auto_renewing": False,
+        }
+
     return {
         "has_monthly_subscription": True,
         "is_auto_renewing": subscription.is_auto_renewing,
-        "last_payment_date": renewal_info["subscriptionStartOfCycle"],
-        "next_payment_date": renewal_info["subscriptionEndOfCycle"],
-        "total": renewal_info["total"],
-        "currency": renewal_info["currency"].upper(),
+        "last_payment_date": renewal_info.get("subscriptionStartOfCycle"),
+        "next_payment_date": renewal_info.get("subscriptionEndOfCycle"),
+        "total": renewal_info.get("total"),
+        "currency": renewal_info.get("currency").upper(),
     }


### PR DESCRIPTION
## Done

- Fix 500 error if auto renewal is off. 
- Turns out the API returns no payment data if the auto renewal is turned off so we cannot show at the moment display the next payment information:

![image](https://user-images.githubusercontent.com/6387619/133783304-ccb2d6ae-0d9d-45d5-aac1-d834235134f0.png)
 

## QA

- Have a montly subscription
- Turn the auto renewal off
- Go to: /advantage/user-info
- You will not get a 500
- You will see
```
{
  has_mothly_subscriptions: True,
  is_auto_renewing: False
}
```

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/274