### PR TITLE
Set up Stripe

### DIFF
--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -9,6 +9,8 @@ import {
 
 export type PendingPurchaseId = string;
 
+export type StripePublishableKey = string;
+
 export type UserSubscriptionEntitlement = {
   enabled_by_default: boolean;
   support_level: SupportLevel | null;

--- a/static/js/src/advantage/react/app.tsx
+++ b/static/js/src/advantage/react/app.tsx
@@ -2,10 +2,23 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
+import { Elements } from "@stripe/react-stripe-js";
+import { loadStripe } from "@stripe/stripe-js";
 
 import { useLoadWindowData } from "./hooks";
 import Subscriptions from "./components/Subscriptions";
+import { StripePublishableKey } from "advantage/api/types";
 
+declare global {
+  interface Window {
+    // This key is added to the window in the template.
+    stripePublishableKey?: StripePublishableKey;
+  }
+}
+
+const stripePromise = window.stripePublishableKey
+  ? loadStripe(window.stripePublishableKey)
+  : null;
 const oneHour = 1000 * 60 * 60;
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -23,7 +36,9 @@ export const App = () => {
   useLoadWindowData(queryClient);
   return (
     <QueryClientProvider client={queryClient}>
-      <Subscriptions />
+      <Elements stripe={stripePromise}>
+        <Subscriptions />
+      </Elements>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import {
   freeSubscriptionFactory,
   userSubscriptionFactory,
+  userSubscriptionStatusesFactory,
 } from "advantage/tests/factories/api";
 import SubscriptionDetails from "./SubscriptionDetails";
 import { UserSubscription } from "advantage/api/types";
@@ -17,7 +18,11 @@ describe("SubscriptionDetails", () => {
 
   beforeEach(() => {
     queryClient = new QueryClient();
-    contract = userSubscriptionFactory.build();
+    contract = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({
+        is_upsizeable: true,
+      }),
+    });
     queryClient.setQueryData("userSubscriptions", [contract]);
   });
 

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -3,5 +3,6 @@ export { useContractToken } from "./useContractToken";
 export { useLastPurchaseIds } from "./useLastPurchaseIds";
 export { useLoadWindowData } from "./useLoadWindowData";
 export { usePendingPurchaseId } from "./usePendingPurchaseId";
+export { useStripePublishableKey } from "./useStripePublishableKey";
 export { useURLs } from "./useURLs";
 export { useUserSubscriptions } from "./useUserSubscriptions";

--- a/static/js/src/advantage/react/hooks/useLoadWindowData.test.tsx
+++ b/static/js/src/advantage/react/hooks/useLoadWindowData.test.tsx
@@ -8,10 +8,12 @@ import { useLoadWindowData } from "./useLoadWindowData";
 describe("useLoadWindowData", () => {
   beforeEach(() => {
     window.pendingPurchaseId = "12345";
+    window.stripePublishableKey = "12345";
   });
 
   afterEach(() => {
     delete window.pendingPurchaseId;
+    delete window.stripePublishableKey;
   });
 
   it("fetches data from the window and inserts into react-query", async () => {

--- a/static/js/src/advantage/react/hooks/useLoadWindowData.ts
+++ b/static/js/src/advantage/react/hooks/useLoadWindowData.ts
@@ -1,19 +1,22 @@
-import { PendingPurchaseId } from "advantage/api/types";
+import { PendingPurchaseId, StripePublishableKey } from "advantage/api/types";
 import type { QueryClient } from "react-query";
 
 declare global {
   interface Window {
     pendingPurchaseId?: PendingPurchaseId;
+    stripePublishableKey?: StripePublishableKey;
   }
 }
 
 const getWindowData = () => ({
   pendingPurchaseId:
     window.pendingPurchaseId === "None" ? null : window.pendingPurchaseId,
+  stripePublishableKey: window.stripePublishableKey,
 });
 
 export const useLoadWindowData = (queryClient: QueryClient) => {
-  const { pendingPurchaseId } = getWindowData();
+  const { pendingPurchaseId, stripePublishableKey } = getWindowData();
   // Insert the data from the template into the react-query store.
   queryClient.setQueryData("pendingPurchaseId", pendingPurchaseId);
+  queryClient.setQueryData("stripePublishableKey", stripePublishableKey);
 };

--- a/static/js/src/advantage/react/hooks/useStripePublishableKey.test.tsx
+++ b/static/js/src/advantage/react/hooks/useStripePublishableKey.test.tsx
@@ -1,0 +1,28 @@
+import React, { PropsWithChildren } from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useStripePublishableKey } from "./useStripePublishableKey";
+
+describe("useStripePublishableKey", () => {
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    wrapper = Wrapper;
+  });
+
+  it("can return the stripe publishable key from the store", async () => {
+    queryClient.setQueryData("stripePublishableKey", "abc123");
+    const { result, waitForNextUpdate } = renderHook(
+      () => useStripePublishableKey(),
+      { wrapper }
+    );
+    await waitForNextUpdate();
+    expect(result.current.stripePublishableKey).toBe("abc123");
+  });
+});

--- a/static/js/src/advantage/react/hooks/useStripePublishableKey.ts
+++ b/static/js/src/advantage/react/hooks/useStripePublishableKey.ts
@@ -1,0 +1,9 @@
+import type { StripePublishableKey } from "advantage/api/types";
+import { useQuery } from "react-query";
+
+export const useStripePublishableKey = () => {
+  const { data: stripePublishableKey } = useQuery<StripePublishableKey>(
+    "stripePublishableKey"
+  );
+  return { stripePublishableKey };
+};

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -43,6 +43,7 @@
 
 <script>
   window.pendingPurchaseId = "{{ pending_purchase_id }}";
+  window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
 </script>
 
 <script


### PR DESCRIPTION
## Done

- Set up Stripe for the resize form.
- Add resize form validation.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10423.demos.haus/advantage?test_backend=true) and log in.
- Select a resizable subscription and then click 'Edit subscription...'.
- Check that the 'Number of machines' field matches what's shown in the card.
- Enter "0" into the field and it should show a validation error.
- Enter a valid number and click 'Resize'.
- In your browser console it should log the stripe key.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/280.
