### PR TITLE
9 replicas

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -112,7 +112,7 @@ extraHosts:
 
 # Overrides for production
 production:
-  replicas: 10
+  replicas: 9
 
   routes:
     - paths: [/blog]


### PR DESCRIPTION
Because we can only have 1 per node with our affinity config, and we only have 9 nodes

