### PR TITLE
Display subscription cost in dollars

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
@@ -46,9 +46,7 @@ describe("DetailsContent", () => {
     );
     expect(wrapper.find("[data-test='expires-col']").text()).toBe("09.07.2022");
     expect(wrapper.find("[data-test='billing-col']").text()).toBe("Yearly");
-    expect(wrapper.find("[data-test='cost-col']").text()).toBe(
-      "$150,000 USD/yr"
-    );
+    expect(wrapper.find("[data-test='cost-col']").text()).toBe("$1,500 USD/yr");
   });
 
   it("displays a spinner while loading the contract token", () => {

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -1,7 +1,6 @@
 import { getUserSubscriptions } from "advantage/api/contracts";
 import {
   UserSubscriptionMarketplace,
-  UserSubscriptionPeriod,
   UserSubscriptionType,
 } from "advantage/api/enum";
 import {

--- a/static/js/src/advantage/react/utils/getSubscriptionCost.test.ts
+++ b/static/js/src/advantage/react/utils/getSubscriptionCost.test.ts
@@ -19,7 +19,7 @@ describe("getSubscriptionCost", () => {
           period: UserSubscriptionPeriod.Yearly,
         })
       )
-    ).toBe("$2,000 USD/yr");
+    ).toBe("$20 USD/yr");
   });
 
   it("handles monthly prices", () => {
@@ -31,6 +31,6 @@ describe("getSubscriptionCost", () => {
           period: UserSubscriptionPeriod.Monthly,
         })
       )
-    ).toBe("$24,000 USD/yr");
+    ).toBe("$240 USD/yr");
   });
 });

--- a/static/js/src/advantage/react/utils/getSubscriptionCost.ts
+++ b/static/js/src/advantage/react/utils/getSubscriptionCost.ts
@@ -14,7 +14,8 @@ export const getSubscriptionCost = (
     minimumFractionDigits: 0,
     style: "currency",
   });
-  let price = subscription.price || 0;
+  // The provided price is in cents, so this converts it to dollars:
+  let price = (subscription.price || 0) / 100;
   if (subscription.period === UserSubscriptionPeriod.Monthly) {
     price *= 12;
   }


### PR DESCRIPTION
## Done

- Convert the subscription cost from cents to dollars

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10404.demos.haus/advantage?test_backend=true) and log in.
- Click on some subscriptions and compare their cost to the price returned by the API (you could use the backoffice tool to easily see the values, note that /advantage accounts for the number of machines as well as converting from months to years).


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/276.

## Screenshots

<img width="144" alt="Screen Shot 2021-09-20 at 12 43 22 pm" src="https://user-images.githubusercontent.com/361637/133952637-f9214a23-8e27-4386-9218-e0265a248ce5.png">

