### PR TITLE
Fixed duplicated normal strip at the end of the page

### DIFF
--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -96,7 +96,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <div class="u-align-text--center u-sv3 u-hide--small">
+    <div class="u-sv3 u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/894ffe5b-ESM+for+ROS+vertical.svg",
         alt="",

--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -44,7 +44,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h2>
@@ -94,7 +94,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <div class="u-align-text--center u-sv3 u-hide--small">
       {{ image (
@@ -114,7 +114,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-6">
       <h2>
@@ -203,7 +203,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-8">
       <h2>
@@ -243,7 +243,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-7 u-vertically-center">
       <h2>


### PR DESCRIPTION
## Done

- Fixed duplicated normal strip at the end of the page

## QA

- Go to https://ubuntu-com-10451.demos.haus/robotics/ros-esm
- Make sure `p-strip` and `.p-strip--light` are applied on sequentially (should be one section light and the section after a bit darker)

## Issue / Card

Fixes #

## Screenshots

### Before
![before](https://user-images.githubusercontent.com/36013798/134352262-bf435667-20ed-4e6c-90d3-508a5876e43b.png)

### After

![Screenshot from 2021-09-22 15-21-02](https://user-images.githubusercontent.com/36013798/134352308-47d03afc-97bd-4e7d-a2e8-793080897c7e.png)

