### PR TITLE
Call the delete trial endpoint when the button is clicked

### DIFF
--- a/static/js/src/advantage/contracts-api.js
+++ b/static/js/src/advantage/contracts-api.js
@@ -334,3 +334,20 @@ export async function postFreeTrial({
   let data = await response.json();
   return data;
 }
+
+export async function endTrial(accountID) {
+  const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
+
+  let response = await fetch(`/advantage/trial/${accountID}${queryString}`, {
+    method: "DELETE",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
+
+  let data = await response.json();
+  return data;
+}

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -2,6 +2,7 @@ import {
   cancelContract,
   getPurchase,
   resizeContract,
+  endTrial,
 } from "./contracts-api.js";
 
 const stripe = window.Stripe(window.stripePublishableKey);
@@ -531,4 +532,30 @@ const editButtons = document.querySelectorAll(".js-change-subscription-button");
 
 editButtons.forEach((button) => {
   button.addEventListener("click", handleChangeClick);
+});
+
+const endTrialButtons = document.querySelectorAll(".js-end-trial");
+const accountId = endTrialButtons[0].dataset.accountId;
+
+endTrialButtons.forEach((endTrialButton) => {
+  endTrialButton.addEventListener("click", function (e) {
+    e.preventDefault();
+    endTrialButton.classList.add("is-processing");
+    endTrialButton.innerHTML =
+      '<i class="p-icon--spinner u-animation--spin is-light"></i>';
+    endTrialButton.setAttribute("disabled", "disabled");
+    endTrial(accountId)
+      .then((data) => {
+        if (data.errors) {
+          endTrialButton.innerHTML = "End trial";
+          endTrialButton.removeAttribute("disabled");
+          endTrialButton.setAttribute("class", "p-button--positive");
+        }
+      })
+      .catch(() => {
+        endTrialButton.innerHTML = "End trial";
+        endTrialButton.removeAttribute("disabled");
+        endTrialButton.setAttribute("class", "p-button--positive");
+      });
+  });
 });

--- a/templates/advantage/table/_free-trial.html
+++ b/templates/advantage/table/_free-trial.html
@@ -23,19 +23,17 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-12 u-align--right">
-        <a 
-          class="p-button--positive u-no-margin--right" 
-          href="/advantage/subscribe?free_trial={{contract["productID"]}}&quantity={{ contract['rowMachineCount'] }}{% if is_test_backend %}&test_backend=true{% endif %}"
-        >
-          {% if contract['contractInfo']['status'] == "expired" %}
-            Buy this subscription
-          {% else %}
-            End trial and buy
-          {% endif %}
-        </a>
+    {% if contract['contractInfo']['status'] != "expired" %}
+      <div class="row">
+        <div class="col-12 u-align--right">
+          <button 
+            class="p-button--positive u-no-margin--right js-end-trial"
+            data-account-id="{{contract['accountInfo']['id']}}"
+          >
+              End trial
+          </button>
+        </div>
       </div>
-    </div>
+    {% endif %}
   </div>
 </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -380,7 +380,7 @@ app.add_url_rule(
     "/advantage/renewals/<renewal_id>", view_func=get_renewal, methods=["GET"]
 )
 app.add_url_rule(
-    "/advantage/trial/<subscription_id>",
+    "/advantage/trial/<account_id>",
     view_func=cancel_trial,
     methods=["DELETE"],
 )


### PR DESCRIPTION
## Done

- Changed the copy to better reflect what the button does
- calls the endpoint on click

## QA

- go to https://ubuntu-com-10422.demos.haus/advantage/subscribe?test_backend=true and add a trial if you don't already have one
- then on https://ubuntu-com-10422.demos.haus/advantage?test_backend=true open the corresponding row
- click the button
- the page should reload and the trial should go away

