### PR TITLE
K8s links fix

### DIFF
--- a/templates/kubernetes/docs/1.16/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.16/charm-kubernetes-master.md
@@ -41,7 +41,7 @@ examples of complete models of Kubernetes clusters.
 
 # Resources
 
-The kubernetes-master charm takes advantage of the [Juju Resources](https://jaas.ai/docs/juju-resources)
+The kubernetes-master charm takes advantage of the [Juju Resources](https://juju.is/docs/sdk/resources)
 feature to deliver the Kubernetes software.
 
 In deployments on public clouds the Charm Store provides the resource to the

--- a/templates/kubernetes/docs/1.16/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.16/charm-tigera-secure-ee.md
@@ -101,4 +101,4 @@ production use.
 
 ## Further information
 
-- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-secure-ee/)
+- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-products/calico-enterprise/)

--- a/templates/kubernetes/docs/1.16/release-notes.md
+++ b/templates/kubernetes/docs/1.16/release-notes.md
@@ -115,7 +115,7 @@ Please see [this page][historic] for release notes of earlier versions.
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
 [upgrading-docker]: /kubernetes/docs/upgrading#upgrading-docker
-[tigera-home]: https://www.tigera.io/tigera-secure-ee/
+[tigera-home]: https://www.tigera.io/tigera-products/calico-enterprise/
 [tigera-docs]: /kubernetes/docs/tigera-secure-ee
 [haoverview]: /kubernetes/docs/high-availability
 [metallb-docs]: /kubernetes/docs/metallb

--- a/templates/kubernetes/docs/1.17/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.17/charm-kubernetes-master.md
@@ -41,7 +41,7 @@ examples of complete models of Kubernetes clusters.
 
 # Resources
 
-The kubernetes-master charm takes advantage of the [Juju Resources](https://jaas.ai/docs/juju-resources)
+The kubernetes-master charm takes advantage of the [Juju Resources](https://juju.is/docs/sdk/resources)
 feature to deliver the Kubernetes software.
 
 In deployments on public clouds the Charm Store provides the resource to the

--- a/templates/kubernetes/docs/1.17/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.17/charm-tigera-secure-ee.md
@@ -101,4 +101,4 @@ production use.
 
 ## Further information
 
-- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-secure-ee/)
+- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-products/calico-enterprise/)

--- a/templates/kubernetes/docs/1.17/release-notes.md
+++ b/templates/kubernetes/docs/1.17/release-notes.md
@@ -117,7 +117,7 @@ Please see [this page][historic] for release notes of earlier versions.
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
 [upgrading-docker]: /kubernetes/docs/upgrading#upgrading-docker
-[tigera-home]: https://www.tigera.io/tigera-secure-ee/
+[tigera-home]: https://www.tigera.io/tigera-products/calico-enterprise/
 [tigera-docs]: /kubernetes/docs/tigera-secure-ee
 [haoverview]: /kubernetes/docs/high-availability
 [metallb-docs]: /kubernetes/docs/metallb

--- a/templates/kubernetes/docs/1.18/charm-containerd.md
+++ b/templates/kubernetes/docs/1.18/charm-containerd.md
@@ -85,7 +85,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.18/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.18/charm-kubernetes-master.md
@@ -42,7 +42,7 @@ examples of complete models of Kubernetes clusters.
 
 # Resources
 
-The kubernetes-master charm takes advantage of the [Juju Resources](https://jaas.ai/docs/juju-resources)
+The kubernetes-master charm takes advantage of the [Juju Resources](https://juju.is/docs/sdk/resources)
 feature to deliver the Kubernetes software.
 
 In deployments on public clouds the Charm Store provides the resource to the

--- a/templates/kubernetes/docs/1.18/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.18/charm-kubernetes-worker.md
@@ -281,7 +281,7 @@ the setting of conntrack-max-per-core vs nf_conntrack_max.
 
 This requires configuration of both the `kubernetes-master` and
 `kubernetes-worker` charms. Please see the configuration section on
-the [kubernetes-master page](../charm-kubernetes-master#config-ipvs).
+the [kubernetes-master page](/kubernetes/docs/charm-kubernetes-master#config-ipvs).
 
 ### Configuring kubelet
 

--- a/templates/kubernetes/docs/1.18/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.18/charm-tigera-secure-ee.md
@@ -105,4 +105,4 @@ production use.
 
 ## Further information
 
-- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-secure-ee/)
+- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-products/calico-enterprise/)

--- a/templates/kubernetes/docs/1.18/release-notes.md
+++ b/templates/kubernetes/docs/1.18/release-notes.md
@@ -169,7 +169,7 @@ Please see [this page][historic] for release notes of earlier versions.
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
 [upgrading-docker]: /kubernetes/docs/upgrading#upgrading-docker
-[tigera-home]: https://www.tigera.io/tigera-secure-ee/
+[tigera-home]: https://www.tigera.io/tigera-products/calico-enterprise/
 [tigera-docs]: /kubernetes/docs/tigera-secure-ee
 [haoverview]: /kubernetes/docs/high-availability
 [metallb-docs]: /kubernetes/docs/metallb

--- a/templates/kubernetes/docs/1.19/charm-containerd.md
+++ b/templates/kubernetes/docs/1.19/charm-containerd.md
@@ -85,7 +85,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.19/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.19/charm-kubernetes-master.md
@@ -42,7 +42,7 @@ examples of complete models of Kubernetes clusters.
 
 # Resources
 
-The kubernetes-master charm takes advantage of the [Juju Resources](https://jaas.ai/docs/juju-resources)
+The kubernetes-master charm takes advantage of the [Juju Resources](https://juju.is/docs/sdk/resources)
 feature to deliver the Kubernetes software.
 
 In deployments on public clouds the Charm Store provides the resource to the

--- a/templates/kubernetes/docs/1.19/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.19/charm-kubernetes-worker.md
@@ -281,7 +281,7 @@ the setting of conntrack-max-per-core vs nf_conntrack_max.
 
 This requires configuration of both the `kubernetes-master` and
 `kubernetes-worker` charms. Please see the configuration section on
-the [kubernetes-master page](../charm-kubernetes-master#config-ipvs).
+the [kubernetes-master page](/kubernetes/docs/charm-kubernetes-master#config-ipvs).
 
 ### Configuring kubelet
 

--- a/templates/kubernetes/docs/1.19/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.19/charm-tigera-secure-ee.md
@@ -105,4 +105,4 @@ production use.
 
 ## Further information
 
-- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-secure-ee/)
+- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-products/calico-enterprise/)

--- a/templates/kubernetes/docs/1.20/charm-containerd.md
+++ b/templates/kubernetes/docs/1.20/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  ``[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]``
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.20/charm-containerd.md
+++ b/templates/kubernetes/docs/1.20/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  ``[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]``
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.20/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.20/charm-kubernetes-master.md
@@ -41,7 +41,7 @@ examples of complete models of Kubernetes clusters.
 
 # Resources
 
-The kubernetes-master charm takes advantage of the [Juju Resources](https://jaas.ai/docs/juju-resources)
+The kubernetes-master charm takes advantage of the [Juju Resources](https://juju.is/docs/sdk/resources)
 feature to deliver the Kubernetes software.
 
 In deployments on public clouds the Charm Store provides the resource to the

--- a/templates/kubernetes/docs/1.20/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.20/charm-kubernetes-worker.md
@@ -280,7 +280,7 @@ the setting of conntrack-max-per-core vs nf_conntrack_max.
 
 This requires configuration of both the `kubernetes-master` and
 `kubernetes-worker` charms. Please see the configuration section on
-the [kubernetes-master page](../charm-kubernetes-master#config-ipvs).
+the [kubernetes-master page](/kubernetes/docs/charm-kubernetes-master#config-ipvs).
 
 ### Configuring kubelet
 

--- a/templates/kubernetes/docs/1.20/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.20/charm-tigera-secure-ee.md
@@ -103,4 +103,4 @@ production use.
 
 ## Further information
 
-- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-secure-ee/)
+- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-products/calico-enterprise/)

--- a/templates/kubernetes/docs/1.21/charm-containerd.md
+++ b/templates/kubernetes/docs/1.21/charm-containerd.md
@@ -84,7 +84,7 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 

--- a/templates/kubernetes/docs/1.21/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.21/charm-kubernetes-worker.md
@@ -280,7 +280,7 @@ the setting of conntrack-max-per-core vs nf_conntrack_max.
 
 This requires configuration of both the `kubernetes-master` and
 `kubernetes-worker` charms. Please see the configuration section on
-the [kubernetes-master page](../charm-kubernetes-master#config-ipvs).
+the [kubernetes-master page](/kubernetes/docs/charm-kubernetes-master#config-ipvs).
 
 ### Configuring kubelet
 
@@ -597,5 +597,5 @@ juju run-action kubernetes-worker ACTION [parameters] [--wait]
 
 
 <!-- LINKS -->
-[charm-kubernetes-master]: /kubernetes/docs/1.21/charm-kubernetes-master
+[charm-kubernetes-master]: /charm-kubernetes-master
 [kubelet-docs]: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

--- a/templates/kubernetes/docs/1.21/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.21/charm-tigera-secure-ee.md
@@ -103,4 +103,4 @@ production use.
 
 ## Further information
 
-- [Tigera Secure EE Homepage](https://www.tigera.io/)
+- [Tigera Secure EE Homepage](https://www.tigera.io/tigera-products/calico-enterprise/)

--- a/templates/kubernetes/docs/1.22/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.22/charm-kubernetes-worker.md
@@ -280,7 +280,7 @@ the setting of conntrack-max-per-core vs nf_conntrack_max.
 
 This requires configuration of both the `kubernetes-master` and
 `kubernetes-worker` charms. Please see the configuration section on
-the [kubernetes-master page](../charm-kubernetes-master#config-ipvs).
+the [kubernetes-master page](/kubernetes/docs/charm-kubernetes-master#config-ipvs).
 
 ### Configuring kubelet
 

--- a/templates/kubernetes/docs/1.22/components.md
+++ b/templates/kubernetes/docs/1.22/components.md
@@ -349,43 +349,42 @@ These are the container images used by this release:
 
 <!-- GENERATED CONTAINER IMAGES -->
  
-- cdkbot/microbot-amd64:latest
-- cdkbot/microbot-arm64:latest
-- cdkbot/microbot-s390x:latest
-- cephcsi/cephcsi:v3.3.1
-- coredns/coredns:1.8.3
-- coreos/kube-state-metrics:v1.9.8
-- defaultbackend-amd64:1.5
-- defaultbackend-arm64:1.5
-- defaultbackend-ppc64le:1.5
-- defaultbackend-s390x:1.4
-- dns/k8s-dns-dnsmasq-nanny:1.17.3
-- dns/k8s-dns-kube-dns:1.17.3
-- dns/k8s-dns-sidecar:1.17.3
-- external_storage/nfs-client-provisioner:v3.1.0-k8s1.11
-- k8s-artifacts-prod/ingress-nginx/controller:v1.0.0-beta.3
-- k8scloudprovider/cinder-csi-plugin:v1.20.0
-- k8scloudprovider/k8s-keystone-auth:v1.20.0
-- k8scloudprovider/openstack-cloud-controller-manager:v1.20.0
-- kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0
-- kubernetesui/dashboard:v2.2.0
-- kubernetesui/metrics-scraper:v1.0.6
-- metrics-server/metrics-server:v0.5.0
-- nvidia/k8s-device-plugin:v0.9.0
-- pause:3.4.1
-- rancher/rancher:latest
-- sig-storage/csi-attacher:v2.2.1
-- sig-storage/csi-attacher:v3.0.2
-- sig-storage/csi-node-driver-registrar:v1.3.0
-- sig-storage/csi-node-driver-registrar:v2.0.1
-- sig-storage/csi-provisioner:v1.6.1
-- sig-storage/csi-provisioner:v2.0.4
-- sig-storage/csi-resizer:v0.5.1
-- sig-storage/csi-resizer:v1.0.1
-- sig-storage/csi-snapshotter:v2.1.3
-- sig-storage/csi-snapshotter:v4.0.0
-- sig-storage/livenessprobe:v2.1.0
-- sonatype/nexus3:latest
+-  cdk/addon-resizer-{{ arch }}:1.8.9
+-  cephcsi/cephcsi:v3.3.1 
+-  coredns/coredns:1.8.3 
+-  coreos/kube-state-metrics:v1.9.8 
+-  k8s-dns-dnsmasq-nanny:1.17.3 
+-  k8s-dns-kube-dns:1.17.3 
+-  k8s-dns-sidecar:1.17.3 
+-  k8scloudprovider/cinder-csi-plugin:v1.20.0 
+-  k8scloudprovider/k8s-keystone-auth:v1.20.0 
+-  k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 
+-  kubernetesui/dashboard:v2.2.0 
+-  kubernetesui/metrics-scraper:v1.0.6 
+-  metrics-server/metrics-server:v0.5.0 
+-  nvidia/k8s-device-plugin:v0.9.0 
+-  sig-storage/csi-attacher:v2.2.1 
+-  sig-storage/csi-attacher:v3.0.2 
+-  sig-storage/csi-node-driver-registrar:v1.3.0 
+-  sig-storage/csi-node-driver-registrar:v2.0.1 
+-  sig-storage/csi-provisioner:v1.6.1 
+-  sig-storage/csi-provisioner:v2.0.4 
+-  sig-storage/csi-resizer:v0.5.1 
+-  sig-storage/csi-resizer:v1.0.1 
+-  sig-storage/csi-snapshotter:v2.1.3 
+-  sig-storage/csi-snapshotter:v4.0.0 
+-  sig-storage/livenessprobe:v2.1.0 
+
+This is a list of the images which have been added or updated since the previous release:
+
+-  cephcsi/cephcsi:v3.3.1 
+-  k8s-dns-dnsmasq-nanny:1.17.3 
+-  k8s-dns-kube-dns:1.17.3 
+-  k8s-dns-sidecar:1.17.3 
+-  metrics-server:v0.5.0 
+-  sig-storage/csi-snapshotter:v4.0.0 
+
+
 
 <!-- CONTAINER IMAGES END -->
 

--- a/templates/kubernetes/docs/charm-azure-integrator.md
+++ b/templates/kubernetes/docs/charm-azure-integrator.md
@@ -223,7 +223,7 @@ in the following:
 
 
 This can be used from bundles with 'include-base64://' (see
-https://jujucharms.com/docs/stable/charms-bundles#setting-charm-configurations-options-in-a-bundle),
+https://juju.is/docs/sdk/bundles),
 or from the command-line with 'juju config aws credentials="$(base64 /path/to/file)"'.
 
 This option will take precedence over the individual config options, if set.

--- a/templates/kubernetes/docs/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/charm-kubernetes-worker.md
@@ -221,7 +221,7 @@ request information it sees. Use this option if NGINX is exposed directly to
 the internet, or it's behind a L3/packet-based load balancer that doesn't alter
 the source IP in the packets.
 
-Reference: https://github.com/kubernetes/ingress-nginx/blob/a9c706be12a8be418c49ab1f60a02f52f9b14e55/
+Reference: https://github.com/kubernetes/ingress-nginx/
 docs/user-guide/nginx-configuration/configmap.md#use-forwarded-headers.
 
 [Back to table](#table-ingress-use-forwarded-headers)
@@ -413,7 +413,7 @@ the setting of conntrack-max-per-core vs nf_conntrack_max.
 
 This requires configuration of both the `kubernetes-master` and
 `kubernetes-worker` charms. Please see the configuration section on
-the [kubernetes-master page](../charm-kubernetes-master#config-ipvs).
+the [kubernetes-master page](/kubernetes/docs/charm-kubernetes-master#config-ipvs).
 
 ### Configuring kubelet
 

--- a/templates/kubernetes/docs/charm-openstack-integrator.md
+++ b/templates/kubernetes/docs/charm-openstack-integrator.md
@@ -211,7 +211,7 @@ password, project-name, user-domain-name, and project-domain-name.
 It could also contain a base64-encoded CA certificate in endpoint-tls-ca key value.
 
 This can be used from bundles with 'include-base64://' (see
-https://jujucharms.com/docs/stable/charms-bundles#setting-charm-configurations-options-in-a-bundle),
+https://juju.is/docs/sdk/bundles),
 or from the command-line with 'juju config openstack-integrator credentials="$(base64 /path/to/file)"'.
 
 It is strongly recommended that you use 'juju trust' instead, if available.

--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -396,7 +396,7 @@ For additional troubleshooting pointers, please see the [dedicated troubleshooti
 [install-manual]:  /kubernetes/docs/install-manual
 [bgp-multiple-subnets-bird-example]: https://gist.github.com/Cynerva/46712dd1e9b75d42cb38fb966abfa932
 [route reflection]: https://tools.ietf.org/html/rfc4456
-[AS Per Rack model]: https://docs.projectcalico.org/v3.6/networking/design/l3-interconnect-fabric#the-as-per-rack-model
+[AS Per Rack model]: https://docs.projectcalico.org/reference/architecture/design/l3-interconnect-fabric
 [Calico charm]: /kubernetes/docs/charm-calico
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -181,7 +181,7 @@ juju config kubernetes-master image-registry=$REGISTRY
 
 <!-- LINKS -->
 
-[registry-charm]: https://github.com/CanonicalLtd/docker-registry-charm
+[registry-charm]: http://jujucharms.com/u/containers/docker-registry
 [upstream-registry]: https://docs.docker.com/registry/
 [quickstart]: /kubernetes/docs/quickstart
 [container-runtime]: /kubernetes/docs/container-runtime

--- a/templates/kubernetes/docs/ipv6.md
+++ b/templates/kubernetes/docs/ipv6.md
@@ -35,7 +35,7 @@ first CIDR in the list being the preferred family for pods.
 For the Kubernetes master, the `service-cidr` configuration can contain two
 comma-separated values, with the first being the default family for services.
 
-Note that Kubernetes supports [explicitly setting the `IPFamily`][ip-family] for a
+Note that Kubernetes supports [explicitly setting the `ipFamilies`][ip-families] for a
 service when creating it.
 
 The following example shows how to deploy Charmed Kubernetes with IPv6 and dual-stack
@@ -99,7 +99,7 @@ metadata:
     run: nginxdualstack
 spec:
   type: NodePort
-  ipFamily: IPv6
+  ipFamilies: [IPv6]
   ports:
   - port: 80
     protocol: TCP
@@ -173,7 +173,7 @@ No additional issues with IPv6 on MAAS are known at this time.
 <!-- LINKS -->
 
 [dual-stack]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-[ip-family]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
+[ip-families]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
 [asset-calico-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/calico-overlay.yaml
 [asset-ipv4-ipv6-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/ipv4-ipv6-overlay.yaml
 [asset-nginx-dual-stack]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/specs/nginx-dual-stack.yaml

--- a/templates/kubernetes/docs/keepalived.md
+++ b/templates/kubernetes/docs/keepalived.md
@@ -98,7 +98,7 @@ balancer.
 [keepalived-home]: http://www.keepalived.org/
 [SANs]: https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name
 [logging-doc]: /kubernetes/docs/logging
-[subordinate-charm]: https://docs.jujucharms.com/stable/en/authors-subordinate-applications
+[subordinate-charm]: https://juju.is/docs/sdk#heading--subordinate-charms
 [openstack-vip]: https://medium.com/jexia/virtual-ip-with-openstack-neutron-dd9378a48bdf
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/logging.md
+++ b/templates/kubernetes/docs/logging.md
@@ -18,7 +18,7 @@ toc: False
     <span class="p-notification__status">Note:</span>
 This documentation assumes you are using version 2.4.0 or later of
 <strong>Juju</strong>. If you are using an earlier version you should check
-the <a href="https://docs.jujucharms.com/stable/en/troubleshooting-logs">
+the <a href="https://juju.is/docs/olm/juju-logs">
 relevant <emphasis>Juju</emphasis> documentation</a> as some of the associated
 commands have changed.
   </p>
@@ -292,7 +292,7 @@ view.
 <!--LINKS -->
 
 [quickstart]: /kubernetes/docs/quickstart
-[juju-logging]: https://docs.jujucharms.com/stable/en/troubleshooting-logs
+[juju-logging]: https://juju.is/docs/olm/juju-logs
 [k8-logs]: https://kubernetes.io/docs/concepts/cluster-administration/logging/
 [logging-egf-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/logging-egf-overlay.yaml
 [graylog-vhost]: https://raw.githubusercontent.com/charmed-kubernetes/kubernetes-docs/master/assets/graylog-vhost.tmpl

--- a/templates/kubernetes/docs/multiple-networks.md
+++ b/templates/kubernetes/docs/multiple-networks.md
@@ -118,7 +118,7 @@ The following endpoints are available for use in bindings:
 | kubernetes-worker | kube-control | Traffic to kubelet, from kube-apiserver (health checks) |
 
 You can read more about bindings in the Juju documentation here:
-[Binding endpoints within a bundle](https://jaas.ai/docs/charm-bundles#heading--binding-endpoints-within-a-bundle)
+[Binding endpoints within a bundle](https://juju.is/docs/sdk/bundles)
 
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -67,7 +67,7 @@ Google. You can see which ones are ready to use by running this command:
           </div>
           <script id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
 
-          <p><a class="p-link--external" href="https://docs.jujucharms.com/clouds">Find out more about Clouds in Juju</a></p>
+          <p><a class="p-link--external" href="https://juju.is/docs/olm/clouds">Find out more about Clouds in Juju</a></p>
         </div>
       </li>
 

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -408,7 +408,7 @@ Please see [this page][historic] for release notes of earlier versions.
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
 [upgrading-docker]: /kubernetes/docs/upgrading#upgrading-docker
-[tigera-home]: https://www.tigera.io/tigera-secure-ee/
+[tigera-home]: https://www.tigera.io/tigera-products/calico-enterprise/
 [tigera-docs]: /kubernetes/docs/tigera-secure-ee
 [haoverview]: /kubernetes/docs/high-availability
 [metallb-docs]: /kubernetes/docs/metallb

--- a/templates/kubernetes/docs/security.md
+++ b/templates/kubernetes/docs/security.md
@@ -60,7 +60,7 @@ documentation, but you may find the following links useful.
 
 -   Amazon Web Services -	<https://aws.amazon.com/security/>
 -   Google Cloud Platform	- <https://cloud.google.com/security/>
--   Metal As A Service(MAAS) -  <https://maas.io/docs/security>
+-   Metal As A Service(MAAS) -  <https://maas.io/docs/snap/3.0/ui/hardening-your-maas-installation>
 -   Microsoft Azure	- <https://docs.microsoft.com/en-us/azure/security/azure-security>
 -   VMWare VSphere	- <https://www.vmware.com/security/hardening-guides.html>
 
@@ -100,7 +100,7 @@ To test your cluster, please see the
 [cis-benchmark]: https://www.cisecurity.org/benchmark/kubernetes/
 [Kubernetes Security documentation]: https://kubernetes.io/docs/concepts/security/overview/
 [Machine auth]: https://juju.is/docs/olm/accessing-individual-machines-with-ssh
-[juju-users]: https://juju.is/docs/working-with-multiple-users
+[juju-users]: https://juju.is/docs/olm/working-with-multiple-users
 [juju-user-types]: https://juju.is/docs/user-types-and-abilities
 [CIS compliance]: /kubernetes/docs/cis-compliance
 [k8s-auth]: /kubernetes/docs/auth

--- a/templates/kubernetes/docs/storage.md
+++ b/templates/kubernetes/docs/storage.md
@@ -278,7 +278,7 @@ There is no requirement that these additional units should have the same amount 
 [kubernetes-storage-docs]: https://kubernetes.io/docs/concepts/storage/
 [ceph-home]: https://ceph.com/
 [ceph-charm]: https://charmhub.io/ceph-osd
-[juju-storage]: https://docs.jujucharms.com/stable/en/charms-storage
+[juju-storage]: https://juju.is/docs/olm/defining-and-using-persistent-storage
 [juju-cmr]: https://juju.is/docs/olm/cross-model-relations
 
 <!-- FEEDBACK -->


### PR DESCRIPTION
## Done

 - Fixed some rendering issues in charm docs
 - updated links to Juju docs to avoid redirects
 - fixed relative links in charm docs
 - updated tigera links

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

