### PR TITLE
added pie chart to page

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -769,10 +769,27 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="u-fixed-width">
+  <div class="u-hide--large u-fixed-width">
     <h2>Number 1 platform for OpenStack implementation</h2>
-    <p>According to the <a class="p-link--external" href="https://www.openstack.org/analytics/">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for private cloud implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
   </div>
+  <div class="row">
+    <div class="u-hide--small u-hide--medium col-6">
+      <h2>Number 1 platform for OpenStack implementation</h2>
+      <p>According to the <a class="p-link--external" href="https://www.openstack.org/analytics/">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for private cloud implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+    </div>
+    <div class="u-hide--small col-6">
+      <div id="openstack-pie-chart"></div>
+    </div>
+    <div class="u-hide--medium u-hide--large col-6">
+      <div id="openstack-table"></div>
+    </div>
+  </div>
+  <div class="u-hide--large u-fixed-width">
+    <p>According to the <a href="https://www.openstack.org/analytics/" class="p-link--external">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+  </div>
+
+  <script src="https://d3js.org/d3.v6.min.js"></script>
+  <script src="{{ versioned_static('js/dist/openstackDeploymentChart.js') }}"></script>
 </section>
 
 <section class="p-strip">


### PR DESCRIPTION
## Done

- Added pit chart to `/openstack` as per: https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#

## QA

- View the site locally in your web browser at: https://ubuntu-com-10448.demos.haus/openstack
- See the pie chart is there and that content is displayed correctly on different page sizes (i.e chart replaced by table on smaller screens and vice versa)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10360

## Screenshots

<img width="1213" alt="Screenshot 2021-09-22 at 14 53 47" src="https://user-images.githubusercontent.com/17607612/134347163-ce72a947-9e4d-43e2-bb98-473139a494d0.png">

