### PR TITLE
Fix display date when when lastLoginAt is null

### DIFF
--- a/static/js/src/advantage/users/api.ts
+++ b/static/js/src/advantage/users/api.ts
@@ -5,10 +5,10 @@ type AccountUsersReponse = {
   name: string;
   users: {
     id: string;
-    name: string;
+    name: string | null;
     email: string;
     user_role_on_account: "admin" | "technical" | "billing";
-    last_login_at: string;
+    last_login_at: string | null;
   }[];
 };
 

--- a/static/js/src/advantage/users/components/TableView/UserRow.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.tsx
@@ -109,7 +109,9 @@ const FormattedDate = ({ dateISO }: { dateISO: string | null }) =>
     <time dateTime={format(new Date(dateISO), "yyyy-MM-dd")}>
       {format(new Date(dateISO), DATE_FORMAT)}
     </time>
-  ) : null;
+  ) : (
+    <>Never</>
+  );
 
 type UserRowProps = {
   setUserInEditModeById: (id: string) => void;

--- a/static/js/src/advantage/users/components/TableView/UserRow.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.tsx
@@ -104,11 +104,12 @@ const UserRole = ({ user, variant }: UserRoleProps) => {
   );
 };
 
-const FormattedDate = ({ dateISO }: { dateISO: string }) => (
-  <time dateTime={format(new Date(dateISO), "yyyy-MM-dd")}>
-    {format(new Date(dateISO), DATE_FORMAT)}
-  </time>
-);
+const FormattedDate = ({ dateISO }: { dateISO: string | null }) =>
+  dateISO ? (
+    <time dateTime={format(new Date(dateISO), "yyyy-MM-dd")}>
+      {format(new Date(dateISO), DATE_FORMAT)}
+    </time>
+  ) : null;
 
 type UserRowProps = {
   setUserInEditModeById: (id: string) => void;

--- a/static/js/src/advantage/users/types.ts
+++ b/static/js/src/advantage/users/types.ts
@@ -2,10 +2,10 @@ export type UserRole = "admin" | "technical" | "billing";
 
 export type User = {
   id: string;
-  name: string;
+  name: string | null;
   email: string;
   role: UserRole;
-  lastLoginAt: string;
+  lastLoginAt: string | null;
 };
 
 export type Users = User[];


### PR DESCRIPTION
## Done

- Fix display date when when lastLoginAt is null

## QA
- Go to /advantage/users
- Add a new user
- Make sure last login column value for that user is empty

## Issue / Card

https://github.com/canonical-web-and-design/commercial-squad/issues/281

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/7452681/134159259-ab9d608b-b661-4653-9666-32db83fa1ecb.png)

### After
![image](https://user-images.githubusercontent.com/7452681/134159278-b7024b1b-3534-4174-8537-7475a47fca0c.png)
