### PR TITLE
Display legacy contracts

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -20,6 +20,7 @@ import React, { ReactNode } from "react";
 
 import DetailsTabs from "../DetailsTabs";
 import { SelectedId } from "../../Content/types";
+import { UserSubscriptionType } from "advantage/api/enum";
 
 type Props = {
   selectedId?: SelectedId;
@@ -56,6 +57,11 @@ const DetailsContent = ({ selectedId }: Props) => {
   if (isLoading || !subscription) {
     return <Spinner />;
   }
+  const billingCol: Feature = {
+    size: 2,
+    title: "Billing",
+    value: isFree ? "None" : getPeriodDisplay(subscription.period),
+  };
   const tokenBlock = token?.contract_token ? (
     <CodeSnippet
       blocks={[
@@ -81,12 +87,15 @@ const DetailsContent = ({ selectedId }: Props) => {
               ? formatDate(subscription.end_date)
               : "Never",
           },
+          ...(subscription.type === UserSubscriptionType.Legacy
+            ? // Don't show the billing column for legacy subscriptions.
+              []
+            : [billingCol]),
           {
-            size: 2,
-            title: "Billing",
-            value: isFree ? "None" : getPeriodDisplay(subscription.period),
-          },
-          {
+            // When a legacy subscription is being displayed then stretch this
+            // column to take up the space where the billing column would
+            // otherwise be.
+            size: subscription.type === UserSubscriptionType.Legacy ? 5 : 3,
             title: "Cost",
             value: getSubscriptionCost(subscription),
           },

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -33,6 +33,9 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
       select: selectSubscriptionById(selectedId),
     });
     const isFree = isFreeSubscription(subscription);
+    const isResizable =
+      subscription?.statuses.is_upsizeable ||
+      subscription?.statuses.is_downsizeable;
 
     useEffect(() => {
       if (!modalActive) {
@@ -83,15 +86,28 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                 >
                   Support portal
                 </Button>
-                <Button
-                  appearance="neutral"
-                  className="p-subscriptions__details-action"
-                  data-test="edit-button"
-                  disabled={editing}
-                  onClick={() => setEditing(true)}
-                >
-                  Edit subscription&hellip;
-                </Button>
+                {subscription.statuses.is_renewable ? (
+                  <Button
+                    appearance="neutral"
+                    className="p-subscriptions__details-action"
+                    data-test="renew-button"
+                    disabled={editing}
+                    onClick={() => setEditing(true)}
+                  >
+                    Renew subscription&hellip;
+                  </Button>
+                ) : null}
+                {isResizable ? (
+                  <Button
+                    appearance="neutral"
+                    className="p-subscriptions__details-action"
+                    data-test="edit-button"
+                    disabled={editing}
+                    onClick={() => setEditing(true)}
+                  >
+                    Edit subscription&hellip;
+                  </Button>
+                ) : null}
               </>
             )}
           </div>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -13,6 +13,7 @@ import {
   ExpiryNotificationSize,
   ORDERED_STATUS_KEYS,
 } from "../../ExpiryNotification/ExpiryNotification";
+import { UserSubscriptionType } from "advantage/api/enum";
 
 type Props = {
   isSelected?: boolean;
@@ -67,12 +68,14 @@ const ListCard = ({
           >
             {isFree ? "Free Personal Token" : subscription.product_name}
           </h5>
-          <span
-            className="p-text--x-small-capitalised u-text--muted p-subscriptions__list-card-period"
-            data-test="card-type"
-          >
-            {subscription.type}
-          </span>
+          {subscription.type === UserSubscriptionType.Legacy ? null : (
+            <span
+              className="p-text--x-small-capitalised u-text--muted p-subscriptions__list-card-period"
+              data-test="card-type"
+            >
+              {subscription.type}
+            </span>
+          )}
         </div>
         <Row>
           <Col medium={3} size={3} small={1}>

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -1,7 +1,6 @@
 import { getUserSubscriptions } from "advantage/api/contracts";
 import {
   UserSubscriptionMarketplace,
-  UserSubscriptionPeriod,
   UserSubscriptionType,
 } from "advantage/api/enum";
 import {


### PR DESCRIPTION
## Done

- Update cards and details for displaying legacy contracts.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10406.demos.haus/advantage?test_backend=true) and log into a UA account with a legacy contract (if you have one).
- Click on a legacy contract.
- You should see the legacy details and both the card and the details should match [the design](https://app.zeplin.io/project/60ec5fb4e07cc90fbbf2b318/screen/60ef0929cb3cd60cbfb63144). Note that the renew button does not doing anything yet.


## Issue / Card

Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/157.
Fixes: https://github.com/canonical-web-and-design/commercial-squad/issues/119.

## Screenshots

<img width="1064" alt="Screen Shot 2021-09-20 at 2 19 14 pm" src="https://user-images.githubusercontent.com/361637/133956981-1257e998-e665-4b79-bdb0-9b62c4ccc3b9.png">

