### PR TITLE
fix new user submission on Enter key

### DIFF
--- a/static/js/src/advantage/users/components/AddNewUser/AddNewUserForm.tsx
+++ b/static/js/src/advantage/users/components/AddNewUser/AddNewUserForm.tsx
@@ -83,7 +83,11 @@ export const AddNewUserForm = ({
               options={userRoleOptions}
             />
             <div className="p-modal__footer">
-              <Button className="u-no-margin--bottom" onClick={handleClose}>
+              <Button
+                type="button"
+                className="u-no-margin--bottom"
+                onClick={handleClose}
+              >
                 Cancel
               </Button>
               <ActionButton


### PR DESCRIPTION
## Done

- fix new user submission on press of an Enter key
  - originally reported by @ClementChaumel here: https://github.com/canonical-web-and-design/ubuntu.com/pull/10381#issuecomment-922777780

This happened because submit is the default if the attribute is not specified for buttons associated with a form

## QA

- login and go to /advantage/users?test_backend=true
- Click "Add new user"
- Fill out the form
- Press enter on the keyboard
- user should be added successfully

