### PR TITLE
Updates to release cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -71,7 +71,7 @@ export var serverAndDesktopReleases = [
 
   {
     startDate: new Date("2019-04-02T00:00:00"),
-    endDate: new Date("2022-04-02T00:00:00"),
+    endDate: new Date("2024-04-02T00:00:00"),
     taskName: "Ubuntu 14.04 LTS",
     status: "ESM",
   },
@@ -89,7 +89,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2021-04-02T00:00:00"),
-    endDate: new Date("2024-04-02T00:00:00"),
+    endDate: new Date("2026-04-02T00:00:00"),
     taskName: "Ubuntu 16.04 LTS",
     status: "ESM",
   },
@@ -289,7 +289,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
-    endDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS",
     taskVersion: "",
     status: "ESM",
@@ -331,7 +331,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
-    endDate: new Date("2022-04-29T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS",
     taskVersion: "",
     status: "ESM",
@@ -345,7 +345,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
-    endDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS",
     taskVersion: "4.4 kernel",
     status: "ESM",
@@ -359,7 +359,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
-    endDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS",
     taskVersion: "",
     status: "ESM",
@@ -373,7 +373,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
-    endDate: new Date("2022-04-29T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS",
     taskVersion: "",
     status: "ESM",
@@ -387,7 +387,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
-    endDate: new Date("2022-04-29T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS",
     taskVersion: "3.13 kernel",
     status: "ESM",
@@ -517,7 +517,7 @@ export var kernelReleases1604 = [
   },
   {
     startDate: new Date("2021-04-20T00:00:00"),
-    endDate: new Date("2024-04-19T00:00:00"),
+    endDate: new Date("2026-04-19T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS (v4.15)",
     status: "ESM",
   },
@@ -547,7 +547,7 @@ export var kernelReleases1604 = [
   },
   {
     startDate: new Date("2021-04-20T00:00:00"),
-    endDate: new Date("2024-04-19T00:00:00"),
+    endDate: new Date("2026-04-19T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS (v4.4)",
     status: "ESM",
   },
@@ -559,7 +559,7 @@ export var kernelReleases1604 = [
   },
   {
     startDate: new Date("2021-04-20T00:00:00"),
-    endDate: new Date("2024-04-19T00:00:00"),
+    endDate: new Date("2026-04-19T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS (v4.4)",
     status: "ESM",
   },
@@ -574,7 +574,7 @@ export var kernelReleases1404 = [
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
-    endDate: new Date("2022-04-19T00:00:00"),
+    endDate: new Date("2024-04-19T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS (v3.13)",
     status: "ESM",
   },
@@ -604,7 +604,7 @@ export var kernelReleases1404 = [
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
-    endDate: new Date("2022-04-19T00:00:00"),
+    endDate: new Date("2024-04-19T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS (v3.13)",
     status: "ESM",
   },
@@ -616,7 +616,7 @@ export var kernelReleases1404 = [
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
-    endDate: new Date("2022-04-19T00:00:00"),
+    endDate: new Date("2024-04-19T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS (v3.13)",
     status: "ESM",
   },

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -88,13 +88,13 @@
               <td><strong>Ubuntu 14.04 LTS</strong></td>
               <td>Apr 2014</td>
               <td>Apr 2019</td>
-              <td>Apr 2022</td>
+              <td>Apr 2024</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 16.04 LTS</strong></td>
               <td>Apr 2016</td>
               <td>Apr 2021</td>
-              <td>Apr 2024</td>
+              <td>Apr 2026</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 18.04 LTS</strong></td>
@@ -207,7 +207,7 @@
             <tr>
               <th>LTS security maintenance</th>
               <th scope="col">5-year initial period</th>
-              <th scope="col">Up to an additional 5 years</th>
+              <th scope="col">Additional 5 years</th>
             </tr>
           </thead>
           <tbody>
@@ -343,7 +343,7 @@
               <td><strong>Ubuntu 16.04.5 LTS</strong></td>
               <td>Aug 2018</td>
               <td>Apr 2021</td>
-              <td>Apr 2024</td>
+              <td>Apr 2026</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 18.04.1 LTS</strong></td>
@@ -362,32 +362,32 @@
               <td><strong>Ubuntu 14.04.5 LTS</strong></td>
               <td>Aug 2016</td>
               <td>Apr 2019</td>
-              <td>Apr 2022</td>
+              <td>Apr 2024</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 16.04.1 LTS</strong></td>
               <td>Jul 2016</td>
               <td>Apr 2021</td>
-              <td>Apr 2024</td>
+              <td>Apr 2026</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 16.04.0 LTS</strong></td>
               <td>Apr 2016</td>
               <td>Apr 2021</td>
-              <td>Apr 2024</td>
+              <td>Apr 2026</td>
             </tr>
             <tr>
               <td rowspan="2"><strong>3.13 kernel</strong></td>
               <td><strong>Ubuntu 14.04.1 LTS</strong></td>
               <td>Jul 2014</td>
               <td>Apr 2019</td>
-              <td>Apr 2022</td>
+              <td>Apr 2024</td>
             </tr>
             <tr>
               <td><strong>Ubuntu 14.04.0 LTS</strong></td>
               <td>Apr 2014</td>
               <td>Apr 2019</td>
-              <td>Apr 2022</td>
+              <td>Apr 2024</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Done

- Update release cycle tables to change end dates for `14.04` to 2024 and `16.06` to 2026 as per copy doc

## QA

- View this page at: https://ubuntu-com-10436.demos.haus/about/release-cycle
- Check against the comments in the [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#) and [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=677434053)
- The only thing to be updated in this PR is the end dates mentioned. Please ignore the other differences in the chart for now. 


## Issue / Card

Fixes #10417 
