### PR TITLE
Hide free trial message on live if not eligible

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
@@ -216,6 +216,20 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
     });
   };
 
+  // Remove this once we want to release free trial
+  const TrialNotAvailable = location.search.includes("test_backend=true") ? (
+    <Row>
+      <Col size={10} emptyLarge={2}>
+        <p>
+          <strong>
+            Free Trial is not available for this account.{" "}
+            <a href="/contact-us">Contact us</a> for further information.
+          </strong>
+        </p>
+      </Col>
+    </Row>
+  ) : null;
+
   return (
     <>
       <ModalHeader title="Your details" />
@@ -232,17 +246,7 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
               setIsUsingFreeTrial={setIsUsingFreeTrial}
             />
           ) : (
-            <Row>
-              <Col size={10} emptyLarge={2}>
-                <p>
-                  <strong>
-                    Free Trial is not available for this account.{" "}
-                    <a href="/contact-us">Contact us</a> for further
-                    information.
-                  </strong>
-                </p>
-              </Col>
-            </Row>
+            { TrialNotAvailable }
           )}
           <PaymentMethodSummary setStep={setStep} />
           <Row className="u-no-padding">

--- a/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
@@ -23,7 +23,7 @@ import Summary from "../../components/Summary";
 import FreeTrialRadio from "../../components/FreeTrialRadio";
 import { checkoutEvent, purchaseEvent } from "../../../../ecom-events";
 import { getSessionData } from "../../../../../utils/getSessionData";
-import { FormValues } from "../../utils/utils";
+import { FormValues, getIsFreeTrialEnabled } from "../../utils/utils";
 
 type StepOneProps = {
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -216,8 +216,7 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
     });
   };
 
-  // Remove this once we want to release free trial
-  const TrialNotAvailable = location.search.includes("test_backend=true") ? (
+  const TrialNotAvailable = getIsFreeTrialEnabled() ? (
     <Row>
       <Col size={10} emptyLarge={2}>
         <p>

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -85,3 +85,6 @@ function getInitialFormValues(
 }
 
 export { getUserInfoFromVariables, getInitialFormValues };
+
+export const getIsFreeTrialEnabled = () =>
+  location.search.includes("test_backend=true");

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -1,3 +1,4 @@
+import { getIsFreeTrialEnabled } from "../react/utils/utils";
 import versionDetails from "./version-details";
 
 export const formatter = new Intl.NumberFormat("en-US", {
@@ -190,7 +191,7 @@ function renderSummary(state) {
       freeTrialLabel.classList.add("u-hide");
 
       // Remove this once we want to release free trial
-      if (location.search.includes("test_backend=true")) {
+      if (getIsFreeTrialEnabled()) {
         trialUnavailableSection.classList.remove("u-hide");
       } else {
         trialUnavailableSection.classList.add("u-hide");

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -189,8 +189,6 @@ function renderSummary(state) {
       trialUnavailableSection.classList.add("u-hide");
     } else {
       freeTrialLabel.classList.add("u-hide");
-
-      // Remove this once we want to release free trial
       if (getIsFreeTrialEnabled()) {
         trialUnavailableSection.classList.remove("u-hide");
       } else {

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -188,7 +188,13 @@ function renderSummary(state) {
       trialUnavailableSection.classList.add("u-hide");
     } else {
       freeTrialLabel.classList.add("u-hide");
-      trialUnavailableSection.classList.remove("u-hide");
+
+      // Remove this once we want to release free trial
+      if (location.search.includes("test_backend=true")) {
+        trialUnavailableSection.classList.remove("u-hide");
+      } else {
+        trialUnavailableSection.classList.add("u-hide");
+      }
     }
     costElement.innerHTML = `${formatter.format((price / 100) * quantity)} / ${
       billing === "monthly" ? "month" : "year"

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -108,11 +108,11 @@
         </button>
       </div>
       <div class="col-8 col-start-large-4 js-trial-unavailable">
-        <p><strong>Free Trial is not available for this account. <a href="/contact-us">Contact us</a> for further information.</strong></p>
+        <p>Free Trial is not available for this account. <a href="/contact-us">Contact us</a> for further information.</p>
       </div>
       {% if is_trialling %}
         <div class="col-8 col-start-large-4">
-          <p><strong>You cannot purchase a new subscription while a Free Trial is active.</strong></p>
+          <p>You cannot purchase a new subscription while a Free Trial is active.</p>
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Done

- Removed free trial messaging on live until we release
- reduced the size of the message

## QA

- go to https://ubuntu-com-10435.demos.haus/advantage/subscribe?test_backend=true
- select a non trialable product (monthly) see that the message is smaller
- go to https://ubuntu-com-10435.demos.haus/advantage/subscribe
- see that the message is not there


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/134173154-1f8e608e-cd1d-4b8f-bf24-d0c6bee30ebe.png)

