### PR TITLE
Reintroduce the ubuntu pro beta invite

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -6,6 +6,17 @@
 
 {% block content %}
   <section class="p-strip--suru-topped" style="padding-bottom: 32px">
+
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification">
+          <p class="p-notification__response" role="status">
+            Are you using Ubuntu in production? <a href="/support/contact-us" class="p-notification__action js-invoke-modal">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+
     <div class="row">
       <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -20,6 +20,16 @@
 
     <div class="row">
       <div class="col-12">
+        <div class="p-notification">
+          <p class="p-notification__response" role="status">
+            Are you using Ubuntu in production? <a href="/support/contact-us" class="p-notification__action js-invoke-modal">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added notification linking to ubuntu pro beta on /advantage

## QA

- go to https://ubuntu-com-10444.demos.haus/advantage
- see the notification
- log in
- check that the notification is also here for the logged in state

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/271

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/134316858-8eb50b69-3649-4f56-b38f-327b2991e0d2.png)

